### PR TITLE
Delay microphone access until user interaction

### DIFF
--- a/3dtoy.html
+++ b/3dtoy.html
@@ -12,6 +12,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <script type="module" src="assets/js/toys/three-d-toy.js"></script>
   </body>
 </html>

--- a/assets/js/toys/cube-wave.js
+++ b/assets/js/toys/cube-wave.js
@@ -75,4 +75,11 @@ function animate() {
 }
 
 init();
-startAudio();
+
+const startButton = document.getElementById('startButton');
+if (startButton) {
+  startButton.addEventListener('click', () => {
+    startButton.remove();
+    startAudio();
+  });
+}

--- a/assets/js/toys/particle-orbit.js
+++ b/assets/js/toys/particle-orbit.js
@@ -70,4 +70,11 @@ function animate() {
 }
 
 init();
-startAudio();
+
+const startButton = document.getElementById('startButton');
+if (startButton) {
+  startButton.addEventListener('click', () => {
+    startButton.remove();
+    startAudio();
+  });
+}

--- a/assets/js/toys/spiral-burst.js
+++ b/assets/js/toys/spiral-burst.js
@@ -75,4 +75,11 @@ function animate() {
 }
 
 init();
-startAudio();
+
+const startButton = document.getElementById('startButton');
+if (startButton) {
+  startButton.addEventListener('click', () => {
+    startButton.remove();
+    startAudio();
+  });
+}

--- a/assets/js/toys/three-d-toy.js
+++ b/assets/js/toys/three-d-toy.js
@@ -173,4 +173,11 @@ function animate() {
 }
 
 init();
-startAudio();
+
+const startButton = document.getElementById('startButton');
+if (startButton) {
+  startButton.addEventListener('click', () => {
+    startButton.remove();
+    startAudio();
+  });
+}

--- a/brand.html
+++ b/brand.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="assets/css/base.css" />
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <!-- Include Three.js library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.js"></script>
     <script type="module">
@@ -125,13 +126,21 @@
 
       // Audio setup using shared utility
       let analyser;
-      initAudio()
-        .then(({ analyser: a }) => {
+
+      async function startAudio() {
+        try {
+          const { analyser: a } = await initAudio();
           analyser = a;
-        })
-        .catch((err) => {
+        } catch (err) {
           console.error('Audio input error: ', err);
-        });
+        }
+      }
+
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        startAudio();
+      });
 
       // Animation loop
       function animate() {

--- a/clayr.html
+++ b/clayr.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -21,6 +21,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <canvas id="visualizerCanvas"></canvas>
     <script type="module">
       const canvas = document.getElementById('visualizerCanvas');
@@ -151,7 +152,11 @@
         frame();
       }
 
-      initializeAudioVisualizer().catch(console.error);
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        initializeAudioVisualizer().catch(console.error);
+      });
     </script>
   </body>
 </html>

--- a/cube-wave.html
+++ b/cube-wave.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="assets/css/base.css" />
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <script type="module" src="assets/js/toys/cube-wave.js"></script>
   </body>
 </html>

--- a/defrag.html
+++ b/defrag.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -21,6 +21,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <canvas id="canvas"></canvas>
     <div id="defragText">Defragmenting Drive C:</div>
 
@@ -75,6 +76,12 @@
         }
       }
 
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        setupAudio();
+      });
+
       function getAudioData() {
         requestAnimationFrame(getAudioData);
         audioDataArray = getFrequencyData(analyser);
@@ -124,7 +131,6 @@
         requestAnimationFrame(defragLoop);
       }
 
-      setupAudio();
       defragLoop();
     </script>
   </body>

--- a/evol.html
+++ b/evol.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -31,6 +31,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <canvas id="glCanvas"></canvas>
     <div id="controls">
       <label>
@@ -223,7 +224,11 @@
         }
       }
 
-      setupAudio();
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        setupAudio();
+      });
 
       document
         .getElementById('fractalIntensity')

--- a/multi.html
+++ b/multi.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -14,6 +14,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <canvas id="webglCanvas"></canvas>
     <script type="module">
       import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
@@ -140,15 +141,23 @@
       // Audio input setup
       let analyser;
       let dataArray;
-      initAudio()
-        .then(({ analyser: a, dataArray: d }) => {
+
+      async function startAudio() {
+        try {
+          const { analyser: a, dataArray: d } = await initAudio();
           analyser = a;
           dataArray = d;
           audioReact();
-        })
-        .catch(function (err) {
+        } catch (err) {
           console.error('The following error occurred: ' + err);
-        });
+        }
+      }
+
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        startAudio();
+      });
 
       function audioReact() {
         function updateAudio() {

--- a/particle-orbit.html
+++ b/particle-orbit.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="assets/css/base.css" />
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <script type="module" src="assets/js/toys/particle-orbit.js"></script>
   </body>
 </html>

--- a/seary.html
+++ b/seary.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -21,6 +21,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <canvas id="gpuCanvas"></canvas>
     <select id="audioSelect">
       <option value="mic">Microphone</option>
@@ -195,7 +196,12 @@
       const audioSelect = document.getElementById('audioSelect');
 
       audioSelect.addEventListener('change', initializeAudio);
-      initializeAudio();
+
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        initializeAudio();
+      });
 
       function initializeAudio() {
         if (audioContext) {

--- a/sgpat.html
+++ b/sgpat.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -28,6 +28,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <div id="error-message" style="display: none"></div>
     <canvas id="glCanvas"></canvas>
     <script type="module">
@@ -200,6 +201,12 @@
         }
       }
 
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        setupAudio();
+      });
+
       function getAudioData() {
         requestAnimationFrame(getAudioData);
         if (analyser) {
@@ -242,8 +249,6 @@
           x += barWidth + 1;
         }
       }
-
-      setupAudio();
 
       // Main render loop
       function render() {

--- a/spiral-burst.html
+++ b/spiral-burst.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="assets/css/base.css" />
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <script type="module" src="assets/js/toys/spiral-burst.js"></script>
   </body>
 </html>

--- a/symph.html
+++ b/symph.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -27,6 +27,7 @@
     </style>
   </head>
   <body>
+    <button id="startButton">Start Visualizer</button>
     <div id="error-message" style="display: none"></div>
     <canvas id="glCanvas"></canvas>
     <script type="module">
@@ -189,6 +190,12 @@
         }
       }
 
+      const startButton = document.getElementById('startButton');
+      startButton.addEventListener('click', () => {
+        startButton.remove();
+        setupAudio();
+      });
+
       function getAudioData() {
         requestAnimationFrame(getAudioData);
         if (analyser) {
@@ -222,8 +229,6 @@
           x += barWidth + 1;
         }
       }
-
-      setupAudio();
 
       function render() {
         time += 0.02;


### PR DESCRIPTION
## Summary
- add Start Visualizer buttons to several audio-reactive pages
- start microphone setup only after clicking the button

## Testing
- `npm test` *(fails: jest is not defined)*
- `npm run lint` *(fails: no-unused-vars in assets/js/app.js)*


------
https://chatgpt.com/codex/tasks/task_e_68538ec501888332b448be3826445d11