### PR TITLE
Add dev server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 ## Local Setup
 
-If you want to mess around with the toys locally, just clone the repo and open the HTML files in your browser. Here’s the quick setup:
+If you want to mess around with the toys locally, clone the repo and run the local server. Here’s the quick setup:
 
 1. Clone the repository:
    ```bash
@@ -84,14 +84,17 @@ If you want to mess around with the toys locally, just clone the repo and open t
    cd stims
    ```
 
-2. Open any of the HTML files in your browser (e.g., `evol.html`, `index.html`).
-
-3. Want to serve locally? Here’s a simple Python server:
+2. Install dependencies:
    ```bash
-   python3 -m http.server
+   npm install
    ```
 
-   This will run everything locally at `http://localhost:8000`.
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+   This serves the project at `http://localhost:8080`. Open any of the HTML files (e.g., `evol.html`, `index.html`) in your browser.
 
 ### Running Tests
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "start": "http-server ."
   },
   "devDependencies": {
-    "jest": "^29.6.1"
+    "jest": "^29.6.1",
+    "http-server": "^14.1.1"
   },
   "jest": {
     "testEnvironment": "jsdom"


### PR DESCRIPTION
## Summary
- add `http-server` dev dependency
- provide `start` script for launching the server
- update setup docs to use `npm install` and `npm start`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/stims/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_685386ec8864833292bcd84ce3c3e134