### PR TITLE
Add user-triggered audio start with retry support

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -61,19 +61,20 @@ function initVisualization() {
   scene.add(cube);
 }
 
-function startAudioAndAnimation() {
-  initAudio()
-    .then((audioData) => {
-      analyser = audioData.analyser;
-      patternRecognizer = new PatternRecognizer(analyser);
-      animate();
-    })
-    .catch((error) => {
-      console.error('initAudio failed:', error);
-      displayError(
-        'Microphone access is required for the visualization to work. Please allow microphone access.'
-      );
-    });
+async function startAudioAndAnimation() {
+  try {
+    const audioData = await initAudio();
+    analyser = audioData.analyser;
+    patternRecognizer = new PatternRecognizer(analyser);
+    animate();
+    return true;
+  } catch (error) {
+    console.error('initAudio failed:', error);
+    displayError(
+      'Microphone access is required for the visualization to work. Please allow microphone access.'
+    );
+    return false;
+  }
 }
 
 function animate() {
@@ -107,7 +108,7 @@ function displayError(message) {
   const errorElement = document.getElementById('error-message');
   if (errorElement) {
     errorElement.innerText = message;
-    errorElement.style.display = 'block';
+    errorElement.style.display = message ? 'block' : 'none';
   }
 }
 
@@ -122,9 +123,16 @@ document.getElementById('light-type').addEventListener('change', (event) => {
 initVisualization();
 
 // Handle audio start button click
-document.getElementById('start-audio-btn').addEventListener('click', () => {
-  startAudioAndAnimation();
-  document.getElementById('start-audio-btn').style.display = 'none'; // Hide button after starting audio
+document.getElementById('start-audio-btn').addEventListener('click', async () => {
+  const startButton = document.getElementById('start-audio-btn');
+  startButton.disabled = true;
+  const started = await startAudioAndAnimation();
+  if (started) {
+    startButton.style.display = 'none'; // Hide button after starting audio
+    displayError('');
+  } else {
+    startButton.disabled = false;
+  }
 });
 
 // Handle window resize

--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -39,8 +39,10 @@ async function startAudio() {
     await toy.initAudio({ fftSize: 128 });
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -43,8 +43,10 @@ async function startAudio() {
     await toy.initAudio({ fftSize: 128 });
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 

--- a/assets/js/toys/particle-orbit.ts
+++ b/assets/js/toys/particle-orbit.ts
@@ -44,8 +44,10 @@ async function startAudio() {
     await toy.initAudio({ fftSize: 256 });
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 
@@ -64,4 +66,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -36,8 +36,10 @@ async function startAudio() {
     await toy.initAudio();
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 
@@ -54,4 +56,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -45,8 +45,10 @@ async function startAudio() {
     await toy.initAudio();
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -37,8 +37,10 @@ async function startAudio() {
     await toy.initAudio();
     analyser = toy.analyser;
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Microphone access denied', e);
+    throw e;
   }
 }
 

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -123,9 +123,11 @@ async function startAudio() {
     analyser = toy.analyser;
     hideError();
     toy.renderer.setAnimationLoop(animate);
+    return true;
   } catch (e) {
     console.error('Error accessing microphone:', e);
     showError('Microphone access was denied. Please allow access and reload.');
+    throw e;
   }
 }
 
@@ -160,4 +162,4 @@ function animate() {
 }
 
 init();
-startAudio();
+(window as any).startAudio = startAudio;

--- a/toy.html
+++ b/toy.html
@@ -8,14 +8,20 @@
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
-    <button id="start-audio-btn">Start</button>
+    <button id="start-audio-btn">Start audio</button>
     <script type="module" src="assets/js/toyMain.js"></script>
     <script>
       const btn = document.getElementById('start-audio-btn');
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', async () => {
         if (window.startAudio) {
-          window.startAudio();
-          btn.style.display = 'none';
+          btn.disabled = true;
+          try {
+            await window.startAudio();
+            btn.style.display = 'none';
+          } catch (error) {
+            console.error('Unable to start audio:', error);
+            btn.disabled = false;
+          }
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- add explicit user-triggered audio start handling so microphone prompts follow a gesture and errors can be retried
- expose audio start hooks across toys instead of auto-starting, keeping visual init intact
- hide the start control only after a successful audio start and clear inline errors when resolved

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad0c0881883328573e096fed631e5)