### PR TITLE
Add WebGPU renderer fallback

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,9 +1,17 @@
 import * as THREE from 'three';
+import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
+
 export function initRenderer(canvas, config = { antialias: true }) {
-  const renderer = new THREE.WebGLRenderer({
-    canvas,
-    antialias: config.antialias,
-  });
+  let renderer;
+  if (navigator.gpu) {
+    renderer = new WebGPURenderer({ canvas, antialias: config.antialias });
+  } else {
+    renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: config.antialias,
+    });
+  }
+  renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   return renderer;
 }


### PR DESCRIPTION
## Summary
- detect support for WebGPU in `initRenderer`
- fall back to `WebGLRenderer` when necessary
- ensure renderer is sized and pixel ratio is set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e8595c0083328959a3a9e6d77870