### PR TITLE
Add disposal lifecycle handling for WebToy instances

### DIFF
--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { initScene } from './scene-setup.ts';
 import { initCamera } from './camera-setup.ts';
 import { initRenderer } from './renderer-setup.ts';
@@ -6,6 +7,16 @@ import { initAudio } from '../utils/audio-handler.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export default class WebToy {
+  canvas: HTMLCanvasElement;
+  scene: THREE.Scene;
+  camera: THREE.Camera;
+  renderer: ReturnType<typeof initRenderer>;
+  analyser: THREE.AudioAnalyser | null;
+  audioListener: THREE.AudioListener | null;
+  audio: THREE.Audio | THREE.PositionalAudio | null;
+  audioStream: MediaStream | null;
+  resizeHandler: (() => void) | null;
+
   constructor({
     cameraOptions = {},
     sceneOptions = {},
@@ -35,7 +46,11 @@ export default class WebToy {
     this.analyser = null;
     this.audioListener = null;
     this.audio = null;
-    window.addEventListener('resize', () => this.handleResize());
+    this.audioStream = null;
+    this.resizeHandler = () => this.handleResize();
+    window.addEventListener('resize', this.resizeHandler);
+
+    (globalThis as Record<string, unknown>).__activeWebToy = this;
   }
 
   handleResize() {
@@ -49,10 +64,79 @@ export default class WebToy {
     this.analyser = audio.analyser;
     this.audioListener = audio.listener;
     this.audio = audio.audio;
+    this.audioStream = audio.stream ?? null;
     return audio;
   }
 
   render() {
     this.renderer.render(this.scene, this.camera);
+  }
+
+  dispose() {
+    if (this.resizeHandler) {
+      window.removeEventListener('resize', this.resizeHandler);
+    }
+
+    if (this.renderer?.setAnimationLoop) {
+      this.renderer.setAnimationLoop(null);
+    }
+
+    if (this.renderer?.dispose) {
+      this.renderer.dispose();
+    }
+
+    if (this.scene) {
+      this.scene.traverse((object: THREE.Object3D) => {
+        const mesh = object as THREE.Mesh;
+        if ((mesh as unknown as { isMesh?: boolean }).isMesh) {
+          if (mesh.geometry) mesh.geometry.dispose();
+          if (mesh.material) {
+            if (Array.isArray(mesh.material)) {
+              mesh.material.forEach((material) => material?.dispose());
+            } else {
+              mesh.material.dispose();
+            }
+          }
+        }
+      });
+
+      while (this.scene.children.length > 0) {
+        this.scene.remove(this.scene.children[0]);
+      }
+    }
+
+    if (this.audio) {
+      if ('stop' in this.audio && typeof this.audio.stop === 'function') {
+        this.audio.stop();
+      }
+      if (
+        'disconnect' in this.audio &&
+        typeof this.audio.disconnect === 'function'
+      ) {
+        this.audio.disconnect();
+      }
+    }
+
+    if (this.audioListener && 'remove' in this.camera) {
+      (
+        this.camera as THREE.Camera & { remove?: (obj: THREE.Object3D) => void }
+      ).remove(this.audioListener);
+    }
+
+    if (this.audioStream) {
+      this.audioStream.getTracks().forEach((track) => track.stop());
+    }
+
+    if (this.analyser?.analyser) {
+      this.analyser.analyser.disconnect();
+    }
+
+    if (this.canvas?.parentElement) {
+      this.canvas.parentElement.removeChild(this.canvas);
+    }
+
+    if ((globalThis as Record<string, unknown>).__activeWebToy === this) {
+      delete (globalThis as Record<string, unknown>).__activeWebToy;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a disposal routine to WebToy to release renderer, scene, audio, and canvas resources
- track the active toy instance for cleanup
- dispose the current toy before navigating away or loading another module

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433c43bdb48332be02fa939631a3c1)