### PR TITLE
Add developer documentation set

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
-For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
 
 ## Quick Start
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,82 @@
+# Development Guide
+
+This guide focuses on day-to-day development tasks for the Stim Webtoys Library. It complements the quick start notes in `README.md` and the contribution checklist in `CONTRIBUTING.md`.
+
+## Tooling and Environment
+
+- **Node.js 22** is required (see `.nvmrc`). Run `nvm use` if you have nvm installed.
+- Install dependencies once per clone:
+  ```bash
+  npm install
+  ```
+- The project uses **TypeScript**, **Vite**, **Three.js**, and **Jest** with ESM. Keep `NODE_OPTIONS=--experimental-vm-modules` when invoking Jest directly.
+- Run the dev server locally:
+  ```bash
+  npm run dev
+  ```
+  The site serves from `http://localhost:5173`.
+
+## Common Scripts
+
+| Task | Command |
+| ---- | ------- |
+| Start dev server | `npm run dev` |
+| Production build | `npm run build` |
+| Preview build locally | `npm run preview` |
+| Run Jest suite | `npm test` |
+| Lint | `npm run lint` |
+| Format with Prettier | `npm run format` |
+
+When debugging a single test file, run:
+```bash
+npm run jest -- --testPathPattern=relative/path/to/spec
+```
+
+## Project Structure
+
+- `assets/js/toys/`: Individual toy implementations. Each module exports a `start` function that receives a DOM canvas/audio context.
+- `assets/js/core/`: Reusable systems such as renderer initialization, audio analysis, camera controls, and device input helpers.
+- `assets/js/utils/`: Small helpers (math, color, randomization, easing).
+- `assets/css/`: Shared styles for HTML entry points.
+- `assets/data/`: Static JSON or other payloads consumed by toys.
+- `tests/`: Jest specs covering utilities and shared behaviors.
+- HTML entry points (`toy.html`, `brand.html`, etc.) load specific toys or groups of toys.
+
+## Development Workflow
+
+1. **Create a branch** from `main` for each change.
+2. **Run linters and tests** before committing.
+3. **Keep changes scoped**: small, reviewable pull requests are easier to land.
+4. **Document additions**: update `assets/js/toys-data.js` when adding toys, and note any new npm scripts or setup steps in the docs.
+5. **Commit style**: prefer descriptive commit messages summarizing intent and outcome.
+
+## Working With Audio and Input
+
+- Toys often request microphone access. Provide clear UI messaging when microphone permissions are missing or denied.
+- When debugging audio issues, confirm `navigator.mediaDevices.getUserMedia` is available and that the page is served over HTTPS or `localhost`.
+- Device motion or touch input may be used on some toys—test on mobile-friendly viewports if you add multi-touch interactions.
+
+## Performance Tips
+
+- Three.js rendering defaults to `window.devicePixelRatio`; pass `maxPixelRatio` to `initRenderer` to cap DPI when targeting lower-powered devices.
+- Profile heavy scenes with the browser performance tools. Reduce geometry complexity, particle counts, or shader work when frame times exceed 16ms.
+- Debounce expensive resize handlers and cache allocations in animation loops.
+
+## Testing Expectations
+
+- Prefer fast, deterministic tests in `tests/`. Mock audio contexts or DOM APIs when real instances are unnecessary.
+- Use Jest’s ESM config from `package.json`; avoid CommonJS-specific globals.
+- Keep tests colocated with utilities when practical, or place shared behaviors in `tests/`.
+
+## Accessibility and UX
+
+- Add keyboard shortcuts or focusable controls when introducing new UI elements.
+- Provide feedback for permission failures, loading states, or unsupported browsers.
+- Avoid autoplaying audio; let users control start/stop actions.
+
+## Deployment Checklist
+
+- `npm run build` completes without errors.
+- Verify the generated `dist/` assets load via `npm run preview` or a simple static server.
+- Spot-check microphone prompts and toy selection flows in the production build.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Developer Docs
+
+This folder contains resources for contributors who are building or maintaining the Stim Webtoys Library:
+
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md): day-to-day setup, scripts, workflow, and performance/testing expectations.
+- [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): playbook for creating or updating toy experiences, including audio, rendering, and debugging tips.
+
+If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -1,0 +1,76 @@
+# Toy Development Playbook
+
+Use this playbook when adding or modifying toys so new experiences integrate cleanly with the rest of the Stim Webtoys Library.
+
+## Core Expectations
+
+- Place new toy modules under `assets/js/toys/` and export a `start(options)` entry point.
+- Register the toy in `assets/js/toys-data.js` with a unique slug, label, and any default parameters.
+- Load toys through `toy.html?toy=<slug>` or a dedicated HTML entry point. Keep query string slugs in sync with `toys-data.js`.
+- Keep assets (textures, JSON data, audio snippets) in `assets/data/` and reference them with relative paths.
+
+## Starter Template
+
+Use this skeleton for new toys to standardize lifecycle hooks and cleanup:
+```ts
+import { initRenderer } from '../core/renderer';
+import { createAnalyzer } from '../core/audio';
+
+export async function start({ canvas, audioContext }) {
+  const { renderer, scene, camera, resize } = initRenderer({ canvas, maxPixelRatio: 2 });
+  const analyzer = await createAnalyzer(audioContext);
+
+  function tick(time) {
+    const { frequency, waveform } = analyzer.sample();
+    // update your objects using frequency/waveform data here
+    renderer.render(scene, camera);
+    requestAnimationFrame(tick);
+  }
+
+  resize();
+  requestAnimationFrame(tick);
+
+  return () => {
+    analyzer.dispose?.();
+    renderer.dispose?.();
+  };
+}
+```
+Adjust imports to match the actual helpers you use.
+
+## Audio Reactivity Tips
+
+- Normalize microphone input: use the analyzer helpers in `assets/js/core/audio` to derive frequency bins, waveform data, and energy levels.
+- Consider a short attack/decay envelope to smooth sudden spikes.
+- Provide fallback visuals or an explicit "Enable mic" button when permission is missing.
+
+## Rendering Patterns
+
+- Keep animation state outside Three.js objects where possible; mutate them inside a `tick` loop driven by `requestAnimationFrame`.
+- Throttle expensive operations on resize and use the `maxPixelRatio` option to keep frame times stable on high-DPI screens.
+- Reuse materials and geometries instead of recreating them each frame. Dispose buffers and textures in the cleanup function.
+
+## Mobile and Interaction
+
+- Test on touch devices or emulators. Avoid interactions that depend solely on hover.
+- For device motion input, gate logic behind feature detection (`window.DeviceMotionEvent`).
+- Ensure important controls are keyboard-focusable and include visible focus states.
+
+## Debugging Checklist
+
+- If visuals are blank, confirm the canvas is attached and the renderer size matches `clientWidth`/`clientHeight`.
+- When audio-driven behavior seems off, log the analyzer samples to verify data ranges and check microphone permissions in the browser.
+- Validate new entries in `toys-data.js` by visiting `toy.html?toy=<slug>` and verifying the selection UI lists the new toy.
+
+## Testing Guidance
+
+- Add Jest specs for math and utility helpers in `assets/js/utils/` as they are shared by multiple toys.
+- For toy-specific logic, prefer unit-testing pure functions (e.g., color pickers, motion curves) rather than WebGL rendering.
+- Keep tests deterministic: mock `performance.now`, random seeds, and any time-based easing functions when needed.
+
+## Documentation
+
+- Update `README.md` and `CONTRIBUTING.md` if you introduce new scripts or global expectations.
+- Describe user-facing controls or setup steps in the associated HTML entry point if they deviate from existing patterns.
+- Include inline comments for novel shader parameters, math tricks, or input handling quirks.
+


### PR DESCRIPTION
## Summary
- add developer documentation folder with setup and workflow guidance
- document toy development playbook for adding or updating webtoys
- link main README to the new developer docs

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694387c73ad483328fb17cb5f8d50549)