### PR TITLE
Standardize Three.js CDN version

### DIFF
--- a/holy.html
+++ b/holy.html
@@ -174,13 +174,13 @@
     </div>
 
     <!-- Three.js Library -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
     <!-- Post-Processing Scripts -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/examples/js/postprocessing/EffectComposer.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/examples/js/postprocessing/RenderPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/examples/js/postprocessing/UnrealBloomPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/examples/js/postprocessing/ShaderPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/examples/js/shaders/FXAAShader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/EffectComposer.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/RenderPass.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/UnrealBloomPass.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/ShaderPass.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/shaders/FXAAShader.js"></script>
 
     <!-- Main Visualizer Script -->
     <script>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Stim Webtoys Library</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
     <style>
         :root {
             --bg-color: #0d0d0d;

--- a/lights.html
+++ b/lights.html
@@ -70,7 +70,7 @@
     <!-- Error message for microphone access -->
     <div id="error-message"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
     <script type="module" src="assets/js/app.js"></script>
 
 </body>

--- a/multi.html
+++ b/multi.html
@@ -19,8 +19,8 @@
 <body>
     <canvas id="webglCanvas"></canvas>
     <script type="module">
-        import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.169.0/three.module.js';
-        import { WebGPURenderer } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.169.0/three.webgpu.min.js';
+        import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+        import { WebGPURenderer } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.webgpu.min.js';
 
         let renderer, isWebGPUSupported = false;
 

--- a/svgtest.html
+++ b/svgtest.html
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Include Three.js -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.169.0/three.webgpu.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.webgpu.min.js"></script>
     
     <script>
         // Set up the Three.js scene


### PR DESCRIPTION
## Summary
- update all HTML examples to use the same Three.js CDN version (`r134`)
- keep `three-d-toy.js` pointing at the same CDN version

## Testing
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_68537946a51483328d96e6294a48340c