### PR TITLE
Introduce color management and positional audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
+Recent updates enable color‑managed rendering with ACES filmic tone mapping for richer visuals and optional positional audio for deeper immersion.
+
 ## Getting Started
 
 ### What You’ll Need:
@@ -95,6 +97,7 @@ If you want to mess around with the toys locally, just clone the repo and open t
    git clone https://github.com/zz-plant/stims.git
    cd stims
    ```
+
 2. Use Node.js 22 (see `.nvmrc`). If you have nvm installed, run `nvm use`.
 
 3. Open any of the HTML files in your browser (e.g., `evol.html`, `index.html`).
@@ -108,6 +111,7 @@ If you want to mess around with the toys locally, just clone the repo and open t
    This will run everything locally at `http://localhost:8000`.
 
 All JavaScript dependencies are installed via npm and bundled locally with Vite, so everything works offline without hitting a CDN.
+
 ### Running Tests
 
 This project uses [Jest](https://jestjs.io/) for its test suite. To install

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,7 +1,13 @@
 import * as THREE from 'three';
-import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
+import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
-export function initRenderer(canvas, config = { antialias: true }) {
+export function initRenderer(
+  canvas,
+  config: { antialias?: boolean; exposure?: number } = {
+    antialias: true,
+    exposure: 1,
+  }
+) {
   let renderer;
   if (navigator.gpu) {
     renderer = new WebGPURenderer({ canvas, antialias: config.antialias });
@@ -13,5 +19,8 @@ export function initRenderer(canvas, config = { antialias: true }) {
   }
   renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = config.exposure ?? 1;
   return renderer;
 }

--- a/assets/js/three.d.ts
+++ b/assets/js/three.d.ts
@@ -4,6 +4,12 @@ declare module 'three' {
     constructor(listener: AudioListener);
     setMediaStreamSource(stream: any): void;
   }
+  export class PositionalAudio extends Audio {
+    constructor(listener: AudioListener);
+  }
+  export class Object3D {
+    add(obj: any): void;
+  }
   export class AudioAnalyser {
     analyser: any;
     constructor(audio: Audio, fftSize?: number);

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -1,9 +1,14 @@
 import * as THREE from 'three';
 
 export async function initAudio(
-  options: { fftSize?: number; camera?: THREE.Camera } = {}
+  options: {
+    fftSize?: number;
+    camera?: THREE.Camera;
+    positional?: boolean;
+    object?: THREE.Object3D;
+  } = {}
 ) {
-  const { fftSize = 256, camera } = options;
+  const { fftSize = 256, camera, positional = false, object } = options;
   try {
     const listener = new THREE.AudioListener();
     if (camera) {
@@ -11,8 +16,13 @@ export async function initAudio(
     }
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    const audio = new THREE.Audio(listener);
+    const audio = positional
+      ? new THREE.PositionalAudio(listener)
+      : new THREE.Audio(listener);
     audio.setMediaStreamSource(stream);
+    if (positional && object) {
+      object.add(audio);
+    }
     const analyser = new THREE.AudioAnalyser(audio, fftSize);
 
     return { analyser, listener, audio, stream };

--- a/brand.html
+++ b/brand.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -7,6 +7,7 @@
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
+    <canvas id="vizCanvas"></canvas>
     <script type="module">
       import * as THREE from 'three';
       import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
@@ -14,6 +15,7 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { initRenderer } from './assets/js/core/renderer-setup.ts';
       const scene = new THREE.Scene();
       scene.fog = new THREE.Fog(0x000000, 10, 200);
 
@@ -28,9 +30,8 @@
       camera.rotation.x = -0.05;
 
       // Renderer setup
-      const renderer = new THREE.WebGLRenderer({ antialias: true });
-      renderer.setSize(window.innerWidth, window.innerHeight);
-      document.body.appendChild(renderer.domElement);
+      const canvas = document.getElementById('vizCanvas');
+      const renderer = initRenderer(canvas, { antialias: true, exposure: 1.2 });
 
       // Lighting setup
       const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
@@ -105,7 +106,9 @@
       const leavesGeo = new THREE.ConeGeometry(0.5, 1.5, 8);
       leavesGeo.translate(0, 0.5, 0);
       const trunkColor = new THREE.Color(0x8b4513);
-      const trunkColors = new Float32Array(trunkGeo.attributes.position.count * 3);
+      const trunkColors = new Float32Array(
+        trunkGeo.attributes.position.count * 3
+      );
       for (let i = 0; i < trunkColors.length; i += 3) {
         trunkColors[i] = trunkColor.r;
         trunkColors[i + 1] = trunkColor.g;
@@ -113,23 +116,39 @@
       }
       trunkGeo.setAttribute('color', new THREE.BufferAttribute(trunkColors, 3));
       const leavesColor = new THREE.Color(0x228b22);
-      const leavesColors = new Float32Array(leavesGeo.attributes.position.count * 3);
+      const leavesColors = new Float32Array(
+        leavesGeo.attributes.position.count * 3
+      );
       for (let i = 0; i < leavesColors.length; i += 3) {
         leavesColors[i] = leavesColor.r;
         leavesColors[i + 1] = leavesColor.g;
         leavesColors[i + 2] = leavesColor.b;
       }
-      leavesGeo.setAttribute('color', new THREE.BufferAttribute(leavesColors, 3));
-      const treeGeo = BufferGeometryUtils.mergeBufferGeometries([trunkGeo, leavesGeo]);
+      leavesGeo.setAttribute(
+        'color',
+        new THREE.BufferAttribute(leavesColors, 3)
+      );
+      const treeGeo = BufferGeometryUtils.mergeBufferGeometries([
+        trunkGeo,
+        leavesGeo,
+      ]);
       const treeMat = new THREE.MeshLambertMaterial({ vertexColors: true });
-      const treeMesh = new THREE.InstancedMesh(treeGeo, treeMat, treeData.length);
+      const treeMesh = new THREE.InstancedMesh(
+        treeGeo,
+        treeMat,
+        treeData.length
+      );
       treeMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       scene.add(treeMesh);
 
       // Pole instanced mesh
       const poleGeo = new THREE.CylinderGeometry(0.1, 0.1, 5);
       const poleMat = new THREE.MeshLambertMaterial({ color: 0xaaaaaa });
-      const poleMesh = new THREE.InstancedMesh(poleGeo, poleMat, poleData.length);
+      const poleMesh = new THREE.InstancedMesh(
+        poleGeo,
+        poleMat,
+        poleData.length
+      );
       poleMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       scene.add(poleMesh);
 
@@ -162,7 +181,7 @@
 
       // Audio setup using shared utility
       let analyser;
-      initAudio()
+      initAudio({ positional: true, object: camera })
         .then(({ analyser: a }) => {
           analyser = a;
         })
@@ -172,7 +191,6 @@
 
       // Animation loop
       function animate() {
-
         let bass = 0;
         if (analyser) {
           const dataArray = getFrequencyData(analyser);

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -35,6 +35,7 @@ describe('audio-handler utilities', () => {
       createAnalyser: jest.fn(() => mockAnalyserNode),
       createMediaStreamSource: jest.fn(() => mockSource),
       createGain: jest.fn(() => ({ connect: jest.fn() })),
+      createPanner: jest.fn(() => ({ connect: jest.fn() })),
       destination: {},
     }));
   });
@@ -59,6 +60,14 @@ describe('audio-handler utilities', () => {
     expect(listener).toBeDefined();
     expect(audio).toBeDefined();
     expect(stream).toBeDefined();
+  });
+
+  test('initAudio can create positional audio', async () => {
+    const { audio } = await initAudio({
+      positional: true,
+      object: { add: jest.fn() },
+    });
+    expect(audio).toBeDefined();
   });
 
   test('initAudio supports custom fftSize', async () => {


### PR DESCRIPTION
## Summary
- enable color management and tone mapping in renderer
- add optional positional audio support
- update brand visualizer to use the shared renderer setup and positional audio
- patch type definitions for new audio classes
- document the new features
- test updates for positional audio

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854cf6c89b08332be15c5f81ed2630e