### PR TITLE
Add peak-driven sparkle and burst controls

### DIFF
--- a/assets/js/utils/fun-controls.ts
+++ b/assets/js/utils/fun-controls.ts
@@ -1,0 +1,128 @@
+const STYLE_ID = 'fun-controls-style';
+
+function ensureStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .fun-controls {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      padding: 12px;
+      background: rgba(0, 0, 0, 0.6);
+      color: #f2f2f2;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      z-index: 1000;
+      min-width: 180px;
+      backdrop-filter: blur(6px);
+    }
+    .fun-controls h3 {
+      margin: 0 0 8px 0;
+      font-size: 14px;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+    .fun-controls label {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 6px 0;
+      font-size: 13px;
+      gap: 8px;
+    }
+    .fun-controls input[type='checkbox'] {
+      accent-color: #7cf0ff;
+      width: 16px;
+      height: 16px;
+    }
+    .fun-controls input[type='range'] {
+      flex: 1;
+      accent-color: #7cf0ff;
+    }
+    .fun-controls .control-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export class FunControls {
+  private readonly container: HTMLDivElement;
+
+  constructor(title = 'Fun Controls') {
+    ensureStyles();
+    this.container = document.createElement('div');
+    this.container.className = 'fun-controls';
+
+    const heading = document.createElement('h3');
+    heading.textContent = title;
+    this.container.appendChild(heading);
+
+    document.body.appendChild(this.container);
+  }
+
+  addToggle(
+    id: string,
+    label: string,
+    defaultValue: boolean,
+    onChange: (value: boolean) => void
+  ) {
+    const wrapper = document.createElement('label');
+    wrapper.htmlFor = id;
+    wrapper.textContent = label;
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.id = id;
+    input.checked = defaultValue;
+    input.addEventListener('change', () => onChange(input.checked));
+
+    wrapper.appendChild(input);
+    this.container.appendChild(wrapper);
+  }
+
+  addRange(
+    id: string,
+    label: string,
+    options: {
+      min: number;
+      max: number;
+      step: number;
+      defaultValue: number;
+      onChange: (value: number) => void;
+    }
+  ) {
+    const wrapper = document.createElement('label');
+    wrapper.htmlFor = id;
+    wrapper.textContent = label;
+
+    const row = document.createElement('div');
+    row.className = 'control-row';
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.id = id;
+    input.min = String(options.min);
+    input.max = String(options.max);
+    input.step = String(options.step);
+    input.value = String(options.defaultValue);
+
+    const valueLabel = document.createElement('span');
+    valueLabel.textContent = options.defaultValue.toFixed(2);
+
+    input.addEventListener('input', () => {
+      const val = Number(input.value);
+      valueLabel.textContent = val.toFixed(2);
+      options.onChange(val);
+    });
+
+    row.appendChild(input);
+    row.appendChild(valueLabel);
+    wrapper.appendChild(row);
+    this.container.appendChild(wrapper);
+  }
+}

--- a/assets/js/utils/peak-detector.ts
+++ b/assets/js/utils/peak-detector.ts
@@ -1,0 +1,64 @@
+export type PeakDetectorOptions = {
+  /**
+   * Multiplier applied to the smoothed signal to determine a transient peak.
+   */
+  sensitivity?: number;
+  /**
+   * Minimum time (ms) between peak callbacks.
+   */
+  cooldownMs?: number;
+  /**
+   * How quickly the smoothed baseline follows the incoming signal.
+   */
+  smoothing?: number;
+  onPeak?: (level: number) => void;
+};
+
+/**
+ * Lightweight peak detector for FFT data. Keeps a smoothed baseline of the
+ * signal and triggers a callback when the incoming level exceeds the baseline
+ * by the configured sensitivity factor. Cooldown prevents rapid re-triggers.
+ */
+export class PeakDetector {
+  private smoothed = 0;
+  private lastPeak = 0;
+  private sensitivity: number;
+  private readonly cooldownMs: number;
+  private readonly smoothing: number;
+  private readonly onPeak?: (level: number) => void;
+
+  constructor(options: PeakDetectorOptions = {}) {
+    const {
+      sensitivity = 1.4,
+      cooldownMs = 180,
+      smoothing = 0.1,
+      onPeak,
+    } = options;
+    this.sensitivity = sensitivity;
+    this.cooldownMs = cooldownMs;
+    this.smoothing = smoothing;
+    this.onPeak = onPeak;
+  }
+
+  update(level: number, now: number = performance.now()): boolean {
+    if (Number.isNaN(level)) return false;
+    this.smoothed += (level - this.smoothed) * this.smoothing;
+    const threshold = this.smoothed * this.sensitivity;
+    if (level > threshold && now - this.lastPeak > this.cooldownMs) {
+      this.lastPeak = now;
+      this.onPeak?.(level);
+      return true;
+    }
+    return false;
+  }
+
+  setSensitivity(value: number) {
+    this.smoothed = 0;
+    this.lastPeak = 0;
+    this.sensitivity = value;
+  }
+}
+
+export function createPeakDetector(options: PeakDetectorOptions = {}) {
+  return new PeakDetector(options);
+}

--- a/assets/js/utils/sparkle-layer.ts
+++ b/assets/js/utils/sparkle-layer.ts
@@ -1,0 +1,81 @@
+interface Sparkle {
+  x: number;
+  y: number;
+  size: number;
+  life: number;
+  ttl: number;
+  hue: number;
+}
+
+export type SparkleLayerOptions = {
+  maxParticles?: number;
+  pixelRatio?: number;
+  throttleMs?: number;
+};
+
+export function createSparkleLayer(
+  host: HTMLElement,
+  options: SparkleLayerOptions = {}
+) {
+  const { maxParticles = 120, pixelRatio = window.devicePixelRatio || 1 } =
+    options;
+  const canvas = document.createElement('canvas');
+  canvas.style.position = 'fixed';
+  canvas.style.top = '0';
+  canvas.style.left = '0';
+  canvas.style.width = '100%';
+  canvas.style.height = '100%';
+  canvas.style.pointerEvents = 'none';
+  canvas.style.mixBlendMode = 'screen';
+  host.appendChild(canvas);
+  const ctx = canvas.getContext('2d');
+  const particles: Sparkle[] = new Array(maxParticles)
+    .fill(null)
+    .map(() => ({ x: 0, y: 0, size: 0, life: 0, ttl: 0, hue: 0 }));
+  let activeCount = 0;
+  let lastSpawn = 0;
+
+  function resize(width: number, height: number) {
+    canvas.width = width * pixelRatio;
+    canvas.height = height * pixelRatio;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+  }
+
+  function spawn(count = 6) {
+    const now = performance.now();
+    if (now - lastSpawn < 40) return;
+    lastSpawn = now;
+    for (let i = 0; i < count; i += 1) {
+      const target =
+        activeCount < maxParticles ? activeCount : i % maxParticles;
+      const p = particles[target];
+      p.x = Math.random() * canvas.width;
+      p.y = Math.random() * canvas.height;
+      p.size = (Math.random() * 2 + 1) * pixelRatio;
+      p.ttl = 400 + Math.random() * 400;
+      p.life = p.ttl;
+      p.hue = Math.random() * 360;
+      if (activeCount < maxParticles) {
+        activeCount += 1;
+      }
+    }
+  }
+
+  function update(deltaMs: number) {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let i = 0; i < activeCount; i += 1) {
+      const p = particles[i];
+      if (p.life <= 0) continue;
+      p.life -= deltaMs;
+      const alpha = Math.max(p.life / p.ttl, 0);
+      ctx.beginPath();
+      ctx.fillStyle = `hsla(${p.hue}, 80%, 65%, ${alpha})`;
+      ctx.arc(p.x, p.y, p.size * (0.5 + alpha), 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  return { canvas, resize, spawn, update };
+}

--- a/multi.html
+++ b/multi.html
@@ -25,8 +25,45 @@
         getContextFrequencyData,
       } from './assets/js/core/animation-loop.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
+      import { createPeakDetector } from './assets/js/utils/peak-detector.ts';
+      import { FunControls } from './assets/js/utils/fun-controls.ts';
+      import { createSparkleLayer } from './assets/js/utils/sparkle-layer.ts';
 
       const canvas = document.getElementById('webglCanvas');
+      const sparkleLayer = createSparkleLayer(document.body, {
+        pixelRatio: Math.min(window.devicePixelRatio, 2),
+      });
+
+      const controls = new FunControls('Effects');
+      const settings = { sparkles: true, bursts: true, sensitivity: 1.4 };
+      controls.addToggle(
+        'multi-sparkles',
+        'Sparkles',
+        settings.sparkles,
+        (v) => {
+          settings.sparkles = v;
+        }
+      );
+      controls.addToggle('multi-bursts', 'Bursts', settings.bursts, (v) => {
+        settings.bursts = v;
+      });
+      controls.addRange('multi-sensitivity', 'Peak Sensitivity', {
+        min: 1,
+        max: 2,
+        step: 0.02,
+        defaultValue: settings.sensitivity,
+        onChange: (v) => {
+          settings.sensitivity = v;
+          peakDetector.setSensitivity(v);
+        },
+      });
+
+      const peakDetector = createPeakDetector({
+        sensitivity: settings.sensitivity,
+        cooldownMs: 180,
+      });
+      let burstStrength = 0;
+      let lastFrame = performance.now();
 
       function displayError(message) {
         const el = document.getElementById('error-message');
@@ -118,34 +155,63 @@
         createRandomShape();
       }
 
+      function handlePeak(intensity) {
+        if (settings.sparkles) {
+          sparkleLayer.spawn(10);
+        }
+        if (settings.bursts) {
+          burstStrength = Math.min(1, burstStrength + intensity * 0.5);
+        }
+      }
+
       window.addEventListener('deviceorientation', (event) => {
         toy.camera.rotation.x = (event.beta / 180) * Math.PI;
         toy.camera.rotation.y = (event.gamma / 90) * Math.PI;
       });
 
       function animate(ctx) {
+        const now = performance.now();
+        const delta = now - lastFrame;
+        lastFrame = now;
         const dataArray = getContextFrequencyData(ctx);
         const avgFrequency = getAverageFrequency(dataArray);
+        const normalized = avgFrequency / 255;
+
+        if (peakDetector.update(normalized)) {
+          handlePeak(normalized);
+        }
 
         torusKnot.rotation.x += avgFrequency / 5000;
         torusKnot.rotation.y += avgFrequency / 5000;
 
-        pointLight.intensity = avgFrequency / 100;
+        pointLight.intensity = avgFrequency / 100 + burstStrength * 2;
 
         particles.rotation.y += 0.001 + avgFrequency / 100000;
 
         shapes.forEach((shape) => {
-          shape.rotation.x += 0.01;
-          shape.rotation.y += 0.01;
-          shape.position.z += 0.5;
+          const burstSpin = burstStrength * 0.05;
+          shape.rotation.x += 0.01 + burstSpin;
+          shape.rotation.y += 0.01 + burstSpin;
+          shape.position.z += 0.5 + burstStrength * 2;
 
           if (shape.position.z > 10) {
             shape.position.z = -500;
           }
         });
 
+        torusKnot.scale.setScalar(1 + burstStrength * 0.6);
+        torusKnot.material.emissiveIntensity = 0.5 + burstStrength;
+        burstStrength = Math.max(0, burstStrength * 0.92 - 0.002);
+
+        sparkleLayer.update(delta);
         ctx.toy.render();
       }
+
+      function resize() {
+        sparkleLayer.resize(window.innerWidth, window.innerHeight);
+      }
+      window.addEventListener('resize', resize);
+      resize();
 
       startAudioLoop(toy, animate).catch((err) => {
         console.error('The following error occurred: ' + err);

--- a/seary.html
+++ b/seary.html
@@ -33,6 +33,9 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { createPeakDetector } from './assets/js/utils/peak-detector.ts';
+      import { createSparkleLayer } from './assets/js/utils/sparkle-layer.ts';
+      import { FunControls } from './assets/js/utils/fun-controls.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
       function displayError(message) {
@@ -95,6 +98,7 @@
             uniform vec2 u_touch0;
             uniform vec2 u_touch1;
             uniform vec3 u_orientation;
+            uniform float u_burst;
             varying vec2 v_uv;
             
             float noise(vec2 p) {
@@ -129,6 +133,10 @@
 
                 // Blend low, mid, and high colors together for synesthetic experience
                 vec3 color = baseColor + lowColor + midColor + highColor;
+
+                // Burst glow overlay on peaks
+                color += vec3(u_burst * 0.35);
+                color *= 1.0 + u_burst * 0.5;
 
                 // Add ripple effects from multi-touch interactions
                 float touchEffect0 = 0.0;
@@ -198,6 +206,41 @@
         program,
         'u_orientation'
       );
+      const burstLocation = gl.getUniformLocation(program, 'u_burst');
+
+      const sparkleLayer = createSparkleLayer(document.body, {
+        pixelRatio: Math.min(window.devicePixelRatio, 2),
+      });
+      let lastFrame = performance.now();
+      let burst = 0;
+
+      const controls = new FunControls('Effects');
+      const settings = { sparkles: true, bursts: true, sensitivity: 1.35 };
+      controls.addToggle(
+        'seary-sparkles',
+        'Sparkles',
+        settings.sparkles,
+        (v) => {
+          settings.sparkles = v;
+        }
+      );
+      controls.addToggle('seary-bursts', 'Bursts', settings.bursts, (v) => {
+        settings.bursts = v;
+      });
+      const peakDetector = createPeakDetector({
+        sensitivity: settings.sensitivity,
+        cooldownMs: 200,
+      });
+      controls.addRange('seary-sensitivity', 'Peak Sensitivity', {
+        min: 1,
+        max: 2,
+        step: 0.02,
+        defaultValue: settings.sensitivity,
+        onChange: (v) => {
+          settings.sensitivity = v;
+          peakDetector.setSensitivity(v);
+        },
+      });
 
       // Audio setup for beat detection and frequency analysis
       let audioContext, analyser, source;
@@ -352,6 +395,16 @@
                 (bufferLength / 3) /
                 256.0;
 
+              const overall = (lowFreq + midFreq + highFreq) / 3;
+              if (peakDetector.update(overall)) {
+                if (settings.sparkles) {
+                  sparkleLayer.spawn(12);
+                }
+                if (settings.bursts) {
+                  burst = Math.min(1, burst + overall * 0.6);
+                }
+              }
+
               // Beat detection based on low frequency threshold
               if (lowFreq > 0.5) {
                 canvas.style.transform = 'scale(1.1)';
@@ -369,6 +422,7 @@
                 orientation.beta / 90.0,
                 orientation.gamma / 90.0
               );
+              gl.uniform1f(burstLocation, burst);
 
               gl.uniform2f(touch0Location, touches[0].x, touches[0].y);
               gl.uniform2f(touch1Location, touches[1].x, touches[1].y);
@@ -388,6 +442,9 @@
       // Render loop
       function render(time) {
         time *= 0.001; // Convert time to seconds
+        const now = performance.now();
+        const delta = now - lastFrame;
+        lastFrame = now;
 
         // Set uniforms
         gl.uniform1f(timeLocation, time);
@@ -397,9 +454,19 @@
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
+        sparkleLayer.update(delta);
+        burst = Math.max(0, burst * 0.94 - 0.001);
+        gl.uniform1f(burstLocation, burst);
+
         requestAnimationFrame(render);
       }
       requestAnimationFrame(render);
+
+      function resize() {
+        sparkleLayer.resize(window.innerWidth, window.innerHeight);
+      }
+      window.addEventListener('resize', resize);
+      resize();
     </script>
   </body>
 </html>

--- a/symph.html
+++ b/symph.html
@@ -35,6 +35,9 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { createPeakDetector } from './assets/js/utils/peak-detector.ts';
+      import { createSparkleLayer } from './assets/js/utils/sparkle-layer.ts';
+      import { FunControls } from './assets/js/utils/fun-controls.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
@@ -65,6 +68,7 @@
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+        sparkleLayer.resize(window.innerWidth, window.innerHeight);
       }
       window.addEventListener('resize', resizeCanvas);
       resizeCanvas();
@@ -83,6 +87,7 @@
             uniform float u_audioData;
             uniform vec3 u_colorOffset;
             uniform vec2 u_touch;
+            uniform float u_burst;
             
             vec3 dreamyGradient(vec2 uv, float timeOffset) {
                 vec3 color = vec3(0.4 + 0.4 * sin(uv.x * 10.0 + u_audioData * 6.0 + timeOffset),
@@ -100,12 +105,14 @@
                 float ripple = sin(dist * 15.0 - u_time * 3.0) * 0.15;
                 float bloom = 0.3 / (dist * dist + 0.25);
                 uv += ripple;
-                
+
                 vec3 color = dreamyGradient(uv, u_time * 0.6) * u_audioData;
-                color += vec3(0.4 + 0.4 * sin(u_time * 0.4 + u_audioData * 2.0), 
-                              0.4 + 0.4 * cos(u_time * 0.5 + u_audioData * 3.0), 
+                color += vec3(0.4 + 0.4 * sin(u_time * 0.4 + u_audioData * 2.0),
+                              0.4 + 0.4 * cos(u_time * 0.5 + u_audioData * 3.0),
                               0.5 + 0.4 * sin(u_time * 0.6 + u_audioData * 1.5));
-                color += bloom * 0.6;
+                color += bloom * (0.6 + u_burst * 0.8);
+                color += vec3(u_burst * 0.35);
+                color *= 1.0 + u_burst * 0.45;
                 
                 gl_FragColor = vec4(color, 1.0);
             }
@@ -185,8 +192,42 @@
         'u_colorOffset'
       );
       const touchUniformLocation = gl.getUniformLocation(program, 'u_touch');
+      const burstUniformLocation = gl.getUniformLocation(program, 'u_burst');
 
       gl.uniform2f(resolutionUniformLocation, canvas.width, canvas.height);
+
+      const sparkleLayer = createSparkleLayer(document.body, {
+        pixelRatio: Math.min(window.devicePixelRatio, 2),
+      });
+      const controls = new FunControls('Effects');
+      const settings = { sparkles: true, bursts: true, sensitivity: 1.4 };
+      controls.addToggle(
+        'symph-sparkles',
+        'Sparkles',
+        settings.sparkles,
+        (v) => {
+          settings.sparkles = v;
+        }
+      );
+      controls.addToggle('symph-bursts', 'Bursts', settings.bursts, (v) => {
+        settings.bursts = v;
+      });
+      const peakDetector = createPeakDetector({
+        sensitivity: settings.sensitivity,
+        cooldownMs: 200,
+      });
+      controls.addRange('symph-sensitivity', 'Peak Sensitivity', {
+        min: 1,
+        max: 2,
+        step: 0.02,
+        defaultValue: settings.sensitivity,
+        onChange: (v) => {
+          settings.sensitivity = v;
+          peakDetector.setSensitivity(v);
+        },
+      });
+      let burst = 0;
+      let lastFrame = performance.now();
 
       let time = 0.0;
       let audioData = 0.0;
@@ -215,6 +256,15 @@
           const average =
             dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
           audioData = average / 128.0;
+          const normalizedLevel = Math.min(audioData, 2);
+          if (peakDetector.update(normalizedLevel)) {
+            if (settings.sparkles) {
+              sparkleLayer.spawn(10);
+            }
+            if (settings.bursts) {
+              burst = Math.min(1, burst + normalizedLevel * 0.4);
+            }
+          }
           updateSpectrograph(dataArray);
         }
       }
@@ -245,14 +295,21 @@
       setupAudio();
 
       function render() {
+        const now = performance.now();
+        const delta = now - lastFrame;
+        lastFrame = now;
         time += 0.02;
+        burst = Math.max(0, burst * 0.94 - 0.001);
         gl.uniform1f(timeUniformLocation, time);
         gl.uniform1f(audioDataUniformLocation, audioData);
         gl.uniform3fv(colorOffsetUniformLocation, colorOffset);
         gl.uniform2fv(touchUniformLocation, touchPoint);
+        gl.uniform1f(burstUniformLocation, burst);
 
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+        sparkleLayer.update(delta);
 
         requestAnimationFrame(render);
       }


### PR DESCRIPTION
## Summary
- add reusable peak detector, sparkle layer, and fun controls helpers
- trigger sparkles and burst reactions on peak events in multi, seary, and symph visualizers
- expose toggles and sensitivity sliders so users can tune the new effects

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437a4c9990833280703a2e9d56d834)