### PR TITLE
Add dev server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 ## Local Setup
 
-If you want to mess around with the toys locally, just clone the repo and open the HTML files in your browser. Here’s the quick setup:
+If you want to mess around with the toys locally, clone the repo and run the local server. Here’s the quick setup:
 
 1. Clone the repository:
    ```bash
@@ -84,14 +84,22 @@ If you want to mess around with the toys locally, just clone the repo and open t
    cd stims
    ```
 
-2. Open any of the HTML files in your browser (e.g., `evol.html`, `index.html`).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
 
-3. Want to serve locally? Here’s a simple Python server:
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+   This serves the project at `http://localhost:8000`. Open any of the HTML files (e.g., `evol.html`, `index.html`) in your browser.
+
+   Or, if you prefer Python, you can run the built-in server:
    ```bash
    python3 -m http.server
    ```
-
-   This will run everything locally at `http://localhost:8000`.
 
 ### Running Tests
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "start": "http-server . -p 8000"
   },
   "devDependencies": {
-    "jest": "^29.6.1"
+    "jest": "^29.6.1",
+    "http-server": "^14.1.1"
   },
   "jest": {
     "testEnvironment": "jsdom"


### PR DESCRIPTION
## Summary
- add `http-server` dev dependency
- provide `start` script for launching the server on port 8000
- update local setup docs with optional Python alternative

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685386ec8864833292bcd84ce3c3e134