### PR TITLE
Use THREE Audio classes

### DIFF
--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -28,6 +28,8 @@ export default class WebToy {
     }
 
     this.analyser = null;
+    this.audioListener = null;
+    this.audio = null;
     window.addEventListener('resize', () => this.handleResize());
   }
 
@@ -38,8 +40,10 @@ export default class WebToy {
   }
 
   async initAudio(options = {}) {
-    const audio = await initAudio(options);
+    const audio = await initAudio({ ...options, camera: this.camera });
     this.analyser = audio.analyser;
+    this.audioListener = audio.listener;
+    this.audio = audio.audio;
     return audio;
   }
 

--- a/assets/js/three.d.ts
+++ b/assets/js/three.d.ts
@@ -1,0 +1,17 @@
+declare module 'three' {
+  export class AudioListener {}
+  export class Audio {
+    constructor(listener: AudioListener);
+    setMediaStreamSource(stream: any): void;
+  }
+  export class AudioAnalyser {
+    analyser: any;
+    constructor(audio: Audio, fftSize?: number);
+    getFrequencyData(): Uint8Array;
+  }
+  export class Camera {
+    add: (obj: any) => void;
+  }
+  const three: any;
+  export default three;
+}

--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -19,7 +19,7 @@ const toy = new WebToy({
 } as ToyConfig);
 
 const spheres: THREE.Mesh[] = [];
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const { scene } = toy;

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -1,4 +1,3 @@
-
 import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import { getFrequencyData } from '../utils/audio-handler';
@@ -20,7 +19,7 @@ const toy = new WebToy({
 } as ToyConfig);
 
 const cubes: THREE.Mesh[] = [];
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const { scene } = toy;

--- a/assets/js/toys/particle-orbit.ts
+++ b/assets/js/toys/particle-orbit.ts
@@ -20,7 +20,7 @@ const toy = new WebToy({
 
 let particles: THREE.Points;
 let particlesMaterial: THREE.PointsMaterial;
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const scene = toy.scene;
@@ -30,7 +30,10 @@ function init() {
   for (let i = 0; i < count * 3; i++) {
     positions[i] = (Math.random() - 0.5) * 80;
   }
-  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  particlesGeometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(positions, 3)
+  );
   particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.5 });
   particles = new THREE.Points(particlesGeometry, particlesMaterial);
   scene.add(particles);

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -16,7 +16,7 @@ const toy = new WebToy({
 } as ToyConfig);
 
 const rings: THREE.Mesh[] = [];
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const geometry = new THREE.TorusGeometry(10, 3, 16, 100);

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -1,4 +1,3 @@
-
 import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import { getFrequencyData } from '../utils/audio-handler';
@@ -17,7 +16,7 @@ const toy = new WebToy({
 } as ToyConfig);
 
 const lines: THREE.Line[] = [];
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const { scene } = toy;
@@ -27,10 +26,14 @@ function init() {
     for (let j = 0; j < 30; j++) {
       const angle = j * 0.2 + i * 0.1;
       const radius = j * 0.5 + i;
-      points.push(new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, j));
+      points.push(
+        new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, j)
+      );
     }
     geometry.setFromPoints(points);
-    const material = new THREE.LineBasicMaterial({ color: Math.random() * 0xffffff });
+    const material = new THREE.LineBasicMaterial({
+      color: Math.random() * 0xffffff,
+    });
     const line = new THREE.Line(geometry, material);
     scene.add(line);
     lines.push(line);

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -17,7 +17,7 @@ const toy = new WebToy({
 
 let stars: THREE.Points;
 let starMaterial: THREE.PointsMaterial;
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function init() {
   const geometry = new THREE.BufferGeometry();

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -24,7 +24,7 @@ const toy = new WebToy({
 
 let torusKnot: THREE.Mesh, particles: THREE.Points;
 const shapes: THREE.Mesh[] = [];
-let analyser: AnalyserNode | null;
+let analyser: THREE.AudioAnalyser | null;
 
 function createRandomShape() {
   const shapeType = Math.floor(Math.random() * 3);
@@ -63,7 +63,11 @@ function init() {
 
   torusKnot = new THREE.Mesh(
     new THREE.TorusKnotGeometry(10, 3, 100, 16),
-    new THREE.MeshStandardMaterial({ color: 0x00ffcc, metalness: 0.7, roughness: 0.4 })
+    new THREE.MeshStandardMaterial({
+      color: 0x00ffcc,
+      metalness: 0.7,
+      roughness: 0.4,
+    })
   );
   scene.add(torusKnot);
 
@@ -73,8 +77,14 @@ function init() {
   for (let i = 0; i < particlesCount * 3; i++) {
     particlesPosition[i] = (Math.random() - 0.5) * 800;
   }
-  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(particlesPosition, 3));
-  const particlesMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.8 });
+  particlesGeometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(particlesPosition, 3)
+  );
+  const particlesMaterial = new THREE.PointsMaterial({
+    color: 0xffffff,
+    size: 1.8,
+  });
   particles = new THREE.Points(particlesGeometry, particlesMaterial);
   scene.add(particles);
 
@@ -123,7 +133,9 @@ function animate() {
   requestAnimationFrame(animate);
 
   const dataArray = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
-  const avgFrequency = dataArray.length ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length : 0;
+  const avgFrequency = dataArray.length
+    ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length
+    : 0;
 
   torusKnot.rotation.x += avgFrequency / 5000;
   torusKnot.rotation.y += avgFrequency / 7000;

--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -1,23 +1,22 @@
 // patternRecognition.js: A pattern recognition and predictive listening script for audio-based visualizers
 
+import * as THREE from 'three';
+
 class PatternRecognizer {
-  analyser: AnalyserNode;
+  analyser: THREE.AudioAnalyser;
   bufferSize: number;
   patternBuffer: number[][];
-  frequencyData: Uint8Array;
-
-  constructor(analyser: AnalyserNode, bufferSize = 30) {
+  constructor(analyser: THREE.AudioAnalyser, bufferSize = 30) {
     // Reduced buffer size for performance
     this.analyser = analyser;
     this.bufferSize = bufferSize;
     this.patternBuffer = [];
-    this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
   }
 
   updatePatternBuffer(): void {
     // Get current frequency data and add to pattern buffer
-    this.analyser.getByteFrequencyData(this.frequencyData);
-    this.patternBuffer.push([...this.frequencyData]);
+    const data = this.analyser.getFrequencyData();
+    this.patternBuffer.push([...data]);
 
     // Limit buffer size
     if (this.patternBuffer.length > this.bufferSize) {

--- a/tests/pattern-recognition.test.js
+++ b/tests/pattern-recognition.test.js
@@ -6,8 +6,7 @@ describe('PatternRecognizer', () => {
     const patterns = [new Uint8Array([1, 1, 1]), new Uint8Array([1, 1, 1])];
     let call = 0;
     const analyser = {
-      frequencyBinCount: 3,
-      getByteFrequencyData: jest.fn((arr) => arr.set(patterns[call++])),
+      getFrequencyData: jest.fn(() => patterns[call++]),
     };
     const recognizer = new PatternRecognizer(analyser, 2);
 
@@ -25,8 +24,7 @@ describe('PatternRecognizer', () => {
     ];
     let call = 0;
     const analyser = {
-      frequencyBinCount: 3,
-      getByteFrequencyData: jest.fn((arr) => arr.set(patterns[call++])),
+      getFrequencyData: jest.fn(() => patterns[call++]),
     };
     const recognizer = new PatternRecognizer(analyser, 2);
 

--- a/tests/pattern-recognizer.test.js
+++ b/tests/pattern-recognizer.test.js
@@ -4,16 +4,13 @@ import PatternRecognizer from '../assets/js/utils/patternRecognition.ts';
 describe('PatternRecognizer', () => {
   test('updatePatternBuffer stores analyser data', () => {
     const analyser = {
-      frequencyBinCount: 3,
-      getByteFrequencyData: jest.fn((arr) => arr.set([1, 2, 3])),
+      getFrequencyData: jest.fn(() => new Uint8Array([1, 2, 3])),
     };
     const recognizer = new PatternRecognizer(analyser, 2);
 
     recognizer.updatePatternBuffer();
 
-    expect(analyser.getByteFrequencyData).toHaveBeenCalledWith(
-      recognizer.frequencyData
-    );
+    expect(analyser.getFrequencyData).toHaveBeenCalled();
     expect(recognizer.patternBuffer.length).toBe(1);
     expect(recognizer.patternBuffer[0]).toEqual([1, 2, 3]);
   });
@@ -25,11 +22,7 @@ describe('PatternRecognizer', () => {
     ];
     let call = 0;
     const analyser = {
-      frequencyBinCount: 3,
-      getByteFrequencyData: jest.fn((arr) => {
-        arr.set(dataSets[call]);
-        call += 1;
-      }),
+      getFrequencyData: jest.fn(() => dataSets[call++]),
     };
     const recognizer = new PatternRecognizer(analyser, 2);
 


### PR DESCRIPTION
## Summary
- refactor audio-handler to use `THREE.Audio`, `THREE.AudioListener` and `THREE.AudioAnalyser`
- expose listener/audio in `WebToy` and pass camera to `initAudio`
- update PatternRecognizer and toys to use `THREE.AudioAnalyser`
- adjust unit tests for new API
- add simple `three.d.ts` declarations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e84fa9dc8332ad187951d743a533