### PR TITLE
Add shared Space Grotesk typography across visualizers

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,8 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
 html,
 body {
   margin: 0;
   overflow: hidden;
   height: 100%;
+  font-family: 'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system,
+    sans-serif;
+  color: #f5f5f5;
+  line-height: 1.6;
 }
 canvas {
   display: block;

--- a/clay.html
+++ b/clay.html
@@ -16,7 +16,6 @@
         top: 10px;
         left: 10px;
         color: #fff;
-        font-family: Arial, sans-serif;
         z-index: 1;
         background: rgba(0, 0, 0, 0.5);
         padding: 10px;

--- a/defrag.html
+++ b/defrag.html
@@ -8,7 +8,6 @@
     <style>
       body {
         background-color: #000000; /* OLED black */
-        font-family: 'Courier New', monospace;
         color: #00ff00; /* Old-school green text */
       }
       #defragText {

--- a/legible.html
+++ b/legible.html
@@ -17,7 +17,6 @@
         align-items: center;
         background-color: #000;
         color: #00ff00;
-        font-family: 'Courier New', monospace;
       }
       #particles-js {
         position: absolute;

--- a/lights.html
+++ b/lights.html
@@ -9,7 +9,6 @@
       body,
       html {
         padding: 0;
-        font-family: Arial, sans-serif;
         background-color: #111;
         color: white;
         display: flex;

--- a/sgpat.html
+++ b/sgpat.html
@@ -13,7 +13,6 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        font-family: Arial, sans-serif;
       }
       #error-message {
         position: absolute;

--- a/symph.html
+++ b/symph.html
@@ -12,7 +12,6 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        font-family: Arial, sans-serif;
       }
       #error-message {
         position: absolute;

--- a/words.html
+++ b/words.html
@@ -19,7 +19,6 @@
         background: linear-gradient(135deg, #6a11cb, #2575fc);
         background-size: 400% 400%;
         animation: backgroundShift 10s ease infinite;
-        font-family: 'Arial', sans-serif;
         position: relative;
       }
 


### PR DESCRIPTION
## Summary
- add a shared Space Grotesk font stack to the base styles used by all pages
- remove page-specific font overrides so visualizer pages inherit the shared typography

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438621c1e08332b48e064e5b78c426)