### PR TITLE
Improve audio initialization cleanup

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,7 +13,7 @@ import PatternRecognizer from './utils/patternRecognition.ts';
 
 const DEFAULT_RENDERER_OPTIONS = { maxPixelRatio: 2 };
 
-let scene, camera, renderer, cube, analyser, patternRecognizer;
+let scene, camera, renderer, cube, analyser, patternRecognizer, audioCleanup;
 let currentLightType = 'PointLight'; // Default light type
 
 function initVisualization() {
@@ -67,6 +67,7 @@ async function startAudioAndAnimation() {
   try {
     const audioData = await initAudio();
     analyser = audioData.analyser;
+    audioCleanup = audioData.cleanup;
     patternRecognizer = new PatternRecognizer(analyser);
     animate();
     return true;
@@ -141,3 +142,10 @@ document
 
 // Handle window resize
 window.addEventListener('resize', handleResize);
+
+// Clean up audio when navigating away
+window.addEventListener('pagehide', () => {
+  if (audioCleanup) {
+    audioCleanup();
+  }
+});

--- a/assets/js/toys/sgpat.ts
+++ b/assets/js/toys/sgpat.ts
@@ -156,17 +156,15 @@ function updateStartButton(label: string, disabled: boolean) {
 }
 
 function stopCurrentAudio() {
-  if (toy.audioStream) {
-    toy.audioStream.getTracks().forEach((track: MediaStreamTrack) => track.stop());
-    toy.audioStream = null;
+  if (toy.audioCleanup) {
+    toy.audioCleanup();
   }
-  if (toy.audio && 'disconnect' in toy.audio && typeof toy.audio.disconnect === 'function') {
-    toy.audio.disconnect();
-  }
-  if (toy.audio && 'stop' in toy.audio && typeof toy.audio.stop === 'function') {
-    toy.audio.stop();
-  }
+
+  toy.audioCleanup = null;
   toy.analyser = null;
+  toy.audio = null;
+  toy.audioListener = null;
+  toy.audioStream = null;
 }
 
 function updateSpectrograph(dataArray: Uint8Array) {


### PR DESCRIPTION
## Summary
- add optional media constraints, custom streams, and cleanup hooks to audio initialization with proper failure cleanup
- centralize WebToy and toy audio teardown through the returned cleanup helper
- ensure callers like the sample app dispose audio streams when leaving the page

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438b79778483329a1e667969e9a408)