### PR TITLE
Add Jest tests for audio utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ If you want to mess around with the toys locally, just clone the repo and open t
 
    This will run everything locally at `http://localhost:8000`.
 
+### Running Tests
+
+This project uses [Jest](https://jestjs.io/) for its test suite. To install
+dependencies and run the tests:
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the tests:
+   ```bash
+   npm test
+   ```
+
 ---
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "stims",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -1,0 +1,48 @@
+import { initAudio, getFrequencyData } from '../assets/js/utils/audio-handler.js';
+
+describe('audio-handler utilities', () => {
+  beforeEach(() => {
+    const mockAnalyser = {
+      frequencyBinCount: 128,
+      getByteFrequencyData: jest.fn(),
+    };
+    const mockSource = { connect: jest.fn() };
+
+    global.navigator = {
+      mediaDevices: {
+        getUserMedia: jest.fn().mockResolvedValue('stream'),
+      },
+    };
+
+    global.AudioContext = jest.fn(() => ({
+      createAnalyser: jest.fn(() => mockAnalyser),
+      createMediaStreamSource: jest.fn(() => mockSource),
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.navigator;
+    delete global.AudioContext;
+  });
+
+  test('initAudio resolves with analyser and data array', async () => {
+    const { analyser, dataArray } = await initAudio();
+    expect(analyser).toBeDefined();
+    expect(dataArray).toBeInstanceOf(Uint8Array);
+    expect(dataArray.length).toBe(analyser.frequencyBinCount);
+  });
+
+  test('getFrequencyData returns array of the expected length', () => {
+    const analyser = {
+      frequencyBinCount: 64,
+      getByteFrequencyData: jest.fn(arr => arr.fill(1)),
+    };
+
+    const result = getFrequencyData(analyser);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(64);
+    expect(analyser.getByteFrequencyData).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Node/Jest setup
- create tests for audio-handler
- document how to run the tests in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537681e30883328d5c4d40ea0c35d0