### PR TITLE
Optimize star field buffer usages

### DIFF
--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -64,11 +64,13 @@ function init() {
     }
   }
 
-  geometry.setAttribute(
-    'position',
-    new THREE.BufferAttribute(starPositions, 3)
-  );
-  geometry.setAttribute('size', new THREE.BufferAttribute(starSizes, 1));
+  const positionAttribute = new THREE.BufferAttribute(starPositions, 3);
+  positionAttribute.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute('position', positionAttribute);
+
+  const sizeAttribute = new THREE.BufferAttribute(starSizes, 1);
+  sizeAttribute.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute('size', sizeAttribute);
   geometry.setAttribute('color', new THREE.BufferAttribute(starColors, 3));
 
   starMaterial = new THREE.PointsMaterial({


### PR DESCRIPTION
## Summary
- set dynamic draw usage on star field position and size buffer attributes for efficient updates

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433cc292d88332b82c80b6f3f53eb9)