### PR TITLE
Use shared audio helper across visualizers

### DIFF
--- a/assets/js/utils/start-audio.ts
+++ b/assets/js/utils/start-audio.ts
@@ -1,13 +1,24 @@
 import type WebToy from '../core/web-toy';
 import { AnimationContext, startAudioLoop } from '../core/animation-loop';
+import type { AudioInitOptions } from './audio-handler';
+
+type StartAudioOptions = AudioInitOptions | number | undefined;
+
+function normalizeOptions(options: StartAudioOptions): AudioInitOptions {
+  if (typeof options === 'number') {
+    return { fftSize: options };
+  }
+
+  return options ?? {};
+}
 
 export async function startToyAudio(
   toy: WebToy,
   animate: (ctx: AnimationContext) => void,
-  fftSize?: number
+  options?: StartAudioOptions
 ): Promise<AnimationContext> {
   try {
-    return await startAudioLoop(toy, animate, fftSize ? { fftSize } : {});
+    return await startAudioLoop(toy, animate, normalizeOptions(options));
   } catch (error) {
     console.error('Microphone access denied', error);
     throw error;

--- a/brand.html
+++ b/brand.html
@@ -13,11 +13,9 @@
       import * as THREE from 'three';
       import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
       import WebToy from './assets/js/core/web-toy.ts';
-      import {
-        startAudioLoop,
-        getContextFrequencyData,
-      } from './assets/js/core/animation-loop.ts';
+      import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
       import { showError } from './assets/js/utils/error-display.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createBrandFunAdapter } from './assets/brand/fun-adapter.ts';
@@ -258,7 +256,7 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate, {
+      startToyAudio(toy, animate, {
         positional: true,
         object: toy.camera,
       }).catch((err) => {

--- a/multi.html
+++ b/multi.html
@@ -20,13 +20,11 @@
     <script type="module">
       import * as THREE from 'three';
       import WebToy from './assets/js/core/web-toy.ts';
-      import {
-        startAudioLoop,
-        getContextFrequencyData,
-      } from './assets/js/core/animation-loop.ts';
+      import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
       import createPeakDetector from './assets/js/utils/peak-detector.ts';
       import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
       import { showError } from './assets/js/utils/error-display.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
@@ -334,7 +332,7 @@
         ctx.toy.render();
       }
 
-      startAudioLoop(toy, animate)
+      startToyAudio(toy, animate)
         .catch((err) => {
           console.error('The following error occurred: ' + err);
           funControls.setAudioAvailable(false);


### PR DESCRIPTION
## Summary
- extend the shared startToyAudio helper to accept broader audio init options
- update the brand and multi visualizers to rely on the shared audio helper instead of direct animation loop calls

## Testing
- npm run lint
- npm run format

## Checklist
- [x] Linting (`npm run lint`) if applicable
- [ ] Tests (`npm test`) if applicable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943859dc6d0833286f20e1746ab8fcc)