### PR TITLE
Add idle-mode controls and palette drift to 3D toy

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -26,3 +26,66 @@ body {
   backdrop-filter: blur(4px);
   z-index: 1000;
 }
+
+.control-panel {
+  position: fixed;
+  bottom: 16px;
+  left: 16px;
+  width: min(320px, 90vw);
+  background: rgba(10, 10, 10, 0.78);
+  color: #f5f5f5;
+  padding: 12px 14px;
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  z-index: 1100;
+}
+
+.control-panel__heading {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  margin-bottom: 4px;
+}
+
+.control-panel__description {
+  margin: 0 0 10px;
+  font-size: 0.85rem;
+  color: rgba(245, 245, 245, 0.78);
+}
+
+.control-panel__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 6px 0;
+  padding: 8px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.control-panel__row:first-of-type {
+  border-top: none;
+}
+
+.control-panel__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.control-panel__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.control-panel small {
+  color: rgba(245, 245, 245, 0.7);
+  line-height: 1.3;
+}
+
+.control-panel input[type='checkbox'] {
+  width: 20px;
+  height: 20px;
+  accent-color: #70f0ff;
+}

--- a/assets/js/utils/control-panel.ts
+++ b/assets/js/utils/control-panel.ts
@@ -1,0 +1,107 @@
+export type ControlPanelState = {
+  idleEnabled: boolean;
+  paletteCycle: boolean;
+  mobilePreset: boolean;
+};
+
+type ChangeHandler = (state: ControlPanelState) => void;
+
+const isMobile =
+  typeof navigator !== 'undefined' &&
+  /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
+
+function createToggle(
+  label: string,
+  checked: boolean,
+  description: string,
+  onChange: (value: boolean) => void
+) {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'control-panel__row';
+
+  const text = document.createElement('div');
+  text.className = 'control-panel__text';
+  text.innerHTML = `<span class="control-panel__label">${label}</span><small>${description}</small>`;
+
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.checked = checked;
+  input.addEventListener('change', () => onChange(input.checked));
+
+  wrapper.appendChild(text);
+  wrapper.appendChild(input);
+  return { wrapper, input };
+}
+
+export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
+  const state: ControlPanelState = {
+    idleEnabled: initial.idleEnabled ?? !isMobile,
+    paletteCycle: initial.paletteCycle ?? true,
+    mobilePreset: initial.mobilePreset ?? isMobile,
+  };
+
+  const listeners: ChangeHandler[] = [];
+  const panel = document.createElement('div');
+  panel.className = 'control-panel';
+
+  const heading = document.createElement('div');
+  heading.className = 'control-panel__heading';
+  heading.textContent = 'Idle Controls';
+
+  const description = document.createElement('p');
+  description.className = 'control-panel__description';
+  description.textContent =
+    'Tweak how the scene behaves when the mic is quiet. Desktop defaults stay vivid; mobile trims intensity.';
+
+  const idleToggle = createToggle(
+    'Idle visuals',
+    state.idleEnabled,
+    'Subtle motion and gradients while audio is quiet.',
+    (value) => {
+      state.idleEnabled = value;
+      emit();
+    }
+  );
+
+  const paletteToggle = createToggle(
+    'Palette drift',
+    state.paletteCycle,
+    'Slow hue cycling that eases when sound returns.',
+    (value) => {
+      state.paletteCycle = value;
+      emit();
+    }
+  );
+
+  const mobileToggle = createToggle(
+    'Mobile-friendly idle',
+    state.mobilePreset,
+    'Lowers drift and wobble for handheld devices.',
+    (value) => {
+      state.mobilePreset = value;
+      emit();
+    }
+  );
+
+  [
+    heading,
+    description,
+    idleToggle.wrapper,
+    paletteToggle.wrapper,
+    mobileToggle.wrapper,
+  ].forEach((el) => panel.appendChild(el));
+
+  function emit() {
+    listeners.forEach((cb) => cb({ ...state }));
+  }
+
+  function onChange(cb: ChangeHandler) {
+    listeners.push(cb);
+  }
+
+  function getState(): ControlPanelState {
+    return { ...state };
+  }
+
+  return { panel, getState, onChange };
+}

--- a/assets/js/utils/idle-detector.ts
+++ b/assets/js/utils/idle-detector.ts
@@ -1,0 +1,50 @@
+import { getAverageFrequency } from './audio-handler';
+
+export type IdleDetectorOptions = {
+  silenceThreshold?: number;
+  idleDelayMs?: number;
+  resumeDelayMs?: number;
+};
+
+export type IdleState = {
+  idle: boolean;
+  idleProgress: number;
+  averageLevel: number;
+};
+
+export function createIdleDetector({
+  silenceThreshold = 12,
+  idleDelayMs = 2200,
+  resumeDelayMs = 350,
+}: IdleDetectorOptions = {}) {
+  let lastActive = performance.now();
+  let smoothedLevel = 0;
+  let idle = false;
+
+  function update(
+    data: Uint8Array,
+    now: number = performance.now()
+  ): IdleState {
+    const average = getAverageFrequency(data);
+    smoothedLevel = smoothedLevel * 0.8 + average * 0.2;
+
+    const aboveThreshold = smoothedLevel > silenceThreshold;
+    if (aboveThreshold) {
+      lastActive = now;
+    }
+
+    const idleTarget = now - lastActive > idleDelayMs;
+    idle = idleTarget;
+
+    const idleElapsed = Math.max(0, now - (lastActive + idleDelayMs));
+    const idleProgress = Math.min(1, idleElapsed / resumeDelayMs);
+
+    return {
+      idle,
+      idleProgress,
+      averageLevel: smoothedLevel,
+    };
+  }
+
+  return { update };
+}


### PR DESCRIPTION
## Summary
- add reusable idle detector and control panel to manage idle visuals, palette drift, and mobile presets
- integrate idle-aware gradients, camera drift, and eased wobble/palette behavior into the 3D toy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437a52e9048332a4453ec83573d36f)