### PR TITLE
Handle zero-length audio slices in animation utils

### DIFF
--- a/assets/js/utils/animation-utils.ts
+++ b/assets/js/utils/animation-utils.ts
@@ -66,8 +66,9 @@ function averageFrequencyRange(
   const start = Math.trunc(audioData.length * startRatio);
   const end = Math.trunc(audioData.length * endRatio);
   const slice = audioData.slice(start, end);
+  if (slice.length === 0) return 0;
   const sum = slice.reduce((acc, val) => acc + val, 0);
-  const rangeLength = audioData.length * denominatorRatio;
+  const rangeLength = slice.length || audioData.length * denominatorRatio || 1;
   return sum / rangeLength;
 }
 


### PR DESCRIPTION
## Summary
- guard averageFrequencyRange against zero-length slices by returning 0 early
- calculate averages with the actual slice length to avoid reduce errors while keeping band helpers on the shared utility

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad068ee388332b82c26deb3d844ee)