### PR TITLE
Return cards synchronously in app shell

### DIFF
--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -3,7 +3,7 @@ import toysData from './toys-data.js';
 
 let allToys = [];
 
-async function createCard(toy) {
+function createCard(toy) {
   const card = document.createElement('div');
   card.className = 'webtoy-card';
   const title = document.createElement('h3');


### PR DESCRIPTION
## Summary
- make the `createCard` helper synchronous in the app shell so it returns DOM nodes directly
- ensure toy cards are appended without involving Promises for cleaner rendering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694338f4fc088332936456c7523bc1d2)