### PR TITLE
Add WebGL support checks

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { initScene } from './core/scene-setup.ts';
 import { initCamera } from './core/camera-setup.ts';
 import { initRenderer } from './core/renderer-setup.ts';
+import { ensureWebGL } from './utils/webgl-check.ts';
 import { initLighting, initAmbientLight } from './lighting/lighting-setup';
 import { initAudio, getFrequencyData } from './utils/audio-handler.ts';
 import {
@@ -14,6 +15,9 @@ let scene, camera, renderer, cube, analyser, patternRecognizer;
 let currentLightType = 'PointLight'; // Default light type
 
 function initVisualization() {
+  if (!ensureWebGL()) {
+    return;
+  }
   scene = initScene();
   camera = initCamera();
   const canvas = document.getElementById('toy-canvas');

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export function initRenderer(
   canvas,
@@ -8,6 +9,10 @@ export function initRenderer(
     exposure: 1,
   }
 ) {
+  if (!ensureWebGL()) {
+    return null;
+  }
+
   let renderer;
   if (navigator.gpu) {
     renderer = new WebGPURenderer({ canvas, antialias: config.antialias });

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -3,6 +3,7 @@ import { initCamera } from './camera-setup.ts';
 import { initRenderer } from './renderer-setup.ts';
 import { initLighting, initAmbientLight } from '../lighting/lighting-setup';
 import { initAudio } from '../utils/audio-handler.ts';
+import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export default class WebToy {
   constructor({
@@ -13,6 +14,10 @@ export default class WebToy {
     ambientLightOptions = null,
     canvas = null,
   } = {}) {
+    if (!ensureWebGL()) {
+      throw new Error('WebGL not supported');
+    }
+
     this.canvas = canvas || document.createElement('canvas');
     document.body.appendChild(this.canvas);
 

--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -1,0 +1,18 @@
+import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+
+export function ensureWebGL(): boolean {
+  if (navigator.gpu || WebGL.isWebGLAvailable()) {
+    return true;
+  }
+
+  const message = document.createElement('div');
+  message.id = 'webgl-error-message';
+  message.style.textAlign = 'center';
+  message.style.padding = '2rem';
+  message.style.background = '#000';
+  message.style.color = '#fff';
+  message.textContent = 'Your browser or device does not support WebGL.';
+  document.body.innerHTML = '';
+  document.body.appendChild(message);
+  return false;
+}

--- a/clay.html
+++ b/clay.html
@@ -50,6 +50,10 @@
     </div>
     <script type="module">
       import * as THREE from 'three';
+      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      if (!ensureWebGL()) {
+        return;
+      }
       // Basic Three.js setup
       let scene, camera, renderer;
       let potteryMesh, wheelMesh;

--- a/holy.html
+++ b/holy.html
@@ -232,6 +232,10 @@
       import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
       import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
       import { FXAAShader } from 'three/examples/jsm/shaders/FXAAShader.js';
+      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      if (!ensureWebGL()) {
+        return;
+      }
       let scene, camera, renderer, composer, bloomPass, fxaaPass;
       let visualizerShape, particles;
       let audioContext, audioAnalyser, dataArray;

--- a/index.html
+++ b/index.html
@@ -51,6 +51,10 @@
 
     <script type="module">
       import * as THREE from 'three';
+      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      if (!ensureWebGL()) {
+        return;
+      }
       // Three.js background
       const scene = new THREE.Scene();
       const camera = new THREE.PerspectiveCamera(

--- a/multi.html
+++ b/multi.html
@@ -19,6 +19,10 @@
     <script type="module">
       import * as THREE from 'three';
       import { WebGPURenderer } from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      if (!ensureWebGL()) {
+        return;
+      }
       import {
         initAudio,
         getFrequencyData,

--- a/svgtest.html
+++ b/svgtest.html
@@ -111,6 +111,10 @@
     <!-- Include Three.js -->
     <script type="module">
       import * as THREE from 'three';
+      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      if (!ensureWebGL()) {
+        return;
+      }
       // Set up the Three.js scene
       const scene = new THREE.Scene();
       const camera = new THREE.PerspectiveCamera(


### PR DESCRIPTION
## Summary
- add `ensureWebGL` helper
- verify WebGL availability in `initRenderer`
- perform the check in the WebToy class and main app
- show fallback message in toy HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f97b099483329b2483729b40c39b