### PR TITLE
Switch toy scripts to local three module

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ If you want to mess around with the toys locally, just clone the repo and open t
 
    This will run everything locally at `http://localhost:8000`.
 
-All external JavaScript dependencies—including the WordCloud library—are stored
-in `assets/js/lib` so everything works offline without hitting a CDN.
-
+All JavaScript dependencies are installed via npm and bundled locally with Vite, so everything works offline without hitting a CDN.
 ### Running Tests
 
 This project uses [Jest](https://jestjs.io/) for its test suite. To install

--- a/assets/js/toys/cube-wave.js
+++ b/assets/js/toys/cube-wave.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+import * as THREE from 'three';
 import WebToy from '../core/web-toy.js';
 import { getFrequencyData } from '../utils/audio-handler.js';
 

--- a/assets/js/toys/particle-orbit.js
+++ b/assets/js/toys/particle-orbit.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+import * as THREE from 'three';
 import WebToy from '../core/web-toy.js';
 import { getFrequencyData } from '../utils/audio-handler.js';
 

--- a/assets/js/toys/spiral-burst.js
+++ b/assets/js/toys/spiral-burst.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+import * as THREE from 'three';
 import WebToy from '../core/web-toy.js';
 import { getFrequencyData } from '../utils/audio-handler.js';
 

--- a/assets/js/toys/three-d-toy.js
+++ b/assets/js/toys/three-d-toy.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.module.js';
+import * as THREE from 'three';
 import WebToy from '../core/web-toy.js';
 import { getFrequencyData } from '../utils/audio-handler.js';
 


### PR DESCRIPTION
## Summary
- load THREE from npm instead of the CDN in all toy scripts
- clarify in the README that dependencies are bundled locally with Vite

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68539d8ab2808332a0986a3bc2937cfb