### PR TITLE
Fix script to use module

### DIFF
--- a/multi.html
+++ b/multi.html
@@ -14,7 +14,7 @@
 </head>
 <body>
     <canvas id="webglCanvas"></canvas>
-    <script>
+    <script type="module">
         import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
         import { WebGPURenderer } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.webgpu.min.js';
         import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';


### PR DESCRIPTION
## Summary
- load modules using the module script type in `multi.html`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/stims/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6853843c71cc83329fc03ab6e891cd09