### PR TITLE
Simplify home landing layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -32,27 +32,10 @@ body,
 html {
   padding: 0;
   font-family: 'Space Grotesk', sans-serif;
-  background: radial-gradient(
-      circle at 20% 20%,
-      rgba(76, 238, 167, 0.1),
-      transparent 35%
-    ),
-    radial-gradient(
-      circle at 80% 10%,
-      rgba(255, 119, 255, 0.1),
-      transparent 35%
-    ),
-    linear-gradient(135deg, var(--bg-color) 0%, var(--bg-color-secondary) 100%);
+  background: linear-gradient(135deg, var(--bg-color) 0%, var(--bg-color-secondary) 100%);
   color: var(--text-color);
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#bg-canvas {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: -1;
 }
 
 .content {
@@ -67,14 +50,7 @@ html {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 0;
-  position: sticky;
-  top: 0;
-  backdrop-filter: blur(8px);
-  background: rgba(0, 0, 0, 0.35);
-  z-index: 10;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
+  padding: 0.5rem 0;
   margin-bottom: 1.5rem;
 }
 
@@ -133,10 +109,16 @@ header.hero {
 }
 
 .hero-grid {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-copy {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.5rem;
-  align-items: stretch;
+  gap: 0.75rem;
 }
 
 .hero-copy h1 {
@@ -153,10 +135,10 @@ header.hero {
 }
 
 .tagline {
-  font-size: 1.1rem;
+  font-size: 1rem;
   margin-top: 0;
-  max-width: 650px;
-  line-height: 1.7;
+  max-width: 520px;
+  line-height: 1.5;
   opacity: 0.85;
 }
 
@@ -184,7 +166,6 @@ header.hero {
 .cta-button.primary {
   background: var(--accent-color);
   color: var(--bg-color);
-  box-shadow: 0 10px 30px rgba(76, 238, 167, 0.35);
 }
 
 .cta-button.ghost {
@@ -198,79 +179,21 @@ header.hero {
   color: var(--text-color);
 }
 
-.chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  opacity: 0.9;
-}
 
-.chip {
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid var(--hover-bg);
-  background: rgba(255, 255, 255, 0.04);
-  font-size: 0.85rem;
-}
-
-.hero-card {
-  padding: 1.75rem;
-  background: var(--card-bg);
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
-  backdrop-filter: blur(10px);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.hero-card-title {
-  font-size: 1.6rem;
-  margin: 0;
-}
-
-.hero-card-subtitle {
-  margin: 0;
-  opacity: 0.75;
-}
-
-.feature-list {
+.hero-list {
   list-style: none;
   padding: 0;
-  margin: 0.5rem 0 1rem;
+  margin: 0;
   display: grid;
-  gap: 0.35rem;
-}
-
-.feature-list li::before {
-  content: '•';
-  margin-right: 0.5rem;
-  color: var(--accent-color);
-}
-
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
+  max-width: 520px;
 }
 
-.stat-card {
-  border: 1px solid rgba(255, 255, 255, 0.08);
+.hero-list li {
+  background: var(--card-bg);
   border-radius: 12px;
-  padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.stat-value {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.stat-label {
-  margin: 0;
-  opacity: 0.65;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 @keyframes hueShift {
@@ -396,8 +319,6 @@ footer {
   text-align: center;
   margin-top: 3rem;
   padding: 1rem;
-  background: rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(5px);
 }
 
 .theme-toggle {
@@ -412,28 +333,6 @@ footer {
 
 .theme-toggle:hover {
   background: var(--hover-bg);
-}
-
-.cursor,
-.cursor-follower {
-  pointer-events: none;
-  position: fixed;
-  border-radius: 50%;
-  z-index: 9999;
-}
-
-.cursor {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--accent-color);
-  transition: all 0.1s ease;
-}
-
-.cursor-follower {
-  width: 40px;
-  height: 40px;
-  background: rgba(0, 255, 170, 0.2);
-  transition: all 0.3s ease;
 }
 
 @media (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -22,9 +22,6 @@
     </script>
   </head>
   <body>
-    <canvas id="bg-canvas"></canvas>
-    <div class="cursor"></div>
-    <div class="cursor-follower"></div>
     <div class="content">
       <nav class="top-nav">
         <div class="brand">
@@ -53,8 +50,9 @@
             <p class="eyebrow">New home for sensory experiments</p>
             <h1>Interactive playgrounds for curious minds.</h1>
             <p class="tagline">
-              Wander through a curated set of audiovisual toys, crafted for
-              play, inspiration, and a bit of mindful stimulus.
+              Browse a lean catalog of audiovisual toys. Each sketch loads
+              instantly—tap a card to jump in or share the link to invite
+              someone else.
             </p>
             <div class="cta-row">
               <a href="#toy-list" class="cta-button primary">Browse library</a>
@@ -66,32 +64,11 @@
                 >View the code</a
               >
             </div>
-            <div class="chip-row" aria-hidden="true">
-              <span class="chip">WebGL</span>
-              <span class="chip">Particles</span>
-              <span class="chip">Kinetic typography</span>
-              <span class="chip">Shader sketches</span>
-            </div>
-          </div>
-          <div class="hero-card">
-            <p class="eyebrow">Live signal</p>
-            <p class="hero-card-title">Stim stream</p>
-            <p class="hero-card-subtitle">Now featuring</p>
-            <ul class="feature-list">
-              <li>20 interactive sketches including HTML standalones</li>
-              <li>Instant load from query</li>
-              <li>Dark / light optimized</li>
+            <ul class="hero-list">
+              <li>Instant access to every stim, no extra clicks.</li>
+              <li>Light and dark modes saved to your preference.</li>
+              <li>Includes both module-based toys and standalone HTML sets.</li>
             </ul>
-            <div class="stat-grid">
-              <div class="stat-card">
-                <p class="stat-value">04</p>
-                <p class="stat-label">New arrivals</p>
-              </div>
-              <div class="stat-card">
-                <p class="stat-value">∞</p>
-                <p class="stat-label">Loops to explore</p>
-              </div>
-            </div>
           </div>
         </div>
       </header>
@@ -101,9 +78,9 @@
           <p class="eyebrow">Library</p>
           <h2>Browse every stim</h2>
           <p class="section-description">
-            Tap a card to open it instantly, or share a URL to load a toy from a
-            query param. The catalog now includes standalone HTML stims like
-            Clay, Geom, Legible, and Lights alongside the module-based set.
+            Tap a card to open it instantly. Standalone stims like Clay, Geom,
+            Legible, and Lights sit alongside the module-based set so everything
+            is easy to reach.
           </p>
         </div>
         <main id="toy-list" class="webtoy-container"></main>
@@ -123,71 +100,6 @@
       </footer>
     </div>
 
-    <script type="module">
-      import * as THREE from 'three';
-      import { initRenderer } from './assets/js/core/renderer-setup.ts';
-
-      function startBackground() {
-        // Three.js background
-        const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(
-          75,
-          window.innerWidth / window.innerHeight,
-          0.1,
-          1000
-        );
-        const renderer = initRenderer(document.getElementById('bg-canvas'), {
-          maxPixelRatio: 1.5,
-          alpha: true,
-        });
-
-        if (!renderer) {
-          return;
-        }
-
-        const geometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
-        const material = new THREE.MeshBasicMaterial({
-          color: 0x00ffaa,
-          wireframe: true,
-        });
-        const torusKnot = new THREE.Mesh(geometry, material);
-        scene.add(torusKnot);
-
-        camera.position.z = 30;
-
-        function animate() {
-          requestAnimationFrame(animate);
-          torusKnot.rotation.x += 0.01;
-          torusKnot.rotation.y += 0.01;
-          renderer.render(scene, camera);
-        }
-        animate();
-
-        // Custom cursor
-        const cursor = document.querySelector('.cursor');
-        const cursorFollower = document.querySelector('.cursor-follower');
-
-        document.addEventListener('pointermove', (e) => {
-          cursor.style.left = e.clientX + 'px';
-          cursor.style.top = e.clientY + 'px';
-
-          setTimeout(() => {
-            cursorFollower.style.left = e.clientX + 'px';
-            cursorFollower.style.top = e.clientY + 'px';
-          }, 100);
-        });
-
-        // Responsive canvas
-        window.addEventListener('resize', () => {
-          camera.aspect = window.innerWidth / window.innerHeight;
-          camera.updateProjectionMatrix();
-          renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
-          renderer.setSize(window.innerWidth, window.innerHeight);
-        });
-      }
-
-      startBackground();
-    </script>
     <script type="module" src="assets/js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline the home hero copy with concise bullets and simpler CTA row
- remove the animated background canvas and cursor chrome to keep the page lightweight
- refresh landing styles for centered layout and pared-back spacing

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943847783e08332970d6506a3e2e22c)