### PR TITLE
Trigger audio start after module toy import

### DIFF
--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,6 +1,7 @@
 import toysData from './toys-data.js';
 
 let manifestPromise;
+let moduleImporter = (path) => import(path);
 
 async function fetchManifest() {
   if (!manifestPromise) {
@@ -25,6 +26,72 @@ async function resolveModulePath(entry) {
   return entry.startsWith('/') || entry.startsWith('.') ? entry : `/${entry}`;
 }
 
+function ensureAudioPrompt(message) {
+  let prompt = document.getElementById('audio-permission-prompt');
+  if (!prompt) {
+    prompt = document.createElement('div');
+    prompt.id = 'audio-permission-prompt';
+    prompt.setAttribute('role', 'status');
+    prompt.style.margin = '1rem 0';
+    document.body.appendChild(prompt);
+  }
+
+  prompt.textContent = message;
+  prompt.style.display = message ? 'block' : 'none';
+}
+
+function ensureStartAudioButton() {
+  let button = document.getElementById('start-audio-btn');
+  if (!button) {
+    button = document.createElement('button');
+    button.id = 'start-audio-btn';
+    button.type = 'button';
+    button.textContent = 'Enable microphone';
+    button.dataset.createdByLoader = 'true';
+    button.style.display = 'block';
+    document.body.appendChild(button);
+  } else {
+    button.style.display = '';
+  }
+
+  return button;
+}
+
+function bindStartAudioClick(button) {
+  if (button.dataset.createdByLoader !== 'true' || button.dataset.loaderBound) {
+    return;
+  }
+
+  button.dataset.loaderBound = 'true';
+  button.addEventListener('click', async () => {
+    await startAudioIfReady();
+  });
+}
+
+async function startAudioIfReady() {
+  const button = ensureStartAudioButton();
+  bindStartAudioClick(button);
+
+  if (typeof window.startAudio !== 'function') {
+    ensureAudioPrompt('Enable microphone access to start audio.');
+    return;
+  }
+
+  button.disabled = true;
+  try {
+    await window.startAudio();
+    button.style.display = 'none';
+    ensureAudioPrompt('');
+  } catch (error) {
+    console.error('Unable to start audio:', error);
+    button.disabled = false;
+    button.style.display = 'block';
+    ensureAudioPrompt(
+      'Microphone access is required. Please allow it and try again.'
+    );
+  }
+}
+
 export async function loadToy(slug) {
   const toys = toysData;
   const toy = toys.find((t) => t.slug === slug);
@@ -38,7 +105,16 @@ export async function loadToy(slug) {
   } else if (toy.type === 'module') {
     document.getElementById('toy-list')?.remove();
     const moduleUrl = await resolveModulePath(toy.module);
-    await import(moduleUrl);
+    try {
+      await moduleImporter(moduleUrl);
+      await startAudioIfReady();
+    } catch (error) {
+      console.error(`Unable to load module ${moduleUrl}:`, error);
+      ensureAudioPrompt(
+        'Unable to start audio automatically. Please enable your microphone.'
+      );
+      ensureStartAudioButton();
+    }
   } else {
     window.location.href = toy.module;
   }
@@ -50,4 +126,12 @@ export async function loadFromQuery() {
   if (slug) {
     await loadToy(slug);
   }
+}
+
+export function setModuleImporter(fn) {
+  moduleImporter = fn;
+}
+
+export function resetModuleImporter() {
+  moduleImporter = (path) => import(path);
 }

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,6 +1,10 @@
-/** @jest-environment node */
+/** @jest-environment jsdom */
 import { jest } from '@jest/globals';
-import { loadToy } from '../assets/js/loader.js';
+import {
+  loadToy,
+  resetModuleImporter,
+  setModuleImporter,
+} from '../assets/js/loader.js';
 
 describe('loadToy', () => {
   beforeEach(() => {
@@ -10,11 +14,31 @@ describe('loadToy', () => {
           Promise.resolve([{ slug: 'brand', module: './toy.html?toy=brand' }]),
       })
     );
-    global.window = { location: { href: '' } };
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: 'http://localhost/' },
+    });
+    resetModuleImporter();
   });
 
   test('navigates to HTML toy page', async () => {
     await loadToy('brand');
     expect(window.location.href).toBe('./brand.html');
+  });
+
+  test('starts audio after importing a module toy', async () => {
+    const startAudio = jest.fn().mockResolvedValue();
+
+    setModuleImporter(async () => {
+      window.startAudio = startAudio;
+      return {};
+    });
+
+    await loadToy('cube-wave');
+
+    expect(startAudio).toHaveBeenCalledTimes(1);
+    const button = document.getElementById('start-audio-btn');
+    expect(button?.style.display).toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- call `startAudio` automatically after module-based toys load and provide clear microphone prompts on errors
- ensure a visible start-audio control is available when imports succeed or fail
- add a regression test to simulate module import and verify `startAudio` is triggered

## Testing
- npm test *(fails: existing animation-utils and lighting-setup suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943382f21648332bc4275b96c8e63c1)