### PR TITLE
Add shared audio-reactive color helper

### DIFF
--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { applyAudioColor } from '../utils/color-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 70 } },
@@ -112,15 +113,22 @@ function animate(ctx: AnimationContext) {
     mesh.rotation.x += 0.01 + normalizedValue * 0.05;
     mesh.rotation.y += 0.015 + normalizedValue * 0.03;
 
-    // Color shift based on audio
     const material = mesh.material as THREE.MeshStandardMaterial;
-    const hue = ((col / COLS) * 0.3 + 0.8 + normalizedValue * 0.2) % 1;
-    material.color.setHSL(
-      hue,
-      0.7 + normalizedValue * 0.3,
-      0.5 + normalizedValue * 0.2
-    );
-    material.emissive.setHSL(hue, 0.5, normalizedValue * 0.3);
+    const baseHue = (col / COLS) * 0.3 + 0.8;
+    applyAudioColor(material, normalizedValue, {
+      baseHue,
+      hueRange: 0.2,
+      baseSaturation: 0.7,
+      saturationRange: 0.3,
+      baseLuminance: 0.5,
+      luminanceRange: 0.2,
+      emissive: {
+        baseHue,
+        baseSaturation: 0.5,
+        baseLuminance: 0,
+        luminanceRange: 0.3,
+      },
+    });
   });
 
   // Camera sway

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { applyAudioColor } from '../utils/color-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 80 } },
@@ -44,13 +45,15 @@ function animate(ctx: AnimationContext) {
   cubes.forEach((cube, i) => {
     const bin = Math.floor(i * binsPerCube);
     const value = dataArray[bin] || avg;
+    const normalizedValue = value / 255;
     const scale = 1 + value / 128;
     cube.scale.y = scale;
-    (cube.material as THREE.MeshStandardMaterial).color.setHSL(
-      0.6 - value / 512,
-      0.8,
-      0.5
-    );
+    applyAudioColor(cube.material, normalizedValue, {
+      baseHue: 0.6,
+      hueRange: -0.5,
+      baseSaturation: 0.8,
+      baseLuminance: 0.5,
+    });
     cube.rotation.y += value / 100000;
   });
 

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { applyAudioColor } from '../utils/color-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
@@ -177,8 +178,13 @@ function animate(ctx: AnimationContext) {
     0.2 + normalizedAvg * 0.3;
 
   // Color shift based on audio
-  const hue = (normalizedAvg * 0.5 + time * 0.05) % 1;
-  starMaterial.color.setHSL(hue, 0.3, 0.9);
+  const hueBase = (time * 0.05) % 1;
+  applyAudioColor(starMaterial, normalizedAvg, {
+    baseHue: hueBase,
+    hueRange: 0.5,
+    baseSaturation: 0.3,
+    baseLuminance: 0.9,
+  });
 
   // Camera effects
   toy.camera.position.x = Math.sin(time * 0.3) * 10;

--- a/assets/js/utils/color-audio.ts
+++ b/assets/js/utils/color-audio.ts
@@ -1,0 +1,78 @@
+import * as THREE from 'three';
+
+type MaterialWithColor = THREE.Material & {
+  color?: THREE.Color;
+  emissive?: THREE.Color;
+};
+
+export type AudioColorParams = {
+  baseHue: number;
+  hueRange?: number;
+  baseSaturation?: number;
+  saturationRange?: number;
+  baseLuminance?: number;
+  luminanceRange?: number;
+  emissive?: {
+    baseHue?: number;
+    hueRange?: number;
+    baseSaturation?: number;
+    saturationRange?: number;
+    baseLuminance?: number;
+    luminanceRange?: number;
+  };
+};
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function applyHsl(
+  material: MaterialWithColor,
+  normalizedValue: number,
+  params: AudioColorParams
+) {
+  const { color } = material;
+  if (!color) return;
+
+  const hue =
+    (params.baseHue + normalizedValue * (params.hueRange ?? 0)) % 1;
+  const saturation = clamp01(
+    (params.baseSaturation ?? 0) + normalizedValue * (params.saturationRange ?? 0)
+  );
+  const luminance = clamp01(
+    (params.baseLuminance ?? 0) + normalizedValue * (params.luminanceRange ?? 0)
+  );
+
+  color.setHSL(hue, saturation, luminance);
+}
+
+function applyEmissive(
+  material: MaterialWithColor,
+  normalizedValue: number,
+  params: AudioColorParams['emissive']
+) {
+  if (!params || !material.emissive) return;
+
+  const hue =
+    ((params.baseHue ?? 0) + normalizedValue * (params.hueRange ?? 0)) % 1;
+  const saturation = clamp01(
+    (params.baseSaturation ?? 0) + normalizedValue * (params.saturationRange ?? 0)
+  );
+  const luminance = clamp01(
+    (params.baseLuminance ?? 0) + normalizedValue * (params.luminanceRange ?? 0)
+  );
+
+  material.emissive.setHSL(hue, saturation, luminance);
+}
+
+export function applyAudioColor(
+  material: THREE.Material,
+  normalizedValue: number,
+  params: AudioColorParams
+) {
+  const clampedValue = clamp01(normalizedValue);
+  const materialWithColor = material as MaterialWithColor;
+
+  applyHsl(materialWithColor, clampedValue, params);
+  applyEmissive(materialWithColor, clampedValue, params.emissive);
+}


### PR DESCRIPTION
## Summary
- add a reusable utility to apply audio-driven HSL adjustments to material colors and emissive values
- refactor bouncy spheres, cube wave, and star field toys to use the shared helper instead of inline color math

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437fb3ba0883329bbbca2be80bf160)