### PR TITLE
Add shared audio mapper helper for audio-driven toys

### DIFF
--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { mapFrequencyToItems } from '../utils/audio-mapper';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 80 } },
@@ -40,19 +41,21 @@ function animate(ctx: AnimationContext) {
   const dataArray = getContextFrequencyData(ctx);
   const avg = getAverageFrequency(dataArray);
 
-  const binsPerCube = dataArray.length / cubes.length;
-  cubes.forEach((cube, i) => {
-    const bin = Math.floor(i * binsPerCube);
-    const value = dataArray[bin] || avg;
-    const scale = 1 + value / 128;
-    cube.scale.y = scale;
-    (cube.material as THREE.MeshStandardMaterial).color.setHSL(
-      0.6 - value / 512,
-      0.8,
-      0.5
-    );
-    cube.rotation.y += value / 100000;
-  });
+  mapFrequencyToItems(
+    dataArray,
+    cubes,
+    (cube, i, value) => {
+      const scale = 1 + value / 128;
+      cube.scale.y = scale;
+      (cube.material as THREE.MeshStandardMaterial).color.setHSL(
+        0.6 - value / 512,
+        0.8,
+        0.5
+      );
+      cube.rotation.y += value / 100000;
+    },
+    { fallbackValue: avg }
+  );
 
   ctx.toy.render();
 }

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { mapFrequencyToItems } from '../utils/audio-mapper';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
@@ -41,17 +42,19 @@ function init() {
 function animate(ctx: AnimationContext) {
   const data = getContextFrequencyData(ctx);
   const avg = getAverageFrequency(data);
-  const binsPerLine = data.length / lines.length;
-  lines.forEach((line, idx) => {
-    const bin = Math.floor(idx * binsPerLine);
-    const value = data[bin] || avg;
-    line.rotation.z += 0.002 + value / 100000;
-    line.rotation.x += 0.001 + idx / 10000;
-    const scale = 1 + value / 256;
-    line.scale.set(scale, scale, scale);
-    const hue = (idx / lines.length + value / 512) % 1;
-    (line.material as THREE.LineBasicMaterial).color.setHSL(hue, 0.6, 0.5);
-  });
+  mapFrequencyToItems(
+    data,
+    lines,
+    (line, idx, value) => {
+      line.rotation.z += 0.002 + value / 100000;
+      line.rotation.x += 0.001 + idx / 10000;
+      const scale = 1 + value / 256;
+      line.scale.set(scale, scale, scale);
+      const hue = (idx / lines.length + value / 512) % 1;
+      (line.material as THREE.LineBasicMaterial).color.setHSL(hue, 0.6, 0.5);
+    },
+    { fallbackValue: avg }
+  );
   ctx.toy.render();
 }
 

--- a/assets/js/utils/audio-mapper.ts
+++ b/assets/js/utils/audio-mapper.ts
@@ -1,0 +1,21 @@
+export type AudioMapperOptions = {
+  fallbackValue?: number;
+};
+
+export function mapFrequencyToItems<T>(
+  data: Uint8Array,
+  items: T[],
+  callback: (item: T, index: number, value: number) => void,
+  options: AudioMapperOptions = {}
+) {
+  if (items.length === 0) return;
+
+  const binsPerItem = data.length / items.length;
+  const { fallbackValue } = options;
+
+  items.forEach((item, index) => {
+    const binIndex = Math.floor(index * binsPerItem);
+    const value = data[binIndex] || fallbackValue || 0;
+    callback(item, index, value);
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable audio mapping utility to iterate items with FFT bin values and optional fallbacks
- refactor cube-wave and spiral-burst toys to rely on the shared mapper instead of inline calculations

## Testing
- npm run lint
- npm run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437fafde908332b058097720c6bf1e)