### PR TITLE
Guard WebGL checks for non-browser environments

### DIFF
--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -1,7 +1,15 @@
 import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 export function ensureWebGL(): boolean {
-  if (navigator.gpu || WebGL.isWebGLAvailable()) {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined') {
+    return false;
+  }
+
+  const { gpu } = navigator as Navigator & { gpu?: unknown };
+  const hasWebGPU = Boolean(gpu);
+  const hasWebGL = typeof WebGL !== 'undefined' && WebGL.isWebGLAvailable();
+
+  if (hasWebGPU || hasWebGL) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- add environment guards around WebGL detection to avoid errors in non-browser contexts
- return false early when DOM or WebGL is unavailable so server or pre-render imports stay safe

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad072389c833285f6d1c7acc98e05)