### PR TITLE
Show mic error in visualizers

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -8,6 +8,7 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="vizCanvas"></canvas>
+    <div id="error-message" style="display: none"></div>
     <script type="module">
       import * as THREE from 'three';
       import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
@@ -18,6 +19,14 @@
       import { initRenderer } from './assets/js/core/renderer-setup.ts';
       const scene = new THREE.Scene();
       scene.fog = new THREE.Fog(0x000000, 10, 200);
+      function displayError(message) {
+        const el = document.getElementById("error-message");
+        if (el) {
+          el.innerText = message;
+          el.style.display = "block";
+        }
+      }
+
 
       // Camera setup
       const camera = new THREE.PerspectiveCamera(
@@ -187,6 +196,7 @@
         })
         .catch((err) => {
           console.error('Audio input error: ', err);
+            displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
         });
 
       // Animation loop

--- a/defrag.html
+++ b/defrag.html
@@ -23,6 +23,7 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="canvas"></canvas>
+    <div id="error-message" style="display: none"></div>
     <div id="defragText">Defragmenting Drive C:</div>
 
     <script type="module">
@@ -32,6 +33,14 @@
       } from './assets/js/utils/audio-handler.ts';
       const canvas = document.getElementById('canvas');
       const ctx = canvas.getContext('2d');
+      function displayError(message) {
+        const el = document.getElementById("error-message");
+        if (el) {
+          el.innerText = message;
+          el.style.display = "block";
+        }
+      }
+
 
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
@@ -71,6 +80,7 @@
           analyser = result.analyser;
         } catch (err) {
           console.error('Error capturing audio: ', err);
+          displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
         }
       }
 

--- a/evol.html
+++ b/evol.html
@@ -66,7 +66,7 @@
       const gl = canvas.getContext('webgl');
       const errorEl = document.getElementById('error-message');
 
-      function showError(message) {
+      function displayError(message) {
         if (errorEl) {
           errorEl.textContent = message;
           errorEl.style.display = 'block';
@@ -81,7 +81,7 @@
       }
 
       if (!gl) {
-        showError(
+        displayError(
           'Unable to initialize WebGL. Your browser may not support it.'
         );
         throw new Error('WebGL not supported');
@@ -240,10 +240,7 @@
           getAudioData();
         } catch (err) {
           console.error('Error capturing audio: ', err);
-          showError(
-            'Unable to access the microphone. Please allow microphone permissions and reload the page.'
-          );
-        }
+          displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
       }
 
       function getAudioData() {

--- a/multi.html
+++ b/multi.html
@@ -16,6 +16,7 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="webglCanvas"></canvas>
+    <div id="error-message" style="display: none"></div>
     <script type="module">
       import * as THREE from 'three';
       import { WebGPURenderer } from 'three/addons/renderers/webgpu/WebGPURenderer.js';
@@ -26,6 +27,14 @@
 
       let renderer,
         isWebGPUSupported = false;
+      function displayError(message) {
+        const el = document.getElementById("error-message");
+        if (el) {
+          el.innerText = message;
+          el.style.display = "block";
+        }
+      }
+
 
       // Try to initialize WebGPU
       if (navigator.gpu) {
@@ -40,6 +49,7 @@
             error
           );
           isWebGPUSupported = false;
+
         }
       }
 
@@ -146,6 +156,7 @@
         })
         .catch(function (err) {
           console.error('The following error occurred: ' + err);
+          displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
         });
 
       // Device orientation handling

--- a/seary.html
+++ b/seary.html
@@ -23,6 +23,7 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="gpuCanvas"></canvas>
+    <div id="error-message" style="display: none"></div>
     <select id="audioSelect">
       <option value="mic">Microphone</option>
       <option value="device">Device Audio</option>
@@ -34,6 +35,14 @@
       } from './assets/js/utils/audio-handler.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
+      function displayError(message) {
+        const el = document.getElementById("error-message");
+        if (el) {
+          el.innerText = message;
+          el.style.display = "block";
+        }
+      }
+
       const gl =
         canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
 
@@ -214,8 +223,10 @@
                 source = audioContext.createMediaStreamSource(stream);
                 source.connect(analyser);
                 startProcessing(d);
+              }).catch((err) => {
+                console.error("Error capturing audio: ", err);
+                displayError("Microphone access is required for the visualization to work. Please allow microphone access.");
               });
-              return;
             } else {
               // Use the audio context's `createMediaElementSource` to capture device audio
               const audioElement = new Audio();

--- a/sgpat.html
+++ b/sgpat.html
@@ -44,7 +44,7 @@
       const ctx2d = canvas.getContext('2d');
 
       if (!gl) {
-        showError(
+        displayError(
           'Unable to initialize WebGL. Your browser may not support it.'
         );
         throw new Error('WebGL not supported');
@@ -197,8 +197,8 @@
           hideError();
           getAudioData();
         } catch (err) {
-          showError(
-            'Unable to access the microphone. Please allow microphone permissions and reload the page.'
+          displayError(
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           console.error('Error capturing audio: ', err);
         }
@@ -273,7 +273,7 @@
       });
 
       // Show error messages
-      function showError(message) {
+      function displayError(message) {
         const errorMessageElement = document.getElementById('error-message');
         errorMessageElement.textContent = message;
         errorMessageElement.style.display = 'block';

--- a/symph.html
+++ b/symph.html
@@ -40,7 +40,7 @@
       const ctx2d = canvas.getContext('2d');
       const errorEl = document.getElementById('error-message');
 
-      function showError(message) {
+      function displayError(message) {
         if (errorEl) {
           errorEl.textContent = message;
           errorEl.style.display = 'block';
@@ -55,7 +55,7 @@
       }
 
       if (!gl) {
-        showError(
+        displayError(
           'Unable to initialize WebGL. Your browser may not support it.'
         );
         throw new Error('WebGL not supported');
@@ -201,8 +201,8 @@
           hideError();
           getAudioData();
         } catch (err) {
-          showError(
-            'Unable to access the microphone. Please allow microphone permissions and reload the page.'
+          displayError(
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           console.error('Error capturing audio: ', err);
         }

--- a/words.html
+++ b/words.html
@@ -159,6 +159,7 @@
 
     <div id="word-cloud-container">
       <canvas id="word-cloud-canvas"></canvas>
+    <div id="error-message" style="display: none"></div>
     </div>
 
     <script type="module">
@@ -172,9 +173,17 @@
         'toggle-speech-button'
       );
       const unmuteIcon = document.getElementById('unmute-icon');
+      }
       const recognition = new (window.SpeechRecognition ||
         window.webkitSpeechRecognition)();
       recognition.interimResults = false;
+      function displayError(message) {
+        const el = document.getElementById("error-message");
+        if (el) {
+          el.innerText = message;
+          el.style.display = "block";
+        }
+      }
       recognition.maxAlternatives = 1;
 
       let isUnmuted = false;
@@ -250,6 +259,7 @@
           visualize();
         } catch (error) {
           console.error('Error accessing microphone for visualizer:', error);
+          displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
           deactivateVisualizer();
         }
       }


### PR DESCRIPTION
## Summary
- add hidden error divs near canvases
- show error message when microphone access fails

## Testing
- `npm test` *(fails: Cannot find module '/workspace/stims/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6854f9725750833283b6347078be2c44