### PR TITLE
Ensure THREE imports at file top

### DIFF
--- a/assets/js/core/renderer-setup.js
+++ b/assets/js/core/renderer-setup.js
@@ -1,4 +1,3 @@
-// renderer-setup.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 export function initRenderer(canvas, config = { antialias: true }) {
   const renderer = new THREE.WebGLRenderer({

--- a/assets/js/core/scene-setup.js
+++ b/assets/js/core/scene-setup.js
@@ -1,4 +1,3 @@
-// scene-setup.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 export function initScene(config = { backgroundColor: 0x000000 }) {
   const scene = new THREE.Scene();

--- a/assets/js/lighting/lighting-setup.js
+++ b/assets/js/lighting/lighting-setup.js
@@ -1,4 +1,3 @@
-// lighting-setup.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
 
 // Initialize a point light with configurable options


### PR DESCRIPTION
## Summary
- remove file header comments so that CDN-based THREE import is the first line of each module

## Testing
- `npm test` *(fails: `jest` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68538fcfe6608332af97d544894633a0