### PR TITLE
Use dynamic toy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 ## Toys in the Collection
 
-### 1. [**Evolutionary Weirdcore**](https://no.toil.fyi/evol.html) (New)
+### 1. [**Evolutionary Weirdcore**](https://no.toil.fyi/toy.html?toy=evol) (New)
 
 - **Description**: A next-level weirdcore visualizer with fractal geometry, glitchy effects, and distortions that evolve as the audio changes.
 - **Technologies**: WebGL, GLSL shaders, real-time audio input.
@@ -25,7 +25,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
   - **Glitches**: Audio peaks trigger glitch effects for that extra weirdcore vibe.
   - **Customizable**: Tweak the fractal intensity yourself and mess with visual behavior.
 
-### 2. [**3dtoy.html**](https://no.toil.fyi/3dtoy.html)
+### 2. [**3dtoy.html**](https://no.toil.fyi/toy.html?toy=3dtoy)
 
 - **Description**: Dive into a surreal 3D space with a twisting torus knot, swirling particles, and random procedural shapes that move with the sound.
 - **Technologies**: Three.js, WebGL, microphone input.
@@ -34,7 +34,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
   - Moving camera and dynamic lighting.
   - Procedural shapes for variety.
 
-### 3. [**brand.html**](https://no.toil.fyi/brand.html)
+### 3. [**brand.html**](https://no.toil.fyi/toy.html?toy=brand)
 
 - **Description**: Inspired by _Star Guitar_, this visual toy procedurally generates scenery—buildings, trees, tracks—that pulse to the beat.
 - **Technologies**: Three.js, WebGL, microphone input.
@@ -43,7 +43,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
   - Dynamic fog and lighting.
   - Buildings, tracks, and more created on the fly.
 
-### 4. [**seary.html**](https://no.toil.fyi/seary.html)
+### 4. [**seary.html**](https://no.toil.fyi/toy.html?toy=seary)
 
 - **Description**: A kaleidoscopic visualizer that reacts to both microphone and device audio. Multi-touch and device orientation effects make it even more engaging.
 - **Technologies**: WebGL, multi-touch input, audio input.
@@ -51,7 +51,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
   - Reacts to touch and device orientation.
   - Trippy patterns synced with the audio.
 
-### 5. [**symph.html**](https://no.toil.fyi/symph.html)
+### 5. [**symph.html**](https://no.toil.fyi/toy.html?toy=symph)
 
 - **Description**: A dreamy spectrograph that blends WebGL and 2D visuals, transforming audio input into a visual journey.
 - **Technologies**: WebGL, 2D Canvas, microphone input.
@@ -97,7 +97,7 @@ If you want to mess around with the toys locally, just clone the repo and open t
    ```
 2. Use Node.js 22 (see `.nvmrc`). If you have nvm installed, run `nvm use`.
 
-3. Open any of the HTML files in your browser (e.g., `evol.html`, `index.html`).
+3. Open any of the toys in your browser (e.g., `toy.html?toy=evol`, `index.html`).
 
 4. Want to serve locally? Here’s a simple Python server:
 

--- a/assets/data/toys.json
+++ b/assets/data/toys.json
@@ -3,7 +3,8 @@
     "slug": "3dtoy",
     "title": "3D Toy",
     "description": "Dive into a twisting 3D tunnel that responds to sound.",
-    "module": "./assets/js/toys/three-d-toy.js"
+    "module": "./toy.html?toy=3dtoy",
+    "script": "./assets/js/toys/three-d-toy.js"
   },
   {
     "slug": "brand",
@@ -63,18 +64,21 @@
     "slug": "cube-wave",
     "title": "Cube Wave",
     "description": "A grid of cubes that rise and fall with your audio.",
-    "module": "./assets/js/toys/cube-wave.js"
+    "module": "./toy.html?toy=cube-wave",
+    "script": "./assets/js/toys/cube-wave.js"
   },
   {
     "slug": "particle-orbit",
     "title": "Particle Orbit",
     "description": "Thousands of particles swirling faster as the music intensifies.",
-    "module": "./assets/js/toys/particle-orbit.js"
+    "module": "./toy.html?toy=particle-orbit",
+    "script": "./assets/js/toys/particle-orbit.js"
   },
   {
     "slug": "spiral-burst",
     "title": "Spiral Burst",
     "description": "Colorful spirals rotate and expand with every beat.",
-    "module": "./assets/js/toys/spiral-burst.js"
+    "module": "./toy.html?toy=spiral-burst",
+    "script": "./assets/js/toys/spiral-burst.js"
   }
 ]

--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -13,11 +13,7 @@ async function createCard(toy) {
   card.appendChild(desc);
 
   card.addEventListener('click', () => {
-    if (toy.module.endsWith('.js')) {
-      loadToy(toy.slug);
-    } else {
-      window.location.href = toy.module;
-    }
+    window.location.href = toy.module;
   });
 
   return card;

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -7,13 +7,11 @@ export async function loadToy(slug) {
     return;
   }
 
-  if (toy.module.includes('toy.html')) {
-    window.location.href = `./${slug}.html`;
-  } else if (toy.module.endsWith('.js')) {
+  if (toy.script) {
     document.getElementById('toy-list')?.remove();
-    await import(toy.module);
+    await import(toy.script);
   } else {
-    window.location.href = toy.module;
+    window.location.href = `./${slug}.html`;
   }
 }
 

--- a/toy.html
+++ b/toy.html
@@ -9,8 +9,12 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <script type="module">
-      import { loadFromQuery } from './assets/js/loader.js';
-      loadFromQuery();
+      import { loadToy } from './assets/js/loader.js';
+      const params = new URLSearchParams(window.location.search);
+      const slug = params.get('toy');
+      if (slug) {
+        loadToy(slug);
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- invoke `loadToy` directly from toy.html
- add `script` field for each toy and route all modules through `toy.html`
- update loader to import from the new field
- always navigate to toy.html from index
- point README links at toy.html

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a44b0220833297be41907b8b7479