### PR TITLE
Replace alerts with inline error messages

### DIFF
--- a/evol.html
+++ b/evol.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -28,10 +28,21 @@
         display: block;
         margin-bottom: 5px;
       }
+      #error-message {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        color: #ff0000;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 10px;
+        border-radius: 5px;
+        z-index: 10;
+      }
     </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
+    <div id="error-message" style="display: none"></div>
     <canvas id="glCanvas"></canvas>
     <div id="controls">
       <label>
@@ -53,9 +64,26 @@
       } from './assets/js/utils/audio-handler.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
+      const errorEl = document.getElementById('error-message');
+
+      function showError(message) {
+        if (errorEl) {
+          errorEl.textContent = message;
+          errorEl.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorEl) {
+          errorEl.style.display = 'none';
+          errorEl.textContent = '';
+        }
+      }
 
       if (!gl) {
-        alert('Unable to initialize WebGL. Your browser may not support it.');
+        showError(
+          'Unable to initialize WebGL. Your browser may not support it.'
+        );
         throw new Error('WebGL not supported');
       }
 
@@ -208,9 +236,13 @@
         try {
           const result = await initAudio();
           analyser = result.analyser;
+          hideError();
           getAudioData();
         } catch (err) {
           console.error('Error capturing audio: ', err);
+          showError(
+            'Unable to access the microphone. Please allow microphone permissions and reload the page.'
+          );
         }
       }
 

--- a/geom.html
+++ b/geom.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Microphone Input Music Visualizer</title>
@@ -19,6 +19,16 @@
         font-size: 16px;
         cursor: pointer;
       }
+      #error-message {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        color: #ff0000;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 10px;
+        border-radius: 5px;
+        z-index: 10;
+      }
     </style>
   </head>
   <body>
@@ -26,6 +36,7 @@
     <div id="controls">
       <button id="startButton">Start Microphone Visualizer</button>
     </div>
+    <div id="error-message" style="display: none"></div>
     <canvas id="gameCanvas"></canvas>
     <script>
       // Get the canvas and context
@@ -38,7 +49,22 @@
 
       // Audio setup
       const startButton = document.getElementById('startButton');
+      const errorEl = document.getElementById('error-message');
       let audioContext, analyzer, source, frequencyData;
+
+      function showError(message) {
+        if (errorEl) {
+          errorEl.textContent = message;
+          errorEl.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorEl) {
+          errorEl.style.display = 'none';
+          errorEl.textContent = '';
+        }
+      }
 
       startButton.addEventListener('click', function () {
         // Disable the button after starting
@@ -53,11 +79,12 @@
           })
           .catch(function (err) {
             console.error('Error accessing microphone:', err);
-            alert('Error accessing microphone: ' + err.message);
+            showError('Error accessing microphone: ' + err.message);
           });
       });
 
       function setupAudioContext(stream) {
+        hideError();
         audioContext = new (window.AudioContext || window.webkitAudioContext)();
         analyzer = audioContext.createAnalyser();
         source = audioContext.createMediaStreamSource(stream);

--- a/holy.html
+++ b/holy.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -25,9 +25,7 @@
         border: none;
         border-radius: 4px;
         cursor: pointer;
-        transition:
-          background-color 0.3s,
-          transform 0.2s;
+        transition: background-color 0.3s, transform 0.2s;
         z-index: 10;
       }
       #startButton:hover,
@@ -144,10 +142,21 @@
       .slider-container input {
         width: 100%;
       }
+      #error-message {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        color: #ff0000;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 10px;
+        border-radius: 5px;
+        z-index: 10;
+      }
     </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
+    <div id="error-message" style="display: none"></div>
     <!-- Loading Overlay -->
     <div id="loadingOverlay">
       <div class="spinner"></div>
@@ -256,6 +265,21 @@
       const shapeDetailValue = document.getElementById('shapeDetailValue');
       const opacitySlider = document.getElementById('opacity');
       const opacityValue = document.getElementById('opacityValue');
+      const errorEl = document.getElementById('error-message');
+
+      function showError(message) {
+        if (errorEl) {
+          errorEl.textContent = message;
+          errorEl.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorEl) {
+          errorEl.style.display = 'none';
+          errorEl.textContent = '';
+        }
+      }
 
       // Initialize Visualizer
       function init() {
@@ -470,15 +494,17 @@
           source.connect(audioAnalyser);
           dataArray = new Uint8Array(audioAnalyser.frequencyBinCount);
           isAudioInitialized = true;
+          hideError();
         } catch (err) {
           console.error('Error accessing microphone:', err);
-          alert('Microphone access is required for the visualizer to work.');
+          showError(
+            'Microphone access is required for the visualizer to work.'
+          );
         }
       }
 
       // Animation Loop
       function animate() {
-
         const delta = clock.getDelta();
         const elapsed = clock.getElapsedTime();
 
@@ -640,7 +666,7 @@
       function toggleFullscreen() {
         if (!document.fullscreenElement) {
           document.documentElement.requestFullscreen().catch((err) => {
-            alert(
+            showError(
               `Error attempting to enable fullscreen mode: ${err.message} (${err.name})`
             );
           });

--- a/legible.html
+++ b/legible.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -113,10 +113,21 @@
           font-size: 1.5vw;
         }
       }
+      #error-message {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        color: #ff0000;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 10px;
+        border-radius: 5px;
+        z-index: 10;
+      }
     </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
+    <div id="error-message" style="display: none"></div>
     <div class="controls">
       <button id="start-button">Start Microphone</button>
       <label for="sensitivity">Beat Sensitivity:</label>
@@ -161,6 +172,22 @@
       let sensitivity = parseFloat(sensitivitySlider.value);
       let wordIndex = 0;
       let cyclingActive = true;
+
+      const errorEl = document.getElementById('error-message');
+
+      function showError(message) {
+        if (errorEl) {
+          errorEl.textContent = message;
+          errorEl.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorEl) {
+          errorEl.style.display = 'none';
+          errorEl.textContent = '';
+        }
+      }
 
       const gridElement = document.getElementById('grid');
       let words = [];
@@ -328,12 +355,14 @@
             micStream.connect(analyser);
             isMicrophoneEnabled = true;
 
+            hideError();
+
             startButton.textContent = 'Microphone Active';
             startButton.disabled = true;
             render(); // Start the visualizer
           })
           .catch((err) => {
-            alert(
+            showError(
               'Microphone access denied. Please allow microphone access to enable the visualizer.'
             );
           });
@@ -433,7 +462,7 @@
       }
 
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        alert(
+        showError(
           'Your browser does not support microphone access. Please update to a modern browser.'
         );
       }

--- a/sgpat.html
+++ b/sgpat.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -44,7 +44,9 @@
       const ctx2d = canvas.getContext('2d');
 
       if (!gl) {
-        alert('Unable to initialize WebGL. Your browser may not support it.');
+        showError(
+          'Unable to initialize WebGL. Your browser may not support it.'
+        );
         throw new Error('WebGL not supported');
       }
 
@@ -192,6 +194,7 @@
           const result = await initAudio();
           analyser = result.analyser;
           patternRecognizer = new PatternRecognizer(analyser);
+          hideError();
           getAudioData();
         } catch (err) {
           showError(
@@ -275,6 +278,12 @@
         const errorMessageElement = document.getElementById('error-message');
         errorMessageElement.textContent = message;
         errorMessageElement.style.display = 'block';
+      }
+
+      function hideError() {
+        const errorMessageElement = document.getElementById('error-message');
+        errorMessageElement.style.display = 'none';
+        errorMessageElement.textContent = '';
       }
     </script>
   </body>

--- a/symph.html
+++ b/symph.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -38,9 +38,26 @@
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
+      const errorEl = document.getElementById('error-message');
+
+      function showError(message) {
+        if (errorEl) {
+          errorEl.textContent = message;
+          errorEl.style.display = 'block';
+        }
+      }
+
+      function hideError() {
+        if (errorEl) {
+          errorEl.style.display = 'none';
+          errorEl.textContent = '';
+        }
+      }
 
       if (!gl) {
-        alert('Unable to initialize WebGL. Your browser may not support it.');
+        showError(
+          'Unable to initialize WebGL. Your browser may not support it.'
+        );
         throw new Error('WebGL not supported');
       }
 
@@ -181,6 +198,7 @@
         try {
           const { analyser: a } = await initAudio();
           analyser = a;
+          hideError();
           getAudioData();
         } catch (err) {
           showError(


### PR DESCRIPTION
## Summary
- add reusable `error-message` element for pages with alert() calls
- display and hide error messages instead of using `alert()`

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6854ef36e9048332bedd8a2a4aa0c8c4