### PR TITLE
Handle microphone denial across pages

### DIFF
--- a/clayr.html
+++ b/clayr.html
@@ -21,9 +21,24 @@
     </style>
   </head>
   <body>
+    <div id="error-message" role="alert" style="display: none; color: #ff0000; background: #fff0f0; text-align: center; padding: 10px;"></div>
     <canvas id="visualizerCanvas"></canvas>
     <script type="module">
       const canvas = document.getElementById('visualizerCanvas');
+      const errorMessageElement = document.getElementById('error-message');
+
+      function showError(message) {
+        if (errorMessageElement) {
+          errorMessageElement.textContent = message;
+          errorMessageElement.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorMessageElement) {
+          errorMessageElement.style.display = 'none';
+        }
+      }
 
       async function initializeAudioVisualizer() {
         if (!navigator.gpu) {
@@ -103,16 +118,25 @@
         });
 
         // Audio setup
-        const stream = await navigator.mediaDevices.getUserMedia({
-          audio: true,
-        });
-        const audioContext = new (window.AudioContext ||
-          window.webkitAudioContext)();
-        const analyser = audioContext.createAnalyser();
-        const source = audioContext.createMediaStreamSource(stream);
-        source.connect(analyser);
-        analyser.fftSize = 128;
-        const dataArray = new Uint8Array(analyser.frequencyBinCount);
+        let analyser;
+        let dataArray;
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: true,
+          });
+          const audioContext = new (window.AudioContext ||
+            window.webkitAudioContext)();
+          analyser = audioContext.createAnalyser();
+          const source = audioContext.createMediaStreamSource(stream);
+          source.connect(analyser);
+          analyser.fftSize = 128;
+          dataArray = new Uint8Array(analyser.frequencyBinCount);
+          hideError();
+        } catch (err) {
+          showError('Microphone access was denied. Please allow access and reload.');
+          console.error('Error accessing microphone:', err);
+          return;
+        }
 
         function frame() {
           analyser.getByteFrequencyData(dataArray);

--- a/geom.html
+++ b/geom.html
@@ -22,6 +22,7 @@
     </style>
   </head>
   <body>
+    <div id="error-message" role="alert" style="display: none; color: #ff0000; background: #fff0f0; text-align: center; padding: 10px;"></div>
     <div id="controls">
       <button id="startButton">Start Microphone Visualizer</button>
     </div>
@@ -37,7 +38,21 @@
 
       // Audio setup
       const startButton = document.getElementById('startButton');
+      const errorMessageElement = document.getElementById('error-message');
       let audioContext, analyzer, source, frequencyData;
+
+      function showError(message) {
+        if (errorMessageElement) {
+          errorMessageElement.textContent = message;
+          errorMessageElement.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorMessageElement) {
+          errorMessageElement.style.display = 'none';
+        }
+      }
 
       startButton.addEventListener('click', function () {
         // Disable the button after starting
@@ -49,10 +64,11 @@
           .getUserMedia({ audio: true })
           .then(function (stream) {
             setupAudioContext(stream);
+            hideError();
           })
           .catch(function (err) {
             console.error('Error accessing microphone:', err);
-            alert('Error accessing microphone: ' + err.message);
+            showError('Microphone access was denied. Please allow access and reload.');
           });
       });
 

--- a/holy.html
+++ b/holy.html
@@ -147,6 +147,7 @@
     </style>
   </head>
   <body>
+    <div id="error-message" role="alert" style="display: none; color: #ff0000; background: #fff0f0; text-align: center; padding: 10px;"></div>
     <!-- Loading Overlay -->
     <div id="loadingOverlay">
       <div class="spinner"></div>
@@ -235,6 +236,7 @@
       let isAudioInitialized = false;
       let lastTap = 0;
       let zoomDistance = 5;
+      const errorMessageElement = document.getElementById('error-message');
       const shapes = ['sphere', 'cube', 'torus', 'dodecahedron'];
       let currentShape = 0;
       let particleCount = 600;
@@ -244,6 +246,19 @@
       let particleMaterial;
       let particleGeometry;
       let animationId;
+
+      function showError(message) {
+        if (errorMessageElement) {
+          errorMessageElement.textContent = message;
+          errorMessageElement.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorMessageElement) {
+          errorMessageElement.style.display = 'none';
+        }
+      }
 
       // UI Elements
       const loadingOverlay = document.getElementById('loadingOverlay');
@@ -473,9 +488,10 @@
           source.connect(audioAnalyser);
           dataArray = new Uint8Array(audioAnalyser.frequencyBinCount);
           isAudioInitialized = true;
+          hideError();
         } catch (err) {
           console.error('Error accessing microphone:', err);
-          alert('Microphone access is required for the visualizer to work.');
+          showError('Microphone access was denied. Please allow access and reload.');
         }
       }
 

--- a/legible.html
+++ b/legible.html
@@ -116,6 +116,7 @@
     </style>
   </head>
   <body>
+    <div id="error-message" role="alert" style="display: none; color: #ff0000; background: #fff0f0; text-align: center; padding: 10px;"></div>
     <div class="controls">
       <button id="start-button">Start Microphone</button>
       <label for="sensitivity">Beat Sensitivity:</label>
@@ -157,6 +158,7 @@
       const resetButton = document.getElementById('reset-button');
       const sensitivitySlider = document.getElementById('sensitivity');
       const colorSchemeSelect = document.getElementById('color-scheme');
+      const errorMessageElement = document.getElementById('error-message');
       let sensitivity = parseFloat(sensitivitySlider.value);
       let wordIndex = 0;
       let cyclingActive = true;
@@ -164,6 +166,19 @@
       const gridElement = document.getElementById('grid');
       let words = [];
       let revealedLocations = [];
+
+      function showError(message) {
+        if (errorMessageElement) {
+          errorMessageElement.textContent = message;
+          errorMessageElement.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorMessageElement) {
+          errorMessageElement.style.display = 'none';
+        }
+      }
 
       // Fetch words using the Datamuse API
       async function fetchWords() {
@@ -327,14 +342,14 @@
             micStream.connect(analyser);
             isMicrophoneEnabled = true;
 
+            hideError();
+
             startButton.textContent = 'Microphone Active';
             startButton.disabled = true;
             render(); // Start the visualizer
           })
           .catch((err) => {
-            alert(
-              'Microphone access denied. Please allow microphone access to enable the visualizer.'
-            );
+            showError('Microphone access was denied. Please allow access and reload.');
           });
       }
 
@@ -432,7 +447,7 @@
       }
 
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        alert(
+        showError(
           'Your browser does not support microphone access. Please update to a modern browser.'
         );
       }

--- a/seary.html
+++ b/seary.html
@@ -21,6 +21,7 @@
     </style>
   </head>
   <body>
+    <div id="error-message" role="alert" style="display: none; color: #ff0000; background: #fff0f0; text-align: center; padding: 10px;"></div>
     <canvas id="gpuCanvas"></canvas>
     <select id="audioSelect">
       <option value="mic">Microphone</option>
@@ -191,8 +192,22 @@
 
       // Audio setup for beat detection and frequency analysis
       let audioContext, analyser, source;
+      const errorMessageElement = document.getElementById('error-message');
       let bufferLength, dataArray;
       const audioSelect = document.getElementById('audioSelect');
+
+      function showError(message) {
+        if (errorMessageElement) {
+          errorMessageElement.textContent = message;
+          errorMessageElement.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorMessageElement) {
+          errorMessageElement.style.display = 'none';
+        }
+      }
 
       audioSelect.addEventListener('change', initializeAudio);
       initializeAudio();
@@ -205,6 +220,7 @@
         navigator.mediaDevices
           .getUserMedia({ audio: true })
           .then((stream) => {
+            hideError();
             audioContext = new (window.AudioContext ||
               window.webkitAudioContext)();
             if (audioSelect.value === 'mic') {
@@ -356,6 +372,7 @@
           })
           .catch((err) => {
             console.error('Error accessing microphone: ' + err);
+            showError('Microphone access was denied. Please allow access and reload.');
           });
       }
 


### PR DESCRIPTION
## Summary
- display microphone access errors in clayr, geom, holy, legible and seary
- hide the error banner once audio starts successfully

## Testing
- `npm test` *(fails: ReferenceError: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68538eba695c8332b6e15dd74ff1a116