### PR TITLE
Refine evol control panel styling

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -105,3 +105,18 @@ body {
   outline: 2px solid rgba(112, 240, 255, 0.6);
   outline-offset: 2px;
 }
+
+#error-message {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  display: none;
+  color: #ff7b7b;
+  background: rgba(0, 0, 0, 0.78);
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 123, 123, 0.35);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  z-index: 1200;
+  font-weight: 600;
+}

--- a/evol.html
+++ b/evol.html
@@ -5,48 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Evolutionary Weirdcore Visualizer</title>
     <link rel="stylesheet" href="assets/css/base.css" />
-    <style>
-      body {
-        background-color: #000000; /* OLED black */
-      }
-      canvas {
-        width: 100vw;
-        height: 100vh;
-      }
-      #controls {
-        position: absolute;
-        top: 10px;
-        left: 10px;
-        z-index: 10;
-        background: rgba(0, 0, 0, 0.7);
-        padding: 15px;
-        border-radius: 8px;
-      }
-      #controls label {
-        color: #ffffff;
-        font-size: 14px;
-        display: block;
-        margin-bottom: 5px;
-      }
-      #error-message {
-        position: absolute;
-        top: 20px;
-        left: 20px;
-        color: #ff0000;
-        background: rgba(0, 0, 0, 0.7);
-        padding: 10px;
-        border-radius: 5px;
-        z-index: 10;
-      }
-    </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
-    <div id="error-message" style="display: none"></div>
+    <div id="error-message"></div>
     <canvas id="glCanvas"></canvas>
-    <div id="controls">
-      <label>
-        Fractal Intensity:
+    <div class="control-panel">
+      <div class="control-panel__row">
+        <label class="control-panel__text" for="fractalIntensity">
+          <span class="control-panel__label">Fractal Intensity</span>
+        </label>
         <input
           type="range"
           id="fractalIntensity"
@@ -55,7 +23,7 @@
           step="0.1"
           value="1.0"
         />
-      </label>
+      </div>
     </div>
     <script type="module">
       import {


### PR DESCRIPTION
## Summary
- replace the evol controls markup with the shared control-panel structure for consistent placement
- centralize the error message styling in the shared base stylesheet after removing the inline block

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438631bcbc8332a92c17dea8835301)