### PR TITLE
Add contribution templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a problem with the stim webtoys
+labels: bug
+---
+
+## Summary
+
+A clear and concise description of what went wrong.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+
+Tell us what you expected to happen.
+
+## Screenshots or recordings
+
+If applicable, add images or videos to help explain the issue.
+
+## Environment
+
+- OS: [e.g. macOS 14, Windows 11]
+- Browser: [e.g. Chrome 124]
+- Device: [e.g. desktop, iPhone 14]
+- Node.js version (if running locally): [e.g. 22.x]
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for the stim webtoys
+labels: enhancement
+---
+
+## Summary
+
+A clear and concise description of the feature you want.
+
+## Problem or use case
+
+What problem does this solve or what experience does it improve?
+
+## Proposed solution
+
+Describe the behavior you’d like to see.
+
+## Alternatives considered
+
+List any alternative solutions or features you’ve considered.
+
+## Additional context
+
+Add any other context, examples, or mockups about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Briefly describe the changes and their purpose. -->
+
+## Testing
+
+<!-- List the tests you ran and the results. Include commands when possible. -->
+
+-
+
+## Checklist
+
+- [ ] Linting (`npm run lint`) if applicable
+- [ ] Tests (`npm test`) if applicable

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ npm run jest -- --testPathPattern=some-file
 
 Before committing, run `npm run lint` to check code style and `npm run format` to automatically format your files. This keeps the project consistent.
 
+## Contributing
+
+If you run into a problem or want to propose an improvement, please use the GitHub issue templates so we get the details we need:
+
+- **Bug reports**: include clear reproduction steps, your environment, and what you expected to happen.
+- **Feature requests**: describe the problem you’re trying to solve, the behavior you’d like, and any alternatives you considered.
+
+When opening a pull request, fill out the PR template with a summary of the change and the tests you ran. Check the lint and test boxes only if you executed those commands.
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add bug report and feature request issue templates capturing reproduction info, environment, and expected behavior
- add a pull request template prompting summaries, testing notes, and lint/test checklist
- update README to point contributors to the templates

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433ae39a588332a1979e8d3e62669b)