### PR TITLE
Refactor toy to share modules

### DIFF
--- a/3dtoy.html
+++ b/3dtoy.html
@@ -4,148 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Revised 3D Toy - Always Dynamic</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        html, body {
-            margin: 0;
-            overflow: hidden;
-            height: 100%;
-            background: radial-gradient(circle, #1CB5E0, #000046); /* Enhanced gradient for background */
-        }
-        canvas {
-            display: block;
+        body {
+            background: radial-gradient(circle, #1CB5E0, #000046);
         }
     </style>
 </head>
 <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.js"></script>
+    <script type="module" src="assets/js/toys/three-d-toy.js"></script>
 
-    <script>
-        // Three.js Scene Setup
-        const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-        const renderer = new THREE.WebGLRenderer({ antialias: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        document.body.appendChild(renderer.domElement);
-
-        // Torus Knot Geometry
-        const torusKnotGeometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
-        const torusMaterial = new THREE.MeshStandardMaterial({ color: 0x00ffcc, metalness: 0.7, roughness: 0.4 });
-        const torusKnot = new THREE.Mesh(torusKnotGeometry, torusMaterial);
-        scene.add(torusKnot);
-
-        // Dynamic Particle system
-        const particlesGeometry = new THREE.BufferGeometry();
-        const particlesCount = 1500; // Increased particle count for visual depth
-        const particlesPosition = new Float32Array(particlesCount * 3);
-        for (let i = 0; i < particlesCount * 3; i++) {
-            particlesPosition[i] = (Math.random() - 0.5) * 800; // Larger spread for more visual diversity
-        }
-        particlesGeometry.setAttribute('position', new THREE.BufferAttribute(particlesPosition, 3));
-        const particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.8 });
-        const particles = new THREE.Points(particlesGeometry, particlesMaterial);
-        scene.add(particles);
-
-        // Lighting - A mix of static and dynamic lights
-        const ambientLight = new THREE.AmbientLight(0x404040, 0.8);
-        scene.add(ambientLight);
-        const pointLight = new THREE.PointLight(0xff00ff, 2, 100);
-        pointLight.position.set(20, 30, 20);
-        scene.add(pointLight);
-
-        // Camera position
-        camera.position.z = 80; // Slightly further back for a more expansive view
-
-        // Randomly generated shapes that interact with the scene over time
-        const shapes = [];
-        function createRandomShape() {
-            const shapeType = Math.floor(Math.random() * 3);
-            let shape;
-            const shapeMaterial = new THREE.MeshStandardMaterial({
-                color: Math.random() * 0xffffff,
-                emissive: Math.random() * 0x444444,
-                metalness: 0.8,
-                roughness: 0.4
-            });
-
-            switch (shapeType) {
-                case 0:
-                    shape = new THREE.SphereGeometry(5, 32, 32);
-                    break;
-                case 1:
-                    shape = new THREE.BoxGeometry(7, 7, 7);
-                    break;
-                case 2:
-                    shape = new THREE.TetrahedronGeometry(6, 0); // Added a more abstract shape
-                    break;
-            }
-
-            const mesh = new THREE.Mesh(shape, shapeMaterial);
-            mesh.position.set(Math.random() * 120 - 60, Math.random() * 120 - 60, Math.random() * -800);
-            scene.add(mesh);
-            shapes.push(mesh);
-        }
-
-        // Generate multiple shapes with more variety
-        for (let i = 0; i < 7; i++) {
-            createRandomShape();
-        }
-
-        // Audio setup
-        let analyser;
-        navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
-            const audioContext = new AudioContext();
-            const audioSource = audioContext.createMediaStreamSource(stream);
-            analyser = audioContext.createAnalyser();
-            analyser.fftSize = 256;
-            audioSource.connect(analyser);
-            animate();
-        }).catch((err) => {
-            console.error('Error accessing microphone:', err);
-        });
-
-        // Animation loop
-        function animate() {
-            requestAnimationFrame(animate);
-
-            const dataArray = new Uint8Array(analyser.frequencyBinCount);
-            analyser.getByteFrequencyData(dataArray);
-            const avgFrequency = dataArray.reduce((acc, val) => acc + val, 0) / dataArray.length;
-
-            // Audio-driven transformations to keep things dynamic
-            torusKnot.rotation.x += avgFrequency / 5000;
-            torusKnot.rotation.y += avgFrequency / 7000;
-            torusKnot.scale.set(1 + avgFrequency / 200, 1 + avgFrequency / 200, 1); // Dynamic scaling
-
-            // Particle rotation speed based on audio
-            particles.rotation.y += 0.001 + avgFrequency / 15000;
-
-            // Shapes rotating and scaling with audio responsiveness
-            shapes.forEach((shape) => {
-                shape.rotation.x += Math.random() * 0.03; // Randomized for constant change
-                shape.rotation.y += Math.random() * 0.03;
-                shape.position.z += 1.5 + avgFrequency / 50;
-
-                if (shape.position.z > 20) {
-                    shape.position.z = -800; // Wrap shapes back around to the scene
-                    shape.position.x = Math.random() * 120 - 60;
-                    shape.position.y = Math.random() * 120 - 60;
-                    shape.material.color.set(Math.random() * 0xffffff); // Change color on loop
-                }
-            });
-
-            // Random torus size fluctuation to add visual variation
-            const randomTorusScale = 1 + Math.sin(Date.now() * 0.001) * 0.3;
-            torusKnot.scale.set(randomTorusScale, randomTorusScale, randomTorusScale);
-
-            renderer.render(scene, camera);
-        }
-
-        // Adjust canvas on resize
-        window.addEventListener('resize', () => {
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            camera.aspect = window.innerWidth / window.innerHeight;
-            camera.updateProjectionMatrix();
-        });
-    </script>
 </body>
 </html>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,0 +1,8 @@
+html, body {
+    margin: 0;
+    overflow: hidden;
+    height: 100%;
+}
+canvas {
+    display: block;
+}

--- a/assets/js/toys/three-d-toy.js
+++ b/assets/js/toys/three-d-toy.js
@@ -1,0 +1,127 @@
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+import { initScene } from '../core/scene-setup.js';
+import { initCamera } from '../core/camera-setup.js';
+import { initRenderer } from '../core/renderer-setup.js';
+import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
+import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
+
+let scene, camera, renderer, torusKnot, particles;
+const shapes = [];
+
+function createRandomShape() {
+    const shapeType = Math.floor(Math.random() * 3);
+    let geometry;
+    const material = new THREE.MeshStandardMaterial({
+        color: Math.random() * 0xffffff,
+        emissive: Math.random() * 0x444444,
+        metalness: 0.8,
+        roughness: 0.4
+    });
+
+    switch (shapeType) {
+        case 0:
+            geometry = new THREE.SphereGeometry(5, 32, 32);
+            break;
+        case 1:
+            geometry = new THREE.BoxGeometry(7, 7, 7);
+            break;
+        default:
+            geometry = new THREE.TetrahedronGeometry(6, 0);
+            break;
+    }
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(Math.random() * 120 - 60, Math.random() * 120 - 60, Math.random() * -800);
+    scene.add(mesh);
+    shapes.push(mesh);
+}
+
+function init() {
+    scene = initScene();
+    camera = initCamera({ position: { x: 0, y: 0, z: 80 } });
+
+    const canvas = document.createElement('canvas');
+    document.body.appendChild(canvas);
+    renderer = initRenderer(canvas);
+
+    torusKnot = new THREE.Mesh(
+        new THREE.TorusKnotGeometry(10, 3, 100, 16),
+        new THREE.MeshStandardMaterial({ color: 0x00ffcc, metalness: 0.7, roughness: 0.4 })
+    );
+    scene.add(torusKnot);
+
+    const particlesGeometry = new THREE.BufferGeometry();
+    const particlesCount = 1500;
+    const particlesPosition = new Float32Array(particlesCount * 3);
+    for (let i = 0; i < particlesCount * 3; i++) {
+        particlesPosition[i] = (Math.random() - 0.5) * 800;
+    }
+    particlesGeometry.setAttribute('position', new THREE.BufferAttribute(particlesPosition, 3));
+    const particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.8 });
+    particles = new THREE.Points(particlesGeometry, particlesMaterial);
+    scene.add(particles);
+
+    initAmbientLight(scene, { color: 0x404040, intensity: 0.8 });
+    initLighting(scene, {
+        type: 'PointLight',
+        color: 0xff00ff,
+        intensity: 2,
+        position: { x: 20, y: 30, z: 20 }
+    });
+
+    for (let i = 0; i < 7; i++) {
+        createRandomShape();
+    }
+
+    window.addEventListener('resize', handleResize);
+}
+
+function handleResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+let analyser;
+
+async function startAudio() {
+    try {
+        const audioData = await initAudio();
+        analyser = audioData.analyser;
+        animate();
+    } catch (e) {
+        console.error('Error accessing microphone:', e);
+    }
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+
+    const dataArray = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
+    const avgFrequency = dataArray.length ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length : 0;
+
+    torusKnot.rotation.x += avgFrequency / 5000;
+    torusKnot.rotation.y += avgFrequency / 7000;
+
+    particles.rotation.y += 0.001 + avgFrequency / 15000;
+
+    shapes.forEach((shape) => {
+        shape.rotation.x += Math.random() * 0.03;
+        shape.rotation.y += Math.random() * 0.03;
+        shape.position.z += 1.5 + avgFrequency / 50;
+        if (shape.position.z > 20) {
+            shape.position.z = -800;
+            shape.position.x = Math.random() * 120 - 60;
+            shape.position.y = Math.random() * 120 - 60;
+            shape.material.color.set(Math.random() * 0xffffff);
+        }
+    });
+
+    const randomScale = 1 + Math.sin(Date.now() * 0.001) * 0.3;
+    torusKnot.scale.set(randomScale, randomScale, randomScale);
+
+    renderer.render(scene, camera);
+}
+
+init();
+startAudio();

--- a/brand.html
+++ b/brand.html
@@ -3,15 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Enhanced Star Guitar Inspired Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        html, body {
-            margin: 0;
-            overflow: hidden;
-            height: 100%;
+        body {
             background: #000;
-        }
-        canvas {
-            display: block;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- extract common body and canvas styles to `base.css`
- replace inline script in `3dtoy.html` with `three-d-toy.js`
- add a reusable Three.js implementation using shared modules
- apply `base.css` to `brand.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685376645210833280f789d7eec1fc7c