### PR TITLE
Add jest script with experimental vm modules flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ dependencies and run the tests:
    npm test
    ```
 
+For custom test filters or file patterns, you can run Jest directly with the required ESM flag via the dedicated script:
+
+```bash
+npm run jest -- --testPathPattern=some-file
+```
+
 ### Linting and Formatting
 
 Before committing, run `npm run lint` to check code style and `npm run format` to automatically format your files. This keeps the project consistent.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "npm run jest --",
+    "jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint",
     "format": "prettier --write .",
     "dev": "vite",


### PR DESCRIPTION
## Summary
- add a reusable npm script for running Jest with the experimental vm modules flag
- update npm test to delegate to the new Jest helper for ESM compatibility
- document direct Jest invocation for custom file filters

## Testing
- npm test *(fails: existing test failures in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694339fac50c8332a7a5e979bde94426)