### PR TITLE
Show microphone error in three-d-toy

### DIFF
--- a/assets/js/toys/three-d-toy.js
+++ b/assets/js/toys/three-d-toy.js
@@ -5,6 +5,8 @@ import { initRenderer } from '../core/renderer-setup.js';
 import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
 import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
 
+let errorElement;
+
 let scene, camera, renderer, torusKnot, particles;
 const shapes = [];
 
@@ -82,15 +84,46 @@ function handleResize() {
     renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
+// Create and reveal an error element so users know microphone access failed
+function showError(message) {
+    if (!errorElement) {
+        errorElement = document.createElement('div');
+        errorElement.id = 'error-message';
+        errorElement.style.position = 'absolute';
+        errorElement.style.top = '20px';
+        errorElement.style.left = '20px';
+        errorElement.style.color = '#ff0000';
+        errorElement.style.background = 'rgba(0, 0, 0, 0.7)';
+        errorElement.style.padding = '10px';
+        errorElement.style.borderRadius = '5px';
+        errorElement.style.zIndex = '10';
+        document.body.appendChild(errorElement);
+    }
+    errorElement.textContent = message;
+    errorElement.style.display = 'block';
+}
+
+// Hide the microphone error message
+function hideError() {
+    if (errorElement) {
+        errorElement.style.display = 'none';
+    }
+}
+
 let analyser;
+
+// Display a user-facing message when microphone access fails and hide it on success
 
 async function startAudio() {
     try {
         const audioData = await initAudio();
         analyser = audioData.analyser;
+        hideError();
         animate();
     } catch (e) {
         console.error('Error accessing microphone:', e);
+        // Show user-friendly message if microphone access fails
+        showError('Microphone access was denied. Please allow access and reload.');
     }
 }
 


### PR DESCRIPTION
## Summary
- show an error message if microphone access is denied
- hide the error message once audio starts
- document the behaviour in comments

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685386dc92c08332a2ab3ea9b66150a0