### PR TITLE
Refactor stims to share audio utils

### DIFF
--- a/assets/js/utils/audio-handler.js
+++ b/assets/js/utils/audio-handler.js
@@ -1,15 +1,16 @@
-export async function initAudio() {
+export async function initAudio(options = {}) {
+    const { fftSize = 256 } = options;
     try {
         const audioContext = new AudioContext();
         const analyser = audioContext.createAnalyser();
-        analyser.fftSize = 256;
+        analyser.fftSize = fftSize;
         const dataArray = new Uint8Array(analyser.frequencyBinCount);
 
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         const audioSource = audioContext.createMediaStreamSource(stream);
         audioSource.connect(analyser);
 
-        return { analyser, dataArray };
+        return { analyser, dataArray, audioContext, stream };
     } catch (error) {
         console.error('Error accessing audio:', error);
         throw new Error('Microphone access was denied.');

--- a/brand.html
+++ b/brand.html
@@ -13,7 +13,8 @@
 <body>
     <!-- Include Three.js library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.js"></script>
-    <script>
+    <script type="module">
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         const scene = new THREE.Scene();
         scene.fog = new THREE.Fog(0x000000, 10, 200);
 
@@ -104,14 +105,10 @@
             createElement(randomType, x, z);
         }
 
-        // Audio setup
+        // Audio setup using shared utility
         let analyser;
-        navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
-            const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            const audioSource = audioContext.createMediaStreamSource(stream);
-            analyser = audioContext.createAnalyser();
-            analyser.fftSize = 256;
-            audioSource.connect(analyser);
+        initAudio().then(({ analyser: a }) => {
+            analyser = a;
         }).catch((err) => {
             console.error('Audio input error: ', err);
         });
@@ -122,8 +119,7 @@
 
             let bass = 0;
             if (analyser) {
-                const dataArray = new Uint8Array(analyser.frequencyBinCount);
-                analyser.getByteFrequencyData(dataArray);
+                const dataArray = getFrequencyData(analyser);
                 bass = dataArray.slice(0, 10).reduce((a, b) => a + b, 0) / 10;
             }
 

--- a/defrag.html
+++ b/defrag.html
@@ -29,7 +29,8 @@
     <canvas id="canvas"></canvas>
     <div id="defragText">Defragmenting Drive C:</div>
 
-    <script>
+    <script type="module">
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         const canvas = document.getElementById('canvas');
         const ctx = canvas.getContext('2d');
 
@@ -67,13 +68,9 @@
 
         async function setupAudio() {
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                const audioContext = new AudioContext();
-                const source = audioContext.createMediaStreamSource(stream);
-                analyser = audioContext.createAnalyser();
-                analyser.fftSize = 64; // Small for faster reactions
-                audioDataArray = new Uint8Array(analyser.frequencyBinCount);
-                source.connect(analyser);
+                const result = await initAudio({ fftSize: 64 });
+                analyser = result.analyser;
+                audioDataArray = result.dataArray;
                 getAudioData();
             } catch (err) {
                 console.error("Error capturing audio: ", err);
@@ -82,7 +79,7 @@
 
         function getAudioData() {
             requestAnimationFrame(getAudioData);
-            analyser.getByteFrequencyData(audioDataArray);
+            audioDataArray = getFrequencyData(analyser);
             idleState = audioDataArray.reduce((sum, value) => sum + value, 0) === 0; // Idle if all audio data is zero
         }
 

--- a/evol.html
+++ b/evol.html
@@ -41,7 +41,8 @@
             <input type="range" id="fractalIntensity" min="0.5" max="2.0" step="0.1" value="1.0">
         </label>
     </div>
-    <script>
+    <script type="module">
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         const canvas = document.getElementById("glCanvas");
         const gl = canvas.getContext("webgl");
 
@@ -171,12 +172,8 @@
 
         async function setupAudio() {
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                const audioContext = new AudioContext();
-                const source = audioContext.createMediaStreamSource(stream);
-                analyser = audioContext.createAnalyser();
-                analyser.fftSize = 256;
-                source.connect(analyser);
+                const result = await initAudio();
+                analyser = result.analyser;
                 getAudioData();
             } catch (err) {
                 console.error("Error capturing audio: ", err);
@@ -186,8 +183,7 @@
         function getAudioData() {
             requestAnimationFrame(getAudioData);
             if (analyser) {
-                const dataArray = new Uint8Array(analyser.frequencyBinCount);
-                analyser.getByteFrequencyData(dataArray);
+                const dataArray = getFrequencyData(analyser);
                 const average = dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
                 audioData = average / 128.0;
             }

--- a/multi.html
+++ b/multi.html
@@ -21,6 +21,7 @@
     <script type="module">
         import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.169.0/three.module.js';
         import { WebGPURenderer } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.169.0/three.webgpu.min.js';
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
 
         let renderer, isWebGPUSupported = false;
 
@@ -112,24 +113,18 @@
 
         // Audio input setup
         let analyser;
-        navigator.mediaDevices.getUserMedia({ audio: true }).then(function(stream) {
-            const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            const audioSource = audioContext.createMediaStreamSource(stream);
-            analyser = audioContext.createAnalyser();
-            analyser.fftSize = 256;
-            const bufferLength = analyser.frequencyBinCount;
-            const dataArray = new Uint8Array(bufferLength);
-            audioSource.connect(analyser);
+        let dataArray;
+        initAudio().then(({ analyser: a, dataArray: d }) => {
+            analyser = a;
+            dataArray = d;
             audioReact();
         }).catch(function(err) {
             console.error('The following error occurred: ' + err);
         });
 
         function audioReact() {
-            const dataArray = new Uint8Array(analyser.frequencyBinCount);
-
             function updateAudio() {
-                analyser.getByteFrequencyData(dataArray);
+                dataArray = getFrequencyData(analyser);
                 const avgFrequency = dataArray.reduce((acc, val) => acc + val, 0) / dataArray.length;
 
                 // Rotate the torus knot based on sound frequency

--- a/seary.html
+++ b/seary.html
@@ -24,7 +24,8 @@
         <option value="mic">Microphone</option>
         <option value="device">Device Audio</option>
     </select>
-    <script>
+    <script type="module">
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         // Fallback to WebGL
         const canvas = document.getElementById('gpuCanvas');
         const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
@@ -179,6 +180,7 @@
 
         // Audio setup for beat detection and frequency analysis
         let audioContext, analyser, source;
+        let bufferLength, dataArray;
         const audioSelect = document.getElementById('audioSelect');
 
         audioSelect.addEventListener('change', initializeAudio);
@@ -191,10 +193,14 @@
 
             navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
                 audioContext = new (window.AudioContext || window.webkitAudioContext)();
-                analyser = audioContext.createAnalyser();
-
                 if (audioSelect.value === 'mic') {
-                    source = audioContext.createMediaStreamSource(stream);
+                    initAudio().then(({ analyser: a, dataArray: d }) => {
+                        analyser = a;
+                        source = audioContext.createMediaStreamSource(stream);
+                        source.connect(analyser);
+                        startProcessing(d);
+                    });
+                    return;
                 } else {
                     // Use the audio context's `createMediaElementSource` to capture device audio
                     const audioElement = new Audio();
@@ -203,11 +209,12 @@
                     source.connect(audioContext.destination); // To allow playback
                     audioElement.play();
                 }
-
-                source.connect(analyser);
+                analyser = audioContext.createAnalyser();
                 analyser.fftSize = 256;
+                source.connect(analyser);
                 const bufferLength = analyser.frequencyBinCount;
                 const dataArray = new Uint8Array(bufferLength);
+                startProcessing(dataArray);
 
                 let lastVibrateTime = 0;
 
@@ -271,8 +278,14 @@
                     }
                 }
 
+                function startProcessing(arr) {
+                    dataArray = arr;
+                    bufferLength = analyser.frequencyBinCount;
+                    updateAudioData();
+                }
+
                 function updateAudioData() {
-                    analyser.getByteFrequencyData(dataArray);
+                    dataArray = getFrequencyData(analyser);
                     const lowFreq = dataArray.slice(0, bufferLength / 3).reduce((sum, value) => sum + value, 0) / (bufferLength / 3) / 256.0;
                     const midFreq = dataArray.slice(bufferLength / 3, 2 * bufferLength / 3).reduce((sum, value) => sum + value, 0) / (bufferLength / 3) / 256.0;
                     const highFreq = dataArray.slice(2 * bufferLength / 3, bufferLength).reduce((sum, value) => sum + value, 0) / (bufferLength / 3) / 256.0;

--- a/sgpat.html
+++ b/sgpat.html
@@ -36,6 +36,7 @@
     <script type="module">
         // Import the pattern recognition logic
         import PatternRecognizer from './assets/js/utils/patternRecognition.js';
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
 
         const canvas = document.getElementById("glCanvas");
         const gl = canvas.getContext("webgl");
@@ -161,13 +162,8 @@
 
         async function setupAudio() {
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                const audioContext = new AudioContext();
-                const source = audioContext.createMediaStreamSource(stream);
-                analyser = audioContext.createAnalyser();
-                analyser.fftSize = 256;
-                source.connect(analyser);
-                // PatternRecognizer expects only the analyser instance
+                const result = await initAudio();
+                analyser = result.analyser;
                 patternRecognizer = new PatternRecognizer(analyser);
                 getAudioData();
             } catch (err) {
@@ -179,8 +175,7 @@
         function getAudioData() {
             requestAnimationFrame(getAudioData);
             if (analyser) {
-                const dataArray = new Uint8Array(analyser.frequencyBinCount);
-                analyser.getByteFrequencyData(dataArray);
+                const dataArray = getFrequencyData(analyser);
                 const average = dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
                 audioData = average / 128.0;
                 updateSpectrograph(dataArray);

--- a/symph.html
+++ b/symph.html
@@ -33,7 +33,8 @@
 <body>
     <div id="error-message" style="display: none;"></div>
     <canvas id="glCanvas"></canvas>
-    <script>
+    <script type="module">
+        import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         const canvas = document.getElementById("glCanvas");
         const gl = canvas.getContext("webgl");
         const ctx2d = canvas.getContext("2d");
@@ -152,12 +153,8 @@
 
         async function setupAudio() {
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                const audioContext = new AudioContext();
-                const source = audioContext.createMediaStreamSource(stream);
-                analyser = audioContext.createAnalyser();
-                analyser.fftSize = 256;
-                source.connect(analyser);
+                const { analyser: a } = await initAudio();
+                analyser = a;
                 getAudioData();
             } catch (err) {
                 showError('Unable to access the microphone. Please allow microphone permissions and reload the page.');
@@ -168,8 +165,7 @@
         function getAudioData() {
             requestAnimationFrame(getAudioData);
             if (analyser) {
-                const dataArray = new Uint8Array(analyser.frequencyBinCount);
-                analyser.getByteFrequencyData(dataArray);
+                const dataArray = getFrequencyData(analyser);
                 const average = dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
                 audioData = average / 128.0;
                 updateSpectrograph(dataArray);

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -27,10 +27,16 @@ describe('audio-handler utilities', () => {
   });
 
   test('initAudio resolves with analyser and data array', async () => {
-    const { analyser, dataArray } = await initAudio();
+    const { analyser, dataArray, audioContext, stream } = await initAudio();
     expect(analyser).toBeDefined();
     expect(dataArray).toBeInstanceOf(Uint8Array);
     expect(dataArray.length).toBe(analyser.frequencyBinCount);
+    expect(audioContext).toBeDefined();
+    expect(stream).toBeDefined();
+  });
+
+  test('initAudio supports custom fftSize', async () => {
+    await expect(initAudio({ fftSize: 512 })).resolves.toBeDefined();
   });
 
   test('getFrequencyData returns array of the expected length', () => {

--- a/words.html
+++ b/words.html
@@ -126,7 +126,8 @@
         <canvas id="word-cloud-canvas"></canvas>
     </div>
 
-<script>
+<script type="module">
+    import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
     const wordCloudCanvas = document.getElementById('word-cloud-canvas');
     const unmuteButton = document.getElementById('unmute-button');
     const toggleSpeechButton = document.getElementById('toggle-speech-button');
@@ -192,29 +193,28 @@
         }
     });
 
-    function activateVisualizer() {
-        audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        analyser = audioContext.createAnalyser();
-        analyser.fftSize = 256;
-
-        navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+    async function activateVisualizer() {
+        try {
+            const { analyser: a, audioContext: ctx, stream } = await initAudio();
+            analyser = a;
+            audioContext = ctx;
             mediaStream = stream;
             microphone = audioContext.createMediaStreamSource(stream);
             microphone.connect(analyser);
             visualize();
-        }).catch(error => {
+        } catch (error) {
             console.error("Error accessing microphone for visualizer:", error);
-            deactivateVisualizer(); // Clean up in case of error
-        });
+            deactivateVisualizer();
+        }
     }
 
     function visualize() {
-        const dataArray = new Uint8Array(analyser.frequencyBinCount);
+        let dataArray = new Uint8Array(analyser.frequencyBinCount);
 
         function draw() {
             if (!isUnmuted) return;
 
-            analyser.getByteFrequencyData(dataArray);
+            dataArray = getFrequencyData(analyser);
             const maxVolume = Math.max(...dataArray);
 
             updateWordCloudWithVisualizer(maxVolume);


### PR DESCRIPTION
## Summary
- update `initAudio` to accept options and return audio context and stream
- add unit tests for new initAudio return fields and custom fftSize
- update visualizer HTML files to import shared `audio-handler.js`
- switch various scripts to modules and reuse `initAudio`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685377b277708332962208cf0633352c