### PR TITLE
Add standalone HTML toys to library catalog

### DIFF
--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -15,6 +15,14 @@ export default [
     type: 'page',
   },
   {
+    slug: 'clay',
+    title: 'Pottery Wheel Sculptor',
+    description:
+      'Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.',
+    module: './clay.html',
+    type: 'page',
+  },
+  {
     slug: 'defrag',
     title: 'Defrag Visualizer',
     description:
@@ -28,6 +36,14 @@ export default [
     description:
       'Watch surreal landscapes evolve with fractals and glitches that react to music.',
     module: './toy.html?toy=evol',
+    type: 'page',
+  },
+  {
+    slug: 'geom',
+    title: 'Microphone Geometry Visualizer',
+    description:
+      'Push shifting geometric forms directly from live mic input with responsive controls.',
+    module: './geom.html',
     type: 'page',
   },
   {
@@ -49,6 +65,14 @@ export default [
     title: 'Pattern Recognition Visualizer',
     description: 'See patterns form dynamically in response to sound.',
     module: './toy.html?toy=sgpat',
+    type: 'page',
+  },
+  {
+    slug: 'legible',
+    title: 'Terminal Word Grid',
+    description:
+      'A retro green text grid that pulses to audio and surfaces fresh words as you play.',
+    module: './legible.html',
     type: 'page',
   },
   {
@@ -88,6 +112,14 @@ export default [
       'Thousands of particles swirling faster as the music intensifies.',
     module: 'assets/js/toys/particle-orbit.ts',
     type: 'module',
+  },
+  {
+    slug: 'lights',
+    title: 'Audio Light Show',
+    description:
+      'Swap shader styles and color palettes while lights ripple with your microphone input.',
+    module: './lights.html',
+    type: 'page',
   },
   {
     slug: 'spiral-burst',

--- a/index.html
+++ b/index.html
@@ -78,13 +78,13 @@
             <p class="hero-card-title">Stim stream</p>
             <p class="hero-card-subtitle">Now featuring</p>
             <ul class="feature-list">
-              <li>30+ interactive sketches</li>
+              <li>20 interactive sketches including HTML standalones</li>
               <li>Instant load from query</li>
               <li>Dark / light optimized</li>
             </ul>
             <div class="stat-grid">
               <div class="stat-card">
-                <p class="stat-value">01</p>
+                <p class="stat-value">04</p>
                 <p class="stat-label">New arrivals</p>
               </div>
               <div class="stat-card">
@@ -102,7 +102,8 @@
           <h2>Browse every stim</h2>
           <p class="section-description">
             Tap a card to open it instantly, or share a URL to load a toy from a
-            query param. The catalog is always expanding.
+            query param. The catalog now includes standalone HTML stims like
+            Clay, Geom, Legible, and Lights alongside the module-based set.
           </p>
         </div>
         <main id="toy-list" class="webtoy-container"></main>


### PR DESCRIPTION
## Summary
- add standalone HTML toys (Clay, Geom, Legible, Lights) to the catalog data so they appear on the homepage
- refresh homepage messaging to highlight the expanded set and updated arrivals count

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943390c67088332bbda2288e6a802a8)