### PR TITLE
Add script index for toys and visualizers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ This folder contains resources for contributors who are building or maintaining 
 
 - [`DEVELOPMENT.md`](./DEVELOPMENT.md): day-to-day setup, scripts, workflow, and performance/testing expectations.
 - [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): playbook for creating or updating toy experiences, including audio, rendering, and debugging tips.
+- [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): map from each toy/visualizer to the JS/TS entry points it uses.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.

--- a/docs/TOY_SCRIPT_INDEX.md
+++ b/docs/TOY_SCRIPT_INDEX.md
@@ -1,0 +1,35 @@
+# Toy and Visualizer Script Index
+
+This index lists which JavaScript or TypeScript entry points power each toy/visualizer. It is organized by how the experiences are loaded so contributors can quickly find the right source files.
+
+## Query-driven toys (`toy.html`)
+`toy.html` pulls the toy slug from the `toy` query parameter and uses `assets/js/toyMain.js` and `assets/js/loader.js` to load the matching module from `assets/js/toys-data.js`.
+
+| Slug | Entry module (TypeScript) | How to load |
+| --- | --- | --- |
+| `3dtoy` | `assets/js/toys/three-d-toy.ts` | `toy.html?toy=3dtoy` |
+| `cube-wave` | `assets/js/toys/cube-wave.ts` | `toy.html?toy=cube-wave` |
+| `cosmic-particles` | `assets/js/toys/cosmic-particles.ts` | `toy.html?toy=cosmic-particles` |
+| `spiral-burst` | `assets/js/toys/spiral-burst.ts` | `toy.html?toy=spiral-burst` |
+| `rainbow-tunnel` | `assets/js/toys/rainbow-tunnel.ts` | `toy.html?toy=rainbow-tunnel` |
+| `star-field` | `assets/js/toys/star-field.ts` | `toy.html?toy=star-field` |
+
+## Standalone HTML visualizers
+These pages embed their own module scripts. Use the imports below to find the main logic.
+
+- **brand.html** → imports `assets/js/core/web-toy.ts`, `assets/js/core/animation-loop.ts`, `assets/js/utils/error-display.ts`, `assets/js/utils/start-audio.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/brand/fun-adapter.ts`.
+- **clay.html** → imports `assets/js/utils/webgl-check.ts`.
+- **defrag.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/error-display.ts`.
+- **evol.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/canvas-resize.ts`.
+- **geom.html** → uses inline canvas and Web Audio logic only (no repo modules).
+- **holy.html** → imports `assets/js/utils/webgl-check.ts` alongside Three.js helpers.
+- **index.html** → uses `assets/js/main.js` to render the toy library.
+- **legible.html** → contains only inline logic plus `particles.js` from a CDN.
+- **lights.html** → loads `assets/js/app.js` as the entry module.
+- **multi.html** → imports `assets/js/core/web-toy.ts`, `assets/js/core/animation-loop.ts`, `assets/js/utils/peak-detector.ts`, `assets/js/utils/audio-handler.ts`, `assets/js/utils/error-display.ts`, `assets/js/utils/start-audio.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/multi/fun-adapter.ts`.
+- **seary.html** → imports `assets/js/utils/audio-handler.ts`, `assets/js/utils/peak-detector.ts`, `assets/js/utils/error-display.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, `assets/seary/fun-adapter.ts`, and `assets/js/utils/canvas-resize.ts`.
+- **sgpat.html** → executes `assets/js/toys/sgpat.ts` directly.
+- **svgtest.html** → imports `assets/js/utils/webgl-check.ts` and `assets/js/utils/audio-handler.ts` alongside Three.js.
+- **symph.html** → imports `assets/js/utils/audio-handler.ts`, `assets/js/utils/canvas-resize.ts`, `assets/js/utils/error-display.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/symph/fun-adapter.ts`.
+- **toy.html** → uses `assets/js/toyMain.js`, which delegates to the loader to import modules listed above.
+- **words.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/error-display.ts` (alongside `wordcloud2` from CDN).


### PR DESCRIPTION
## Summary
- add a TOY_SCRIPT_INDEX document describing which JS/TS entry points power each toy or visualizer
- link the new index from the developer docs overview for discoverability

## Testing
- Not run (not needed for docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438b3f95188332a4fc3ba3ea18b09e)