### PR TITLE
Add shared error display helper

### DIFF
--- a/assets/js/utils/error-display.ts
+++ b/assets/js/utils/error-display.ts
@@ -1,0 +1,15 @@
+export function showError(id: string, message: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  el.textContent = message;
+  el.style.display = 'block';
+}
+
+export function clearError(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  el.textContent = '';
+  el.style.display = 'none';
+}

--- a/brand.html
+++ b/brand.html
@@ -17,19 +17,12 @@
         startAudioLoop,
         getContextFrequencyData,
       } from './assets/js/core/animation-loop.ts';
+      import { showError } from './assets/js/utils/error-display.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createBrandFunAdapter } from './assets/brand/fun-adapter.ts';
 
       const canvas = document.getElementById('vizCanvas');
-
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'brand-visualizer',
@@ -271,7 +264,8 @@
       }).catch((err) => {
         console.error('Audio input error: ', err);
         funControls.setAudioAvailable(false);
-        displayError(
+        showError(
+          'error-message',
           'Microphone access is unavailable. Visuals will run without audio reactivity.'
         );
         const silentContext = { toy, analyser: null };

--- a/defrag.html
+++ b/defrag.html
@@ -31,15 +31,9 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { showError } from './assets/js/utils/error-display.ts';
       const canvas = document.getElementById('canvas');
       const ctx = canvas.getContext('2d');
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
@@ -79,7 +73,8 @@
           analyser = result.analyser;
         } catch (err) {
           console.error('Error capturing audio: ', err);
-          displayError(
+          showError(
+            'error-message',
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
         }

--- a/multi.html
+++ b/multi.html
@@ -26,20 +26,12 @@
       } from './assets/js/core/animation-loop.ts';
       import createPeakDetector from './assets/js/utils/peak-detector.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
+      import { showError } from './assets/js/utils/error-display.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
-
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
-
       initHints({
         id: 'multi-visualizer',
         tips: [
@@ -346,7 +338,8 @@
         .catch((err) => {
           console.error('The following error occurred: ' + err);
           funControls.setAudioAvailable(false);
-          displayError(
+          showError(
+            'error-message',
             'Microphone access is unavailable. Visuals will run without audio reactivity.'
           );
           const silentContext = { toy, analyser: null };

--- a/seary.html
+++ b/seary.html
@@ -33,18 +33,12 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { showError } from './assets/js/utils/error-display.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSearyFunAdapter } from './assets/seary/fun-adapter.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'seary-visualizer',
@@ -305,7 +299,8 @@
                 })
                 .catch((err) => {
                   console.error('Error capturing audio: ', err);
-                  displayError(
+                  showError(
+                    'error-message',
                     'Microphone access is required for the visualization to work. Please allow microphone access.'
                   );
                 });

--- a/symph.html
+++ b/symph.html
@@ -35,20 +35,16 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import {
+        clearError,
+        showError,
+      } from './assets/js/utils/error-display.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSymphFunAdapter } from './assets/symph/fun-adapter.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
-      const errorEl = document.getElementById('error-message');
-
-      function displayError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'symph-visualizer',
@@ -59,15 +55,9 @@
         ],
       });
 
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
-
       if (!gl) {
-        displayError(
+        showError(
+          'error-message',
           'Unable to initialize WebGL. Your browser may not support it.'
         );
         throw new Error('WebGL not supported');
@@ -223,11 +213,12 @@
         try {
           const { analyser: a } = await initAudio();
           analyser = a;
-          hideError();
+          clearError('error-message');
           getAudioData();
           funControls.setAudioAvailable(true);
         } catch (err) {
-          displayError(
+          showError(
+            'error-message',
             'Microphone access is unavailable. Visuals will run without audio reactivity.'
           );
           funControls.setAudioAvailable(false);

--- a/words.html
+++ b/words.html
@@ -165,23 +165,16 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { showError } from './assets/js/utils/error-display.ts';
       const wordCloudCanvas = document.getElementById('word-cloud-canvas');
       const unmuteButton = document.getElementById('unmute-button');
       const toggleSpeechButton = document.getElementById(
         'toggle-speech-button'
       );
       const unmuteIcon = document.getElementById('unmute-icon');
-      }
       const recognition = new (window.SpeechRecognition ||
         window.webkitSpeechRecognition)();
       recognition.interimResults = false;
-      function displayError(message) {
-        const el = document.getElementById("error-message");
-        if (el) {
-          el.innerText = message;
-          el.style.display = "block";
-        }
-      }
       recognition.maxAlternatives = 1;
 
       let isUnmuted = false;
@@ -257,7 +250,10 @@
           visualize();
         } catch (error) {
           console.error('Error accessing microphone for visualizer:', error);
-          displayError('Microphone access is required for the visualization to work. Please allow microphone access.');
+          showError(
+            'error-message',
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
+          );
           deactivateVisualizer();
         }
       }


### PR DESCRIPTION
## Summary
- add a reusable error-display utility for consistent UI handling
- update visualizer pages to use the shared helper instead of local functions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437f85841883328f3ecb049562aece)