### PR TITLE
Refactor average frequency helper implementation

### DIFF
--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -85,5 +85,11 @@ export function getFrequencyData(analyser: THREE.AudioAnalyser) {
  */
 export function getAverageFrequency(data: Uint8Array): number {
   if (data.length === 0) return 0;
-  return data.reduce((a, b) => a + b, 0) / data.length;
+
+  let sum = 0;
+  for (let i = 0; i < data.length; i += 1) {
+    sum += data[i];
+  }
+
+  return sum / data.length;
 }


### PR DESCRIPTION
## Summary
- replace the getAverageFrequency reducer call with a manual loop and empty-array short circuit
- preserve the helper API used by toy modules while keeping frequency averaging behavior unchanged

## Testing
- npm run lint
- npm run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433cc88b3c8332bab0f47eeb7e378d)