### PR TITLE
Add reusable canvas resize helper

### DIFF
--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -1,0 +1,56 @@
+export type CanvasContext =
+  | CanvasRenderingContext2D
+  | WebGLRenderingContext
+  | WebGL2RenderingContext;
+
+export interface CanvasResizeOptions {
+  maxPixelRatio?: number;
+  onResize?: (dimensions: {
+    width: number;
+    height: number;
+    cssWidth: number;
+    cssHeight: number;
+    pixelRatio: number;
+  }) => void;
+}
+
+export function setupCanvasResize(
+  canvas: HTMLCanvasElement,
+  context: CanvasContext,
+  { maxPixelRatio, onResize }: CanvasResizeOptions = {}
+) {
+  const resize = () => {
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, maxPixelRatio ?? window.devicePixelRatio || 1);
+    const cssWidth = window.innerWidth;
+    const cssHeight = window.innerHeight;
+    const width = Math.max(1, Math.floor(cssWidth * pixelRatio));
+    const height = Math.max(1, Math.floor(cssHeight * pixelRatio));
+
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+
+    if ('viewport' in context && typeof context.viewport === 'function') {
+      const viewportWidth =
+        'drawingBufferWidth' in context && typeof context.drawingBufferWidth === 'number'
+          ? context.drawingBufferWidth
+          : width;
+      const viewportHeight =
+        'drawingBufferHeight' in context && typeof context.drawingBufferHeight === 'number'
+          ? context.drawingBufferHeight
+          : height;
+
+      context.viewport(0, 0, viewportWidth, viewportHeight);
+    } else {
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    }
+
+    onResize?.({ width, height, cssWidth, cssHeight, pixelRatio });
+  };
+
+  resize();
+  window.addEventListener('resize', resize);
+
+  return () => window.removeEventListener('resize', resize);
+}

--- a/evol.html
+++ b/evol.html
@@ -62,6 +62,7 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { setupCanvasResize } from './assets/js/utils/canvas-resize.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const errorEl = document.getElementById('error-message');
@@ -86,14 +87,6 @@
         );
         throw new Error('WebGL not supported');
       }
-
-      function resizeCanvas() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-      }
-      window.addEventListener('resize', resizeCanvas);
-      resizeCanvas();
 
       const vertexShaderSource = `
             attribute vec4 a_position;
@@ -265,7 +258,12 @@
         'u_fractalIntensity'
       );
 
-      gl.uniform2f(resolutionUniformLocation, canvas.width, canvas.height);
+      const disposeResize = setupCanvasResize(canvas, gl, {
+        maxPixelRatio: 2,
+        onResize: ({ width, height }) => {
+          gl.uniform2f(resolutionUniformLocation, width, height);
+        },
+      });
 
       let time = 0.0;
       let audioData = 0.0;
@@ -317,6 +315,7 @@
       }
 
       requestAnimationFrame(render);
+      window.addEventListener('pagehide', disposeResize);
     </script>
   </body>
 </html>

--- a/seary.html
+++ b/seary.html
@@ -36,6 +36,7 @@
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSearyFunAdapter } from './assets/seary/fun-adapter.ts';
+      import { setupCanvasResize } from './assets/js/utils/canvas-resize.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
       function displayError(message) {
@@ -72,14 +73,7 @@
         throw new Error('WebGL not supported');
       }
 
-      // Resize canvas
-      function resizeCanvas() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-        gl.viewport(0, 0, canvas.width, canvas.height);
-      }
-      window.addEventListener('resize', resizeCanvas);
-      resizeCanvas();
+      const disposeResize = setupCanvasResize(canvas, gl, { maxPixelRatio: 2 });
 
       // Compile shader
       function compileShader(source, type) {
@@ -458,6 +452,7 @@
         requestAnimationFrame(render);
       }
       requestAnimationFrame(render);
+      window.addEventListener('pagehide', disposeResize);
     </script>
   </body>
 </html>

--- a/symph.html
+++ b/symph.html
@@ -35,6 +35,7 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { setupCanvasResize } from './assets/js/utils/canvas-resize.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSymphFunAdapter } from './assets/symph/fun-adapter.ts';
@@ -72,14 +73,6 @@
         );
         throw new Error('WebGL not supported');
       }
-
-      function resizeCanvas() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-      }
-      window.addEventListener('resize', resizeCanvas);
-      resizeCanvas();
 
       const vertexShaderSource = `
             attribute vec4 a_position;
@@ -198,7 +191,12 @@
       );
       const touchUniformLocation = gl.getUniformLocation(program, 'u_touch');
 
-      gl.uniform2f(resolutionUniformLocation, canvas.width, canvas.height);
+      const disposeResize = setupCanvasResize(canvas, gl, {
+        maxPixelRatio: 2,
+        onResize: ({ width, height }) => {
+          gl.uniform2f(resolutionUniformLocation, width, height);
+        },
+      });
 
       const adapter = createSymphFunAdapter();
       const funControls = initFunControls({
@@ -289,10 +287,11 @@
 
       // Handle pointer input
       canvas.addEventListener('pointermove', (event) => {
-        const x = (event.clientX / canvas.width) * 2.0 - 1.0;
-        const y = -(event.clientY / canvas.height) * 2.0 + 1.0;
+        const x = (event.clientX / canvas.clientWidth) * 2.0 - 1.0;
+        const y = -(event.clientY / canvas.clientHeight) * 2.0 + 1.0;
         touchPoint = [x, y];
       });
+      window.addEventListener('pagehide', disposeResize);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared canvas resize utility for canvas and WebGL contexts with optional pixel-ratio caps
- update sgpat, evol, seary, and symph visualizers to use the helper for consistent sizing
- ensure resize listeners can be cleaned up and pointer math stays aligned with CSS dimensions

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437f8b277083329da0e15dbeb45dde)