### PR TITLE
Use shared renderer helper for landing background

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -4,30 +4,43 @@ import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export function initRenderer(
   canvas,
-  config: { antialias?: boolean; exposure?: number; maxPixelRatio?: number } = {
+  config: {
+    antialias?: boolean;
+    exposure?: number;
+    maxPixelRatio?: number;
+    alpha?: boolean;
+  } = {
     antialias: true,
     exposure: 1,
     maxPixelRatio: 2,
+    alpha: false,
   }
 ) {
   if (!ensureWebGL()) {
     return null;
   }
 
+  const {
+    antialias = true,
+    exposure = 1,
+    maxPixelRatio = 2,
+    alpha = false,
+  } = config;
+
   let renderer;
   if (navigator.gpu) {
-    renderer = new WebGPURenderer({ canvas, antialias: config.antialias });
+    renderer = new WebGPURenderer({ canvas, antialias, alpha });
   } else {
     renderer = new THREE.WebGLRenderer({
       canvas,
-      antialias: config.antialias,
+      antialias,
+      alpha,
     });
   }
-  const maxPixelRatio = config.maxPixelRatio ?? 2;
   renderer.setPixelRatio(Math.min(window.devicePixelRatio, maxPixelRatio));
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = config.exposure ?? 1;
+  renderer.toneMappingExposure = exposure;
   return renderer;
 }

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -14,7 +14,7 @@ function disposeActiveToy() {
     }
   }
 
-  delete (globalThis as Record<string, unknown>).__activeWebToy;
+  delete globalThis.__activeWebToy;
 }
 
 async function fetchManifest() {

--- a/index.html
+++ b/index.html
@@ -125,13 +125,9 @@
 
     <script type="module">
       import * as THREE from 'three';
-      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      import { initRenderer } from './assets/js/core/renderer-setup.ts';
 
       function startBackground() {
-        if (!ensureWebGL()) {
-          return;
-        }
-
         // Three.js background
         const scene = new THREE.Scene();
         const camera = new THREE.PerspectiveCamera(
@@ -140,11 +136,14 @@
           0.1,
           1000
         );
-        const renderer = new THREE.WebGLRenderer({
-          canvas: document.getElementById('bg-canvas'),
+        const renderer = initRenderer(document.getElementById('bg-canvas'), {
+          maxPixelRatio: 1.5,
           alpha: true,
         });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+
+        if (!renderer) {
+          return;
+        }
 
         const geometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
         const material = new THREE.MeshBasicMaterial({
@@ -182,6 +181,7 @@
         window.addEventListener('resize', () => {
           camera.aspect = window.innerWidth / window.innerHeight;
           camera.updateProjectionMatrix();
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
           renderer.setSize(window.innerWidth, window.innerHeight);
         });
       }


### PR DESCRIPTION
## Summary
- reuse the shared renderer initializer for the landing page background and cap pixel ratio before sizing
- extend the renderer setup helper with optional alpha support for transparent canvases
- clean up loader teardown to avoid type syntax that broke formatting

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694377f680d48332893c96d67c740eac)