### PR TITLE
Use build manifest for toy modules

### DIFF
--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -14,7 +14,7 @@ async function createCard(toy) {
   card.appendChild(desc);
 
   card.addEventListener('click', () => {
-    if (toy.module.endsWith('.js') || toy.module.endsWith('.ts')) {
+    if (toy.type === 'module') {
       loadToy(toy.slug);
     } else {
       window.location.href = toy.module;

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,5 +1,30 @@
 import toysData from './toys-data.js';
 
+let manifestPromise;
+
+async function fetchManifest() {
+  if (!manifestPromise) {
+    manifestPromise = fetch('./manifest.json')
+      .then((response) => (response.ok ? response.json() : null))
+      .catch(() => null);
+  }
+  return manifestPromise;
+}
+
+async function resolveModulePath(entry) {
+  const manifest = await fetchManifest();
+  const manifestEntry = manifest?.[entry];
+
+  if (manifestEntry) {
+    const compiledFile = manifestEntry.file || manifestEntry.url;
+    if (compiledFile) {
+      return new URL(compiledFile, window.location.origin).pathname;
+    }
+  }
+
+  return entry.startsWith('/') || entry.startsWith('.') ? entry : `/${entry}`;
+}
+
 export async function loadToy(slug) {
   const toys = toysData;
   const toy = toys.find((t) => t.slug === slug);
@@ -8,11 +33,12 @@ export async function loadToy(slug) {
     return;
   }
 
-  if (toy.module.includes('toy.html')) {
+  if (toy.type === 'page') {
     window.location.href = `./${slug}.html`;
-  } else if (toy.module.endsWith('.js') || toy.module.endsWith('.ts')) {
+  } else if (toy.type === 'module') {
     document.getElementById('toy-list')?.remove();
-    await import(toy.module);
+    const moduleUrl = await resolveModulePath(toy.module);
+    await import(moduleUrl);
   } else {
     window.location.href = toy.module;
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -75,7 +75,7 @@ function renderToys(toys) {
 }
 
 function openToy(toy) {
-  if (toy.module.endsWith('.js') || toy.module.endsWith('.ts')) {
+  if (toy.type === 'module') {
     loadToy(toy.slug);
   } else {
     window.location.href = toy.module;

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -3,97 +3,113 @@ export default [
     "slug": "3dtoy",
     "title": "3D Toy",
     "description": "Dive into a twisting 3D tunnel that responds to sound.",
-    "module": "./assets/js/toys/three-d-toy.ts"
+    "module": "assets/js/toys/three-d-toy.ts",
+    "type": "module"
   },
   {
     "slug": "brand",
     "title": "Star Guitar Visualizer",
     "description": "A visual journey inspired by an iconic music video, synced to your music.",
-    "module": "./toy.html?toy=brand"
+    "module": "./toy.html?toy=brand",
+    "type": "page"
   },
   {
     "slug": "defrag",
     "title": "Defrag Visualizer",
     "description": "A nostalgic, sound-reactive visualizer evoking old defragmentation screens.",
-    "module": "./toy.html?toy=defrag"
+    "module": "./toy.html?toy=defrag",
+    "type": "page"
   },
   {
     "slug": "evol",
     "title": "Evolutionary Weirdcore",
     "description": "Watch surreal landscapes evolve with fractals and glitches that react to music.",
-    "module": "./toy.html?toy=evol"
+    "module": "./toy.html?toy=evol",
+    "type": "page"
   },
   {
     "slug": "multi",
     "title": "Multi-Capability Visualizer",
     "description": "Shapes and lights move with both sound and device motion.",
-    "module": "./toy.html?toy=multi"
+    "module": "./toy.html?toy=multi",
+    "type": "page"
   },
   {
     "slug": "seary",
     "title": "Trippy Synesthetic Visualizer",
     "description": "Blend audio and visuals in a rich synesthetic experience.",
-    "module": "./toy.html?toy=seary"
+    "module": "./toy.html?toy=seary",
+    "type": "page"
   },
   {
     "slug": "sgpat",
     "title": "Pattern Recognition Visualizer",
     "description": "See patterns form dynamically in response to sound.",
-    "module": "./toy.html?toy=sgpat"
+    "module": "./toy.html?toy=sgpat",
+    "type": "page"
   },
   {
     "slug": "svgtest",
     "title": "SVG + Three.js Visualizer",
     "description": "A hybrid visualizer blending 2D and 3D elements, reacting in real time.",
-    "module": "./toy.html?toy=svgtest"
+    "module": "./toy.html?toy=svgtest",
+    "type": "page"
   },
   {
     "slug": "symph",
     "title": "Dreamy Spectrograph",
     "description": "A relaxing spectrograph that moves gently with your audio.",
-    "module": "./toy.html?toy=symph"
+    "module": "./toy.html?toy=symph",
+    "type": "page"
   },
   {
     "slug": "words",
     "title": "Interactive Word Cloud",
     "description": "Speak and watch the word cloud react and shift with your voice.",
-    "module": "./toy.html?toy=words"
+    "module": "./toy.html?toy=words",
+    "type": "page"
   },
   {
     "slug": "cube-wave",
     "title": "Cube Wave",
     "description": "A grid of cubes that rise and fall with your audio.",
-    "module": "./assets/js/toys/cube-wave.ts"
+    "module": "assets/js/toys/cube-wave.ts",
+    "type": "module"
   },
   {
     "slug": "particle-orbit",
     "title": "Particle Orbit",
     "description": "Thousands of particles swirling faster as the music intensifies.",
-    "module": "./assets/js/toys/particle-orbit.ts"
+    "module": "assets/js/toys/particle-orbit.ts",
+    "type": "module"
   },
   {
     "slug": "spiral-burst",
     "title": "Spiral Burst",
     "description": "Colorful spirals rotate and expand with every beat.",
-    "module": "./assets/js/toys/spiral-burst.ts"
+    "module": "assets/js/toys/spiral-burst.ts",
+    "type": "module"
   },
   {
     "slug": "bouncy-spheres",
     "title": "Bouncy Spheres",
     "description": "Lines of spheres bounce and change color with audio.",
-    "module": "./assets/js/toys/bouncy-spheres.ts"
+    "module": "assets/js/toys/bouncy-spheres.ts",
+    "type": "module"
   },
   {
     "slug": "rainbow-tunnel",
     "title": "Rainbow Tunnel",
     "description": "Fly through colorful rings that spin to your music.",
-    "module": "./assets/js/toys/rainbow-tunnel.ts"
+    "module": "assets/js/toys/rainbow-tunnel.ts",
+    "type": "module"
   },
   {
     "slug": "star-field",
     "title": "Star Field",
     "description": "A field of shimmering stars reacts to the beat.",
-    "module": "./assets/js/toys/star-field.ts"
+    "module": "assets/js/toys/star-field.ts",
+    "type": "module"
   }
 ]
 ;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     outDir: 'dist',
+    manifest: true,
   },
 });


### PR DESCRIPTION
## Summary
- add Vite manifest generation to map toy modules to built bundle URLs
- route toy loader imports through manifest-aware resolver and classify toy entries by module type
- update toy listings to use module/page type checks for navigation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad0c243a48332b67f564b44c023a9)