### PR TITLE
Switch to module-based three.js imports

### DIFF
--- a/3dtoy.html
+++ b/3dtoy.html
@@ -12,7 +12,6 @@
     </style>
 </head>
 <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.js"></script>
     <script type="module" src="assets/js/toys/three-d-toy.js"></script>
 
 </body>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,4 @@
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 import { initScene } from './core/scene-setup.js';
 import { initCamera } from './core/camera-setup.js';
 import { initRenderer } from './core/renderer-setup.js';

--- a/assets/js/core/camera-setup.js
+++ b/assets/js/core/camera-setup.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 
 export function initCamera({
   fov = 75,

--- a/assets/js/core/renderer-setup.js
+++ b/assets/js/core/renderer-setup.js
@@ -1,4 +1,5 @@
 // renderer-setup.js
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 export function initRenderer(canvas, config = { antialias: true }) {
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: config.antialias });
   renderer.setSize(window.innerWidth, window.innerHeight);

--- a/assets/js/core/scene-setup.js
+++ b/assets/js/core/scene-setup.js
@@ -1,4 +1,5 @@
 // scene-setup.js
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 export function initScene(config = { backgroundColor: 0x000000 }) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(config.backgroundColor);

--- a/assets/js/lighting/lighting-setup.js
+++ b/assets/js/lighting/lighting-setup.js
@@ -1,4 +1,5 @@
 // lighting-setup.js
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 
 // Initialize a point light with configurable options
 export function initLighting(scene, config = { 

--- a/lights.html
+++ b/lights.html
@@ -70,7 +70,6 @@
     <!-- Error message for microphone access -->
     <div id="error-message"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script type="module" src="assets/js/app.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- update renderer and scene setup modules to import three.js
- switch camera and lighting modules to module-based three.js
- import three.js in app.js and remove redundant CDN scripts from lights and 3dtoy pages

## Testing
- `npm test` *(fails: Cannot find module '/workspace/stims/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68537943e3c08332b1bc1df2d59861c4