### PR TITLE
Allow offline toy listing by inlining JSON data

### DIFF
--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -1,4 +1,5 @@
 import { loadToy, loadFromQuery } from './loader.js';
+import toysData from './toys-data.js';
 
 let allToys = [];
 
@@ -41,8 +42,7 @@ function filterToys(query) {
 }
 
 async function init() {
-  const res = await fetch('assets/data/toys.json');
-  allToys = await res.json();
+  allToys = toysData;
   renderToys(allToys);
 
   const search = document.getElementById('search-bar');

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,6 +1,7 @@
+import toysData from './toys-data.js';
+
 export async function loadToy(slug) {
-  const res = await fetch('assets/data/toys.json');
-  const toys = await res.json();
+  const toys = toysData;
   const toy = toys.find((t) => t.slug === slug);
   if (!toy) {
     console.error(`Toy not found: ${slug}`);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,5 @@
 import { loadToy, loadFromQuery } from './loader.js';
+import toysData from './toys-data.js';
 
 let allToys = [];
 
@@ -82,8 +83,7 @@ function openToy(toy) {
 }
 
 async function init() {
-  const res = await fetch('assets/data/toys.json');
-  allToys = await res.json();
+  allToys = toysData;
   renderToys(allToys);
 
   setupDarkModeToggle();

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -1,0 +1,99 @@
+export default [
+  {
+    "slug": "3dtoy",
+    "title": "3D Toy",
+    "description": "Dive into a twisting 3D tunnel that responds to sound.",
+    "module": "./assets/js/toys/three-d-toy.ts"
+  },
+  {
+    "slug": "brand",
+    "title": "Star Guitar Visualizer",
+    "description": "A visual journey inspired by an iconic music video, synced to your music.",
+    "module": "./toy.html?toy=brand"
+  },
+  {
+    "slug": "defrag",
+    "title": "Defrag Visualizer",
+    "description": "A nostalgic, sound-reactive visualizer evoking old defragmentation screens.",
+    "module": "./toy.html?toy=defrag"
+  },
+  {
+    "slug": "evol",
+    "title": "Evolutionary Weirdcore",
+    "description": "Watch surreal landscapes evolve with fractals and glitches that react to music.",
+    "module": "./toy.html?toy=evol"
+  },
+  {
+    "slug": "multi",
+    "title": "Multi-Capability Visualizer",
+    "description": "Shapes and lights move with both sound and device motion.",
+    "module": "./toy.html?toy=multi"
+  },
+  {
+    "slug": "seary",
+    "title": "Trippy Synesthetic Visualizer",
+    "description": "Blend audio and visuals in a rich synesthetic experience.",
+    "module": "./toy.html?toy=seary"
+  },
+  {
+    "slug": "sgpat",
+    "title": "Pattern Recognition Visualizer",
+    "description": "See patterns form dynamically in response to sound.",
+    "module": "./toy.html?toy=sgpat"
+  },
+  {
+    "slug": "svgtest",
+    "title": "SVG + Three.js Visualizer",
+    "description": "A hybrid visualizer blending 2D and 3D elements, reacting in real time.",
+    "module": "./toy.html?toy=svgtest"
+  },
+  {
+    "slug": "symph",
+    "title": "Dreamy Spectrograph",
+    "description": "A relaxing spectrograph that moves gently with your audio.",
+    "module": "./toy.html?toy=symph"
+  },
+  {
+    "slug": "words",
+    "title": "Interactive Word Cloud",
+    "description": "Speak and watch the word cloud react and shift with your voice.",
+    "module": "./toy.html?toy=words"
+  },
+  {
+    "slug": "cube-wave",
+    "title": "Cube Wave",
+    "description": "A grid of cubes that rise and fall with your audio.",
+    "module": "./assets/js/toys/cube-wave.ts"
+  },
+  {
+    "slug": "particle-orbit",
+    "title": "Particle Orbit",
+    "description": "Thousands of particles swirling faster as the music intensifies.",
+    "module": "./assets/js/toys/particle-orbit.ts"
+  },
+  {
+    "slug": "spiral-burst",
+    "title": "Spiral Burst",
+    "description": "Colorful spirals rotate and expand with every beat.",
+    "module": "./assets/js/toys/spiral-burst.ts"
+  },
+  {
+    "slug": "bouncy-spheres",
+    "title": "Bouncy Spheres",
+    "description": "Lines of spheres bounce and change color with audio.",
+    "module": "./assets/js/toys/bouncy-spheres.ts"
+  },
+  {
+    "slug": "rainbow-tunnel",
+    "title": "Rainbow Tunnel",
+    "description": "Fly through colorful rings that spin to your music.",
+    "module": "./assets/js/toys/rainbow-tunnel.ts"
+  },
+  {
+    "slug": "star-field",
+    "title": "Star Field",
+    "description": "A field of shimmering stars reacts to the beat.",
+    "module": "./assets/js/toys/star-field.ts"
+  }
+]
+;


### PR DESCRIPTION
## Summary
- embed `toys.json` content as a JS module
- load the embedded data in `main.js`, `loader.js` and `app-shell.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f31ca8ac83328fdc90f06c468e89