### PR TITLE
Add maxPixelRatio cap to renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 - **Issue**: Some toys are heavy on resources and might lag on lower-end devices.
 - **Fix**: Add settings to adjust visual quality (e.g., reduce particle count or resolution).
 
+If you want to reduce GPU load on high-DPI screens without degrading visuals too much, pass a `maxPixelRatio` option to
+`initRenderer` (defaults to `2`). This caps the renderer to `Math.min(window.devicePixelRatio, maxPixelRatio)`, so setting
+`maxPixelRatio` to `1.5` or `1` can significantly cut per-frame work while retaining clarity.
+
 ### **Audio Permissions**
 
 - **Issue**: Not much feedback when audio permissions are denied or unavailable.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -11,6 +11,8 @@ import {
 } from './utils/animation-utils.ts';
 import PatternRecognizer from './utils/patternRecognition.ts';
 
+const DEFAULT_RENDERER_OPTIONS = { maxPixelRatio: 2 };
+
 let scene, camera, renderer, cube, analyser, patternRecognizer;
 let currentLightType = 'PointLight'; // Default light type
 
@@ -43,7 +45,7 @@ function initVisualization() {
   scene = initScene();
   camera = initCamera();
   const canvas = document.getElementById('toy-canvas');
-  renderer = initRenderer(canvas);
+  renderer = initRenderer(canvas, DEFAULT_RENDERER_OPTIONS);
 
   // Set up lighting based on user selection
   initLighting(scene, {

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -4,9 +4,10 @@ import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export function initRenderer(
   canvas,
-  config: { antialias?: boolean; exposure?: number } = {
+  config: { antialias?: boolean; exposure?: number; maxPixelRatio?: number } = {
     antialias: true,
     exposure: 1,
+    maxPixelRatio: 2,
   }
 ) {
   if (!ensureWebGL()) {
@@ -22,7 +23,8 @@ export function initRenderer(
       antialias: config.antialias,
     });
   }
-  renderer.setPixelRatio(window.devicePixelRatio);
+  const maxPixelRatio = config.maxPixelRatio ?? 2;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, maxPixelRatio));
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/assets/js/core/types.ts
+++ b/assets/js/core/types.ts
@@ -10,7 +10,7 @@ import type {
 export interface ToyConfig {
   cameraOptions?: Record<string, unknown>;
   sceneOptions?: { backgroundColor?: number };
-  rendererOptions?: { antialias?: boolean; exposure?: number };
+  rendererOptions?: { antialias?: boolean; exposure?: number; maxPixelRatio?: number };
   lightingOptions?: LightConfig;
   ambientLightOptions?: AmbientLightConfig;
   canvas?: HTMLCanvasElement | null;

--- a/brand.html
+++ b/brand.html
@@ -39,7 +39,11 @@
 
       // Renderer setup
       const canvas = document.getElementById('vizCanvas');
-      const renderer = initRenderer(canvas, { antialias: true, exposure: 1.2 });
+      const renderer = initRenderer(canvas, {
+        antialias: true,
+        exposure: 1.2,
+        maxPixelRatio: 2,
+      });
 
       // Lighting setup
       const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);


### PR DESCRIPTION
## Summary
- add a maxPixelRatio renderer option (default 2) and cap pixel ratio when initializing
- update renderer consumers and shared types to propagate the new option
- document the setting so high-DPI devices can lower GPU load

## Testing
- not run (missing @typescript-eslint/eslint-plugin in lint hook)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694338a093c0833293821255d6bc043e)