### PR TITLE
Use local Three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 ## Local Setup
 
-If you want to mess around with the toys locally, just clone the repo and open the HTML files in your browser. Here’s the quick setup:
+To explore the toys locally, clone the repo, install the dependencies, and serve the files from a simple web server:
 
 1. Clone the repository:
    ```bash
@@ -84,14 +84,17 @@ If you want to mess around with the toys locally, just clone the repo and open t
    cd stims
    ```
 
-2. Open any of the HTML files in your browser (e.g., `evol.html`, `index.html`).
+2. Install dependencies (including Three.js):
+   ```bash
+   npm install
+   ```
 
-3. Want to serve locally? Here’s a simple Python server:
+3. Serve the files locally. A quick way is with Python:
    ```bash
    python3 -m http.server
    ```
 
-   This will run everything locally at `http://localhost:8000`.
+   Then open your browser at `http://localhost:8000` and navigate to any of the HTML files (e.g., `evol.html`, `index.html`).
 
 ### Running Tests
 

--- a/brand.html
+++ b/brand.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <!-- Include Three.js library -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.js"></script>
+    <script src="./node_modules/three/build/three.js"></script>
     <script type="module">
         import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
         const scene = new THREE.Scene();

--- a/clay.html
+++ b/clay.html
@@ -43,7 +43,7 @@
         <button data-tool="pinch">Pinch</button>
     </div>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+<script src="./node_modules/three/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/cannon-es@0.18.0/dist/cannon-es.js"></script>
 <script>
     // Basic Three.js setup

--- a/holy.html
+++ b/holy.html
@@ -174,13 +174,13 @@
     </div>
 
     <!-- Three.js Library -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="./node_modules/three/build/three.min.js"></script>
     <!-- Post-Processing Scripts -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/EffectComposer.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/RenderPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/UnrealBloomPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/postprocessing/ShaderPass.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/shaders/FXAAShader.js"></script>
+    <script src="./node_modules/three/examples/js/postprocessing/EffectComposer.js"></script>
+    <script src="./node_modules/three/examples/js/postprocessing/RenderPass.js"></script>
+    <script src="./node_modules/three/examples/js/postprocessing/UnrealBloomPass.js"></script>
+    <script src="./node_modules/three/examples/js/postprocessing/ShaderPass.js"></script>
+    <script src="./node_modules/three/examples/js/shaders/FXAAShader.js"></script>
 
     <!-- Main Visualizer Script -->
     <script>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Stim Webtoys Library</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="./node_modules/three/build/three.min.js"></script>
     <style>
         :root {
             --bg-color: #0d0d0d;

--- a/multi.html
+++ b/multi.html
@@ -15,8 +15,8 @@
 <body>
     <canvas id="webglCanvas"></canvas>
     <script type="module">
-        import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
-        import { WebGPURenderer } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.webgpu.min.js';
+        import * as THREE from './node_modules/three/build/three.module.js';
+        import { WebGPURenderer } from './node_modules/three/examples/jsm/renderers/webgpu/WebGPURenderer.js';
         import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.js';
 
         let renderer, isWebGPUSupported = false;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "devDependencies": {
     "jest": "^29.6.1"
   },
+  "dependencies": {
+    "three": "^0.164.0"
+  },
   "jest": {
     "testEnvironment": "jsdom"
   }

--- a/svgtest.html
+++ b/svgtest.html
@@ -54,7 +54,8 @@
     </div>
 
     <!-- Include Three.js -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.webgpu.min.js"></script>
+    <script src="./node_modules/three/build/three.min.js"></script>
+    <script type="module" src="./node_modules/three/examples/jsm/renderers/webgpu/WebGPURenderer.js"></script>
     
     <script>
         // Set up the Three.js scene


### PR DESCRIPTION
## Summary
- include `three` in dependencies
- load Three.js from `node_modules`
- explain installing dependencies and serving locally

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685386e7b2ec8332a0ae91c8adbf796a