### PR TITLE
Add shared audio fallback helper

### DIFF
--- a/assets/js/utils/error-helper.ts
+++ b/assets/js/utils/error-helper.ts
@@ -1,0 +1,29 @@
+const ERROR_ELEMENT_ID = 'error-message';
+
+function getErrorElement(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(ERROR_ELEMENT_ID);
+}
+
+export function showError(message: string) {
+  const el = getErrorElement();
+  if (!el) return;
+
+  el.textContent = message;
+  el.style.display = 'block';
+}
+
+export function hideError() {
+  const el = getErrorElement();
+  if (!el) return;
+
+  el.textContent = '';
+  el.style.display = 'none';
+}
+
+export const AUDIO_UNAVAILABLE_MESSAGE =
+  'Microphone access is unavailable. Visuals will run without audio reactivity.';
+
+export function showAudioUnavailableError() {
+  showError(AUDIO_UNAVAILABLE_MESSAGE);
+}

--- a/brand.html
+++ b/brand.html
@@ -16,20 +16,13 @@
       import {
         startAudioLoop,
         getContextFrequencyData,
+        handleAudioFallback,
       } from './assets/js/core/animation-loop.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createBrandFunAdapter } from './assets/brand/fun-adapter.ts';
 
       const canvas = document.getElementById('vizCanvas');
-
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'brand-visualizer',
@@ -268,15 +261,7 @@
       startAudioLoop(toy, animate, {
         positional: true,
         object: toy.camera,
-      }).catch((err) => {
-        console.error('Audio input error: ', err);
-        funControls.setAudioAvailable(false);
-        displayError(
-          'Microphone access is unavailable. Visuals will run without audio reactivity.'
-        );
-        const silentContext = { toy, analyser: null };
-        toy.renderer.setAnimationLoop(() => animate(silentContext));
-      });
+      }).catch(handleAudioFallback(toy, animate, funControls));
     </script>
   </body>
 </html>

--- a/multi.html
+++ b/multi.html
@@ -23,6 +23,7 @@
       import {
         startAudioLoop,
         getContextFrequencyData,
+        handleAudioFallback,
       } from './assets/js/core/animation-loop.ts';
       import createPeakDetector from './assets/js/utils/peak-detector.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
@@ -31,14 +32,6 @@
       import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
-
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'multi-visualizer',
@@ -342,16 +335,9 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate)
-        .catch((err) => {
-          console.error('The following error occurred: ' + err);
-          funControls.setAudioAvailable(false);
-          displayError(
-            'Microphone access is unavailable. Visuals will run without audio reactivity.'
-          );
-          const silentContext = { toy, analyser: null };
-          toy.renderer.setAnimationLoop(() => animate(silentContext));
-        });
+      startAudioLoop(toy, animate).catch(
+        handleAudioFallback(toy, animate, funControls)
+      );
     </script>
   </body>
 </html>

--- a/seary.html
+++ b/seary.html
@@ -33,18 +33,13 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { showAudioUnavailableError } from './assets/js/utils/error-helper.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSearyFunAdapter } from './assets/seary/fun-adapter.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
+      
 
       initHints({
         id: 'seary-visualizer',
@@ -305,9 +300,7 @@
                 })
                 .catch((err) => {
                   console.error('Error capturing audio: ', err);
-                  displayError(
-                    'Microphone access is required for the visualization to work. Please allow microphone access.'
-                  );
+                  showAudioUnavailableError();
                 });
             } else {
               // Use the audio context's `createMediaElementSource` to capture device audio

--- a/symph.html
+++ b/symph.html
@@ -35,20 +35,18 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import {
+        hideError,
+        showAudioUnavailableError,
+        showError,
+      } from './assets/js/utils/error-helper.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSymphFunAdapter } from './assets/symph/fun-adapter.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
-      const errorEl = document.getElementById('error-message');
-
-      function displayError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
+      
 
       initHints({
         id: 'symph-visualizer',
@@ -59,17 +57,8 @@
         ],
       });
 
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
-
       if (!gl) {
-        displayError(
-          'Unable to initialize WebGL. Your browser may not support it.'
-        );
+        showError('Unable to initialize WebGL. Your browser may not support it.');
         throw new Error('WebGL not supported');
       }
 
@@ -227,9 +216,7 @@
           getAudioData();
           funControls.setAudioAvailable(true);
         } catch (err) {
-          displayError(
-            'Microphone access is unavailable. Visuals will run without audio reactivity.'
-          );
+          showAudioUnavailableError();
           funControls.setAudioAvailable(false);
           audioData = adapter.transformAudioValue(0);
           console.error('Error capturing audio: ', err);


### PR DESCRIPTION
## Summary
- add shared audio fallback handler with standardized audio error messaging
- update audio-reactive pages to reuse the shared fallback instead of duplicating logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437f90d0a08332bb1a072fb3dc6344)