### PR TITLE
Add back-to-library control in active toy view

### DIFF
--- a/assets/js/__mocks__/fake-module.js
+++ b/assets/js/__mocks__/fake-module.js
@@ -1,0 +1,1 @@
+export default function noop() {}

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -65,7 +65,44 @@ function showLibraryView() {
 
 function showActiveToyView() {
   hideElement(getToyList());
-  showElement(ensureActiveToyContainer());
+  const container = ensureActiveToyContainer();
+  ensureBackToLibraryControl(container);
+  showElement(container);
+}
+
+function updateHistoryToLibraryView() {
+  const win = getWindow();
+  if (!win?.history) return;
+
+  const url = new URL(win.location.href);
+  if (!url.searchParams.has(TOY_QUERY_PARAM)) {
+    return;
+  }
+
+  url.searchParams.delete(TOY_QUERY_PARAM);
+  win.history.pushState({}, '', url);
+}
+
+function ensureBackToLibraryControl(container) {
+  const doc = getDocument();
+  if (!doc || !container) return null;
+
+  let control = container.querySelector('[data-back-to-library]');
+  if (control) return control;
+
+  control = doc.createElement('button');
+  control.type = 'button';
+  control.className = 'home-link';
+  control.textContent = 'Back to Library';
+  control.setAttribute('data-back-to-library', 'true');
+  control.addEventListener('click', () => {
+    disposeActiveToy();
+    showLibraryView();
+    updateHistoryToLibraryView();
+  });
+
+  container.appendChild(control);
+  return control;
 }
 
 function disposeActiveToy() {

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,7 +1,41 @@
-/** @jest-environment node */
 import { jest } from '@jest/globals';
 
 const loaderModule = '../assets/js/loader.js';
+const originalLocation = window.location;
+const originalHistory = window.history;
+
+function createMockLocation(href) {
+  const url = new URL(href);
+  return {
+    get href() {
+      return url.href;
+    },
+    set href(value) {
+      url.href = new URL(value, url.href).href;
+    },
+    get search() {
+      return url.search;
+    },
+    set search(value) {
+      url.search = value;
+    },
+    get origin() {
+      return url.origin;
+    },
+  };
+}
+
+function createMockHistory(locationObject) {
+  return {
+    pushState: (_state, _title, nextUrl) => {
+      const targetUrl =
+        typeof nextUrl === 'string'
+          ? new URL(nextUrl, locationObject.href)
+          : nextUrl;
+      locationObject.href = targetUrl.href;
+    },
+  };
+}
 
 describe('loadToy', () => {
   let loadToy;
@@ -14,19 +48,110 @@ describe('loadToy', () => {
           Promise.resolve([{ slug: 'brand', module: './toy.html?toy=brand' }]),
       })
     );
-    global.window = { location: { href: '' } };
+    const location = createMockLocation('http://example.com');
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      configurable: true,
+      value: location,
+    });
+    Object.defineProperty(window, 'history', {
+      writable: true,
+      configurable: true,
+      value: createMockHistory(location),
+    });
     ({ loadToy } = await import(loaderModule));
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML = '';
     delete global.fetch;
-    delete global.window;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      configurable: true,
+      value: originalLocation,
+    });
+    Object.defineProperty(window, 'history', {
+      writable: true,
+      configurable: true,
+      value: originalHistory,
+    });
   });
 
   test('navigates to HTML toy page', async () => {
     await loadToy('brand');
-    expect(window.location.href).toBe('./brand.html');
+    expect(window.location.href).toBe('http://example.com/brand.html');
+  });
+});
+
+describe('active toy navigation affordance', () => {
+  let loadToy;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="toy-list"></div>';
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
+
+    await jest.unstable_mockModule('../assets/js/toys-data.js', () => ({
+      default: [
+        {
+          slug: 'module-toy',
+          title: 'Module Test',
+          module: './__mocks__/fake-module.js',
+          type: 'module',
+          requiresWebGPU: false,
+        },
+      ],
+    }));
+
+    ({ loadToy } = await import(loaderModule));
+    const location = createMockLocation('http://example.com/library');
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      configurable: true,
+      value: location,
+    });
+    Object.defineProperty(window, 'history', {
+      writable: true,
+      configurable: true,
+      value: createMockHistory(location),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML = '';
+    delete global.fetch;
+    delete globalThis.__activeWebToy;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      configurable: true,
+      value: originalLocation,
+    });
+    Object.defineProperty(window, 'history', {
+      writable: true,
+      configurable: true,
+      value: originalHistory,
+    });
+  });
+
+  test('renders and wires a Back to Library control', async () => {
+    await loadToy('module-toy', { pushState: true });
+
+    const backControl = document.querySelector('[data-back-to-library]');
+    expect(backControl).not.toBeNull();
+
+    globalThis.__activeWebToy = { dispose: jest.fn() };
+
+    backControl.click();
+
+    expect(globalThis.__activeWebToy).toBeUndefined();
+    expect(document.getElementById('toy-list')?.classList.contains('is-hidden')).toBe(
+      false
+    );
+    expect(window.location.search).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary
- add a Back to Library control to the active toy container that disposes the current toy, returns to the library view, and cleans up history
- add loader navigation tests with DOM-friendly location and history mocks
- include a mock module fixture for loader tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694388f51c648332896a61a5b17201cc)