### PR TITLE
Add fun control panel across visualizers

### DIFF
--- a/assets/brand/fun-adapter.ts
+++ b/assets/brand/fun-adapter.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+import type { PaletteOption } from '../ui/fun-controls';
+
+type InstancedMesh = THREE.InstancedMesh<
+  THREE.BufferGeometry,
+  THREE.Material
+> & {
+  instanceColor?: THREE.InstancedBufferAttribute;
+  count: number;
+};
+
+export const brandPalettes: Record<PaletteOption, string[]> = {
+  bright: ['#ff6b6b', '#ffd166', '#4d9de0'],
+  pastel: ['#d8a7b1', '#c7e2d0', '#f6eec7'],
+  neon: ['#39ff14', '#ff00a0', '#00d1ff'],
+};
+
+interface BrandAdapterOptions {
+  buildingMesh: InstancedMesh;
+  treeMaterial: THREE.MeshLambertMaterial;
+  poleMaterial: THREE.MeshLambertMaterial;
+}
+
+export function createBrandFunAdapter({
+  buildingMesh,
+  treeMaterial,
+  poleMaterial,
+}: BrandAdapterOptions) {
+  let motionIntensity = 0.6;
+  let partyMode: 'calm' | 'party' = 'calm';
+  let audioReactive = true;
+
+  function applyPalette(_palette: PaletteOption, colors: string[]) {
+    const [primary, secondary, accent] = colors;
+
+    for (let i = 0; i < buildingMesh.count; i += 1) {
+      const color = new THREE.Color(primary).offsetHSL(
+        0,
+        0,
+        (Math.random() - 0.5) * 0.08
+      );
+      buildingMesh.instanceColor?.setXYZ(i, color.r, color.g, color.b);
+    }
+    if (buildingMesh.instanceColor) {
+      buildingMesh.instanceColor.needsUpdate = true;
+    }
+
+    treeMaterial.color = new THREE.Color(secondary);
+    poleMaterial.color = new THREE.Color(accent);
+  }
+
+  function computeSpeed(bass: number) {
+    const reactiveBass = audioReactive ? bass : 30;
+    const motionBoost = 0.6 + motionIntensity * 1.2;
+    const partyBoost = partyMode === 'party' ? 1.4 : 0.9;
+    return (0.25 + reactiveBass / 120) * motionBoost * partyBoost;
+  }
+
+  return {
+    paletteOptions: brandPalettes,
+    setPalette: applyPalette,
+    setMotion(intensity: number, mode: 'calm' | 'party') {
+      motionIntensity = intensity;
+      partyMode = mode;
+    },
+    setAudioReactive(enabled: boolean) {
+      audioReactive = enabled;
+    },
+    computeSpeed,
+  };
+}

--- a/assets/multi/fun-adapter.ts
+++ b/assets/multi/fun-adapter.ts
@@ -1,0 +1,76 @@
+import * as THREE from 'three';
+import type { PaletteOption } from '../ui/fun-controls';
+
+interface MultiAdapterOptions {
+  torusMaterial: THREE.MeshStandardMaterial;
+  pointLight: THREE.PointLight;
+  particlesMaterial: THREE.PointsMaterial;
+  shapes: THREE.Mesh[];
+}
+
+export const multiPalettes: Record<PaletteOption, string[]> = {
+  bright: ['#ff6b6b', '#ffd166', '#00d1ff'],
+  pastel: ['#d7c0ae', '#a5d8ff', '#f8edeb'],
+  neon: ['#39ff14', '#ff00a0', '#00fff2'],
+};
+
+export function createMultiFunAdapter({
+  torusMaterial,
+  pointLight,
+  particlesMaterial,
+  shapes,
+}: MultiAdapterOptions) {
+  let motionIntensity = 0.6;
+  let mode: 'calm' | 'party' = 'calm';
+  let audioReactive = true;
+  let currentPalette: PaletteOption = 'bright';
+
+  function recolorShapes(colors: string[]) {
+    const materials = colors.map(
+      (color) =>
+        new THREE.MeshStandardMaterial({
+          color,
+          emissive: color,
+          emissiveIntensity: 0.2,
+          metalness: 0.6,
+          roughness: 0.35,
+        })
+    );
+
+    shapes.forEach((shape, idx) => {
+      shape.material = materials[idx % materials.length];
+    });
+  }
+
+  function setPalette(palette: PaletteOption, colors: string[]) {
+    currentPalette = palette;
+    torusMaterial.color = new THREE.Color(colors[0]);
+    particlesMaterial.color = new THREE.Color(colors[1]);
+    pointLight.color = new THREE.Color(colors[2]);
+    recolorShapes(colors);
+  }
+
+  function computeMotion(avgFrequency: number) {
+    const reactiveValue = audioReactive ? avgFrequency : 45;
+    const baseSpin = 0.0015 + reactiveValue / 8000;
+    const motionScale = 0.5 + motionIntensity * 1.2;
+    const modeScale = mode === 'party' ? 1.6 : 0.85;
+    return baseSpin * motionScale * modeScale;
+  }
+
+  return {
+    paletteOptions: multiPalettes,
+    setPalette,
+    setMotion(intensity: number, nextMode: 'calm' | 'party') {
+      motionIntensity = intensity;
+      mode = nextMode;
+    },
+    setAudioReactive(enabled: boolean) {
+      audioReactive = enabled;
+    },
+    computeMotion,
+    get palette() {
+      return currentPalette;
+    },
+  };
+}

--- a/assets/seary/fun-adapter.ts
+++ b/assets/seary/fun-adapter.ts
@@ -1,0 +1,61 @@
+import type { PaletteOption } from '../ui/fun-controls';
+
+const toVec3 = (hex: string) => {
+  const value = hex.startsWith('#') ? hex.slice(1) : hex;
+  const int = parseInt(value, 16);
+  return [
+    ((int >> 16) & 255) / 255,
+    ((int >> 8) & 255) / 255,
+    (int & 255) / 255,
+  ] as const;
+};
+
+export const searyPalettes: Record<PaletteOption, string[]> = {
+  bright: ['#ff6b6b', '#ffd166', '#6c5ce7'],
+  pastel: ['#f6e7cb', '#cce2f1', '#e2cfea'],
+  neon: ['#39ff14', '#ff00f0', '#00e5ff'],
+};
+
+type FrequencyTriple = {
+  low: number;
+  mid: number;
+  high: number;
+};
+
+export function createSearyFunAdapter() {
+  let paletteAccent: readonly number[] = toVec3(searyPalettes.bright[0]);
+  let motionIntensity = 0.6;
+  let mode: 'calm' | 'party' = 'calm';
+  let audioReactive = true;
+
+  function setPalette(_palette: PaletteOption, colors: string[]) {
+    paletteAccent = toVec3(colors[0]);
+  }
+
+  function transformFrequencies(values: FrequencyTriple) {
+    const base = audioReactive ? values : { low: 0.25, mid: 0.2, high: 0.15 };
+    const motionBoost = 0.6 + motionIntensity * 1.4;
+    const modeBoost = mode === 'party' ? 1.5 : 0.95;
+    return {
+      low: base.low * motionBoost * modeBoost,
+      mid: base.mid * motionBoost * modeBoost,
+      high: base.high * motionBoost * modeBoost,
+    };
+  }
+
+  return {
+    paletteOptions: searyPalettes,
+    setPalette,
+    setMotion(intensity: number, nextMode: 'calm' | 'party') {
+      motionIntensity = intensity;
+      mode = nextMode;
+    },
+    setAudioReactive(enabled: boolean) {
+      audioReactive = enabled;
+    },
+    transformFrequencies,
+    get paletteAccent() {
+      return paletteAccent;
+    },
+  };
+}

--- a/assets/symph/fun-adapter.ts
+++ b/assets/symph/fun-adapter.ts
@@ -1,0 +1,51 @@
+import type { PaletteOption } from '../ui/fun-controls';
+
+const toVec3 = (hex: string) => {
+  const value = hex.startsWith('#') ? hex.slice(1) : hex;
+  const int = parseInt(value, 16);
+  return [
+    ((int >> 16) & 255) / 255,
+    ((int >> 8) & 255) / 255,
+    (int & 255) / 255,
+  ] as const;
+};
+
+export const symphPalettes: Record<PaletteOption, string[]> = {
+  bright: ['#ff6b6b', '#ffd166', '#6c5ce7'],
+  pastel: ['#f6e7cb', '#cce2f1', '#d0f4de'],
+  neon: ['#39ff14', '#ff00f0', '#00e5ff'],
+};
+
+export function createSymphFunAdapter() {
+  let paletteAccent: readonly number[] = toVec3(symphPalettes.bright[2]);
+  let motionIntensity = 0.6;
+  let mode: 'calm' | 'party' = 'calm';
+  let audioReactive = true;
+
+  function setPalette(_palette: PaletteOption, colors: string[]) {
+    paletteAccent = toVec3(colors[2]);
+  }
+
+  function transformAudioValue(value: number) {
+    const base = audioReactive ? value : 42;
+    const motionBoost = 0.6 + motionIntensity * 1.4;
+    const modeBoost = mode === 'party' ? 1.6 : 0.95;
+    return (base / 255) * motionBoost * modeBoost;
+  }
+
+  return {
+    paletteOptions: symphPalettes,
+    setPalette,
+    setMotion(intensity: number, nextMode: 'calm' | 'party') {
+      motionIntensity = intensity;
+      mode = nextMode;
+    },
+    setAudioReactive(enabled: boolean) {
+      audioReactive = enabled;
+    },
+    transformAudioValue,
+    get paletteAccent() {
+      return paletteAccent;
+    },
+  };
+}

--- a/assets/ui/fun-controls.ts
+++ b/assets/ui/fun-controls.ts
@@ -1,0 +1,253 @@
+export type PaletteOption = 'bright' | 'pastel' | 'neon';
+
+export interface FunControlsCallbacks {
+  onPaletteChange?: (palette: PaletteOption, colors: string[]) => void;
+  onMotionChange?: (intensity: number, mode: 'calm' | 'party') => void;
+  onAudioToggle?: (enabled: boolean) => void;
+}
+
+export interface FunControlsInit extends FunControlsCallbacks {
+  paletteOptions?: Record<PaletteOption, string[]>;
+  initialPalette?: PaletteOption;
+  initialMotion?: number;
+  initialMode?: 'calm' | 'party';
+  audioAvailable?: boolean;
+  audioEnabled?: boolean;
+}
+
+const defaultPalettes: Record<PaletteOption, string[]> = {
+  bright: ['#ff3366', '#ffd166', '#33ffcc'],
+  pastel: ['#f4b6c2', '#c9e4de', '#faedcb'],
+  neon: ['#39ff14', '#00f0ff', '#ff00ff'],
+};
+
+function ensureStyles() {
+  if (document.getElementById('fun-controls-style')) return;
+
+  const style = document.createElement('style');
+  style.id = 'fun-controls-style';
+  style.textContent = `
+      .fun-controls {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        display: grid;
+        gap: 0.5rem;
+        padding: 0.75rem;
+        background: rgba(0, 0, 0, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 12px;
+        backdrop-filter: blur(8px);
+        color: #f5f5f5;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        min-width: 240px;
+        z-index: 20;
+      }
+      .fun-controls label {
+        font-size: 0.85rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+      }
+      .fun-controls fieldset {
+        border: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: space-between;
+      }
+      .fun-controls legend {
+        font-size: 0.85rem;
+        margin-bottom: 0.25rem;
+      }
+      .fun-chip {
+        flex: 1;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        background: rgba(255, 255, 255, 0.06);
+        color: inherit;
+        border-radius: 8px;
+        padding: 0.35rem 0.5rem;
+        font-size: 0.85rem;
+        cursor: pointer;
+        transition: background 0.2s, border-color 0.2s, transform 0.2s;
+      }
+      .fun-chip[aria-pressed='true'],
+      .fun-chip:focus-visible {
+        outline: 2px solid #6dd3ff;
+        outline-offset: 2px;
+        background: rgba(109, 211, 255, 0.15);
+        border-color: rgba(109, 211, 255, 0.5);
+      }
+      .fun-slider {
+        flex: 1;
+        appearance: none;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #ff3366, #ffd166, #33ffcc);
+      }
+      .fun-slider::-webkit-slider-thumb {
+        appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #ffffff;
+        border: 1px solid rgba(0,0,0,0.2);
+        box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+      }
+      .fun-slider::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #ffffff;
+        border: 1px solid rgba(0,0,0,0.2);
+        box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+      }
+      .fun-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.85rem;
+      }
+      .fun-toggle input {
+        width: 18px;
+        height: 18px;
+        accent-color: #6dd3ff;
+      }
+      @media (max-width: 640px) {
+        .fun-controls {
+          left: 0.5rem;
+          right: 0.5rem;
+          bottom: 0.5rem;
+          min-width: unset;
+          grid-template-columns: 1fr;
+          font-size: 0.9rem;
+        }
+        .fun-controls fieldset {
+          flex-wrap: wrap;
+        }
+        .fun-chip {
+          flex: 1 1 30%;
+          text-align: center;
+        }
+      }
+    `;
+  document.head.appendChild(style);
+}
+
+export function initFunControls(options: FunControlsInit = {}) {
+  ensureStyles();
+
+  const palettes = options.paletteOptions || defaultPalettes;
+  let palette: PaletteOption = options.initialPalette || 'bright';
+  let motion = options.initialMotion ?? 0.5;
+  let mode: 'calm' | 'party' = options.initialMode || 'calm';
+  let audioAvailable = options.audioAvailable !== false;
+  let audioEnabled = options.audioEnabled !== false;
+
+  const container = document.createElement('section');
+  container.className = 'fun-controls';
+  container.setAttribute('aria-label', 'Visualizer controls');
+  container.innerHTML = `
+      <fieldset>
+        <legend>Palette</legend>
+        ${(['bright', 'pastel', 'neon'] as PaletteOption[])
+          .map(
+            (key) => `
+              <button class="fun-chip" data-palette="${key}" aria-pressed="${
+              palette === key
+            }">${key}</button>
+            `
+          )
+          .join('')}
+      </fieldset>
+      <label>
+        Motion
+        <input class="fun-slider" type="range" min="0" max="1" step="0.01" value="${motion}" aria-valuemin="0" aria-valuemax="1" aria-valuenow="${motion}" aria-label="Motion intensity" />
+      </label>
+      <button class="fun-chip" data-mode="toggle" aria-pressed="${
+        mode === 'party'
+      }">${mode === 'party' ? 'Party' : 'Calm'} mode</button>
+      <label class="fun-toggle">
+        <input type="checkbox" class="fun-audio" ${
+          audioEnabled ? 'checked' : ''
+        } ${audioAvailable ? '' : 'disabled'} aria-label="Audio reactive" />
+        Audio reactive
+      </label>
+    `;
+
+  document.body.appendChild(container);
+
+  function notifyPalette() {
+    options.onPaletteChange?.(palette, palettes[palette]);
+  }
+
+  function notifyMotion() {
+    options.onMotionChange?.(motion, mode);
+  }
+
+  function notifyAudio() {
+    options.onAudioToggle?.(audioEnabled && audioAvailable);
+  }
+
+  container
+    .querySelectorAll<HTMLButtonElement>('[data-palette]')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        palette = btn.dataset.palette as PaletteOption;
+        container
+          .querySelectorAll<HTMLButtonElement>('[data-palette]')
+          .forEach((b) => b.setAttribute('aria-pressed', String(b === btn)));
+        notifyPalette();
+      });
+    });
+
+  const slider = container.querySelector<HTMLInputElement>('.fun-slider');
+  slider?.addEventListener('input', (event) => {
+    const value = Number((event.target as HTMLInputElement).value);
+    motion = Math.min(1, Math.max(0, value));
+    slider.setAttribute('aria-valuenow', motion.toString());
+    notifyMotion();
+  });
+
+  const modeButton = container.querySelector<HTMLButtonElement>(
+    '[data-mode="toggle"]'
+  );
+  modeButton?.addEventListener('click', () => {
+    mode = mode === 'party' ? 'calm' : 'party';
+    modeButton.textContent = `${mode === 'party' ? 'Party' : 'Calm'} mode`;
+    modeButton.setAttribute('aria-pressed', String(mode === 'party'));
+    notifyMotion();
+  });
+
+  const audioToggle = container.querySelector<HTMLInputElement>('.fun-audio');
+  audioToggle?.addEventListener('change', (event) => {
+    audioEnabled = (event.target as HTMLInputElement).checked;
+    notifyAudio();
+  });
+
+  notifyPalette();
+  notifyMotion();
+  notifyAudio();
+
+  return {
+    setAudioAvailable(available: boolean) {
+      audioAvailable = available;
+      if (audioToggle) {
+        audioToggle.disabled = !available;
+        if (!available) {
+          audioToggle.checked = false;
+        }
+      }
+      notifyAudio();
+    },
+    updateAudioEnabled(enabled: boolean) {
+      audioEnabled = enabled;
+      if (audioToggle) {
+        audioToggle.checked = enabled;
+      }
+      notifyAudio();
+    },
+  };
+}

--- a/brand.html
+++ b/brand.html
@@ -18,6 +18,8 @@
         getContextFrequencyData,
       } from './assets/js/core/animation-loop.ts';
       import { initHints } from './assets/ui/hints.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createBrandFunAdapter } from './assets/brand/fun-adapter.ts';
 
       const canvas = document.getElementById('vizCanvas');
 
@@ -165,6 +167,25 @@
       poleMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       toy.scene.add(poleMesh);
 
+      const adapter = createBrandFunAdapter({
+        buildingMesh,
+        treeMaterial: treeMat,
+        poleMaterial: poleMat,
+      });
+
+      const funControls = initFunControls({
+        paletteOptions: adapter.paletteOptions,
+        onPaletteChange: (palette, colors) => {
+          adapter.setPalette(palette, colors);
+        },
+        onMotionChange: (intensity, mode) => {
+          adapter.setMotion(intensity, mode);
+        },
+        onAudioToggle: (enabled) => {
+          adapter.setAudioReactive(enabled);
+        },
+      });
+
       const dummy = new THREE.Object3D();
       buildingData.forEach((d, i) => {
         dummy.position.set(d.x, 0, d.z);
@@ -194,12 +215,15 @@
 
       function animate(ctx) {
         const dataArray = getContextFrequencyData(ctx);
-        const bassBand = dataArray.slice(0, Math.max(1, Math.min(10, dataArray.length)));
+        const bassBand = dataArray.slice(
+          0,
+          Math.max(1, Math.min(10, dataArray.length))
+        );
         const bass = bassBand.length
           ? bassBand.reduce((a, b) => a + b, 0) / bassBand.length
           : 0;
 
-        const speed = 0.5 + bass / 100;
+        const speed = adapter.computeSpeed(bass);
         buildingData.forEach((d, i) => {
           d.z += speed;
           if (d.z > 5) {
@@ -241,14 +265,18 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate, { positional: true, object: toy.camera }).catch(
-        (err) => {
-          console.error('Audio input error: ', err);
-          displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
-          );
-        }
-      );
+      startAudioLoop(toy, animate, {
+        positional: true,
+        object: toy.camera,
+      }).catch((err) => {
+        console.error('Audio input error: ', err);
+        funControls.setAudioAvailable(false);
+        displayError(
+          'Microphone access is unavailable. Visuals will run without audio reactivity.'
+        );
+        const silentContext = { toy, analyser: null };
+        toy.renderer.setAnimationLoop(() => animate(silentContext));
+      });
     </script>
   </body>
 </html>

--- a/multi.html
+++ b/multi.html
@@ -26,6 +26,8 @@
       } from './assets/js/core/animation-loop.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
       import { initHints } from './assets/ui/hints.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
 
@@ -128,6 +130,20 @@
         createRandomShape();
       }
 
+      const adapter = createMultiFunAdapter({
+        torusMaterial: torusKnot.material as THREE.MeshStandardMaterial,
+        pointLight,
+        particlesMaterial,
+        shapes,
+      });
+
+      const funControls = initFunControls({
+        paletteOptions: adapter.paletteOptions,
+        onPaletteChange: (palette, colors) => adapter.setPalette(palette, colors),
+        onMotionChange: (intensity, mode) => adapter.setMotion(intensity, mode),
+        onAudioToggle: (enabled) => adapter.setAudioReactive(enabled),
+      });
+
       window.addEventListener('deviceorientation', (event) => {
         toy.camera.rotation.x = (event.beta / 180) * Math.PI;
         toy.camera.rotation.y = (event.gamma / 90) * Math.PI;
@@ -137,17 +153,19 @@
         const dataArray = getContextFrequencyData(ctx);
         const avgFrequency = getAverageFrequency(dataArray);
 
-        torusKnot.rotation.x += avgFrequency / 5000;
-        torusKnot.rotation.y += avgFrequency / 5000;
+        const spin = adapter.computeMotion(avgFrequency);
 
-        pointLight.intensity = avgFrequency / 100;
+        torusKnot.rotation.x += spin;
+        torusKnot.rotation.y += spin;
 
-        particles.rotation.y += 0.001 + avgFrequency / 100000;
+        pointLight.intensity = Math.max(0.6, avgFrequency / 140) * (spin * 500 + 0.5);
+
+        particles.rotation.y += 0.001 + spin / 10;
 
         shapes.forEach((shape) => {
-          shape.rotation.x += 0.01;
-          shape.rotation.y += 0.01;
-          shape.position.z += 0.5;
+          shape.rotation.x += 0.01 + spin * 2;
+          shape.rotation.y += 0.01 + spin * 1.5;
+          shape.position.z += 0.5 + spin * 60;
 
           if (shape.position.z > 10) {
             shape.position.z = -500;
@@ -157,12 +175,16 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate).catch((err) => {
-        console.error('The following error occurred: ' + err);
-        displayError(
-          'Microphone access is required for the visualization to work. Please allow microphone access.'
-        );
-      });
+      startAudioLoop(toy, animate)
+        .catch((err) => {
+          console.error('The following error occurred: ' + err);
+          funControls.setAudioAvailable(false);
+          displayError(
+            'Microphone access is unavailable. Visuals will run without audio reactivity.'
+          );
+          const silentContext = { toy, analyser: null };
+          toy.renderer.setAnimationLoop(() => animate(silentContext));
+        });
     </script>
   </body>
 </html>

--- a/seary.html
+++ b/seary.html
@@ -34,6 +34,8 @@
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
       import { initHints } from './assets/ui/hints.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createSearyFunAdapter } from './assets/seary/fun-adapter.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
       function displayError(message) {
@@ -51,6 +53,15 @@
           'Switch to Party Mode for bigger motion.',
           'Use the audio source menu to swap between mic and device audio.',
         ],
+      });
+
+      const adapter = createSearyFunAdapter();
+      const funControls = initFunControls({
+        paletteOptions: adapter.paletteOptions,
+        onPaletteChange: (palette, colors) =>
+          adapter.setPalette(palette, colors),
+        onMotionChange: (intensity, mode) => adapter.setMotion(intensity, mode),
+        onAudioToggle: (enabled) => adapter.setAudioReactive(enabled),
       });
 
       const gl =
@@ -105,6 +116,7 @@
             uniform vec2 u_touch0;
             uniform vec2 u_touch1;
             uniform vec3 u_orientation;
+            uniform vec3 u_palette_accent;
             varying vec2 v_uv;
             
             float noise(vec2 p) {
@@ -163,6 +175,8 @@
                 float glow = exp(-10.0 * dist) * (u_low_freq + u_mid_freq + u_high_freq);
                 color += vec3(glow * 0.4, glow * 0.6, glow * 0.8);
 
+                color = mix(color, color * u_palette_accent, 0.35);
+
                 gl_FragColor = vec4(color, 1.0);
             }
         `;
@@ -208,6 +222,59 @@
         program,
         'u_orientation'
       );
+      const paletteLocation = gl.getUniformLocation(
+        program,
+        'u_palette_accent'
+      );
+
+      let currentFreqs = adapter.transformFrequencies({
+        low: 0,
+        mid: 0,
+        high: 0,
+      });
+      let orientation = { alpha: 0, beta: 0, gamma: 0 };
+      const touches = [
+        { x: 0.0, y: 0.0 },
+        { x: 0.0, y: 0.0 },
+      ];
+      const activePointers = new Map();
+
+      canvas.addEventListener('pointerdown', (event) => {
+        updatePointer(event);
+        event.preventDefault();
+      });
+
+      canvas.addEventListener('pointermove', (event) => {
+        updatePointer(event);
+        event.preventDefault();
+      });
+
+      canvas.addEventListener('pointerup', (event) => {
+        activePointers.delete(event.pointerId);
+        refreshTouches();
+      });
+
+      function updatePointer(event) {
+        activePointers.set(event.pointerId, {
+          x: event.clientX,
+          y: event.clientY,
+        });
+        refreshTouches();
+      }
+
+      function refreshTouches() {
+        const values = Array.from(activePointers.values());
+        for (let i = 0; i < touches.length; i++) {
+          if (i < values.length) {
+            const p = values[i];
+            touches[i].x = (p.x / window.innerWidth) * 2.0 - 1.0;
+            touches[i].y = 1.0 - (p.y / window.innerHeight) * 2.0;
+          } else {
+            touches[i].x = 0.0;
+            touches[i].y = 0.0;
+          }
+        }
+      }
 
       // Audio setup for beat detection and frequency analysis
       let audioContext, analyser, source;
@@ -225,6 +292,7 @@
         navigator.mediaDevices
           .getUserMedia({ audio: true })
           .then((stream) => {
+            funControls.setAudioAvailable(true);
             audioContext = new (window.AudioContext ||
               window.webkitAudioContext)();
             if (audioSelect.value === 'mic') {
@@ -284,56 +352,11 @@
             }
 
             // Device orientation-based distortion
-            let orientation = { alpha: 0, beta: 0, gamma: 0 };
             window.addEventListener('deviceorientation', (event) => {
               orientation.alpha = event.alpha;
               orientation.beta = event.beta;
               orientation.gamma = event.gamma;
             });
-
-            // Pointer-based multi-touch effects
-            let touches = [
-              { x: 0.0, y: 0.0 },
-              { x: 0.0, y: 0.0 },
-            ];
-            const activePointers = new Map();
-
-            canvas.addEventListener('pointerdown', (event) => {
-              updatePointer(event);
-              event.preventDefault();
-            });
-
-            canvas.addEventListener('pointermove', (event) => {
-              updatePointer(event);
-              event.preventDefault();
-            });
-
-            canvas.addEventListener('pointerup', (event) => {
-              activePointers.delete(event.pointerId);
-              refreshTouches();
-            });
-
-            function updatePointer(event) {
-              activePointers.set(event.pointerId, {
-                x: event.clientX,
-                y: event.clientY,
-              });
-              refreshTouches();
-            }
-
-            function refreshTouches() {
-              const values = Array.from(activePointers.values());
-              for (let i = 0; i < touches.length; i++) {
-                if (i < values.length) {
-                  const p = values[i];
-                  touches[i].x = (p.x / window.innerWidth) * 2.0 - 1.0;
-                  touches[i].y = 1.0 - (p.y / window.innerHeight) * 2.0;
-                } else {
-                  touches[i].x = 0.0;
-                  touches[i].y = 0.0;
-                }
-              }
-            }
 
             function startProcessing(arr) {
               dataArray = arr;
@@ -370,21 +393,23 @@
                 }, 100);
               }
 
-              gl.uniform1f(lowFreqLocation, lowFreq);
-              gl.uniform1f(midFreqLocation, midFreq);
-              gl.uniform1f(highFreqLocation, highFreq);
-              gl.uniform3f(
-                orientationLocation,
-                orientation.alpha / 360.0,
-                orientation.beta / 90.0,
-                orientation.gamma / 90.0
+              currentFreqs = adapter.transformFrequencies({
+                low: lowFreq,
+                mid: midFreq,
+                high: highFreq,
+              });
+
+              vibrateBasedOnAudio(
+                currentFreqs.low,
+                currentFreqs.mid,
+                currentFreqs.high
               );
-
-              gl.uniform2f(touch0Location, touches[0].x, touches[0].y);
-              gl.uniform2f(touch1Location, touches[1].x, touches[1].y);
-
-              vibrateBasedOnAudio(lowFreq, midFreq, highFreq);
-              vibrateBasedOnVisuals(lowFreq, midFreq, highFreq, Math.random());
+              vibrateBasedOnVisuals(
+                currentFreqs.low,
+                currentFreqs.mid,
+                currentFreqs.high,
+                Math.random()
+              );
 
               requestAnimationFrame(updateAudioData);
             }
@@ -392,6 +417,12 @@
           })
           .catch((err) => {
             console.error('Error accessing microphone: ' + err);
+            funControls.setAudioAvailable(false);
+            currentFreqs = adapter.transformFrequencies({
+              low: 0,
+              mid: 0,
+              high: 0,
+            });
           });
       }
 
@@ -401,6 +432,23 @@
 
         // Set uniforms
         gl.uniform1f(timeLocation, time);
+        gl.uniform1f(lowFreqLocation, currentFreqs.low);
+        gl.uniform1f(midFreqLocation, currentFreqs.mid);
+        gl.uniform1f(highFreqLocation, currentFreqs.high);
+        gl.uniform3f(
+          orientationLocation,
+          orientation.alpha / 360.0,
+          orientation.beta / 90.0,
+          orientation.gamma / 90.0
+        );
+        gl.uniform2f(touch0Location, touches[0].x, touches[0].y);
+        gl.uniform2f(touch1Location, touches[1].x, touches[1].y);
+        gl.uniform3f(
+          paletteLocation,
+          adapter.paletteAccent[0],
+          adapter.paletteAccent[1],
+          adapter.paletteAccent[2]
+        );
 
         // Draw
         gl.clearColor(0, 0, 0, 1);

--- a/symph.html
+++ b/symph.html
@@ -36,6 +36,8 @@
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
       import { initHints } from './assets/ui/hints.ts';
+      import { initFunControls } from './assets/ui/fun-controls.ts';
+      import { createSymphFunAdapter } from './assets/symph/fun-adapter.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
@@ -198,9 +200,22 @@
 
       gl.uniform2f(resolutionUniformLocation, canvas.width, canvas.height);
 
+      const adapter = createSymphFunAdapter();
+      const funControls = initFunControls({
+        paletteOptions: adapter.paletteOptions,
+        onPaletteChange: (palette, colors) => {
+          adapter.setPalette(palette, colors);
+          colorOffset = [...adapter.paletteAccent];
+          gradientStops = colors;
+        },
+        onMotionChange: (intensity, mode) => adapter.setMotion(intensity, mode),
+        onAudioToggle: (enabled) => adapter.setAudioReactive(enabled),
+      });
+
+      let gradientStops = adapter.paletteOptions.bright;
       let time = 0.0;
-      let audioData = 0.0;
-      let colorOffset = [0.0, 0.0, 0.0];
+      let audioData = adapter.transformAudioValue(0);
+      let colorOffset = [...adapter.paletteAccent];
       let touchPoint = [0.0, 0.0];
       let analyser;
 
@@ -210,10 +225,13 @@
           analyser = a;
           hideError();
           getAudioData();
+          funControls.setAudioAvailable(true);
         } catch (err) {
           displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
+            'Microphone access is unavailable. Visuals will run without audio reactivity.'
           );
+          funControls.setAudioAvailable(false);
+          audioData = adapter.transformAudioValue(0);
           console.error('Error capturing audio: ', err);
         }
       }
@@ -224,7 +242,7 @@
           const dataArray = getFrequencyData(analyser);
           const average =
             dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
-          audioData = average / 128.0;
+          audioData = adapter.transformAudioValue(average);
           updateSpectrograph(dataArray);
         }
       }
@@ -237,9 +255,9 @@
           canvas.width,
           canvas.height
         );
-        gradient.addColorStop(0, '#ff6ec7');
-        gradient.addColorStop(0.5, '#8e44ad');
-        gradient.addColorStop(1, '#3498db');
+        gradient.addColorStop(0, gradientStops[0]);
+        gradient.addColorStop(0.5, gradientStops[1]);
+        gradient.addColorStop(1, gradientStops[2]);
         ctx2d.fillStyle = gradient;
         const barWidth = (canvas.width / dataArray.length) * 1.5;
         let barHeight;


### PR DESCRIPTION
## Summary
- add a reusable fun controls UI with palette, motion, and audio-reactive toggles
- wire the control adapters into the brand, multi, seary, and symph visualizers
- ensure graceful fallbacks when audio input is unavailable

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437c97a2cc83329b289589f57d189c)