### PR TITLE
Fix script tag in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Stim Webtoys Library</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
-<<<    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
     <style>
         :root {
             --bg-color: #0d0d0d;


### PR DESCRIPTION
## Summary
- fix stray `<<<` characters in index.html script tag

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6853841ec5548332bc2048844e930b05