### PR TITLE
Add shared audio start helper for toys

### DIFF
--- a/assets/js/toys/bouncy-spheres.ts
+++ b/assets/js/toys/bouncy-spheres.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 70 } },
@@ -131,13 +131,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate, { fftSize: 256 });
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate, 256);
 }
 
 init();

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 30, z: 80 } },
@@ -58,13 +58,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate, { fftSize: 128 });
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate, 128);
 }
 
 init();

--- a/assets/js/toys/particle-orbit.ts
+++ b/assets/js/toys/particle-orbit.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 60 } },
@@ -52,13 +52,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate, { fftSize: 256 });
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate, 256);
 }
 
 init();

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
@@ -179,13 +179,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate, { fftSize: 256 });
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate, 256);
 }
 
 init();

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
@@ -56,13 +56,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate);
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate);
 }
 
 init();

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -2,11 +2,11 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
+import { startToyAudio } from '../utils/start-audio';
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
@@ -189,13 +189,7 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  try {
-    await startAudioLoop(toy, animate, { fftSize: 256 });
-    return true;
-  } catch (e) {
-    console.error('Microphone access denied', e);
-    throw e;
-  }
+  return startToyAudio(toy, animate, 256);
 }
 
 init();

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -2,7 +2,6 @@ import * as THREE from 'three';
 import WebToy from '../core/web-toy';
 import type { ToyConfig } from '../core/types';
 import {
-  startAudioLoop,
   getContextFrequencyData,
   AnimationContext,
 } from '../core/animation-loop';
@@ -12,6 +11,7 @@ import {
   createControlPanel,
   type ControlPanelState,
 } from '../utils/control-panel';
+import { startToyAudio } from '../utils/start-audio';
 
 let errorElement: HTMLElement | null;
 
@@ -204,11 +204,10 @@ function animate(ctx: AnimationContext) {
 
 async function startAudio() {
   try {
-    await startAudioLoop(toy, animate);
+    await startToyAudio(toy, animate);
     hideError();
     return true;
   } catch (e) {
-    console.error('Error accessing microphone:', e);
     showError('Microphone access was denied. Please allow access and reload.');
     throw e;
   }

--- a/assets/js/utils/start-audio.ts
+++ b/assets/js/utils/start-audio.ts
@@ -1,0 +1,15 @@
+import type WebToy from '../core/web-toy';
+import { AnimationContext, startAudioLoop } from '../core/animation-loop';
+
+export async function startToyAudio(
+  toy: WebToy,
+  animate: (ctx: AnimationContext) => void,
+  fftSize?: number
+): Promise<AnimationContext> {
+  try {
+    return await startAudioLoop(toy, animate, fftSize ? { fftSize } : {});
+  } catch (error) {
+    console.error('Microphone access denied', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `startToyAudio` helper to wrap `startAudioLoop` with consistent logging
- update audio-enabled toy modules to use the helper while keeping window exports
- keep optional FFT size configuration when starting audio loops

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437faa72d88332b865b7ebe0f2c4df)