### PR TITLE
Improve word visualizer controls and speech fallbacks

### DIFF
--- a/assets/ui/mic-off.svg
+++ b/assets/ui/mic-off.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9a2f2f" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="#f5b7b1" stroke="#9a2f2f"/>
+  <path d="M12 18v4" />
+  <path d="M9 22h6" />
+  <path d="M5 11v1a7 7 0 0 0 9.5 6.5" />
+  <path d="M19 5.5v6.5a7 7 0 0 1-.7 3" />
+  <line x1="5" y1="5" x2="19" y2="19" />
+</svg>

--- a/assets/ui/mic-on.svg
+++ b/assets/ui/mic-on.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="#57d38c" stroke="#1c7c4b"/>
+  <path d="M12 2v4" stroke="#1c7c4b"/>
+  <path d="M5 11v1a7 7 0 0 0 14 0v-1" stroke="#1c7c4b"/>
+  <path d="M12 18v4" stroke="#1c7c4b"/>
+  <path d="M9 22h6" stroke="#1c7c4b"/>
+</svg>

--- a/assets/ui/speech-off.svg
+++ b/assets/ui/speech-off.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7a2b87" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 6h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V9a3 3 0 0 1 3-3z" fill="#f2d9f8" />
+  <path d="M15 16v1a3 3 0 0 1-3 3h-2l-3 2v-5" />
+  <line x1="5" y1="5" x2="19" y2="19" />
+</svg>

--- a/assets/ui/speech-on.svg
+++ b/assets/ui/speech-on.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1b5fad" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 5h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V8a3 3 0 0 1 3-3z" fill="#b6d4ff" />
+  <path d="M15 15v1a3 3 0 0 1-3 3h-2l-3 2v-5" />
+  <circle cx="18" cy="8" r="3" fill="#1b5fad" stroke="none" />
+  <path d="M18 6v4" stroke="#fff" />
+  <path d="M16 8h4" stroke="#fff" />
+</svg>

--- a/words.html
+++ b/words.html
@@ -54,14 +54,21 @@
         height: 100%;
       }
 
-      .controls {
+      .control-panel {
         position: fixed;
-        bottom: 5vh;
+        bottom: 4vh;
         left: 50%;
         transform: translateX(-50%);
+        display: grid;
+        gap: 8px;
+        z-index: 15;
+        text-align: center;
+      }
+
+      .controls {
         display: flex;
         gap: 20px;
-        z-index: 15;
+        justify-content: center;
       }
 
       .control-button {
@@ -80,6 +87,12 @@
         position: relative;
       }
 
+      .control-button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+
       .control-button.active {
         box-shadow: 0 0 60px rgba(255, 255, 255, 0.9);
         background-color: rgba(255, 255, 255, 0.3);
@@ -94,6 +107,15 @@
         height: 35px;
         transition: filter 1.5s ease;
         filter: drop-shadow(0 0 15px rgba(255, 255, 255, 0.7));
+      }
+
+      .control-hint {
+        color: rgba(255, 255, 255, 0.9);
+        font-size: 0.95rem;
+        text-shadow: 0 1px 6px rgba(0, 0, 0, 0.35);
+        max-width: 520px;
+        margin: 0 auto;
+        line-height: 1.3;
       }
 
       .particle {
@@ -124,34 +146,39 @@
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
-    <div class="controls">
-      <button
-        id="unmute-button"
-        class="control-button"
-        aria-label="Unmute Visualizer"
-        title="Toggle Visualizer"
-      >
-        <img
-          id="unmute-icon"
-          class="control-icon"
-          src="https://cdn-icons-png.flaticon.com/512/5539/5539962.png"
-          alt="Mic Access Icon"
-        />
-      </button>
+    <div class="control-panel">
+      <div class="controls">
+        <button
+          id="unmute-button"
+          class="control-button"
+          aria-label="Unmute Visualizer"
+          title="Toggle Visualizer"
+        >
+          <img
+            id="unmute-icon"
+            class="control-icon"
+            src="./assets/ui/mic-off.svg"
+            alt="Mic Access Icon"
+          />
+        </button>
 
-      <button
-        id="toggle-speech-button"
-        class="control-button"
-        aria-label="Speech Recognition"
-        title="Toggle Speech Recognition"
-      >
-        <img
-          id="toggle-speech-icon"
-          class="control-icon"
-          src="https://cdn-icons-png.flaticon.com/512/4049/4049754.png"
-          alt="Add Word Icon"
-        />
-      </button>
+        <button
+          id="toggle-speech-button"
+          class="control-button"
+          aria-label="Speech Recognition"
+          title="Toggle Speech Recognition"
+        >
+          <img
+            id="toggle-speech-icon"
+            class="control-icon"
+            src="./assets/ui/speech-off.svg"
+            alt="Add Word Icon"
+          />
+        </button>
+      </div>
+      <p class="control-hint">
+        Unmute to sync the visuals with your microphone. Enable speech to drop your spoken words into the cloud—if your browser supports it.
+      </p>
     </div>
 
     <div id="word-cloud-container">
@@ -171,14 +198,29 @@
         'toggle-speech-button'
       );
       const unmuteIcon = document.getElementById('unmute-icon');
-      const recognition = new (window.SpeechRecognition ||
-        window.webkitSpeechRecognition)();
-      recognition.interimResults = false;
-      recognition.maxAlternatives = 1;
+      const toggleSpeechIcon = document.getElementById('toggle-speech-icon');
+      const SpeechRecognition =
+        window.SpeechRecognition || window.webkitSpeechRecognition;
+      const speechSupported = Boolean(SpeechRecognition);
+      let recognition = null;
+
+      const seedWords = [
+        'pulse',
+        'color',
+        'flow',
+        'echo',
+        'harmony',
+        'spark',
+        'glow',
+        'breathe',
+        'calm',
+        'wave',
+        'rhythm',
+      ];
 
       let isUnmuted = false;
       let isAddingWords = false;
-      let wordsArray = [];
+      let wordsArray = [...seedWords];
       let wordCloudData = [];
 
       let audioContext = null;
@@ -188,6 +230,41 @@
 
       // Word cloud shapes for randomness
       const shapes = ['circle', 'star', 'triangle', 'diamond'];
+
+      const speechUnavailableMessage =
+        'Speech recognition is unavailable. Words will stay on the default seed set unless you add more manually in a supported browser.';
+
+      function updateUnmuteIcon() {
+        unmuteIcon.src = isUnmuted
+          ? './assets/ui/mic-on.svg'
+          : './assets/ui/mic-off.svg';
+      }
+
+      function updateSpeechIcon() {
+        toggleSpeechIcon.src = isAddingWords
+          ? './assets/ui/speech-on.svg'
+          : './assets/ui/speech-off.svg';
+      }
+
+      function disableSpeechToggle(message) {
+        isAddingWords = false;
+        toggleSpeechButton.classList.remove('active');
+        toggleSpeechButton.disabled = true;
+        toggleSpeechButton.title = message;
+        updateSpeechIcon();
+        showError('error-message', message);
+      }
+
+      function initSpeechRecognition() {
+        if (!speechSupported) {
+          disableSpeechToggle(speechUnavailableMessage);
+          return;
+        }
+
+        recognition = new SpeechRecognition();
+        recognition.interimResults = false;
+        recognition.maxAlternatives = 1;
+      }
 
       function updateWordCloud(words) {
         if (WordCloud.isSupported) {
@@ -225,15 +302,13 @@
         if (!isUnmuted) {
           isUnmuted = true;
           unmuteButton.classList.add('active');
-          unmuteIcon.src =
-            'https://cdn-icons-png.flaticon.com/512/5539/5539899.png'; // Unmuted mic icon
+          updateUnmuteIcon();
           deactivateSpeechRecognition(); // Ensure speech recognition is turned off before starting visualizer
           activateVisualizer();
         } else {
           isUnmuted = false;
           unmuteButton.classList.remove('active');
-          unmuteIcon.src =
-            'https://cdn-icons-png.flaticon.com/512/5539/5539962.png'; // Muted mic icon
+          updateUnmuteIcon();
           deactivateVisualizer();
         }
       });
@@ -253,6 +328,9 @@
             'error-message',
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
+          isUnmuted = false;
+          unmuteButton.classList.remove('active');
+          updateUnmuteIcon();
           deactivateVisualizer();
         }
       }
@@ -331,55 +409,84 @@
 
       // Toggle speech button logic for speech detection
       toggleSpeechButton.addEventListener('click', () => {
+        if (!recognition) {
+          disableSpeechToggle(speechUnavailableMessage);
+          return;
+        }
+
         if (!isAddingWords) {
           isAddingWords = true;
           toggleSpeechButton.classList.add('active');
+          updateSpeechIcon();
           deactivateVisualizer(); // Ensure visualizer is turned off before starting speech recognition
-          recognition.start();
+          try {
+            recognition.start();
+          } catch (error) {
+            console.error('Unable to start speech recognition:', error);
+            disableSpeechToggle(
+              'Speech recognition could not start. Please check your permissions and try again.'
+            );
+          }
         } else {
           isAddingWords = false;
           toggleSpeechButton.classList.remove('active');
+          updateSpeechIcon();
           recognition.stop();
         }
       });
 
       function deactivateSpeechRecognition() {
-        if (isAddingWords) {
+        if (isAddingWords && recognition) {
           isAddingWords = false;
           toggleSpeechButton.classList.remove('active');
+          updateSpeechIcon();
           recognition.stop();
         }
       }
 
-      recognition.onresult = (event) => {
-        const transcript = event.results[0][0].transcript;
-        const newWords = transcript.split(' ');
+      initSpeechRecognition();
 
-        wordsArray = wordsArray.concat(newWords);
+      if (recognition) {
+        recognition.onresult = (event) => {
+          const transcript = event.results[0][0].transcript;
+          const newWords = transcript.split(' ');
 
-        if (wordsArray.length > 1000) {
-          wordsArray = wordsArray.slice(wordsArray.length - 1000);
-        }
+          wordsArray = wordsArray.concat(newWords);
 
-        updateWordCloud(wordsArray);
-      };
+          if (wordsArray.length > 1000) {
+            wordsArray = wordsArray.slice(wordsArray.length - 1000);
+          }
 
-      recognition.onspeechend = () => {
-        if (isAddingWords) {
-          recognition.start(); // Keep listening as long as the toggle is active
-        } else {
-          recognition.stop();
-        }
-      };
+          updateWordCloud(wordsArray);
+        };
 
-      recognition.onerror = (event) => {
-        console.error('Speech recognition error:', event.error);
-        if (isAddingWords) {
-          recognition.start();
-        }
-      };
+        recognition.onspeechend = () => {
+          if (isAddingWords) {
+            recognition.start(); // Keep listening as long as the toggle is active
+          } else {
+            recognition.stop();
+          }
+        };
+
+        recognition.onerror = (event) => {
+          console.error('Speech recognition error:', event.error);
+
+          if (event.error === 'not-allowed' || event.error === 'service-not-allowed') {
+            disableSpeechToggle(
+              'Speech recognition permission was denied. You can keep using the default word cloud.'
+            );
+            return;
+          }
+
+          if (isAddingWords) {
+            recognition.start();
+          }
+        };
+      }
 
       // Initial word cloud rendering for visibility testing
+      updateUnmuteIcon();
+      updateSpeechIcon();
       updateWordCloud(wordsArray);
     </script>
   </body>


### PR DESCRIPTION
## Summary
- replace remote control icons in the word visualizer with local assets and add inline usage hints near the controls
- add speech-recognition availability and permission handling that disables the toggle and surfaces inline messages when unsupported or denied
- seed the word cloud with defaults and keep control icons in sync with active/inactive states for both audio and speech modes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438a2283cc8332af5c0f220f0b8e04)