### PR TITLE
Improve webtoy card accessibility

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -430,6 +430,11 @@ h1 {
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
+  color: inherit;
+  width: 100%;
+  display: block;
+  text-decoration: none;
+  appearance: none;
 }
 
 .webtoy-card:hover {
@@ -438,6 +443,12 @@ h1 {
   box-shadow: 0 18px 35px rgba(100, 244, 255, 0.22), 0 0 30px rgba(255, 46, 230, 0.18);
   border-color: var(--accent-color);
   filter: hue-rotate(10deg);
+}
+
+.webtoy-card:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 4px;
+  box-shadow: 0 0 24px var(--glow-color), 0 12px 30px rgba(0, 0, 0, 0.3);
 }
 
 .webtoy-card:focus-within {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -190,8 +190,9 @@ function createSVGAnimation(slug) {
 }
 
 function createCard(toy) {
-  const card = document.createElement('div');
+  const card = document.createElement('button');
   card.className = 'webtoy-card';
+  card.type = 'button';
   card.appendChild(createSVGAnimation(toy.slug));
   const title = document.createElement('h3');
   title.textContent = toy.title;
@@ -230,7 +231,15 @@ function createCard(toy) {
     card.appendChild(metaRow);
   }
 
-  card.addEventListener('click', () => openToy(toy));
+  const handleOpenToy = () => openToy(toy);
+
+  card.addEventListener('click', handleOpenToy);
+  card.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleOpenToy();
+    }
+  });
 
   return card;
 }


### PR DESCRIPTION
## Summary
- wrap each toy card in a semantic button and add keyboard activation
- enhance toy card styles to preserve focus outlines while resetting default button appearance

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694388caf6008332a2ed437fb275146d)