### PR TITLE
Refactor page toys into module-driven loader entries

### DIFF
--- a/assets/js/__mocks__/fake-module.js
+++ b/assets/js/__mocks__/fake-module.js
@@ -1,1 +1,13 @@
+import { jest } from '@jest/globals';
+
 export default function noop() {}
+
+export function start({ container } = {}) {
+  const placeholder = document.createElement('div');
+  placeholder.setAttribute('data-fake-toy', 'true');
+  container?.appendChild(placeholder);
+
+  const active = { dispose: jest.fn(() => placeholder.remove()) };
+  globalThis.__activeWebToy = active;
+  return active;
+}

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -21,8 +21,8 @@ export default [
     title: 'Star Guitar Visualizer',
     description:
       'A visual journey inspired by an iconic music video, synced to your music.',
-    module: './brand.html',
-    type: 'page',
+    module: 'assets/js/toys/brand.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -30,8 +30,8 @@ export default [
     title: 'Pottery Wheel Sculptor',
     description:
       'Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.',
-    module: './clay.html',
-    type: 'page',
+    module: 'assets/js/toys/clay.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -39,8 +39,8 @@ export default [
     title: 'Defrag Visualizer',
     description:
       'A nostalgic, sound-reactive visualizer evoking old defragmentation screens.',
-    module: './toy.html?toy=defrag',
-    type: 'page',
+    module: 'assets/js/toys/defrag.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -48,8 +48,8 @@ export default [
     title: 'Evolutionary Weirdcore',
     description:
       'Watch surreal landscapes evolve with fractals and glitches that react to music.',
-    module: './toy.html?toy=evol',
-    type: 'page',
+    module: 'assets/js/toys/evol.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -57,8 +57,8 @@ export default [
     title: 'Microphone Geometry Visualizer',
     description:
       'Push shifting geometric forms directly from live mic input with responsive controls.',
-    module: './geom.html',
-    type: 'page',
+    module: 'assets/js/toys/geom.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -66,32 +66,32 @@ export default [
     title: 'Ultimate Satisfying Visualizer',
     description:
       'Layered halos, particles, and morphing shapes that respond to your music.',
-    module: './holy.html',
-    type: 'page',
+    module: 'assets/js/toys/holy.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
     slug: 'multi',
     title: 'Multi-Capability Visualizer',
     description: 'Shapes and lights move with both sound and device motion.',
-    module: './multi.html',
-    type: 'page',
+    module: 'assets/js/toys/multi.ts',
+    type: 'module',
     requiresWebGPU: true,
   },
   {
     slug: 'seary',
     title: 'Trippy Synesthetic Visualizer',
     description: 'Blend audio and visuals in a rich synesthetic experience.',
-    module: './seary.html',
-    type: 'page',
+    module: 'assets/js/toys/seary.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
     slug: 'sgpat',
     title: 'Pattern Recognition Visualizer',
     description: 'See patterns form dynamically in response to sound.',
-    module: './sgpat.html',
-    type: 'page',
+    module: 'assets/js/toys/sgpat.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -99,8 +99,8 @@ export default [
     title: 'Terminal Word Grid',
     description:
       'A retro green text grid that pulses to audio and surfaces fresh words as you play.',
-    module: './legible.html',
-    type: 'page',
+    module: 'assets/js/toys/legible.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -108,16 +108,16 @@ export default [
     title: 'SVG + Three.js Visualizer',
     description:
       'A hybrid visualizer blending 2D and 3D elements, reacting in real time.',
-    module: './svgtest.html',
-    type: 'page',
+    module: 'assets/js/toys/svgtest.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
     slug: 'symph',
     title: 'Dreamy Spectrograph',
     description: 'A relaxing spectrograph that moves gently with your audio.',
-    module: './symph.html',
-    type: 'page',
+    module: 'assets/js/toys/symph.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -125,8 +125,8 @@ export default [
     title: 'Interactive Word Cloud',
     description:
       'Speak and watch the word cloud react and shift with your voice.',
-    module: './toy.html?toy=words',
-    type: 'page',
+    module: 'assets/js/toys/words.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {
@@ -161,8 +161,8 @@ export default [
     title: 'Audio Light Show',
     description:
       'Swap shader styles and color palettes while lights ripple with your microphone input.',
-    module: './lights.html',
-    type: 'page',
+    module: 'assets/js/toys/lights.ts',
+    type: 'module',
     requiresWebGPU: false,
   },
   {

--- a/assets/js/toys/brand.ts
+++ b/assets/js/toys/brand.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './brand.html',
+    title: 'Star Guitar Visualizer',
+  });
+}

--- a/assets/js/toys/clay.ts
+++ b/assets/js/toys/clay.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './clay.html',
+    title: 'Pottery Wheel Sculptor',
+  });
+}

--- a/assets/js/toys/defrag.ts
+++ b/assets/js/toys/defrag.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './toy.html?toy=defrag',
+    title: 'Defrag Visualizer',
+  });
+}

--- a/assets/js/toys/evol.ts
+++ b/assets/js/toys/evol.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './toy.html?toy=evol',
+    title: 'Evolutionary Weirdcore',
+  });
+}

--- a/assets/js/toys/geom.ts
+++ b/assets/js/toys/geom.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './geom.html',
+    title: 'Microphone Geometry Visualizer',
+  });
+}

--- a/assets/js/toys/holy.ts
+++ b/assets/js/toys/holy.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './holy.html',
+    title: 'Ultimate Satisfying Visualizer',
+  });
+}

--- a/assets/js/toys/iframe-toy.ts
+++ b/assets/js/toys/iframe-toy.ts
@@ -1,0 +1,41 @@
+type StartOptions = {
+  container?: HTMLElement | null;
+  path: string;
+  title?: string;
+  allow?: string;
+};
+
+function resolveIframeSrc(path: string) {
+  if (path.startsWith('http://') || path.startsWith('https://')) return path;
+  return new URL(path, window.location.origin).toString();
+}
+
+export function startIframeToy({ container, path, title, allow }: StartOptions) {
+  const target = container ?? document.getElementById('active-toy-container');
+
+  if (!target) {
+    throw new Error('Active toy container is missing.');
+  }
+
+  const iframe = document.createElement('iframe');
+  iframe.src = resolveIframeSrc(path);
+  iframe.title = title ?? 'Web toy';
+  iframe.allow = allow ?? 'microphone; camera; fullscreen';
+  iframe.style.width = '100%';
+  iframe.style.height = '100%';
+  iframe.style.border = 'none';
+
+  const activeToy = {
+    dispose() {
+      iframe.remove();
+      if ((globalThis as Record<string, unknown>).__activeWebToy === activeToy) {
+        delete (globalThis as Record<string, unknown>).__activeWebToy;
+      }
+    },
+  };
+
+  (globalThis as Record<string, unknown>).__activeWebToy = activeToy;
+  target.appendChild(iframe);
+
+  return activeToy;
+}

--- a/assets/js/toys/legible.ts
+++ b/assets/js/toys/legible.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './legible.html',
+    title: 'Terminal Word Grid',
+  });
+}

--- a/assets/js/toys/lights.ts
+++ b/assets/js/toys/lights.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './lights.html',
+    title: 'Audio Light Show',
+  });
+}

--- a/assets/js/toys/multi.ts
+++ b/assets/js/toys/multi.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './multi.html',
+    title: 'Multi-Capability Visualizer',
+  });
+}

--- a/assets/js/toys/seary.ts
+++ b/assets/js/toys/seary.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './seary.html',
+    title: 'Trippy Synesthetic Visualizer',
+  });
+}

--- a/assets/js/toys/svgtest.ts
+++ b/assets/js/toys/svgtest.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './svgtest.html',
+    title: 'SVG + Three.js Visualizer',
+  });
+}

--- a/assets/js/toys/symph.ts
+++ b/assets/js/toys/symph.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './symph.html',
+    title: 'Dreamy Spectrograph',
+  });
+}

--- a/assets/js/toys/words.ts
+++ b/assets/js/toys/words.ts
@@ -1,0 +1,9 @@
+import { startIframeToy } from './iframe-toy';
+
+export function start({ container } = {}) {
+  return startIframeToy({
+    container,
+    path: './toy.html?toy=words',
+    title: 'Interactive Word Cloud',
+  });
+}


### PR DESCRIPTION
## Summary
- add module wrappers for legacy page-based toys and register them as module entries
- update loader to initialize module exports with start/dispose support and keep library navigation client-side
- refresh loader tests to cover module-driven loading and shared fake module

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694390434d3083328715daf18f47a6e9)