### PR TITLE
Fix loader cleanup for ESM compatibility

### DIFF
--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -14,7 +14,8 @@ function disposeActiveToy() {
     }
   }
 
-  delete (globalThis as Record<string, unknown>).__activeWebToy;
+  const globalObject = globalThis;
+  delete globalObject.__activeWebToy;
 }
 
 async function fetchManifest() {


### PR DESCRIPTION
## Summary
- remove TypeScript-style cast when clearing __activeWebToy in loader to keep the module valid JavaScript

## Testing
- lint (pre-commit)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943780938048332b570ae9a4f6319aa)