### PR TITLE
Fix README toy links to use toy.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 
 | Toy | Description |
 | --- | --- |
-| [3D Toy](./3dtoy.html) | Dive into a twisting 3D tunnel that responds to sound. |
+| [3D Toy](./toy.html?toy=3dtoy) | Dive into a twisting 3D tunnel that responds to sound. |
 | [Star Guitar Visualizer](./brand.html) | A visual journey inspired by an iconic music video, synced to your music. |
 | [Defrag Visualizer](./defrag.html) | A nostalgic, sound-reactive visualizer evoking old defragmentation screens. |
 | [Evolutionary Weirdcore](./evol.html) | Watch surreal landscapes evolve with fractals and glitches that react to music. |
@@ -35,12 +35,12 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 | [SVG + Three.js Visualizer](./svgtest.html) | A hybrid visualizer blending 2D and 3D elements, reacting in real time. |
 | [Dreamy Spectrograph](./symph.html) | A relaxing spectrograph that moves gently with your audio. |
 | [Interactive Word Cloud](./words.html) | Speak and watch the word cloud react and shift with your voice. |
-| [Cube Wave](./cube-wave.html) | A grid of cubes that rise and fall with your audio. |
-| [Particle Orbit](./particle-orbit.html) | Thousands of particles swirling faster as the music intensifies. |
-| [Spiral Burst](./spiral-burst.html) | Colorful spirals rotate and expand with every beat. |
-| [Bouncy Spheres](./bouncy-spheres.html) | Lines of spheres bounce and change color with audio. |
-| [Rainbow Tunnel](./rainbow-tunnel.html) | Fly through colorful rings that spin to your music. |
-| [Star Field](./star-field.html) | A field of shimmering stars reacts to the beat. |
+| [Cube Wave](./toy.html?toy=cube-wave) | A grid of cubes that rise and fall with your audio. |
+| [Particle Orbit](./toy.html?toy=particle-orbit) | Thousands of particles swirling faster as the music intensifies. |
+| [Spiral Burst](./toy.html?toy=spiral-burst) | Colorful spirals rotate and expand with every beat. |
+| [Bouncy Spheres](./toy.html?toy=bouncy-spheres) | Lines of spheres bounce and change color with audio. |
+| [Rainbow Tunnel](./toy.html?toy=rainbow-tunnel) | Fly through colorful rings that spin to your music. |
+| [Star Field](./toy.html?toy=star-field) | A field of shimmering stars reacts to the beat. |
 
 ---
 


### PR DESCRIPTION
## Summary
- update README table to link module-based toys through `toy.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854f4a7791c8332a2e8d6f62c9a9b69