### PR TITLE
Handle default offsets when partially overriding light position

### DIFF
--- a/assets/js/lighting/lighting-setup.ts
+++ b/assets/js/lighting/lighting-setup.ts
@@ -36,11 +36,11 @@ export function initLighting(
     type = 'PointLight',
     color = 0xffffff,
     intensity = 1,
-    position = { x: 10, y: 10, z: 10 },
+    position,
     castShadow = false,
   } = config ?? {};
 
-  const { x = 0, y = 0, z = 0 } = position ?? {};
+  const { x, y, z } = { x: 10, y: 10, z: 10, ...(position ?? {}) };
   let light: Light;
 
   switch (type) {

--- a/tests/lighting-setup.test.js
+++ b/tests/lighting-setup.test.js
@@ -18,6 +18,17 @@ describe('initLighting', () => {
     expect(light.position.z).toBe(10);
   });
 
+  it('merges partial position values with defaults', () => {
+    const scene = new Scene();
+
+    initLighting(scene, { type: 'DirectionalLight', position: { y: 5 } });
+
+    const light = scene.children[0];
+    expect(light.position.x).toBe(10);
+    expect(light.position.y).toBe(5);
+    expect(light.position.z).toBe(10);
+  });
+
   it('does not require a position for non-positional lights', () => {
     const scene = new Scene();
 


### PR DESCRIPTION
## Summary
- merge provided lighting positions with default offsets before destructuring
- ensure partial position overrides retain default axis values
- add test coverage for merging partial lighting positions

## Testing
- npm test -- --runInBand (fails: existing test failures unrelated to changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433a39447c8332ba28afc3a23e3825)