### PR TITLE
Add tests for animation utils and pattern recognition

### DIFF
--- a/tests/animation-utils.test.js
+++ b/tests/animation-utils.test.js
@@ -1,0 +1,29 @@
+import { applyAudioRotation, applyAudioScale } from '../assets/js/utils/animation-utils.js';
+
+describe('animation-utils', () => {
+  test('applyAudioRotation updates rotation based on average frequency', () => {
+    const object = { rotation: { x: 0, y: 0 } };
+    const audioData = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90]);
+
+    applyAudioRotation(object, audioData, 0.1);
+
+    const avg = audioData.reduce((a, b) => a + b, 0) / audioData.length;
+    const expected = 0.1 * (avg / 255);
+    expect(object.rotation.x).toBeCloseTo(expected);
+    expect(object.rotation.y).toBeCloseTo(expected);
+  });
+
+  test('applyAudioScale sets scale based on specified band', () => {
+    const called = [];
+    const object = { scale: { set: jest.fn((x, y, z) => called.push([x, y, z])) } };
+    const audioData = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90]);
+
+    applyAudioScale(object, audioData, 50, 'high');
+
+    const highAvg = audioData.slice(Math.trunc(audioData.length * 0.66))
+      .reduce((acc, val) => acc + val, 0) / (audioData.length * 0.33);
+    const scale = 1 + highAvg / 50;
+    expect(object.scale.set).toHaveBeenCalledWith(scale, scale, scale);
+    expect(called[0]).toEqual([scale, scale, scale]);
+  });
+});

--- a/tests/patternRecognition.test.js
+++ b/tests/patternRecognition.test.js
@@ -1,0 +1,41 @@
+import PatternRecognizer from '../assets/js/utils/patternRecognition.js';
+
+describe('PatternRecognizer', () => {
+  test('detectPattern returns pattern when last two patterns match', () => {
+    const patterns = [
+      new Uint8Array([1, 1, 1]),
+      new Uint8Array([1, 1, 1])
+    ];
+    let call = 0;
+    const analyser = {
+      frequencyBinCount: 3,
+      getByteFrequencyData: jest.fn(arr => arr.set(patterns[call++]))
+    };
+    const recognizer = new PatternRecognizer(analyser, 2);
+
+    recognizer.updatePatternBuffer();
+    recognizer.updatePatternBuffer();
+
+    const result = recognizer.detectPattern();
+    expect(result).toEqual([...patterns[1]]);
+  });
+
+  test('detectPattern returns null when patterns differ', () => {
+    const patterns = [
+      new Uint8Array([1, 1, 1]),
+      new Uint8Array([2, 2, 2])
+    ];
+    let call = 0;
+    const analyser = {
+      frequencyBinCount: 3,
+      getByteFrequencyData: jest.fn(arr => arr.set(patterns[call++]))
+    };
+    const recognizer = new PatternRecognizer(analyser, 2);
+
+    recognizer.updatePatternBuffer();
+    recognizer.updatePatternBuffer();
+
+    const result = recognizer.detectPattern();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add new unit tests covering animation-utils
- add PatternRecognizer detection tests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68538430d5888332a6dc27ff2f6fad71