### PR TITLE
Migrate lighting and toys to TS

### DIFF
--- a/assets/data/toys.json
+++ b/assets/data/toys.json
@@ -3,7 +3,7 @@
     "slug": "3dtoy",
     "title": "3D Toy",
     "description": "Dive into a twisting 3D tunnel that responds to sound.",
-    "module": "./assets/js/toys/three-d-toy.js"
+    "module": "./assets/js/toys/three-d-toy.ts"
   },
   {
     "slug": "brand",
@@ -63,18 +63,18 @@
     "slug": "cube-wave",
     "title": "Cube Wave",
     "description": "A grid of cubes that rise and fall with your audio.",
-    "module": "./assets/js/toys/cube-wave.js"
+    "module": "./assets/js/toys/cube-wave.ts"
   },
   {
     "slug": "particle-orbit",
     "title": "Particle Orbit",
     "description": "Thousands of particles swirling faster as the music intensifies.",
-    "module": "./assets/js/toys/particle-orbit.js"
+    "module": "./assets/js/toys/particle-orbit.ts"
   },
   {
     "slug": "spiral-burst",
     "title": "Spiral Burst",
     "description": "Colorful spirals rotate and expand with every beat.",
-    "module": "./assets/js/toys/spiral-burst.js"
+    "module": "./assets/js/toys/spiral-burst.ts"
   }
 ]

--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -13,7 +13,7 @@ async function createCard(toy) {
   card.appendChild(desc);
 
   card.addEventListener('click', () => {
-    if (toy.module.endsWith('.js')) {
+    if (toy.module.endsWith('.js') || toy.module.endsWith('.ts')) {
       loadToy(toy.slug);
     } else {
       window.location.href = toy.module;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { initScene } from './core/scene-setup.ts';
 import { initCamera } from './core/camera-setup.ts';
 import { initRenderer } from './core/renderer-setup.ts';
-import { initLighting, initAmbientLight } from './lighting/lighting-setup.js';
+import { initLighting, initAmbientLight } from './lighting/lighting-setup';
 import { initAudio, getFrequencyData } from './utils/audio-handler.ts';
 import {
   applyAudioRotation,

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -1,7 +1,7 @@
 import { initScene } from './scene-setup.ts';
 import { initCamera } from './camera-setup.ts';
 import { initRenderer } from './renderer-setup.ts';
-import { initLighting, initAmbientLight } from '../lighting/lighting-setup.js';
+import { initLighting, initAmbientLight } from '../lighting/lighting-setup';
 import { initAudio } from '../utils/audio-handler.ts';
 
 export default class WebToy {

--- a/assets/js/lighting/lighting-setup.ts
+++ b/assets/js/lighting/lighting-setup.ts
@@ -1,17 +1,30 @@
 import * as THREE from 'three';
 
+export interface LightConfig {
+  type?: 'DirectionalLight' | 'SpotLight' | 'HemisphereLight' | 'PointLight';
+  color?: number | string;
+  intensity?: number;
+  position?: { x: number; y: number; z: number };
+  castShadow?: boolean;
+}
+
+export interface AmbientLightConfig {
+  color?: number | string;
+  intensity?: number;
+}
+
 // Initialize a point light with configurable options
 export function initLighting(
-  scene,
-  config = {
-    type: 'PointLight', // Allow different types of lights
+  scene: THREE.Scene,
+  config: LightConfig = {
+    type: 'PointLight',
     color: 0xffffff,
     intensity: 1,
     position: { x: 10, y: 10, z: 10 },
-    castShadow: false, // Enable shadow support
+    castShadow: false,
   }
-) {
-  let light;
+): void {
+  let light: THREE.Light;
 
   switch (config.type) {
     case 'DirectionalLight':
@@ -60,9 +73,9 @@ export function initLighting(
 }
 
 export function initAmbientLight(
-  scene,
-  config = { color: 0x404040, intensity: 0.5 }
-) {
+  scene: THREE.Scene,
+  config: AmbientLightConfig = { color: 0x404040, intensity: 0.5 }
+): void {
   const ambientLight = new THREE.AmbientLight(config.color, config.intensity);
   scene.add(ambientLight);
 }

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -9,7 +9,7 @@ export async function loadToy(slug) {
 
   if (toy.module.includes('toy.html')) {
     window.location.href = `./${slug}.html`;
-  } else if (toy.module.endsWith('.js')) {
+  } else if (toy.module.endsWith('.js') || toy.module.endsWith('.ts')) {
     document.getElementById('toy-list')?.remove();
     await import(toy.module);
   } else {

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -1,7 +1,14 @@
 
 import * as THREE from 'three';
-import WebToy from '../core/web-toy.js';
-import { getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy';
+import { getFrequencyData } from '../utils/audio-handler';
+import { LightConfig, AmbientLightConfig } from '../lighting/lighting-setup';
+
+interface ToyConfig {
+  cameraOptions?: Record<string, unknown>;
+  lightingOptions?: LightConfig;
+  ambientLightOptions?: AmbientLightConfig;
+}
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 80 } },
@@ -10,10 +17,10 @@ const toy = new WebToy({
     position: { x: 0, y: 50, z: 50 },
   },
   ambientLightOptions: {},
-});
+} as ToyConfig);
 
-const cubes = [];
-let analyser;
+const cubes: THREE.Mesh[] = [];
+let analyser: AnalyserNode | null;
 
 function init() {
   const { scene } = toy;

--- a/assets/js/toys/particle-orbit.ts
+++ b/assets/js/toys/particle-orbit.ts
@@ -1,6 +1,13 @@
 import * as THREE from 'three';
-import WebToy from '../core/web-toy.js';
-import { getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy';
+import { getFrequencyData } from '../utils/audio-handler';
+import { LightConfig, AmbientLightConfig } from '../lighting/lighting-setup';
+
+interface ToyConfig {
+  cameraOptions?: Record<string, unknown>;
+  lightingOptions?: LightConfig;
+  ambientLightOptions?: AmbientLightConfig;
+}
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 60 } },
@@ -9,10 +16,11 @@ const toy = new WebToy({
     position: { x: 20, y: 20, z: 20 },
   },
   ambientLightOptions: {},
-});
+} as ToyConfig);
 
-let particles, particlesMaterial;
-let analyser;
+let particles: THREE.Points;
+let particlesMaterial: THREE.PointsMaterial;
+let analyser: AnalyserNode | null;
 
 function init() {
   const scene = toy.scene;

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -1,16 +1,23 @@
 
 import * as THREE from 'three';
-import WebToy from '../core/web-toy.js';
-import { getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy';
+import { getFrequencyData } from '../utils/audio-handler';
+import { LightConfig, AmbientLightConfig } from '../lighting/lighting-setup';
+
+interface ToyConfig {
+  cameraOptions?: Record<string, unknown>;
+  lightingOptions?: LightConfig;
+  ambientLightOptions?: AmbientLightConfig;
+}
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
   lightingOptions: { type: 'HemisphereLight' },
   ambientLightOptions: {},
-});
+} as ToyConfig);
 
-const lines = [];
-let analyser;
+const lines: THREE.Line[] = [];
+let analyser: AnalyserNode | null;
 
 function init() {
   const { scene } = toy;

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -1,8 +1,15 @@
 import * as THREE from 'three';
-import WebToy from '../core/web-toy.js';
-import { getFrequencyData } from '../utils/audio-handler.js';
+import WebToy from '../core/web-toy';
+import { getFrequencyData } from '../utils/audio-handler';
+import { LightConfig, AmbientLightConfig } from '../lighting/lighting-setup';
 
-let errorElement;
+interface ToyConfig {
+  cameraOptions?: Record<string, unknown>;
+  lightingOptions?: LightConfig;
+  ambientLightOptions?: AmbientLightConfig;
+}
+
+let errorElement: HTMLElement | null;
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 80 } },
@@ -13,11 +20,11 @@ const toy = new WebToy({
     position: { x: 20, y: 30, z: 20 },
   },
   ambientLightOptions: { color: 0x404040, intensity: 0.8 },
-});
+} as ToyConfig);
 
-let torusKnot, particles;
-const shapes = [];
-let analyser;
+let torusKnot: THREE.Mesh, particles: THREE.Points;
+const shapes: THREE.Mesh[] = [];
+let analyser: AnalyserNode | null;
 
 function createRandomShape() {
   const shapeType = Math.floor(Math.random() * 3);


### PR DESCRIPTION
## Summary
- convert lighting setup to TypeScript and export types
- update imports for lighting setup
- convert toy scripts to TypeScript with typed configs
- allow `.ts` files in loader and card click handler
- reference new toy scripts in `toys.json`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853a5a05a9c8332a7f3793d78a0cb85