### PR TITLE
Add quick start, CI, and husky precommit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint && npm run format

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
+## Quick Start
+
+1. Clone the repo and `cd` into it.
+2. Use Node.js 22: run `nvm use` if you have nvm installed.
+3. Install dependencies with `npm install`.
+4. Start the dev server with `npm run dev` and open `http://localhost:5173` in your browser.
+
+
 ## Getting Started
 
 ### What You’ll Need:
@@ -16,48 +24,24 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 ## Toys in the Collection
 
-### 1. [**Evolutionary Weirdcore**](https://no.toil.fyi/evol.html) (New)
-
-- **Description**: A next-level weirdcore visualizer with fractal geometry, glitchy effects, and distortions that evolve as the audio changes.
-- **Technologies**: WebGL, GLSL shaders, real-time audio input.
-- **Key Features**:
-  - **Fractals**: Dynamic fractals that shift and evolve with the audio.
-  - **Glitches**: Audio peaks trigger glitch effects for that extra weirdcore vibe.
-  - **Customizable**: Tweak the fractal intensity yourself and mess with visual behavior.
-
-### 2. [**3dtoy.html**](https://no.toil.fyi/3dtoy.html)
-
-- **Description**: Dive into a surreal 3D space with a twisting torus knot, swirling particles, and random procedural shapes that move with the sound.
-- **Technologies**: Three.js, WebGL, microphone input.
-- **Key Features**:
-  - Audio-reactive visuals.
-  - Moving camera and dynamic lighting.
-  - Procedural shapes for variety.
-
-### 3. [**brand.html**](https://no.toil.fyi/brand.html)
-
-- **Description**: Inspired by _Star Guitar_, this visual toy procedurally generates scenery—buildings, trees, tracks—that pulse to the beat.
-- **Technologies**: Three.js, WebGL, microphone input.
-- **Key Features**:
-  - Audio-reactive scenery.
-  - Dynamic fog and lighting.
-  - Buildings, tracks, and more created on the fly.
-
-### 4. [**seary.html**](https://no.toil.fyi/seary.html)
-
-- **Description**: A kaleidoscopic visualizer that reacts to both microphone and device audio. Multi-touch and device orientation effects make it even more engaging.
-- **Technologies**: WebGL, multi-touch input, audio input.
-- **Key Features**:
-  - Reacts to touch and device orientation.
-  - Trippy patterns synced with the audio.
-
-### 5. [**symph.html**](https://no.toil.fyi/symph.html)
-
-- **Description**: A dreamy spectrograph that blends WebGL and 2D visuals, transforming audio input into a visual journey.
-- **Technologies**: WebGL, 2D Canvas, microphone input.
-- **Key Features**:
-  - Spectrograph overlays that respond to sound.
-  - Gradients and ripples for a smooth, immersive experience.
+| Toy | Description |
+| --- | --- |
+| [3D Toy](./3dtoy.html) | Dive into a twisting 3D tunnel that responds to sound. |
+| [Star Guitar Visualizer](./brand.html) | A visual journey inspired by an iconic music video, synced to your music. |
+| [Defrag Visualizer](./defrag.html) | A nostalgic, sound-reactive visualizer evoking old defragmentation screens. |
+| [Evolutionary Weirdcore](./evol.html) | Watch surreal landscapes evolve with fractals and glitches that react to music. |
+| [Multi-Capability Visualizer](./multi.html) | Shapes and lights move with both sound and device motion. |
+| [Trippy Synesthetic Visualizer](./seary.html) | Blend audio and visuals in a rich synesthetic experience. |
+| [Pattern Recognition Visualizer](./sgpat.html) | See patterns form dynamically in response to sound. |
+| [SVG + Three.js Visualizer](./svgtest.html) | A hybrid visualizer blending 2D and 3D elements, reacting in real time. |
+| [Dreamy Spectrograph](./symph.html) | A relaxing spectrograph that moves gently with your audio. |
+| [Interactive Word Cloud](./words.html) | Speak and watch the word cloud react and shift with your voice. |
+| [Cube Wave](./cube-wave.html) | A grid of cubes that rise and fall with your audio. |
+| [Particle Orbit](./particle-orbit.html) | Thousands of particles swirling faster as the music intensifies. |
+| [Spiral Burst](./spiral-burst.html) | Colorful spirals rotate and expand with every beat. |
+| [Bouncy Spheres](./bouncy-spheres.html) | Lines of spheres bounce and change color with audio. |
+| [Rainbow Tunnel](./rainbow-tunnel.html) | Fly through colorful rings that spin to your music. |
+| [Star Field](./star-field.html) | A field of shimmering stars reacts to the beat. |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "eslint": "^8.55.0",
+        "husky": "^9.0.11",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.1",
         "prettier": "^2.8.8",
@@ -3763,6 +3764,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "eslint": "^8.55.0",
@@ -16,7 +17,8 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "husky": "^8.0.0"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",


### PR DESCRIPTION
## Summary
- document Node 22 in README and add a Quick Start section
- list every toy in a table for easy reference
- install husky and set up a pre-commit hook for linting/formatting
- create GitHub Actions workflow to run lint and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854eaf1551c83328f9ac9ddcbf96803