### PR TITLE
Update toy script index with module loader entries

### DIFF
--- a/docs/TOY_SCRIPT_INDEX.md
+++ b/docs/TOY_SCRIPT_INDEX.md
@@ -8,11 +8,14 @@ This index lists which JavaScript or TypeScript entry points power each toy/visu
 | Slug | Entry module (TypeScript) | How to load |
 | --- | --- | --- |
 | `3dtoy` | `assets/js/toys/three-d-toy.ts` | `toy.html?toy=3dtoy` |
+| `aurora-painter` | `assets/js/toys/aurora-painter.ts` | `toy.html?toy=aurora-painter` |
 | `cube-wave` | `assets/js/toys/cube-wave.ts` | `toy.html?toy=cube-wave` |
+| `bubble-harmonics` | `assets/js/toys/bubble-harmonics.ts` | `toy.html?toy=bubble-harmonics` |
 | `cosmic-particles` | `assets/js/toys/cosmic-particles.ts` | `toy.html?toy=cosmic-particles` |
 | `spiral-burst` | `assets/js/toys/spiral-burst.ts` | `toy.html?toy=spiral-burst` |
 | `rainbow-tunnel` | `assets/js/toys/rainbow-tunnel.ts` | `toy.html?toy=rainbow-tunnel` |
 | `star-field` | `assets/js/toys/star-field.ts` | `toy.html?toy=star-field` |
+| `fractal-kite-garden` | `assets/js/toys/fractal-kite-garden.ts` | `toy.html?toy=fractal-kite-garden` |
 
 ## Standalone HTML visualizers
 These pages embed their own module scripts. Use the imports below to find the main logic.


### PR DESCRIPTION
## Summary
- add missing query-driven module toys to the toy script index so all loader-based entries are discoverable

## Testing
- Not run (doc-only change)

## Checklist
- [ ] Linting (`npm run lint`) if applicable
- [ ] Tests (`npm test`) if applicable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438c9c757083329cdcf25efb590391)