### PR TITLE
Set renderer output color space and pixel ratio

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -4,6 +4,9 @@ export function initRenderer(canvas, config = { antialias: true }) {
     canvas,
     antialias: config.antialias,
   });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   return renderer;
 }


### PR DESCRIPTION
## Summary
- configure WebGL renderer color space and tone mapping
- make renderer respect device pixel ratio for high-DPI displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e998ed508332b07c50a99314afe0