### PR TITLE
Add reusable fun controls module and adapters

### DIFF
--- a/assets/brand/fun-adapter.ts
+++ b/assets/brand/fun-adapter.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+import type { MotionMode, PaletteName } from '../ui/fun-controls';
+import { FUN_PALETTES } from '../ui/fun-controls';
+
+interface InstanceData {
+  x: number;
+  z: number;
+  scale: number;
+  type: string;
+}
+
+interface BrandAdapterConfig {
+  buildingMesh: THREE.InstancedMesh;
+  buildingData: InstanceData[];
+  treeMesh: THREE.InstancedMesh;
+  poleMesh: THREE.InstancedMesh;
+  ground: THREE.Mesh;
+}
+
+export function createBrandAdapter(config: BrandAdapterConfig) {
+  let motionIntensity = 0.6;
+  let motionMode: MotionMode = 'calm';
+  let audioReactive = true;
+
+  function paletteColors(name: PaletteName) {
+    return FUN_PALETTES[name].map((value) => new THREE.Color(value));
+  }
+
+  function applyPalette(name: PaletteName) {
+    const colors = paletteColors(name);
+    config.buildingData.forEach((_, index) => {
+      const color = colors[index % colors.length];
+      config.buildingMesh.instanceColor?.setXYZ(
+        index,
+        color.r,
+        color.g,
+        color.b
+      );
+    });
+    if (config.buildingMesh.instanceColor) {
+      config.buildingMesh.instanceColor.needsUpdate = true;
+    }
+
+    const poleMaterial = config.poleMesh.material as THREE.MeshLambertMaterial;
+    poleMaterial.color.copy(colors[1 % colors.length]);
+
+    const groundMaterial = config.ground.material as THREE.MeshLambertMaterial;
+    groundMaterial.color.copy(colors[2 % colors.length]);
+
+    const treeMaterial = config.treeMesh.material as THREE.MeshLambertMaterial;
+    treeMaterial.color.copy(colors[3 % colors.length]);
+  }
+
+  function setMotion(intensity: number, mode: MotionMode) {
+    motionIntensity = intensity;
+    motionMode = mode;
+  }
+
+  function setAudioReactive(enabled: boolean) {
+    audioReactive = enabled;
+  }
+
+  function getSpeedMultiplier(bass: number) {
+    const base = 0.6 + motionIntensity * 1.2;
+    const modeBoost = motionMode === 'party' ? 1.5 : 0.85;
+    const reactiveBoost = audioReactive ? 0.7 + bass / 90 : 1;
+    return base * modeBoost * reactiveBoost;
+  }
+
+  return { applyPalette, setMotion, setAudioReactive, getSpeedMultiplier };
+}

--- a/assets/multi/fun-adapter.ts
+++ b/assets/multi/fun-adapter.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+import type { MotionMode, PaletteName } from '../ui/fun-controls';
+import { FUN_PALETTES } from '../ui/fun-controls';
+
+interface MultiAdapterConfig {
+  torusMaterial: THREE.MeshStandardMaterial;
+  particlesMaterial: THREE.PointsMaterial;
+  shapes: THREE.Mesh[];
+  pointLight: THREE.PointLight;
+}
+
+export function createMultiAdapter(config: MultiAdapterConfig) {
+  let motionIntensity = 0.6;
+  let motionMode: MotionMode = 'calm';
+  let audioReactive = true;
+
+  function applyPalette(name: PaletteName) {
+    const colors = FUN_PALETTES[name];
+    config.torusMaterial.color = new THREE.Color(colors[0]);
+    config.torusMaterial.emissive = new THREE.Color(colors[1]);
+    config.particlesMaterial.color = new THREE.Color(colors[2]);
+    config.shapes.forEach((shape, index) => {
+      const mat = shape.material as THREE.MeshStandardMaterial;
+      mat.color = new THREE.Color(colors[(index + 3) % colors.length]);
+      mat.emissive = new THREE.Color(colors[(index + 1) % colors.length]);
+    });
+  }
+
+  function setMotion(intensity: number, mode: MotionMode) {
+    motionIntensity = intensity;
+    motionMode = mode;
+  }
+
+  function setAudioReactive(enabled: boolean) {
+    audioReactive = enabled;
+  }
+
+  function getMotionValues(avgFrequency: number) {
+    const baseRotation = 0.0025 + motionIntensity * 0.01;
+    const modeBoost = motionMode === 'party' ? 1.6 : 0.9;
+    const reactive = audioReactive
+      ? avgFrequency / 5000
+      : 0.01 * motionIntensity;
+    const lightBoost = audioReactive
+      ? Math.max(0.6, avgFrequency / 80)
+      : 0.8 + motionIntensity * 0.8;
+    return {
+      rotationStep: (baseRotation + reactive) * modeBoost,
+      particleSpin: 0.0008 + motionIntensity * 0.003,
+      shapeAdvance: 0.4 + motionIntensity * 1.2,
+      lightIntensity: lightBoost * modeBoost,
+    };
+  }
+
+  return { applyPalette, setMotion, setAudioReactive, getMotionValues };
+}

--- a/assets/seary/fun-adapter.ts
+++ b/assets/seary/fun-adapter.ts
@@ -1,0 +1,74 @@
+import {
+  FUN_PALETTES,
+  type MotionMode,
+  type PaletteName,
+} from '../ui/fun-controls';
+
+interface SearyUniforms {
+  paletteTint: WebGLUniformLocation | null;
+  motionScale: WebGLUniformLocation | null;
+  audioMix: WebGLUniformLocation | null;
+}
+
+function hexToVec3(hex: string): [number, number, number] {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = ((num >> 16) & 255) / 255;
+  const g = ((num >> 8) & 255) / 255;
+  const b = (num & 255) / 255;
+  return [r, g, b];
+}
+
+export function createSearyAdapter(
+  gl: WebGLRenderingContext,
+  uniforms: SearyUniforms
+) {
+  let motionIntensity = 0.6;
+  let motionMode: MotionMode = 'calm';
+  let audioReactive = true;
+
+  function currentMotionScale() {
+    const base = 0.8 + motionIntensity * 1.2;
+    return motionMode === 'party' ? base * 1.4 : base;
+  }
+
+  function applyPalette(name: PaletteName) {
+    const tint = hexToVec3(FUN_PALETTES[name][0]);
+    if (uniforms.paletteTint) {
+      gl.uniform3f(uniforms.paletteTint, tint[0], tint[1], tint[2]);
+    }
+  }
+
+  function setMotion(intensity: number, mode: MotionMode) {
+    motionIntensity = intensity;
+    motionMode = mode;
+    const scale = currentMotionScale();
+    if (uniforms.motionScale) {
+      gl.uniform1f(uniforms.motionScale, scale);
+    }
+  }
+
+  function setAudioReactive(enabled: boolean) {
+    audioReactive = enabled;
+    if (uniforms.audioMix) {
+      gl.uniform1f(uniforms.audioMix, enabled ? 1 : 0);
+    }
+  }
+
+  function scaleFrequencies(low: number, mid: number, high: number) {
+    const scale = currentMotionScale();
+    if (!audioReactive) {
+      return {
+        low: 0.25 * scale,
+        mid: 0.2 * scale,
+        high: 0.18 * scale,
+      };
+    }
+    return {
+      low: low * scale,
+      mid: mid * scale,
+      high: high * scale,
+    };
+  }
+
+  return { applyPalette, setMotion, setAudioReactive, scaleFrequencies };
+}

--- a/assets/symph/fun-adapter.ts
+++ b/assets/symph/fun-adapter.ts
@@ -1,0 +1,64 @@
+import {
+  FUN_PALETTES,
+  type MotionMode,
+  type PaletteName,
+} from '../ui/fun-controls';
+
+interface SymphAdapterConfig {
+  gl: WebGLRenderingContext;
+  colorOffsetLocation: WebGLUniformLocation | null;
+}
+
+function hexToVec3(hex: string): [number, number, number] {
+  const num = parseInt(hex.replace('#', ''), 16);
+  return [
+    ((num >> 16) & 255) / 255,
+    ((num >> 8) & 255) / 255,
+    (num & 255) / 255,
+  ];
+}
+
+export function createSymphAdapter(config: SymphAdapterConfig) {
+  let motionIntensity = 0.6;
+  let motionMode: MotionMode = 'calm';
+  let audioReactive = true;
+  let palette: PaletteName = 'bright';
+
+  function applyPalette(name: PaletteName) {
+    palette = name;
+    const tint = hexToVec3(FUN_PALETTES[name][2]);
+    if (config.colorOffsetLocation) {
+      config.gl.uniform3fv(config.colorOffsetLocation, tint);
+    }
+  }
+
+  function setMotion(intensity: number, mode: MotionMode) {
+    motionIntensity = intensity;
+    motionMode = mode;
+  }
+
+  function setAudioReactive(enabled: boolean) {
+    audioReactive = enabled;
+  }
+
+  function transformAudioData(raw: number) {
+    const base = 0.55 + motionIntensity * 0.9;
+    const modeBoost = motionMode === 'party' ? 1.5 : 1;
+    if (!audioReactive) {
+      return base * modeBoost * 0.8;
+    }
+    return raw * base * modeBoost;
+  }
+
+  function getPaletteName() {
+    return palette;
+  }
+
+  return {
+    applyPalette,
+    setMotion,
+    setAudioReactive,
+    transformAudioData,
+    getPaletteName,
+  };
+}

--- a/assets/ui/fun-controls.ts
+++ b/assets/ui/fun-controls.ts
@@ -1,0 +1,311 @@
+export type PaletteName = 'bright' | 'pastel' | 'neon';
+export type MotionMode = 'calm' | 'party';
+
+export interface FunControlState {
+  palette: PaletteName;
+  motion: number; // 0 - 1
+  mode: MotionMode;
+  audioReactive: boolean;
+}
+
+export interface FunControlOptions {
+  container?: HTMLElement;
+  initialState?: Partial<FunControlState>;
+  audioAvailable?: boolean;
+  onPaletteChange?: (palette: PaletteName) => void;
+  onMotionChange?: (intensity: number, mode: MotionMode) => void;
+  onAudioReactiveChange?: (enabled: boolean) => void;
+}
+
+export interface FunControlHandles {
+  root: HTMLElement;
+  state: FunControlState;
+  setAudioAvailable: (available: boolean) => void;
+  setState: (next: Partial<FunControlState>) => void;
+}
+
+export const FUN_PALETTES: Record<PaletteName, string[]> = {
+  bright: ['#ff6b6b', '#ffd166', '#4ecdc4', '#5c7cfa', '#f06595'],
+  pastel: ['#ffd1dc', '#c3f0ca', '#cce7ff', '#ffe6a7', '#d7bde2'],
+  neon: ['#39ff14', '#ff0099', '#00e5ff', '#f6ff00', '#ff6ec7'],
+};
+
+function injectStyles() {
+  const styleId = 'fun-controls-styles';
+  if (document.getElementById(styleId)) return;
+
+  const style = document.createElement('style');
+  style.id = styleId;
+  style.textContent = `
+      .fun-controls-panel {
+        position: fixed;
+        right: 1rem;
+        bottom: 1rem;
+        z-index: 30;
+        background: rgba(8, 8, 12, 0.88);
+        color: #f5f5f5;
+        padding: 0.9rem;
+        border-radius: 12px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
+        max-width: 320px;
+        font-family: 'Inter', system-ui, -apple-system, sans-serif;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+      .fun-controls-panel h3 {
+        margin: 0 0 0.5rem;
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+      }
+      .fun-controls-panel .fun-row {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 0.35rem;
+        margin-bottom: 0.65rem;
+      }
+      .fun-controls-panel label {
+        font-size: 0.85rem;
+        color: #d6d6d6;
+      }
+      .fun-controls-panel select,
+      .fun-controls-panel input[type='range'],
+      .fun-controls-panel button,
+      .fun-controls-panel input[type='checkbox'] {
+        width: 100%;
+      }
+      .fun-controls-panel select,
+      .fun-controls-panel input[type='range'],
+      .fun-controls-panel button {
+        background: rgba(255, 255, 255, 0.06);
+        color: #f5f5f5;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 10px;
+        padding: 0.5rem 0.6rem;
+        font-size: 0.9rem;
+        transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+      }
+      .fun-controls-panel select:focus,
+      .fun-controls-panel input[type='range']:focus,
+      .fun-controls-panel button:focus,
+      .fun-controls-panel input[type='checkbox']:focus-visible {
+        outline: 2px solid #7ad7f0;
+        outline-offset: 2px;
+      }
+      .fun-controls-panel button:hover {
+        background: rgba(255, 255, 255, 0.12);
+        transform: translateY(-1px);
+      }
+      .fun-controls-panel .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+      }
+      .fun-controls-panel .toggle-row label {
+        margin: 0;
+      }
+      .fun-controls-panel .mode-button {
+        text-transform: capitalize;
+      }
+      .fun-controls-panel .audio-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+      .fun-controls-panel .hint {
+        font-size: 0.78rem;
+        color: #a8b2c1;
+        margin: 0.1rem 0 0;
+      }
+      @media (max-width: 720px) {
+        .fun-controls-panel {
+          left: 0.5rem;
+          right: 0.5rem;
+          bottom: 0.5rem;
+          max-width: none;
+        }
+      }
+    `;
+
+  document.head.append(style);
+}
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function initFunControls(
+  options: FunControlOptions = {}
+): FunControlHandles {
+  if (typeof document === 'undefined') {
+    throw new Error('fun-controls requires a DOM to render controls.');
+  }
+
+  injectStyles();
+
+  const container = options.container ?? document.body;
+  const state: FunControlState = {
+    palette: options.initialState?.palette ?? 'bright',
+    motion: clamp01(options.initialState?.motion ?? 0.6),
+    mode: options.initialState?.mode ?? 'calm',
+    audioReactive: options.initialState?.audioReactive ?? true,
+  };
+
+  const panel = document.createElement('section');
+  panel.className = 'fun-controls-panel';
+  panel.setAttribute('aria-label', 'Visualizer controls');
+
+  const title = document.createElement('h3');
+  title.textContent = 'Fun Controls';
+  panel.append(title);
+
+  const paletteRow = document.createElement('div');
+  paletteRow.className = 'fun-row';
+  const paletteLabel = document.createElement('label');
+  paletteLabel.textContent = 'Color palette';
+  paletteLabel.htmlFor = 'fun-palette-select';
+  const paletteSelect = document.createElement('select');
+  paletteSelect.id = 'fun-palette-select';
+  paletteSelect.name = 'fun-palette-select';
+  (['bright', 'pastel', 'neon'] as PaletteName[]).forEach((key) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = key.charAt(0).toUpperCase() + key.slice(1);
+    paletteSelect.append(option);
+  });
+  paletteSelect.value = state.palette;
+  paletteRow.append(paletteLabel, paletteSelect);
+  panel.append(paletteRow);
+
+  const motionRow = document.createElement('div');
+  motionRow.className = 'fun-row';
+  const motionLabel = document.createElement('label');
+  motionLabel.textContent = 'Motion intensity';
+  motionLabel.htmlFor = 'fun-motion-range';
+  const motionRange = document.createElement('input');
+  motionRange.type = 'range';
+  motionRange.id = 'fun-motion-range';
+  motionRange.min = '0';
+  motionRange.max = '100';
+  motionRange.value = String(Math.round(state.motion * 100));
+  motionRange.step = '1';
+  const motionHint = document.createElement('p');
+  motionHint.className = 'hint';
+  const calmPartyButton = document.createElement('button');
+  calmPartyButton.type = 'button';
+  calmPartyButton.className = 'mode-button';
+  calmPartyButton.ariaPressed = String(state.mode === 'party');
+  calmPartyButton.textContent = state.mode === 'party' ? 'Party' : 'Calm';
+
+  motionRow.append(motionLabel, motionRange, calmPartyButton, motionHint);
+  panel.append(motionRow);
+
+  const audioRow = document.createElement('div');
+  audioRow.className = 'toggle-row';
+  const audioLabel = document.createElement('label');
+  audioLabel.textContent = 'Audio-reactive';
+  audioLabel.htmlFor = 'fun-audio-toggle';
+  const audioToggleWrapper = document.createElement('div');
+  audioToggleWrapper.className = 'audio-toggle';
+  const audioToggle = document.createElement('input');
+  audioToggle.type = 'checkbox';
+  audioToggle.id = 'fun-audio-toggle';
+  audioToggle.checked = state.audioReactive;
+  const audioStatus = document.createElement('span');
+  audioStatus.textContent = state.audioReactive ? 'Enabled' : 'Disabled';
+  audioToggleWrapper.append(audioToggle, audioStatus);
+  audioRow.append(audioLabel, audioToggleWrapper);
+  panel.append(audioRow);
+
+  function updateMotionHint() {
+    const level = Math.round(state.motion * 100);
+    const modeLabel = state.mode === 'party' ? 'party' : 'calm';
+    motionHint.textContent = `${modeLabel} · ${level}% intensity`;
+  }
+
+  function emitPalette() {
+    options.onPaletteChange?.(state.palette);
+  }
+  function emitMotion() {
+    options.onMotionChange?.(state.motion, state.mode);
+    updateMotionHint();
+  }
+  function emitAudio() {
+    options.onAudioReactiveChange?.(state.audioReactive);
+    audioStatus.textContent = state.audioReactive ? 'Enabled' : 'Disabled';
+  }
+
+  paletteSelect.addEventListener('change', () => {
+    state.palette = paletteSelect.value as PaletteName;
+    emitPalette();
+  });
+
+  motionRange.addEventListener('input', () => {
+    state.motion = clamp01(Number(motionRange.value) / 100);
+    emitMotion();
+  });
+
+  calmPartyButton.addEventListener('click', () => {
+    state.mode = state.mode === 'party' ? 'calm' : 'party';
+    calmPartyButton.textContent = state.mode === 'party' ? 'Party' : 'Calm';
+    calmPartyButton.ariaPressed = String(state.mode === 'party');
+    emitMotion();
+  });
+
+  audioToggle.addEventListener('change', () => {
+    state.audioReactive = audioToggle.checked;
+    emitAudio();
+  });
+
+  updateMotionHint();
+  emitPalette();
+  emitMotion();
+  emitAudio();
+
+  container.append(panel);
+
+  function setAudioAvailable(available: boolean) {
+    audioToggle.disabled = !available;
+    audioStatus.textContent = available
+      ? state.audioReactive
+        ? 'Enabled'
+        : 'Disabled'
+      : 'Unavailable';
+    if (!available) {
+      audioToggle.checked = false;
+      state.audioReactive = false;
+      options.onAudioReactiveChange?.(false);
+    }
+  }
+
+  function setState(next: Partial<FunControlState>) {
+    if (next.palette) {
+      state.palette = next.palette;
+      paletteSelect.value = state.palette;
+      emitPalette();
+    }
+    if (typeof next.motion === 'number') {
+      state.motion = clamp01(next.motion);
+      motionRange.value = String(Math.round(state.motion * 100));
+      emitMotion();
+    }
+    if (next.mode) {
+      state.mode = next.mode;
+      calmPartyButton.textContent = state.mode === 'party' ? 'Party' : 'Calm';
+      calmPartyButton.ariaPressed = String(state.mode === 'party');
+      emitMotion();
+    }
+    if (typeof next.audioReactive === 'boolean') {
+      state.audioReactive = next.audioReactive;
+      audioToggle.checked = state.audioReactive;
+      emitAudio();
+    }
+  }
+
+  if (options.audioAvailable === false) {
+    setAudioAvailable(false);
+  }
+
+  return { root: panel, state, setAudioAvailable, setState };
+}

--- a/brand.html
+++ b/brand.html
@@ -17,6 +17,8 @@
         startAudioLoop,
         getContextFrequencyData,
       } from './assets/js/core/animation-loop.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createBrandAdapter } from './assets/brand/fun-adapter.ts';
 
       const canvas = document.getElementById('vizCanvas');
 
@@ -156,6 +158,21 @@
       poleMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       toy.scene.add(poleMesh);
 
+      const brandAdapter = createBrandAdapter({
+        buildingMesh,
+        buildingData,
+        treeMesh,
+        poleMesh,
+        ground,
+      });
+
+      const funControls = initFunControls({
+        onPaletteChange: brandAdapter.applyPalette,
+        onMotionChange: brandAdapter.setMotion,
+        onAudioReactiveChange: brandAdapter.setAudioReactive,
+      });
+      brandAdapter.applyPalette(funControls.state.palette);
+
       const dummy = new THREE.Object3D();
       buildingData.forEach((d, i) => {
         dummy.position.set(d.x, 0, d.z);
@@ -185,12 +202,15 @@
 
       function animate(ctx) {
         const dataArray = getContextFrequencyData(ctx);
-        const bassBand = dataArray.slice(0, Math.max(1, Math.min(10, dataArray.length)));
+        const bassBand = dataArray.slice(
+          0,
+          Math.max(1, Math.min(10, dataArray.length))
+        );
         const bass = bassBand.length
           ? bassBand.reduce((a, b) => a + b, 0) / bassBand.length
           : 0;
 
-        const speed = 0.5 + bass / 100;
+        const speed = brandAdapter.getSpeedMultiplier(bass);
         buildingData.forEach((d, i) => {
           d.z += speed;
           if (d.z > 5) {
@@ -232,14 +252,16 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate, { positional: true, object: toy.camera }).catch(
-        (err) => {
-          console.error('Audio input error: ', err);
-          displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
-          );
-        }
-      );
+      startAudioLoop(toy, animate, {
+        positional: true,
+        object: toy.camera,
+      }).catch((err) => {
+        console.error('Audio input error: ', err);
+        funControls.setAudioAvailable(false);
+        displayError(
+          'Microphone access is required for the visualization to work. Please allow microphone access.'
+        );
+      });
     </script>
   </body>
 </html>

--- a/multi.html
+++ b/multi.html
@@ -25,6 +25,8 @@
         getContextFrequencyData,
       } from './assets/js/core/animation-loop.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createMultiAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
 
@@ -118,6 +120,20 @@
         createRandomShape();
       }
 
+      const multiAdapter = createMultiAdapter({
+        torusMaterial: torusKnot.material as THREE.MeshStandardMaterial,
+        particlesMaterial: particles.material as THREE.PointsMaterial,
+        shapes,
+        pointLight,
+      });
+
+      const funControls = initFunControls({
+        onPaletteChange: multiAdapter.applyPalette,
+        onMotionChange: multiAdapter.setMotion,
+        onAudioReactiveChange: multiAdapter.setAudioReactive,
+      });
+      multiAdapter.applyPalette(funControls.state.palette);
+
       window.addEventListener('deviceorientation', (event) => {
         toy.camera.rotation.x = (event.beta / 180) * Math.PI;
         toy.camera.rotation.y = (event.gamma / 90) * Math.PI;
@@ -126,18 +142,19 @@
       function animate(ctx) {
         const dataArray = getContextFrequencyData(ctx);
         const avgFrequency = getAverageFrequency(dataArray);
+        const motionValues = multiAdapter.getMotionValues(avgFrequency);
 
-        torusKnot.rotation.x += avgFrequency / 5000;
-        torusKnot.rotation.y += avgFrequency / 5000;
+        torusKnot.rotation.x += motionValues.rotationStep;
+        torusKnot.rotation.y += motionValues.rotationStep;
 
-        pointLight.intensity = avgFrequency / 100;
+        pointLight.intensity = motionValues.lightIntensity;
 
-        particles.rotation.y += 0.001 + avgFrequency / 100000;
+        particles.rotation.y += motionValues.particleSpin;
 
         shapes.forEach((shape) => {
           shape.rotation.x += 0.01;
           shape.rotation.y += 0.01;
-          shape.position.z += 0.5;
+          shape.position.z += motionValues.shapeAdvance;
 
           if (shape.position.z > 10) {
             shape.position.z = -500;
@@ -149,6 +166,7 @@
 
       startAudioLoop(toy, animate).catch((err) => {
         console.error('The following error occurred: ' + err);
+        funControls.setAudioAvailable(false);
         displayError(
           'Microphone access is required for the visualization to work. Please allow microphone access.'
         );

--- a/seary.html
+++ b/seary.html
@@ -33,6 +33,8 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createSearyAdapter } from './assets/seary/fun-adapter.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
       function displayError(message) {
@@ -95,6 +97,9 @@
             uniform vec2 u_touch0;
             uniform vec2 u_touch1;
             uniform vec3 u_orientation;
+            uniform vec3 u_paletteTint;
+            uniform float u_motionScale;
+            uniform float u_audioMix;
             varying vec2 v_uv;
             
             float noise(vec2 p) {
@@ -112,23 +117,24 @@
                     0.5 + 0.5 * cos(u_time + angle * 2.0 + u_mid_freq * 3.0),
                     0.5 + 0.5 * sin(u_time * 0.5 + angle * 3.0 + u_high_freq * 7.0)
                 );
+                baseColor = mix(baseColor, baseColor * u_paletteTint, 0.45);
 
                 // Low frequency pulsing waves
-                float lowWave = 0.5 + 0.5 * sin(15.0 * dist - u_time + angle * 3.0) * (u_low_freq + 0.3);
+                float lowWave = 0.5 + 0.5 * sin(15.0 * dist - u_time + angle * 3.0) * (u_low_freq + 0.3) * u_motionScale;
                 vec3 lowColor = vec3(lowWave * 0.5, lowWave * 0.3, lowWave);
 
                 // Mid frequency oscillations with noise distortion
-                float midOscillation = 0.5 + 0.5 * cos(20.0 * dist - u_time * 1.5 + angle * 4.0) * (u_mid_freq + 0.4);
-                midOscillation += noise(uv * 10.0) * 0.2 * u_mid_freq;
+                float midOscillation = 0.5 + 0.5 * cos(20.0 * dist - u_time * 1.5 + angle * 4.0) * (u_mid_freq + 0.4) * u_motionScale;
+                midOscillation += noise(uv * 10.0) * 0.2 * u_mid_freq * u_motionScale;
                 vec3 midColor = vec3(midOscillation * 0.3, midOscillation, midOscillation * 0.6);
 
                 // High frequency sparks with strobe effect
                 float highSpark = 0.5 + 0.5 * sin(25.0 * dist - u_time * 2.0 + angle * 6.0) * (u_high_freq + 0.5);
-                highSpark += step(0.9, fract(sin(u_time * 10.0) * 43758.5453)) * 0.3 * u_high_freq;
+                highSpark += step(0.9, fract(sin(u_time * 10.0) * 43758.5453)) * 0.3 * u_high_freq * u_motionScale;
                 vec3 highColor = vec3(highSpark, highSpark * 0.5, highSpark * 0.2);
 
                 // Blend low, mid, and high colors together for synesthetic experience
-                vec3 color = baseColor + lowColor + midColor + highColor;
+                vec3 color = (baseColor + lowColor + midColor + highColor) * mix(0.5 + 0.35 * u_motionScale, 1.0, u_audioMix);
 
                 // Add ripple effects from multi-touch interactions
                 float touchEffect0 = 0.0;
@@ -198,6 +204,29 @@
         program,
         'u_orientation'
       );
+      const paletteTintLocation = gl.getUniformLocation(
+        program,
+        'u_paletteTint'
+      );
+      const motionScaleLocation = gl.getUniformLocation(
+        program,
+        'u_motionScale'
+      );
+      const audioMixLocation = gl.getUniformLocation(program, 'u_audioMix');
+
+      const searyAdapter = createSearyAdapter(gl, {
+        paletteTint: paletteTintLocation,
+        motionScale: motionScaleLocation,
+        audioMix: audioMixLocation,
+      });
+      const funControls = initFunControls({
+        onPaletteChange: searyAdapter.applyPalette,
+        onMotionChange: searyAdapter.setMotion,
+        onAudioReactiveChange: searyAdapter.setAudioReactive,
+      });
+      searyAdapter.applyPalette(funControls.state.palette);
+      searyAdapter.setMotion(funControls.state.motion, funControls.state.mode);
+      searyAdapter.setAudioReactive(funControls.state.audioReactive);
 
       // Audio setup for beat detection and frequency analysis
       let audioContext, analyser, source;
@@ -227,6 +256,7 @@
                 })
                 .catch((err) => {
                   console.error('Error capturing audio: ', err);
+                  funControls.setAudioAvailable(false);
                   displayError(
                     'Microphone access is required for the visualization to work. Please allow microphone access.'
                   );
@@ -352,17 +382,23 @@
                 (bufferLength / 3) /
                 256.0;
 
+              const scaledFrequencies = searyAdapter.scaleFrequencies(
+                lowFreq,
+                midFreq,
+                highFreq
+              );
+
               // Beat detection based on low frequency threshold
-              if (lowFreq > 0.5) {
+              if (scaledFrequencies.low > 0.5) {
                 canvas.style.transform = 'scale(1.1)';
                 setTimeout(() => {
                   canvas.style.transform = 'scale(1)';
                 }, 100);
               }
 
-              gl.uniform1f(lowFreqLocation, lowFreq);
-              gl.uniform1f(midFreqLocation, midFreq);
-              gl.uniform1f(highFreqLocation, highFreq);
+              gl.uniform1f(lowFreqLocation, scaledFrequencies.low);
+              gl.uniform1f(midFreqLocation, scaledFrequencies.mid);
+              gl.uniform1f(highFreqLocation, scaledFrequencies.high);
               gl.uniform3f(
                 orientationLocation,
                 orientation.alpha / 360.0,
@@ -373,8 +409,17 @@
               gl.uniform2f(touch0Location, touches[0].x, touches[0].y);
               gl.uniform2f(touch1Location, touches[1].x, touches[1].y);
 
-              vibrateBasedOnAudio(lowFreq, midFreq, highFreq);
-              vibrateBasedOnVisuals(lowFreq, midFreq, highFreq, Math.random());
+              vibrateBasedOnAudio(
+                scaledFrequencies.low,
+                scaledFrequencies.mid,
+                scaledFrequencies.high
+              );
+              vibrateBasedOnVisuals(
+                scaledFrequencies.low,
+                scaledFrequencies.mid,
+                scaledFrequencies.high,
+                Math.random()
+              );
 
               requestAnimationFrame(updateAudioData);
             }
@@ -382,6 +427,7 @@
           })
           .catch((err) => {
             console.error('Error accessing microphone: ' + err);
+            funControls.setAudioAvailable(false);
           });
       }
 

--- a/symph.html
+++ b/symph.html
@@ -35,6 +35,11 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import {
+        initFunControls,
+        FUN_PALETTES,
+      } from './assets/ui/fun-controls.ts';
+      import { createSymphAdapter } from './assets/symph/fun-adapter.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
@@ -194,6 +199,33 @@
       let touchPoint = [0.0, 0.0];
       let analyser;
 
+      function paletteToOffset(palette) {
+        const hex = FUN_PALETTES[palette][2];
+        const num = parseInt(hex.replace('#', ''), 16);
+        return [
+          ((num >> 16) & 255) / 255,
+          ((num >> 8) & 255) / 255,
+          (num & 255) / 255,
+        ];
+      }
+
+      const symphAdapter = createSymphAdapter({
+        gl,
+        colorOffsetLocation: colorOffsetUniformLocation,
+      });
+      const funControls = initFunControls({
+        onPaletteChange: (palette) => {
+          symphAdapter.applyPalette(palette);
+          colorOffset = paletteToOffset(palette);
+        },
+        onMotionChange: symphAdapter.setMotion,
+        onAudioReactiveChange: symphAdapter.setAudioReactive,
+      });
+      colorOffset = paletteToOffset(funControls.state.palette);
+      symphAdapter.applyPalette(funControls.state.palette);
+      symphAdapter.setMotion(funControls.state.motion, funControls.state.mode);
+      symphAdapter.setAudioReactive(funControls.state.audioReactive);
+
       async function setupAudio() {
         try {
           const { analyser: a } = await initAudio();
@@ -205,6 +237,7 @@
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           console.error('Error capturing audio: ', err);
+          funControls.setAudioAvailable(false);
         }
       }
 
@@ -214,7 +247,7 @@
           const dataArray = getFrequencyData(analyser);
           const average =
             dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
-          audioData = average / 128.0;
+          audioData = symphAdapter.transformAudioData(average / 128.0);
           updateSpectrograph(dataArray);
         }
       }


### PR DESCRIPTION
## Summary
- add reusable fun controls panel with palette, motion, and audio toggles
- connect new adapters to brand, multi, seary, and symph visualizers for palette and motion tuning
- adjust shaders and visuals to respect palette tinting and non-audio fallbacks

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437a629a308332bae719538dd1aa9d)