### PR TITLE
Refactor toys to use common WebToy base

### DIFF
--- a/assets/js/core/web-toy.js
+++ b/assets/js/core/web-toy.js
@@ -1,0 +1,49 @@
+import { initScene } from './scene-setup.js';
+import { initCamera } from './camera-setup.js';
+import { initRenderer } from './renderer-setup.js';
+import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
+import { initAudio } from '../utils/audio-handler.js';
+
+export default class WebToy {
+  constructor({
+    cameraOptions = {},
+    sceneOptions = {},
+    rendererOptions = {},
+    lightingOptions = null,
+    ambientLightOptions = null,
+    canvas = null,
+  } = {}) {
+    this.canvas = canvas || document.createElement('canvas');
+    document.body.appendChild(this.canvas);
+
+    this.scene = initScene(sceneOptions);
+    this.camera = initCamera(cameraOptions);
+    this.renderer = initRenderer(this.canvas, rendererOptions);
+
+    if (ambientLightOptions) {
+      initAmbientLight(this.scene, ambientLightOptions);
+    }
+    if (lightingOptions) {
+      initLighting(this.scene, lightingOptions);
+    }
+
+    this.analyser = null;
+    window.addEventListener('resize', () => this.handleResize());
+  }
+
+  handleResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  async initAudio(options = {}) {
+    const audio = await initAudio(options);
+    this.analyser = audio.analyser;
+    return audio;
+  }
+
+  render() {
+    this.renderer.render(this.scene, this.camera);
+  }
+}

--- a/assets/js/toys/cube-wave.js
+++ b/assets/js/toys/cube-wave.js
@@ -1,26 +1,21 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
-import { initScene } from '../core/scene-setup.js';
-import { initCamera } from '../core/camera-setup.js';
-import { initRenderer } from '../core/renderer-setup.js';
-import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
-import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy.js';
+import { getFrequencyData } from '../utils/audio-handler.js';
 
-let scene, camera, renderer, analyser;
-const cubes = [];
-
-function init() {
-  scene = initScene();
-  camera = initCamera({ position: { x: 0, y: 30, z: 80 } });
-  const canvas = document.createElement('canvas');
-  document.body.appendChild(canvas);
-  renderer = initRenderer(canvas);
-
-  initAmbientLight(scene);
-  initLighting(scene, {
+const toy = new WebToy({
+  cameraOptions: { position: { x: 0, y: 30, z: 80 } },
+  lightingOptions: {
     type: 'DirectionalLight',
     position: { x: 0, y: 50, z: 50 },
-  });
+  },
+  ambientLightOptions: {},
+});
 
+const cubes = [];
+let analyser;
+
+function init() {
+  const { scene } = toy;
   const gridSize = 10;
   const spacing = 5;
   const geometry = new THREE.BoxGeometry(4, 4, 4);
@@ -34,20 +29,12 @@ function init() {
       cubes.push(cube);
     }
   }
-
-  window.addEventListener('resize', handleResize);
-}
-
-function handleResize() {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
 async function startAudio() {
   try {
-    const audio = await initAudio({ fftSize: 128 });
-    analyser = audio.analyser;
+    await toy.initAudio({ fftSize: 128 });
+    analyser = toy.analyser;
     animate();
   } catch (e) {
     console.error('Microphone access denied', e);
@@ -71,7 +58,7 @@ function animate() {
     cube.rotation.y += value / 100000;
   });
 
-  renderer.render(scene, camera);
+  toy.render();
 }
 
 init();

--- a/assets/js/toys/particle-orbit.js
+++ b/assets/js/toys/particle-orbit.js
@@ -1,53 +1,37 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
-import { initScene } from '../core/scene-setup.js';
-import { initCamera } from '../core/camera-setup.js';
-import { initRenderer } from '../core/renderer-setup.js';
-import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
-import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy.js';
+import { getFrequencyData } from '../utils/audio-handler.js';
 
-let scene, camera, renderer, analyser;
-let particles, particlesMaterial;
-
-function init() {
-  scene = initScene();
-  camera = initCamera({ position: { x: 0, y: 0, z: 60 } });
-  const canvas = document.createElement('canvas');
-  document.body.appendChild(canvas);
-  renderer = initRenderer(canvas);
-
-  initAmbientLight(scene);
-  initLighting(scene, {
+const toy = new WebToy({
+  cameraOptions: { position: { x: 0, y: 0, z: 60 } },
+  lightingOptions: {
     type: 'PointLight',
     position: { x: 20, y: 20, z: 20 },
-  });
+  },
+  ambientLightOptions: {},
+});
 
+let particles, particlesMaterial;
+let analyser;
+
+function init() {
+  const scene = toy.scene;
   const particlesGeometry = new THREE.BufferGeometry();
   const count = 2000;
   const positions = new Float32Array(count * 3);
   for (let i = 0; i < count * 3; i++) {
     positions[i] = (Math.random() - 0.5) * 80;
   }
-  particlesGeometry.setAttribute(
-    'position',
-    new THREE.BufferAttribute(positions, 3)
-  );
+  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.5 });
   particles = new THREE.Points(particlesGeometry, particlesMaterial);
   scene.add(particles);
-
-  window.addEventListener('resize', handleResize);
-}
-
-function handleResize() {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
 async function startAudio() {
   try {
-    const audio = await initAudio({ fftSize: 256 });
-    analyser = audio.analyser;
+    await toy.initAudio({ fftSize: 256 });
+    analyser = toy.analyser;
     animate();
   } catch (e) {
     console.error('Microphone access denied', e);
@@ -66,7 +50,7 @@ function animate() {
   const hue = (avg / 256) % 1;
   particlesMaterial.color.setHSL(hue, 0.7, 0.6);
 
-  renderer.render(scene, camera);
+  toy.render();
 }
 
 init();

--- a/assets/js/toys/spiral-burst.js
+++ b/assets/js/toys/spiral-burst.js
@@ -1,55 +1,38 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
-import { initScene } from '../core/scene-setup.js';
-import { initCamera } from '../core/camera-setup.js';
-import { initRenderer } from '../core/renderer-setup.js';
-import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
-import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy.js';
+import { getFrequencyData } from '../utils/audio-handler.js';
 
-let scene, camera, renderer, analyser;
+const toy = new WebToy({
+  cameraOptions: { position: { x: 0, y: 0, z: 100 } },
+  lightingOptions: { type: 'HemisphereLight' },
+  ambientLightOptions: {},
+});
+
 const lines = [];
+let analyser;
 
 function init() {
-  scene = initScene();
-  camera = initCamera({ position: { x: 0, y: 0, z: 100 } });
-  const canvas = document.createElement('canvas');
-  document.body.appendChild(canvas);
-  renderer = initRenderer(canvas);
-
-  initAmbientLight(scene);
-  initLighting(scene, { type: 'HemisphereLight' });
-
+  const { scene } = toy;
   for (let i = 0; i < 50; i++) {
     const geometry = new THREE.BufferGeometry();
     const points = [];
     for (let j = 0; j < 30; j++) {
       const angle = j * 0.2 + i * 0.1;
       const radius = j * 0.5 + i;
-      points.push(
-        new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, j)
-      );
+      points.push(new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, j));
     }
     geometry.setFromPoints(points);
-    const material = new THREE.LineBasicMaterial({
-      color: Math.random() * 0xffffff,
-    });
+    const material = new THREE.LineBasicMaterial({ color: Math.random() * 0xffffff });
     const line = new THREE.Line(geometry, material);
     scene.add(line);
     lines.push(line);
   }
-
-  window.addEventListener('resize', handleResize);
-}
-
-function handleResize() {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
 async function startAudio() {
   try {
-    const audio = await initAudio();
-    analyser = audio.analyser;
+    await toy.initAudio();
+    analyser = toy.analyser;
     animate();
   } catch (e) {
     console.error('Microphone access denied', e);
@@ -71,7 +54,7 @@ function animate() {
     const hue = (idx / lines.length + value / 512) % 1;
     line.material.color.setHSL(hue, 0.6, 0.5);
   });
-  renderer.render(scene, camera);
+  toy.render();
 }
 
 init();

--- a/assets/js/toys/three-d-toy.js
+++ b/assets/js/toys/three-d-toy.js
@@ -1,14 +1,23 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
-import { initScene } from '../core/scene-setup.js';
-import { initCamera } from '../core/camera-setup.js';
-import { initRenderer } from '../core/renderer-setup.js';
-import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
-import { initAudio, getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy.js';
+import { getFrequencyData } from '../utils/audio-handler.js';
 
 let errorElement;
 
-let scene, camera, renderer, torusKnot, particles;
+const toy = new WebToy({
+  cameraOptions: { position: { x: 0, y: 0, z: 80 } },
+  lightingOptions: {
+    type: 'PointLight',
+    color: 0xff00ff,
+    intensity: 2,
+    position: { x: 20, y: 30, z: 20 },
+  },
+  ambientLightOptions: { color: 0x404040, intensity: 0.8 },
+});
+
+let torusKnot, particles;
 const shapes = [];
+let analyser;
 
 function createRandomShape() {
   const shapeType = Math.floor(Math.random() * 3);
@@ -38,25 +47,16 @@ function createRandomShape() {
     Math.random() * 120 - 60,
     Math.random() * -800
   );
-  scene.add(mesh);
+  toy.scene.add(mesh);
   shapes.push(mesh);
 }
 
 function init() {
-  scene = initScene();
-  camera = initCamera({ position: { x: 0, y: 0, z: 80 } });
-
-  const canvas = document.createElement('canvas');
-  document.body.appendChild(canvas);
-  renderer = initRenderer(canvas);
+  const { scene } = toy;
 
   torusKnot = new THREE.Mesh(
     new THREE.TorusKnotGeometry(10, 3, 100, 16),
-    new THREE.MeshStandardMaterial({
-      color: 0x00ffcc,
-      metalness: 0.7,
-      roughness: 0.4,
-    })
+    new THREE.MeshStandardMaterial({ color: 0x00ffcc, metalness: 0.7, roughness: 0.4 })
   );
   scene.add(torusKnot);
 
@@ -66,39 +66,16 @@ function init() {
   for (let i = 0; i < particlesCount * 3; i++) {
     particlesPosition[i] = (Math.random() - 0.5) * 800;
   }
-  particlesGeometry.setAttribute(
-    'position',
-    new THREE.BufferAttribute(particlesPosition, 3)
-  );
-  const particlesMaterial = new THREE.PointsMaterial({
-    color: 0xffffff,
-    size: 1.8,
-  });
+  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(particlesPosition, 3));
+  const particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.8 });
   particles = new THREE.Points(particlesGeometry, particlesMaterial);
   scene.add(particles);
-
-  initAmbientLight(scene, { color: 0x404040, intensity: 0.8 });
-  initLighting(scene, {
-    type: 'PointLight',
-    color: 0xff00ff,
-    intensity: 2,
-    position: { x: 20, y: 30, z: 20 },
-  });
 
   for (let i = 0; i < 7; i++) {
     createRandomShape();
   }
-
-  window.addEventListener('resize', handleResize);
 }
 
-function handleResize() {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-}
-
-// Create and reveal an error element so users know microphone access failed
 function showError(message) {
   if (!errorElement) {
     errorElement = document.createElement('div');
@@ -117,26 +94,20 @@ function showError(message) {
   errorElement.style.display = 'block';
 }
 
-// Hide the microphone error message
 function hideError() {
   if (errorElement) {
     errorElement.style.display = 'none';
   }
 }
 
-let analyser;
-
-// Display a user-facing message when microphone access fails and hide it on success
-
 async function startAudio() {
   try {
-    const audioData = await initAudio();
-    analyser = audioData.analyser;
+    await toy.initAudio();
+    analyser = toy.analyser;
     hideError();
     animate();
   } catch (e) {
     console.error('Error accessing microphone:', e);
-    // Show user-friendly message if microphone access fails
     showError('Microphone access was denied. Please allow access and reload.');
   }
 }
@@ -145,9 +116,7 @@ function animate() {
   requestAnimationFrame(animate);
 
   const dataArray = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
-  const avgFrequency = dataArray.length
-    ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length
-    : 0;
+  const avgFrequency = dataArray.length ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length : 0;
 
   torusKnot.rotation.x += avgFrequency / 5000;
   torusKnot.rotation.y += avgFrequency / 7000;
@@ -169,7 +138,7 @@ function animate() {
   const randomScale = 1 + Math.sin(Date.now() * 0.001) * 0.3;
   torusKnot.scale.set(randomScale, randomScale, randomScale);
 
-  renderer.render(scene, camera);
+  toy.render();
 }
 
 init();


### PR DESCRIPTION
## Summary
- add new core `WebToy` class for common scene/renderer setup
- refactor cube-wave, particle-orbit, spiral-burst and three-d-toy to use the new class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853992e88348332a79fc466ef7a22c3