### PR TITLE
Add loading and error states to toy loader

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -31,6 +31,74 @@ body {
   z-index: 2;
 }
 
+.active-toy-status {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #e9fbff;
+  text-align: center;
+  padding: 24px;
+  isolation: isolate;
+}
+
+.active-toy-status__glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 40%, rgba(111, 247, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 20% 70%, rgba(255, 0, 153, 0.18), transparent 35%),
+    radial-gradient(circle at 80% 75%, rgba(17, 216, 255, 0.18), transparent 35%);
+  filter: blur(16px);
+  opacity: 0.8;
+  z-index: -1;
+  animation: pulseGlow 5s ease-in-out infinite;
+}
+
+.active-toy-status__content {
+  background: rgba(6, 10, 20, 0.75);
+  border: 1px solid rgba(111, 247, 255, 0.45);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45), 0 0 24px rgba(17, 216, 255, 0.35);
+  border-radius: 16px;
+  padding: 22px 26px;
+  max-width: 460px;
+  width: min(90vw, 480px);
+  backdrop-filter: blur(10px) saturate(130%);
+}
+
+.active-toy-status h2 {
+  margin: 12px 0 6px;
+  font-size: 1.4rem;
+  letter-spacing: 0.01em;
+}
+
+.active-toy-status p {
+  margin: 0;
+  color: rgba(233, 251, 255, 0.78);
+  line-height: 1.5;
+}
+
+.active-toy-status.is-error .active-toy-status__content {
+  border-color: rgba(255, 120, 150, 0.75);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45), 0 0 24px rgba(255, 120, 150, 0.35);
+}
+
+.active-toy-status__actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+.toy-loading-spinner {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 3px solid rgba(233, 251, 255, 0.25);
+  border-top-color: rgba(17, 216, 255, 0.9);
+  border-right-color: rgba(255, 0, 153, 0.8);
+  margin: 0 auto 12px;
+  animation: spin 0.9s linear infinite, hueShift 8s linear infinite;
+}
+
 /* Small link to return to the main library */
 .home-link {
   position: fixed;
@@ -192,6 +260,34 @@ body {
   }
   to {
     transform: translateY(-18px);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@keyframes hueShift {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
   }
 }
 

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -58,6 +58,94 @@ function clearActiveToyContainer() {
   }
 }
 
+function createStatusElement(container, { title, message, type }) {
+  if (!container) return null;
+
+  const existing = container.querySelector('.active-toy-status');
+  if (existing) {
+    existing.remove();
+  }
+
+  const status = document.createElement('div');
+  status.className = `active-toy-status ${type === 'error' ? 'is-error' : 'is-loading'}`;
+
+  const glow = document.createElement('div');
+  glow.className = 'active-toy-status__glow';
+  status.appendChild(glow);
+
+  const content = document.createElement('div');
+  content.className = 'active-toy-status__content';
+  status.appendChild(content);
+
+  if (type === 'loading') {
+    const spinner = document.createElement('div');
+    spinner.className = 'toy-loading-spinner';
+    content.appendChild(spinner);
+  }
+
+  const heading = document.createElement('h2');
+  heading.textContent = title;
+  content.appendChild(heading);
+
+  const body = document.createElement('p');
+  body.textContent = message;
+  content.appendChild(body);
+
+  container.appendChild(status);
+  return status;
+}
+
+function showLoadingIndicator(container, toyTitle) {
+  return createStatusElement(container, {
+    type: 'loading',
+    title: 'Preparing toy...',
+    message: toyTitle ? `${toyTitle} is loading.` : 'Loading toy...'
+  });
+}
+
+function removeStatusElement(container) {
+  const status = container?.querySelector('.active-toy-status');
+  if (status) {
+    status.remove();
+  }
+}
+
+function showImportError(container, toy) {
+  clearActiveToyContainer();
+
+  const status = createStatusElement(container, {
+    type: 'error',
+    title: 'Unable to load this toy',
+    message:
+      toy?.title
+        ? `${toy.title} hit a snag while loading. Try again or return to the library.`
+        : 'Something went wrong while loading this toy. Try again or return to the library.'
+  });
+
+  if (!status) return;
+
+  const actions = document.createElement('div');
+  actions.className = 'active-toy-status__actions';
+
+  const retry = document.createElement('button');
+  retry.className = 'cta-button primary';
+  retry.type = 'button';
+  retry.textContent = 'Back to library';
+  retry.addEventListener('click', () => {
+    disposeActiveToy();
+    const win = getWindow();
+    if (win?.history) {
+      const url = new URL(win.location.href);
+      url.searchParams.delete(TOY_QUERY_PARAM);
+      win.history.pushState({}, '', url);
+    }
+    showLibraryView();
+  });
+
+  actions.appendChild(retry);
+  status.querySelector('.active-toy-status__content')?.appendChild(actions);
+}
+
 function showLibraryView() {
   showElement(getToyList());
   hideElement(findActiveToyContainer());
@@ -136,8 +224,23 @@ export async function loadToy(slug, { pushState = false } = {}) {
 
     disposeActiveToy();
     showActiveToyView();
+    const container = ensureActiveToyContainer();
+    showLoadingIndicator(container, toy.title || toy.slug);
+
     const moduleUrl = await resolveModulePath(toy.module);
-    await import(moduleUrl);
+    let importError = null;
+
+    await import(moduleUrl).catch((error) => {
+      importError = error;
+    });
+
+    if (importError) {
+      console.error('Error loading toy module:', importError);
+      showImportError(container, toy);
+      return;
+    }
+
+    removeStatusElement(container);
   } else {
     disposeActiveToy();
     window.location.href = toy.module;


### PR DESCRIPTION
## Summary
- show a loading indicator inside the active toy container while module toys are importing
- remove the indicator once a toy is ready and surface a friendly error with a return action if import fails
- add styling for the loading and error overlays

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694388dd22188332835ee3bb5483d81d)