### PR TITLE
Add dark mode toggle to library index

### DIFF
--- a/assets/js/components/DarkModeToggle.tsx
+++ b/assets/js/components/DarkModeToggle.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [dark, setDark] = useState(() => {
+    return localStorage.getItem('theme') !== 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.remove('light');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.add('light');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [dark]);
+
+  return (
+    <button className="theme-toggle" onClick={() => setDark(!dark)}>
+      {dark ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+}

--- a/assets/js/components/Layout.tsx
+++ b/assets/js/components/Layout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import DarkModeToggle from './DarkModeToggle';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="content">
       <header>
+        <DarkModeToggle />
         <h1>Stim Webtoys Library</h1>
         <p>
           Explore a collection of interactive visual experiences to engage your

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -12,20 +12,40 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap"
       rel="stylesheet"
     />
+    <script>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'light') {
+        document.documentElement.classList.add('light');
+      }
+    </script>
     <style>
       :root {
         --bg-color: #0d0d0d;
+        --bg-color-secondary: #1c1c1c;
         --text-color: #e0ffe0;
         --accent-color: #4ceea7;
         --card-bg: rgba(255, 255, 255, 0.07);
         --hover-bg: rgba(255, 255, 255, 0.15);
       }
 
+      html.light {
+        --bg-color: #ffffff;
+        --bg-color-secondary: #f5f5f5;
+        --text-color: #222222;
+        --accent-color: #007acc;
+        --card-bg: rgba(0, 0, 0, 0.05);
+        --hover-bg: rgba(0, 0, 0, 0.1);
+      }
+
       body,
       html {
         padding: 0;
         font-family: 'Space Grotesk', sans-serif;
-        background: linear-gradient(135deg, #0d0d0d 0%, #1c1c1c 100%);
+        background: linear-gradient(
+          135deg,
+          var(--bg-color) 0%,
+          var(--bg-color-secondary) 100%
+        );
         color: var(--text-color);
         overflow-x: hidden;
       }
@@ -46,6 +66,7 @@
       header {
         text-align: center;
         margin-bottom: 2rem;
+        position: relative;
       }
 
       @keyframes hueShift {
@@ -139,6 +160,22 @@
         padding: 1rem;
         background: rgba(255, 255, 255, 0.05);
         backdrop-filter: blur(5px);
+      }
+
+      .theme-toggle {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        background: var(--card-bg);
+        color: var(--text-color);
+        border: 1px solid var(--hover-bg);
+        border-radius: 4px;
+        cursor: pointer;
+      }
+
+      .theme-toggle:hover {
+        background: var(--hover-bg);
       }
 
       .cursor,


### PR DESCRIPTION
## Summary
- allow ESLint to run using flat config
- add a new `DarkModeToggle` component
- show dark/light mode switch in header
- support light theme styles and persist preference

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854914fd1248332a1b49c5052c1fc98