### PR TITLE
Switch to setAnimationLoop for toys

### DIFF
--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -38,14 +38,13 @@ async function startAudio() {
   try {
     await toy.initAudio({ fftSize: 128 });
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const data = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const binsPerSphere = data.length / spheres.length;
   spheres.forEach((sphere, idx) => {

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -43,14 +43,13 @@ async function startAudio() {
   try {
     await toy.initAudio({ fftSize: 128 });
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const dataArray = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avg = dataArray.length
     ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length

--- a/assets/js/toys/particle-orbit.ts
+++ b/assets/js/toys/particle-orbit.ts
@@ -40,14 +40,13 @@ async function startAudio() {
   try {
     await toy.initAudio({ fftSize: 256 });
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const data = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avg = data.length ? data.reduce((a, b) => a + b, 0) / data.length : 0;
   const rotationSpeed = 0.001 + avg / 100000;

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -35,14 +35,13 @@ async function startAudio() {
   try {
     await toy.initAudio();
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const data = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avg = data.length ? data.reduce((a, b) => a + b, 0) / data.length : 0;
   rings.forEach((ring, idx) => {

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -41,14 +41,13 @@ async function startAudio() {
   try {
     await toy.initAudio();
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const data = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avg = data.length ? data.reduce((a, b) => a + b, 0) / data.length : 0;
   const binsPerLine = data.length / lines.length;

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -36,14 +36,13 @@ async function startAudio() {
   try {
     await toy.initAudio();
     analyser = toy.analyser;
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Microphone access denied', e);
   }
 }
 
 function animate() {
-  requestAnimationFrame(animate);
   const data = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avg = data.length ? data.reduce((a, b) => a + b, 0) / data.length : 0;
   stars.rotation.y += 0.001 + avg / 50000;

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -112,7 +112,7 @@ async function startAudio() {
     await toy.initAudio();
     analyser = toy.analyser;
     hideError();
-    animate();
+    toy.renderer.setAnimationLoop(animate);
   } catch (e) {
     console.error('Error accessing microphone:', e);
     showError('Microphone access was denied. Please allow access and reload.');
@@ -120,7 +120,6 @@ async function startAudio() {
 }
 
 function animate() {
-  requestAnimationFrame(animate);
 
   const dataArray = analyser ? getFrequencyData(analyser) : new Uint8Array(0);
   const avgFrequency = dataArray.length ? dataArray.reduce((a, b) => a + b, 0) / dataArray.length : 0;

--- a/brand.html
+++ b/brand.html
@@ -135,7 +135,6 @@
 
       // Animation loop
       function animate() {
-        requestAnimationFrame(animate);
 
         let bass = 0;
         if (analyser) {
@@ -156,7 +155,7 @@
         renderer.render(scene, camera);
       }
 
-      animate();
+      renderer.setAnimationLoop(animate);
 
       // Handle window resizing
       window.addEventListener('resize', () => {

--- a/holy.html
+++ b/holy.html
@@ -241,7 +241,6 @@
       let instancedParticles;
       let particleMaterial;
       let particleGeometry;
-      let animationId;
 
       // UI Elements
       const loadingOverlay = document.getElementById('loadingOverlay');
@@ -479,7 +478,6 @@
 
       // Animation Loop
       function animate() {
-        animationId = requestAnimationFrame(animate);
 
         const delta = clock.getDelta();
         const elapsed = clock.getElapsedTime();
@@ -682,7 +680,7 @@
         init();
         await setupAudio();
         loadingOverlay.style.display = 'none';
-        animate();
+        renderer.setAnimationLoop(animate);
       });
 
       // Settings Panel Initialization

--- a/multi.html
+++ b/multi.html
@@ -145,14 +145,20 @@
         .then(({ analyser: a, dataArray: d }) => {
           analyser = a;
           dataArray = d;
-          audioReact();
         })
         .catch(function (err) {
           console.error('The following error occurred: ' + err);
         });
 
-      function audioReact() {
-        function updateAudio() {
+      // Device orientation handling
+      window.addEventListener('deviceorientation', (event) => {
+        camera.rotation.x = (event.beta / 180) * Math.PI;
+        camera.rotation.y = (event.gamma / 90) * Math.PI;
+      });
+
+      // Animation loop
+      function animate() {
+        if (analyser) {
           dataArray = getFrequencyData(analyser);
           const avgFrequency =
             dataArray.reduce((acc, val) => acc + val, 0) / dataArray.length;
@@ -177,25 +183,10 @@
               shape.position.z = -500;
             }
           });
-
-          renderer.render(scene, camera);
-          requestAnimationFrame(updateAudio);
         }
-        updateAudio();
-      }
-
-      // Device orientation handling
-      window.addEventListener('deviceorientation', (event) => {
-        camera.rotation.x = (event.beta / 180) * Math.PI;
-        camera.rotation.y = (event.gamma / 90) * Math.PI;
-      });
-
-      // Animation loop
-      function animate() {
-        requestAnimationFrame(animate);
         renderer.render(scene, camera);
       }
-      animate();
+      renderer.setAnimationLoop(animate);
 
       // Handle window resizing
       window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- use `renderer.setAnimationLoop` in Three.js toy pages and modules
- drop `requestAnimationFrame` usage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e99a446883328b186023da280667