### PR TITLE
Add manual start to audio visualizer toys

### DIFF
--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -61,4 +61,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -68,4 +68,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -68,4 +68,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -52,4 +52,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/toy.html
+++ b/toy.html
@@ -8,6 +8,16 @@
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
+    <button id="start-audio-btn">Start</button>
     <script type="module" src="assets/js/toyMain.js"></script>
+    <script>
+      const btn = document.getElementById('start-audio-btn');
+      btn.addEventListener('click', () => {
+        if (window.startAudio) {
+          window.startAudio();
+          btn.style.display = 'none';
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- delay microphone access for audio-responsive toys
- hook up a Start button in `toy.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ef0f181c8332bfd0229b428f8864