### PR TITLE
Improve toy navigation with History API

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -11,6 +11,20 @@ body {
   background-color: #000;
 }
 
+.is-hidden {
+  display: none !important;
+}
+
+.active-toy-container {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  overflow: hidden;
+  z-index: 2;
+}
+
 /* Small link to return to the main library */
 .home-link {
   position: fixed;

--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -1,4 +1,4 @@
-import { loadToy, loadFromQuery } from './loader.js';
+import { initNavigation, loadToy, loadFromQuery } from './loader.js';
 import toysData from './toys-data.js';
 
 let allToys = [];
@@ -15,7 +15,7 @@ function createCard(toy) {
 
   card.addEventListener('click', () => {
     if (toy.type === 'module') {
-      loadToy(toy.slug);
+      loadToy(toy.slug, { pushState: true });
     } else {
       window.location.href = toy.module;
     }
@@ -47,6 +47,7 @@ async function init() {
 
   const search = document.getElementById('search-bar');
   search?.addEventListener('input', (e) => filterToys(e.target.value));
+  initNavigation();
   await loadFromQuery();
 }
 

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -30,7 +30,10 @@ export default class WebToy {
     }
 
     this.canvas = canvas || document.createElement('canvas');
-    document.body.appendChild(this.canvas);
+
+    const host =
+      document.getElementById('active-toy-container') || document.body;
+    host.appendChild(this.canvas);
 
     this.scene = initScene(sceneOptions);
     this.camera = initCamera(cameraOptions);

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,7 +1,72 @@
 import toysData from './toys-data.js';
 
 const MANIFEST_PATH = '/.vite/manifest.json';
+const TOY_QUERY_PARAM = 'toy';
 let manifestPromise;
+let navigationInitialized = false;
+
+function getDocument() {
+  return typeof document === 'undefined' ? null : document;
+}
+
+function getWindow() {
+  return typeof window === 'undefined' ? null : window;
+}
+
+function getToyList() {
+  const doc = getDocument();
+  return doc?.getElementById('toy-list') ?? null;
+}
+
+function findActiveToyContainer() {
+  const doc = getDocument();
+  return doc?.getElementById('active-toy-container') ?? null;
+}
+
+function ensureActiveToyContainer() {
+  const existing = findActiveToyContainer();
+  if (existing) return existing;
+
+  const doc = getDocument();
+  if (!doc) return null;
+
+  const container = doc.createElement('div');
+  container.id = 'active-toy-container';
+  container.className = 'active-toy-container is-hidden';
+  doc.body.appendChild(container);
+  return container;
+}
+
+function hideElement(element) {
+  if (element && !element.classList.contains('is-hidden')) {
+    element.classList.add('is-hidden');
+  }
+}
+
+function showElement(element) {
+  if (element && element.classList.contains('is-hidden')) {
+    element.classList.remove('is-hidden');
+  }
+}
+
+function clearActiveToyContainer() {
+  const container = findActiveToyContainer();
+  if (!container) return;
+
+  while (container.firstChild) {
+    container.removeChild(container.firstChild);
+  }
+}
+
+function showLibraryView() {
+  showElement(getToyList());
+  hideElement(findActiveToyContainer());
+}
+
+function showActiveToyView() {
+  hideElement(getToyList());
+  showElement(ensureActiveToyContainer());
+}
 
 function disposeActiveToy() {
   const activeToy = globalThis.__activeWebToy;
@@ -13,6 +78,8 @@ function disposeActiveToy() {
       console.error('Error disposing existing toy', error);
     }
   }
+
+  clearActiveToyContainer();
 
   const globalObject = globalThis;
   delete globalObject.__activeWebToy;
@@ -41,11 +108,21 @@ export async function resolveModulePath(entry) {
   return entry.startsWith('/') || entry.startsWith('.') ? entry : `/${entry}`;
 }
 
-export async function loadToy(slug) {
+function pushToyState(slug) {
+  const win = getWindow();
+  if (!win?.history) return;
+
+  const url = new URL(win.location.href);
+  url.searchParams.set(TOY_QUERY_PARAM, slug);
+  win.history.pushState({ toy: slug }, '', url);
+}
+
+export async function loadToy(slug, { pushState = false } = {}) {
   const toys = toysData;
   const toy = toys.find((t) => t.slug === slug);
   if (!toy) {
     console.error(`Toy not found: ${slug}`);
+    showLibraryView();
     return;
   }
 
@@ -53,8 +130,12 @@ export async function loadToy(slug) {
     disposeActiveToy();
     window.location.href = `./${slug}.html`;
   } else if (toy.type === 'module') {
+    if (pushState) {
+      pushToyState(slug);
+    }
+
     disposeActiveToy();
-    document.getElementById('toy-list')?.remove();
+    showActiveToyView();
     const moduleUrl = await resolveModulePath(toy.module);
     await import(moduleUrl);
   } else {
@@ -64,9 +145,26 @@ export async function loadToy(slug) {
 }
 
 export async function loadFromQuery() {
-  const params = new URLSearchParams(window.location.search);
-  const slug = params.get('toy');
+  const win = getWindow();
+  if (!win) return;
+
+  const params = new URLSearchParams(win.location.search);
+  const slug = params.get(TOY_QUERY_PARAM);
+
   if (slug) {
     await loadToy(slug);
+  } else {
+    disposeActiveToy();
+    showLibraryView();
   }
+}
+
+export function initNavigation() {
+  const win = getWindow();
+  if (!win || navigationInitialized) return;
+
+  navigationInitialized = true;
+  win.addEventListener('popstate', () => {
+    loadFromQuery();
+  });
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import { loadToy, loadFromQuery } from './loader.js';
+import { initNavigation, loadToy, loadFromQuery } from './loader.js';
 import toysData from './toys-data.js';
 
 let allToys = [];
@@ -106,7 +106,7 @@ function renderToys(toys) {
 
 function openToy(toy) {
   if (toy.type === 'module') {
-    loadToy(toy.slug);
+    loadToy(toy.slug, { pushState: true });
   } else {
     window.location.href = toy.module;
   }
@@ -117,6 +117,7 @@ async function init() {
   renderToys(allToys);
 
   setupDarkModeToggle();
+  initNavigation();
   await loadFromQuery();
 }
 

--- a/assets/js/toyMain.js
+++ b/assets/js/toyMain.js
@@ -1,2 +1,4 @@
-import { loadFromQuery } from './loader.js';
+import { initNavigation, loadFromQuery } from './loader.js';
+
+initNavigation();
 loadFromQuery();


### PR DESCRIPTION
## Summary
- add History API support so module cards push state and popstate restores the library view
- hide the library grid instead of removing it while directing active toys into a dedicated container that is cleared on teardown
- initialize navigation helpers across entry points so querystring loads and back/forward navigation stay in sync

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943863be8d48332be404990f9ff2aba)