### PR TITLE
Add loader front-end test

### DIFF
--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import { jest } from '@jest/globals';
+import { loadToy } from '../assets/js/loader.js';
+
+describe('loadToy', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([{ slug: 'brand', module: './toy.html?toy=brand' }]),
+      })
+    );
+    global.window = { location: { href: '' } };
+  });
+
+  test('navigates to HTML toy page', async () => {
+    await loadToy('brand');
+    expect(window.location.href).toBe('./brand.html');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "jsx": "preserve"
   },
   "include": ["assets/js/**/*"],


### PR DESCRIPTION
## Summary
- enable TypeScript `.ts` imports by allowing them in `tsconfig.json`
- add Jest test for `loadToy` loader logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f0fff5188332b24c51c8b3297a93