### PR TITLE
Add audio loop controller with manual start controls

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -1,5 +1,5 @@
 import type * as THREE from 'three';
-import { getFrequencyData } from '../utils/audio-handler';
+import { AudioAccessError, getFrequencyData } from '../utils/audio-handler';
 import type { AudioInitOptions } from '../utils/audio-handler';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,6 +13,27 @@ export interface AnimationContext {
   analyser: THREE.AudioAnalyser | null;
 }
 
+export interface AudioLoopController {
+  context: AnimationContext | null;
+  error: AudioAccessError | null;
+  start: () => Promise<AnimationContext>;
+  retry: () => Promise<AnimationContext>;
+  stop: () => void;
+}
+
+export interface StartAudioLoopOptions {
+  autostart?: boolean;
+}
+
+function cleanupLoop(toy: WebToyInstance) {
+  if (toy?.renderer?.setAnimationLoop) {
+    toy.renderer.setAnimationLoop(null);
+  }
+  if (typeof toy.stopAudio === 'function') {
+    toy.stopAudio();
+  }
+}
+
 /**
  * Shared helper to initialize audio and start the animation loop.
  * Replaces duplicated startAudio() functions in each toy.
@@ -20,17 +41,77 @@ export interface AnimationContext {
  * @param toy - The WebToy instance
  * @param animate - Animation callback that receives the context
  * @param audioOptions - Optional audio initialization options
- * @returns The animation context
+ * @param options - Controller options
+ * @returns A controller with lifecycle callbacks
  */
-export async function startAudioLoop(
+export function startAudioLoop(
   toy: WebToyInstance,
   animate: (ctx: AnimationContext) => void,
-  audioOptions: AudioInitOptions = {}
-): Promise<AnimationContext> {
-  await toy.initAudio(audioOptions);
-  const ctx: AnimationContext = { toy, analyser: toy.analyser };
-  toy.renderer.setAnimationLoop(() => animate(ctx));
-  return ctx;
+  audioOptions: AudioInitOptions = {},
+  options: StartAudioLoopOptions = {}
+): AudioLoopController {
+  let ctx: AnimationContext | null = null;
+  let error: AudioAccessError | null = null;
+  let isStarting = false;
+  let startPromise: Promise<AnimationContext> | null = null;
+
+  async function start() {
+    if (startPromise) return startPromise;
+    isStarting = true;
+    error = null;
+    cleanupLoop(toy);
+
+    startPromise = (async () => {
+      try {
+        await toy.initAudio(audioOptions);
+        ctx = { toy, analyser: toy.analyser };
+        toy.renderer.setAnimationLoop(() => ctx && animate(ctx));
+        return ctx as AnimationContext;
+      } catch (err) {
+        cleanupLoop(toy);
+        if (err instanceof AudioAccessError) {
+          error = err;
+        }
+        throw err;
+      } finally {
+        isStarting = false;
+      }
+    })();
+
+    try {
+      return await startPromise;
+    } finally {
+      startPromise = null;
+    }
+  }
+
+  function stop() {
+    cleanupLoop(toy);
+    ctx = null;
+    startPromise = null;
+    isStarting = false;
+  }
+
+  async function retry() {
+    stop();
+    return start();
+  }
+
+  if (options.autostart) {
+    void start().catch(() => null);
+  }
+
+  return {
+    get context() {
+      return ctx;
+    },
+    get error() {
+      return error;
+    },
+    start,
+    retry,
+    stop,
+  };
 }
 
 /**

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -75,6 +75,39 @@ export default class WebToy {
     this.renderer.render(this.scene, this.camera);
   }
 
+  stopAudio() {
+    if (this.audio) {
+      if ('stop' in this.audio && typeof this.audio.stop === 'function') {
+        this.audio.stop();
+      }
+      if (
+        'disconnect' in this.audio &&
+        typeof this.audio.disconnect === 'function'
+      ) {
+        this.audio.disconnect();
+      }
+    }
+
+    if (this.audioListener && 'remove' in this.camera) {
+      (
+        this.camera as THREE.Camera & { remove?: (obj: THREE.Object3D) => void }
+      ).remove(this.audioListener);
+    }
+
+    if (this.audioStream) {
+      this.audioStream.getTracks().forEach((track) => track.stop());
+    }
+
+    if (this.analyser?.analyser) {
+      this.analyser.analyser.disconnect();
+    }
+
+    this.analyser = null;
+    this.audioListener = null;
+    this.audio = null;
+    this.audioStream = null;
+  }
+
   dispose() {
     if (this.resizeHandler) {
       window.removeEventListener('resize', this.resizeHandler);
@@ -108,31 +141,7 @@ export default class WebToy {
       }
     }
 
-    if (this.audio) {
-      if ('stop' in this.audio && typeof this.audio.stop === 'function') {
-        this.audio.stop();
-      }
-      if (
-        'disconnect' in this.audio &&
-        typeof this.audio.disconnect === 'function'
-      ) {
-        this.audio.disconnect();
-      }
-    }
-
-    if (this.audioListener && 'remove' in this.camera) {
-      (
-        this.camera as THREE.Camera & { remove?: (obj: THREE.Object3D) => void }
-      ).remove(this.audioListener);
-    }
-
-    if (this.audioStream) {
-      this.audioStream.getTracks().forEach((track) => track.stop());
-    }
-
-    if (this.analyser?.analyser) {
-      this.analyser.analyser.disconnect();
-    }
+    this.stopAudio();
 
     if (this.canvas?.parentElement) {
       this.canvas.parentElement.removeChild(this.canvas);

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   getContextFrequencyData,
   AnimationContext,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
@@ -27,6 +28,7 @@ const presetButtons: Record<PresetKey, HTMLButtonElement> = {
   orbit: document.createElement('button'),
   nebula: document.createElement('button'),
 };
+let audioController: AudioLoopController | null = null;
 
 function createOrbitPreset(): PresetInstance {
   const group = new THREE.Group();
@@ -326,7 +328,9 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+  audioController =
+    audioController || startToyAudio(toy, animate, { fftSize: 256 });
+  return audioController.start();
 }
 
 init();

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   AnimationContext,
   getContextFrequencyData,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor, type AudioColorParams } from '../utils/color-audio';
@@ -69,6 +70,7 @@ const toy = new WebToy({
 
 const gridGroup = new THREE.Group();
 const gridItems: GridItem[] = [];
+let audioController: AudioLoopController | null = null;
 
 const presets: Record<ShapeMode, GridPreset> = {
   cubes: {
@@ -323,7 +325,9 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+  audioController =
+    audioController || startToyAudio(toy, animate, { fftSize: 256 });
+  return audioController.start();
 }
 
 function init() {

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   getContextFrequencyData,
   AnimationContext,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
@@ -25,6 +26,7 @@ const rings: RingData[] = [];
 const RING_COUNT = 20;
 const RING_SPACING = 30;
 const TUNNEL_LENGTH = RING_COUNT * RING_SPACING;
+let audioController: AudioLoopController | null = null;
 
 function init() {
   const { scene } = toy;
@@ -179,7 +181,9 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+  audioController =
+    audioController || startToyAudio(toy, animate, { fftSize: 256 });
+  return audioController.start();
 }
 
 init();

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   getContextFrequencyData,
   AnimationContext,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
@@ -14,6 +15,8 @@ const toy = new WebToy({
   lightingOptions: { type: 'HemisphereLight' },
   ambientLightOptions: {},
 } as ToyConfig);
+
+let audioController: AudioLoopController | null = null;
 
 const lines: THREE.Line[] = [];
 
@@ -59,7 +62,8 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  return startToyAudio(toy, animate);
+  audioController = audioController || startToyAudio(toy, animate);
+  return audioController.start();
 }
 
 init();

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   getContextFrequencyData,
   AnimationContext,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
@@ -27,6 +28,7 @@ type StarFieldBuffers = {
 
 const STAR_COUNT = 2400;
 let starField!: StarFieldBuffers;
+let audioController: AudioLoopController | null = null;
 
 function createStarField(): StarFieldBuffers {
   const geometry = new THREE.BufferGeometry();
@@ -113,7 +115,9 @@ function animate(ctx: AnimationContext) {
 }
 
 async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+  audioController =
+    audioController || startToyAudio(toy, animate, { fftSize: 256 });
+  return audioController.start();
 }
 
 init();

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -4,6 +4,7 @@ import type { ToyConfig } from '../core/types';
 import {
   getContextFrequencyData,
   AnimationContext,
+  type AudioLoopController,
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { createIdleDetector } from '../utils/idle-detector';
@@ -34,6 +35,7 @@ let idleBlend = 0;
 let controlState: ControlPanelState;
 const idleDetector = createIdleDetector();
 const clock = new THREE.Clock();
+let audioController: AudioLoopController | null = null;
 
 const controlPanel = createControlPanel();
 controlState = controlPanel.getState();
@@ -204,7 +206,8 @@ function animate(ctx: AnimationContext) {
 
 async function startAudio() {
   try {
-    await startToyAudio(toy, animate);
+    audioController = audioController || startToyAudio(toy, animate);
+    await audioController.start();
     hideError();
     return true;
   } catch (e) {

--- a/brand.html
+++ b/brand.html
@@ -14,7 +14,8 @@
       import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
       import WebToy from './assets/js/core/web-toy.ts';
       import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
-      import { showError } from './assets/js/utils/error-display.ts';
+      import { AudioAccessError } from './assets/js/utils/audio-handler.ts';
+      import { clearError, showError } from './assets/js/utils/error-display.ts';
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
@@ -256,19 +257,47 @@
         ctx.toy.render();
       }
 
-      startToyAudio(toy, animate, {
+      const audioController = startToyAudio(toy, animate, {
         positional: true,
         object: toy.camera,
-      }).catch((err) => {
-        console.error('Audio input error: ', err);
-        funControls.setAudioAvailable(false);
-        showError(
-          'error-message',
-          'Microphone access is unavailable. Visuals will run without audio reactivity.'
-        );
-        const silentContext = { toy, analyser: null };
-        toy.renderer.setAnimationLoop(() => animate(silentContext));
+        autostart: false,
       });
+
+      const silentContext = { toy, analyser: null };
+      const runSilentLoop = () => toy.renderer.setAnimationLoop(() => animate(silentContext));
+      runSilentLoop();
+
+      const audioButton = document.createElement('button');
+      audioButton.type = 'button';
+      audioButton.className = 'fun-chip';
+      audioButton.textContent = 'Start audio';
+
+      async function startAudio() {
+        audioButton.disabled = true;
+        try {
+          await audioController.start();
+          clearError('error-message');
+          funControls.setAudioAvailable(true);
+          audioButton.textContent = 'Restart audio';
+        } catch (error) {
+          console.error('Audio input error: ', error);
+          const reason = error instanceof AudioAccessError ? error.reason : null;
+          const message =
+            reason === 'denied'
+              ? 'Microphone access was denied. Enable it to make the visuals reactive.'
+              : reason === 'unsupported'
+                ? 'This browser does not support microphone capture.'
+                : 'Microphone access is unavailable. Visuals will run without audio reactivity.';
+          showError('error-message', message);
+          funControls.setAudioAvailable(false);
+          runSilentLoop();
+          audioButton.textContent = 'Retry audio';
+        }
+        audioButton.disabled = false;
+      }
+
+      audioButton.addEventListener('click', startAudio);
+      funControls.appendControl(audioButton);
     </script>
   </body>
 </html>

--- a/multi.html
+++ b/multi.html
@@ -22,8 +22,8 @@
       import WebToy from './assets/js/core/web-toy.ts';
       import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
       import createPeakDetector from './assets/js/utils/peak-detector.ts';
-      import { getAverageFrequency } from './assets/js/utils/audio-handler.ts';
-      import { showError } from './assets/js/utils/error-display.ts';
+      import { AudioAccessError, getAverageFrequency } from './assets/js/utils/audio-handler.ts';
+      import { clearError, showError } from './assets/js/utils/error-display.ts';
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
@@ -332,17 +332,46 @@
         ctx.toy.render();
       }
 
-      startToyAudio(toy, animate)
-        .catch((err) => {
-          console.error('The following error occurred: ' + err);
+      const audioController = startToyAudio(toy, animate, {
+        fftSize: 256,
+        autostart: false,
+      });
+
+      const silentContext = { toy, analyser: null };
+      const runSilentLoop = () => toy.renderer.setAnimationLoop(() => animate(silentContext));
+      runSilentLoop();
+
+      const audioButton = document.createElement('button');
+      audioButton.type = 'button';
+      audioButton.className = 'fun-chip';
+      audioButton.textContent = 'Start audio';
+
+      async function startAudio() {
+        audioButton.disabled = true;
+        try {
+          await audioController.start();
+          clearError('error-message');
+          funControls.setAudioAvailable(true);
+          audioButton.textContent = 'Restart audio';
+        } catch (error) {
+          console.error('The following error occurred: ', error);
+          const reason = error instanceof AudioAccessError ? error.reason : null;
+          const message =
+            reason === 'denied'
+              ? 'Microphone access was denied. Enable it to make the visuals reactive.'
+              : reason === 'unsupported'
+                ? 'This browser does not support microphone capture.'
+                : 'Microphone access is unavailable. Visuals will run without audio reactivity.';
+          showError('error-message', message);
           funControls.setAudioAvailable(false);
-          showError(
-            'error-message',
-            'Microphone access is unavailable. Visuals will run without audio reactivity.'
-          );
-          const silentContext = { toy, analyser: null };
-          toy.renderer.setAnimationLoop(() => animate(silentContext));
-        });
+          runSilentLoop();
+          audioButton.textContent = 'Retry audio';
+        }
+        audioButton.disabled = false;
+      }
+
+      audioButton.addEventListener('click', startAudio);
+      funControls.appendControl(audioButton);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an audio loop controller that exposes start/stop/retry and defers microphone requests until explicitly triggered
- add audio cleanup support on WebToy instances and update toy modules to use the controller-based startup flow
- introduce explicit audio start/retry buttons for the brand and multi experiences with silent fallbacks and messaging

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438b69802083328eeaec789b3aae64)