### PR TITLE
Use type-only import for pattern recognizer

### DIFF
--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -1,12 +1,12 @@
 // patternRecognition.js: A pattern recognition and predictive listening script for audio-based visualizers
 
-import * as THREE from 'three';
+import type { AudioAnalyser } from 'three';
 
 class PatternRecognizer {
-  analyser: THREE.AudioAnalyser;
+  analyser: AudioAnalyser;
   bufferSize: number;
   patternBuffer: number[][];
-  constructor(analyser: THREE.AudioAnalyser, bufferSize = 30) {
+  constructor(analyser: AudioAnalyser, bufferSize = 30) {
     // Reduced buffer size for performance
     this.analyser = analyser;
     this.bufferSize = bufferSize;


### PR DESCRIPTION
## Summary
- switch PatternRecognizer to use a type-only AudioAnalyser import
- ensure the pattern recognition utility no longer pulls in a runtime three dependency

## Testing
- npm test -- pattern-recognizer


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694336bc88308332a9a77309e5a08d09)