### PR TITLE
Remove unused cannon-es dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "stims",
       "version": "1.0.0",
       "dependencies": {
-        "cannon-es": "^0.20.0",
         "three": "^0.177.0"
       },
       "devDependencies": {
@@ -2802,12 +2801,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/cannon-es": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
-      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
-      "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "node": "^22"
   },
   "dependencies": {
-    "cannon-es": "^0.20.0",
     "three": "^0.177.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove cannon-es from runtime dependencies
- regenerate package-lock without cannon-es

## Testing
- npm test (fails: existing loader and pattern recognizer test issues)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694377ee8f58833295a1aa9aea93c80f)