### PR TITLE
Use circular buffer for analyser pattern snapshots

### DIFF
--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -5,31 +5,45 @@ import type { AudioAnalyser } from 'three';
 class PatternRecognizer {
   analyser: AudioAnalyser;
   bufferSize: number;
-  patternBuffer: number[][];
+  patternBuffer: Uint8Array[];
+  writeIndex: number;
+  filled: number;
   constructor(analyser: AudioAnalyser, bufferSize = 30) {
     // Reduced buffer size for performance
     this.analyser = analyser;
     this.bufferSize = bufferSize;
     this.patternBuffer = [];
+    this.writeIndex = 0;
+    this.filled = 0;
   }
 
   updatePatternBuffer(): void {
     // Get current frequency data and add to pattern buffer
     const data = this.analyser.getFrequencyData();
-    this.patternBuffer.push([...data]);
+    if (this.patternBuffer.length === 0) {
+      this.patternBuffer = Array.from({ length: this.bufferSize }, () =>
+        new (data.constructor as typeof Uint8Array)(data.length)
+      );
+    }
 
-    // Limit buffer size
-    if (this.patternBuffer.length > this.bufferSize) {
-      this.patternBuffer.shift();
+    const target = this.patternBuffer[this.writeIndex];
+    target.set(data);
+
+    this.writeIndex = (this.writeIndex + 1) % this.bufferSize;
+    if (this.filled < this.bufferSize) {
+      this.filled++;
     }
   }
 
-  detectPattern(): number[] | null {
+  detectPattern(): Uint8Array | null {
     // Compare the current pattern to past patterns in the buffer
-    if (this.patternBuffer.length < this.bufferSize) return null;
+    if (this.filled < this.bufferSize) return null;
 
-    const lastPattern = this.patternBuffer[this.bufferSize - 1];
-    const secondLastPattern = this.patternBuffer[this.bufferSize - 2];
+    const lastIndex = (this.writeIndex + this.bufferSize - 1) % this.bufferSize;
+    const secondLastIndex = (this.writeIndex + this.bufferSize - 2) % this.bufferSize;
+
+    const lastPattern = this.patternBuffer[lastIndex];
+    const secondLastPattern = this.patternBuffer[secondLastIndex];
 
     // Check if the last two patterns are similar
     if (this.comparePatterns(lastPattern, secondLastPattern)) {
@@ -40,8 +54,8 @@ class PatternRecognizer {
   }
 
   comparePatterns(
-    pattern1: number[],
-    pattern2: number[],
+    pattern1: Uint8Array,
+    pattern2: Uint8Array,
     tolerance = 0.85
   ): boolean {
     // Higher tolerance for stricter matching


### PR DESCRIPTION
## Summary
- add a fixed-length circular buffer for analyser frequency snapshots
- reuse typed array slots and track read/write indices to avoid per-frame allocations

## Testing
- not run (lint hook missing @typescript-eslint/eslint-plugin dependency)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694338aa8d0c8332ace07d64fc74aea0)