### PR TITLE
Add reusable camera motion helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thanks for helping build and refine the Stim Webtoys Library! This guide covers 
 ## Running the Dev Server
 
 Start the local development server and open the site at `http://localhost:5173`:
+
 ```bash
 npm run dev
 ```

--- a/assets/js/core/types.ts
+++ b/assets/js/core/types.ts
@@ -10,7 +10,11 @@ import type {
 export interface ToyConfig {
   cameraOptions?: Record<string, unknown>;
   sceneOptions?: { backgroundColor?: number };
-  rendererOptions?: { antialias?: boolean; exposure?: number; maxPixelRatio?: number };
+  rendererOptions?: {
+    antialias?: boolean;
+    exposure?: number;
+    maxPixelRatio?: number;
+  };
   lightingOptions?: LightConfig;
   ambientLightOptions?: AmbientLightConfig;
   canvas?: HTMLCanvasElement | null;

--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -7,6 +7,7 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { updateCameraMotion } from '../utils/camera-motion';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 70 } },
@@ -17,6 +18,9 @@ const toy = new WebToy({
   },
   ambientLightOptions: { intensity: 0.6 },
 } as ToyConfig);
+
+const baseCameraPosition = new THREE.Vector3(0, 30, 70);
+const cameraLookTarget = new THREE.Vector3(0, 5, 0);
 
 interface SphereData {
   mesh: THREE.Mesh;
@@ -123,9 +127,15 @@ function animate(ctx: AnimationContext) {
     material.emissive.setHSL(hue, 0.5, normalizedValue * 0.3);
   });
 
-  // Camera sway
-  toy.camera.position.x = Math.sin(time * 0.2) * 5;
-  toy.camera.lookAt(0, 5, 0);
+  updateCameraMotion(toy.camera, time, {
+    basePosition: baseCameraPosition,
+    oscillation: {
+      x: { amplitude: 5, frequency: 0.2 },
+    },
+    lookAt: {
+      target: cameraLookTarget,
+    },
+  });
 
   ctx.toy.render();
 }

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -7,12 +7,16 @@ import {
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { updateCameraMotion } from '../utils/camera-motion';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
   lightingOptions: { type: 'PointLight', position: { x: 10, y: 20, z: 50 } },
   ambientLightOptions: { intensity: 0.3 },
 } as ToyConfig);
+
+const baseCameraPosition = new THREE.Vector3(0, 0, 100);
+const cameraLookTarget = new THREE.Vector3(0, 0, -100);
 
 let stars: THREE.Points;
 let starMaterial: THREE.PointsMaterial;
@@ -180,10 +184,16 @@ function animate(ctx: AnimationContext) {
   const hue = (normalizedAvg * 0.5 + time * 0.05) % 1;
   starMaterial.color.setHSL(hue, 0.3, 0.9);
 
-  // Camera effects
-  toy.camera.position.x = Math.sin(time * 0.3) * 10;
-  toy.camera.position.y = Math.cos(time * 0.2) * 5;
-  toy.camera.lookAt(0, 0, -100);
+  updateCameraMotion(toy.camera, time, {
+    basePosition: baseCameraPosition,
+    oscillation: {
+      x: { amplitude: 10, frequency: 0.3 },
+      y: { amplitude: 5, frequency: 0.2, fn: 'cos' },
+    },
+    lookAt: {
+      target: cameraLookTarget,
+    },
+  });
 
   ctx.toy.render();
 }

--- a/assets/js/utils/animation-utils.ts
+++ b/assets/js/utils/animation-utils.ts
@@ -67,7 +67,8 @@ function averageFrequencyRange(
     audioData.length,
     Math.ceil(audioData.length * endRatio)
   );
-  const bucketWidth = Math.ceil(audioData.length * endRatio) -
+  const bucketWidth =
+    Math.ceil(audioData.length * endRatio) -
     Math.floor(audioData.length * startRatio);
 
   if (bucketWidth <= 0 || endIndex <= startIndex) return 0;

--- a/assets/js/utils/camera-motion.ts
+++ b/assets/js/utils/camera-motion.ts
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+
+export type AxisFunction = 'sin' | 'cos';
+
+export interface AxisMotionOptions {
+  amplitude: number;
+  frequency?: number;
+  phase?: number;
+  fn?: AxisFunction;
+}
+
+export interface Vector3Like {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface LookAtConfig {
+  target?: Vector3Like | THREE.Vector3;
+  oscillation?: Partial<Record<'x' | 'y' | 'z', AxisMotionOptions>>;
+}
+
+export interface CameraMotionConfig {
+  basePosition?: Vector3Like | THREE.Vector3;
+  oscillation?: Partial<Record<'x' | 'y' | 'z', AxisMotionOptions>>;
+  lookAt?: LookAtConfig;
+}
+
+const DEFAULT_AXIS_FUNCTION: AxisFunction = 'sin';
+const DEFAULT_FREQUENCY = 1;
+
+const asVector3 = (value?: Vector3Like | THREE.Vector3): THREE.Vector3 => {
+  if (!value) return new THREE.Vector3();
+  return value instanceof THREE.Vector3
+    ? value.clone()
+    : new THREE.Vector3(value.x, value.y, value.z);
+};
+
+const applyAxisMotion = (
+  base: number,
+  elapsedSeconds: number,
+  motion?: AxisMotionOptions
+): number => {
+  if (!motion) return base;
+
+  const fn = motion.fn ?? DEFAULT_AXIS_FUNCTION;
+  const frequency = motion.frequency ?? DEFAULT_FREQUENCY;
+  const phase = motion.phase ?? 0;
+  const oscillator = fn === 'cos' ? Math.cos : Math.sin;
+
+  return (
+    base + oscillator(elapsedSeconds * frequency + phase) * motion.amplitude
+  );
+};
+
+export function updateCameraMotion(
+  camera: THREE.Camera,
+  elapsedSeconds: number,
+  config: CameraMotionConfig
+) {
+  const basePosition = asVector3(config.basePosition ?? camera.position);
+  const positionMotion = config.oscillation ?? {};
+
+  camera.position.set(
+    applyAxisMotion(basePosition.x, elapsedSeconds, positionMotion.x),
+    applyAxisMotion(basePosition.y, elapsedSeconds, positionMotion.y),
+    applyAxisMotion(basePosition.z, elapsedSeconds, positionMotion.z)
+  );
+
+  const lookAtConfig = config.lookAt;
+  if (lookAtConfig) {
+    const baseTarget = asVector3(lookAtConfig.target);
+    const targetMotion = lookAtConfig.oscillation ?? {};
+    const target = new THREE.Vector3(
+      applyAxisMotion(baseTarget.x, elapsedSeconds, targetMotion.x),
+      applyAxisMotion(baseTarget.y, elapsedSeconds, targetMotion.y),
+      applyAxisMotion(baseTarget.z, elapsedSeconds, targetMotion.z)
+    );
+    camera.lookAt(target);
+  }
+}

--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -21,8 +21,9 @@ class PatternRecognizer {
     // Get current frequency data and add to pattern buffer
     const data = this.analyser.getFrequencyData();
     if (this.patternBuffer.length === 0) {
-      this.patternBuffer = Array.from({ length: this.bufferSize }, () =>
-        new (data.constructor as typeof Uint8Array)(data.length)
+      this.patternBuffer = Array.from(
+        { length: this.bufferSize },
+        () => new (data.constructor as typeof Uint8Array)(data.length)
       );
     }
 
@@ -40,7 +41,8 @@ class PatternRecognizer {
     if (this.filled < this.bufferSize) return null;
 
     const lastIndex = (this.writeIndex + this.bufferSize - 1) % this.bufferSize;
-    const secondLastIndex = (this.writeIndex + this.bufferSize - 2) % this.bufferSize;
+    const secondLastIndex =
+      (this.writeIndex + this.bufferSize - 2) % this.bufferSize;
 
     const lastPattern = this.patternBuffer[lastIndex];
     const secondLastPattern = this.patternBuffer[secondLastIndex];

--- a/assets/ui/hints.ts
+++ b/assets/ui/hints.ts
@@ -125,7 +125,7 @@ export function initHints({
   id,
   tips,
   title = 'Quick tips',
-  ctaLabel = "Got it",
+  ctaLabel = 'Got it',
   container = document.body,
 }: HintOptions): void {
   if (!tips?.length || hasDismissed(id)) return;

--- a/tests/animation-utils.test.js
+++ b/tests/animation-utils.test.js
@@ -6,9 +6,13 @@ import {
 
 function expectedBandAverage(audioData, startRatio, endRatio) {
   const startIndex = Math.max(0, Math.floor(audioData.length * startRatio));
-  const endIndex = Math.min(audioData.length, Math.ceil(audioData.length * endRatio));
+  const endIndex = Math.min(
+    audioData.length,
+    Math.ceil(audioData.length * endRatio)
+  );
   const bucketWidth =
-    Math.ceil(audioData.length * endRatio) - Math.floor(audioData.length * startRatio);
+    Math.ceil(audioData.length * endRatio) -
+    Math.floor(audioData.length * startRatio);
 
   if (bucketWidth <= 0 || endIndex <= startIndex) return 0;
 
@@ -34,7 +38,9 @@ describe('animation-utils', () => {
   });
 
   test('applyAudioRotation uses consistent bucket widths for low/mid/high bands', () => {
-    const audioData = new Uint8Array([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]);
+    const audioData = new Uint8Array([
+      5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60,
+    ]);
     const object = { rotation: { x: 0, y: 0 } };
 
     const bands = [


### PR DESCRIPTION
## Summary
- add a reusable camera motion utility to drive oscillating positions and look targets
- refactor bouncy spheres and star field toys to use the shared camera motion helper instead of inline sway code
- apply formatting updates from the repository prettier pass

## Testing
- npm run lint
- npm run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437fb95f7483328d4547f7859d6a04)