### PR TITLE
Consolidate shared styles

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -6,3 +6,6 @@ html, body {
 canvas {
     display: block;
 }
+body {
+    background-color: #000;
+}

--- a/brand.html
+++ b/brand.html
@@ -4,11 +4,6 @@
     <meta charset="UTF-8">
     <title>Enhanced Star Guitar Inspired Visualizer</title>
     <link rel="stylesheet" href="assets/css/base.css">
-    <style>
-        body {
-            background: #000;
-        }
-    </style>
 </head>
 <body>
     <!-- Include Three.js library -->

--- a/clay.html
+++ b/clay.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="utf-8">
     <title>Enhanced Pottery Wheel Simulation</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body { margin: 0; overflow: hidden; background: #000; }
-        canvas { display: block; touch-action: none; }
+        body { background: #000; }
+        canvas { touch-action: none; }
         #ui {
             position: absolute;
             top: 10px;

--- a/clayr.html
+++ b/clayr.html
@@ -4,10 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WebGPU Audio Visualizer</title>
+  <link rel="stylesheet" href="assets/css/base.css">
   <style>
     body, html {
-      margin: 0;
-      overflow: hidden;
       background-color: #000;
       display: flex;
       justify-content: center;
@@ -15,7 +14,6 @@
       height: 100vh;
     }
     canvas {
-      display: block;
       width: 100vw;
       height: 100vh;
     }

--- a/defrag.html
+++ b/defrag.html
@@ -4,17 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Defrag Sound-Reactive Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body, html {
-            margin: 0;
-            overflow: hidden;
-            height: 100%;
+        body {
             background-color: #000000; /* OLED black */
             font-family: 'Courier New', monospace;
             color: #00FF00; /* Old-school green text */
-        }
-        #canvas {
-            display: block;
         }
         #defragText {
             position: absolute;

--- a/evol.html
+++ b/evol.html
@@ -4,15 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Evolutionary Weirdcore Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body, html {
-            margin: 0;
-            overflow: hidden;
-            height: 100%;
+        body {
             background-color: #000000; /* OLED black */
         }
         canvas {
-            display: block;
             width: 100vw;
             height: 100vh;
         }

--- a/geom.html
+++ b/geom.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>Microphone Input Music Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body { margin: 0; overflow: hidden; background: #000; }
-        canvas { display: block; }
+        body { background: #000; }
         #controls {
             position: absolute;
             top: 10px;

--- a/holy.html
+++ b/holy.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Ultimate Satisfying Audio Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body { margin: 0; overflow: hidden; background-color: black; touch-action: none; }
-        canvas { display: block; }
+        body { background-color: black; touch-action: none; }
         #startButton, #infoButton, #settingsButton, #fullscreenButton {
             position: absolute;
             padding: 12px 20px;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Stim Webtoys Library</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/base.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
@@ -17,7 +18,6 @@
         }
 
         body, html {
-            margin: 0;
             padding: 0;
             font-family: 'Space Grotesk', sans-serif;
             background: linear-gradient(135deg, #0d0d0d 0%, #1c1c1c 100%);

--- a/legible.html
+++ b/legible.html
@@ -7,10 +7,10 @@
 
   <!-- Particles.js Library -->
   <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+  <link rel="stylesheet" href="assets/css/base.css">
 
   <style>
     body {
-      margin: 0;
       height: 100vh;
       display: flex;
       justify-content: center;
@@ -18,7 +18,6 @@
       background-color: #000;
       color: #00ff00;
       font-family: 'Courier New', monospace;
-      overflow: hidden;
     }
     #particles-js {
       position: absolute;

--- a/lights.html
+++ b/lights.html
@@ -4,11 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audio-Responsive Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         body, html {
-            margin: 0;
             padding: 0;
-            overflow: hidden;
             font-family: Arial, sans-serif;
             background-color: #111;
             color: white;

--- a/multi.html
+++ b/multi.html
@@ -4,15 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Multi-Capability Visualizer (WebGPU/WebGL Fallback)</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         body, html {
-            margin: 0;
-            overflow: hidden;
             height: 100%;
             background-color: #000000;
-        }
-        canvas {
-            display: block;
         }
     </style>
 </head>

--- a/seary.html
+++ b/seary.html
@@ -4,15 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Trippy Synesthetic Visualizer with WebGL</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         body, html {
-            margin: 0;
-            overflow: hidden;
             height: 100%;
             background-color: #000000; /* OLED black */
         }
         canvas {
-            display: block;
             width: 100vw;
             height: 100vh;
         }

--- a/sgpat.html
+++ b/sgpat.html
@@ -4,19 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pattern Recognition & Spectrograph Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         body, html {
-            margin: 0;
-            overflow: hidden;
             background-color: black;
             touch-action: none;
             display: flex;
             justify-content: center;
             align-items: center;
             font-family: Arial, sans-serif;
-        }
-        canvas {
-            display: block;
         }
         #error-message {
             position: absolute;

--- a/svgtest.html
+++ b/svgtest.html
@@ -4,11 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SVG + Three.js Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
-        body {
-            margin: 0;
-            overflow: hidden;
-        }
         #overlay {
             position: absolute;
             top: 0;

--- a/symph.html
+++ b/symph.html
@@ -4,19 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dreamy Interactive Spectrograph Music Visualizer</title>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         body {
-            margin: 0;
-            overflow: hidden;
             background-color: black;
             touch-action: none;
             display: flex;
             justify-content: center;
             align-items: center;
             font-family: Arial, sans-serif;
-        }
-        canvas {
-            display: block;
         }
         #error-message {
             position: absolute;

--- a/words.html
+++ b/words.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Word Cloud & Visualizer</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wordcloud2.js/1.0.1/wordcloud2.min.js"></script>
+    <link rel="stylesheet" href="assets/css/base.css">
     <style>
         * {
             box-sizing: border-box;
         }
 
         body {
-            margin: 0;
             height: 100vh;
             display: flex;
             justify-content: center;
@@ -20,7 +20,6 @@
             background-size: 400% 400%;
             animation: backgroundShift 10s ease infinite;
             font-family: 'Arial', sans-serif;
-            overflow: hidden;
             position: relative;
         }
 


### PR DESCRIPTION
## Summary
- centralize page resets in `assets/css/base.css`
- clean up redundant inline CSS rules
- link every HTML page to the shared stylesheet

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68537935c40c8332b018672799cccc5d