### PR TITLE
Refresh toy documentation for updated catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,28 +41,31 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 
 ## Toys in the Collection
 
-| Toy                                             | Description |
-| ----------------------------------------------- | ----------- |
-| [3D Toy](./toy.html?toy=3dtoy)                  | Dive into a twisting 3D tunnel that responds to sound. |
-| [Star Guitar Visualizer](./brand.html)          | A visual journey inspired by an iconic music video, synced to your music. |
-| [Pottery Wheel Sculptor](./clay.html)           | Spin and shape a clay vessel with tactile smoothing and carving tools. |
-| [Defrag Visualizer](./defrag.html)              | A nostalgic, sound-reactive visualizer evoking old defragmentation screens. |
+| Toy | Description |
+| --- | --- |
+| [3D Toy](./toy.html?toy=3dtoy) | Dive into a twisting 3D tunnel that responds to sound. |
 | [Aurora Painter](./toy.html?toy=aurora-painter) | Paint flowing aurora ribbons that react to your microphone in layered waves. |
-| [Evolutionary Weirdcore](./evol.html)           | Watch surreal landscapes evolve with fractals and glitches that react to music. |
-| [Geometry Visualizer](./geom.html)              | Push shifting geometric forms directly from live mic input. |
-| [Ultimate Satisfying Visualizer](./holy.html)   | Layered halos, particles, and morphing shapes that respond to your music. |
-| [Lights Visualizer](./lights.html)              | Swap shader styles and palettes while lights ripple with your microphone input. |
-| [Multi-Capability Visualizer](./multi.html)     | Shapes and lights move with both sound and device motion. |
-| [Trippy Synesthetic Visualizer](./seary.html)   | Blend audio and visuals in a rich synesthetic experience. |
-| [Pattern Recognition Visualizer](./sgpat.html)  | See patterns form dynamically in response to sound. |
-| [SVG + Three.js Visualizer](./svgtest.html)     | A hybrid visualizer blending 2D and 3D elements, reacting in real time. |
-| [Dreamy Spectrograph](./symph.html)             | A relaxing spectrograph that moves gently with your audio. |
-| [Interactive Word Cloud](./words.html)          | Speak and watch the word cloud react and shift with your voice. |
-| [Grid Visualizer](./toy.html?toy=cube-wave)     | Swap between cube waves and bouncing spheres without stopping the music. |
+| [Star Guitar Visualizer](./toy.html?toy=brand) | A visual journey inspired by an iconic music video, synced to your music. |
+| [Pottery Wheel Sculptor](./toy.html?toy=clay) | Spin and shape a clay vessel with tactile smoothing and carving tools. |
+| [Defrag Visualizer](./toy.html?toy=defrag) | A nostalgic, sound-reactive visualizer evoking old defragmentation screens. |
+| [Evolutionary Weirdcore](./toy.html?toy=evol) | Watch surreal landscapes evolve with fractals and glitches that react to music. |
+| [Geometry Visualizer](./toy.html?toy=geom) | Push shifting geometric forms directly from live mic input. |
+| [Ultimate Satisfying Visualizer](./toy.html?toy=holy) | Layered halos, particles, and morphing shapes that respond to your music. |
+| [Multi-Capability Visualizer](./toy.html?toy=multi) | Shapes and lights move with both sound and device motion. (Requires WebGPU.) |
+| [Trippy Synesthetic Visualizer](./toy.html?toy=seary) | Blend audio and visuals in a rich synesthetic experience. |
+| [Pattern Recognition Visualizer](./toy.html?toy=sgpat) | See patterns form dynamically in response to sound. |
+| [Terminal Word Grid](./toy.html?toy=legible) | A retro green text grid that pulses to audio and surfaces fresh words as you play. |
+| [SVG + Three.js Visualizer](./toy.html?toy=svgtest) | A hybrid visualizer blending 2D and 3D elements, reacting in real time. |
+| [Dreamy Spectrograph](./toy.html?toy=symph) | A relaxing spectrograph that moves gently with your audio. |
+| [Interactive Word Cloud](./toy.html?toy=words) | Speak and watch the word cloud react and shift with your voice. |
+| [Grid Visualizer](./toy.html?toy=cube-wave) | Swap between cube waves and bouncing spheres without stopping the music. |
+| [Bubble Harmonics](./toy.html?toy=bubble-harmonics) | Translucent, audio-inflated bubbles that split into harmonics on high frequencies. |
 | [Cosmic Particles](./toy.html?toy=cosmic-particles) | Jump between orbiting swirls and nebula fly-throughs with a single toggle. |
-| [Spiral Burst](./toy.html?toy=spiral-burst)     | Colorful spirals rotate and expand with every beat. |
+| [Audio Light Show](./toy.html?toy=lights) | Swap shader styles and color palettes while lights ripple with your microphone input. |
+| [Spiral Burst](./toy.html?toy=spiral-burst) | Colorful spirals rotate and expand with every beat. |
 | [Rainbow Tunnel](./toy.html?toy=rainbow-tunnel) | Fly through colorful rings that spin to your music. |
-| [Star Field](./toy.html?toy=star-field)         | A field of shimmering stars reacts to the beat. |
+| [Star Field](./toy.html?toy=star-field) | A field of shimmering stars reacts to the beat. |
+| [Fractal Kite Garden](./toy.html?toy=fractal-kite-garden) | Grow branching kite fractals that sway with mids and shimmer with crisp highs. |
 
 ---
 

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -73,4 +73,5 @@ Adjust imports to match the actual helpers you use.
 - Update `README.md` and `CONTRIBUTING.md` if you introduce new scripts or global expectations.
 - Describe user-facing controls or setup steps in the associated HTML entry point if they deviate from existing patterns.
 - Include inline comments for novel shader parameters, math tricks, or input handling quirks.
+- When you wrap an existing HTML page for use in `toy.html`, expose it through `startIframeToy` (see `assets/js/toys/*`) and add the slug to `assets/js/toys-data.js` so the loader can surface it in the library view.
 

--- a/docs/TOY_SCRIPT_INDEX.md
+++ b/docs/TOY_SCRIPT_INDEX.md
@@ -1,38 +1,35 @@
 # Toy and Visualizer Script Index
 
-This index lists which JavaScript or TypeScript entry points power each toy/visualizer. It is organized by how the experiences are loaded so contributors can quickly find the right source files.
+This index maps each toy slug to the module that powers it and how the experience loads inside `toy.html`. Use it to find the right entry point quickly when updating assets or debugging loading behavior.
 
 ## Query-driven toys (`toy.html`)
-`toy.html` pulls the toy slug from the `toy` query parameter and uses `assets/js/toyMain.js` and `assets/js/loader.js` to load the matching module from `assets/js/toys-data.js`.
+`toy.html` reads the `toy` query parameter, looks up the matching entry in `assets/js/toys-data.js`, and imports the corresponding module through `assets/js/toyMain.js` and `assets/js/loader.js`. Many modules render directly; others use the `startIframeToy` helper to embed an existing HTML page inside the library shell.
 
-| Slug | Entry module (TypeScript) | How to load |
+| Slug | Entry module | How it loads |
 | --- | --- | --- |
-| `3dtoy` | `assets/js/toys/three-d-toy.ts` | `toy.html?toy=3dtoy` |
-| `aurora-painter` | `assets/js/toys/aurora-painter.ts` | `toy.html?toy=aurora-painter` |
-| `cube-wave` | `assets/js/toys/cube-wave.ts` | `toy.html?toy=cube-wave` |
-| `bubble-harmonics` | `assets/js/toys/bubble-harmonics.ts` | `toy.html?toy=bubble-harmonics` |
-| `cosmic-particles` | `assets/js/toys/cosmic-particles.ts` | `toy.html?toy=cosmic-particles` |
-| `spiral-burst` | `assets/js/toys/spiral-burst.ts` | `toy.html?toy=spiral-burst` |
-| `rainbow-tunnel` | `assets/js/toys/rainbow-tunnel.ts` | `toy.html?toy=rainbow-tunnel` |
-| `star-field` | `assets/js/toys/star-field.ts` | `toy.html?toy=star-field` |
-| `fractal-kite-garden` | `assets/js/toys/fractal-kite-garden.ts` | `toy.html?toy=fractal-kite-garden` |
+| `3dtoy` | `assets/js/toys/three-d-toy.ts` | Direct module; load with `toy.html?toy=3dtoy`. |
+| `aurora-painter` | `assets/js/toys/aurora-painter.ts` | Direct module; load with `toy.html?toy=aurora-painter`. |
+| `brand` | `assets/js/toys/brand.ts` | Iframe wrapper around `brand.html`. |
+| `clay` | `assets/js/toys/clay.ts` | Iframe wrapper around `clay.html`. |
+| `defrag` | `assets/js/toys/defrag.ts` | Iframe wrapper around `defrag.html`. |
+| `evol` | `assets/js/toys/evol.ts` | Iframe wrapper around `evol.html`. |
+| `geom` | `assets/js/toys/geom.ts` | Iframe wrapper around `geom.html`. |
+| `holy` | `assets/js/toys/holy.ts` | Iframe wrapper around `holy.html`. |
+| `multi` | `assets/js/toys/multi.ts` | Iframe wrapper around `multi.html`; requires WebGPU support. |
+| `seary` | `assets/js/toys/seary.ts` | Iframe wrapper around `seary.html`. |
+| `sgpat` | `assets/js/toys/sgpat.ts` | Direct module; load with `toy.html?toy=sgpat`. |
+| `legible` | `assets/js/toys/legible.ts` | Direct module; load with `toy.html?toy=legible`. |
+| `svgtest` | `assets/js/toys/svgtest.ts` | Iframe wrapper around `svgtest.html`. |
+| `symph` | `assets/js/toys/symph.ts` | Iframe wrapper around `symph.html`. |
+| `words` | `assets/js/toys/words.ts` | Iframe wrapper around `words.html`. |
+| `cube-wave` | `assets/js/toys/cube-wave.ts` | Direct module; load with `toy.html?toy=cube-wave`. |
+| `bubble-harmonics` | `assets/js/toys/bubble-harmonics.ts` | Direct module; load with `toy.html?toy=bubble-harmonics`. |
+| `cosmic-particles` | `assets/js/toys/cosmic-particles.ts` | Direct module; load with `toy.html?toy=cosmic-particles`. |
+| `lights` | `assets/js/toys/lights.ts` | Iframe wrapper around `lights.html`. |
+| `spiral-burst` | `assets/js/toys/spiral-burst.ts` | Direct module; load with `toy.html?toy=spiral-burst`. |
+| `rainbow-tunnel` | `assets/js/toys/rainbow-tunnel.ts` | Direct module; load with `toy.html?toy=rainbow-tunnel`. |
+| `star-field` | `assets/js/toys/star-field.ts` | Direct module; load with `toy.html?toy=star-field`. |
+| `fractal-kite-garden` | `assets/js/toys/fractal-kite-garden.ts` | Direct module; load with `toy.html?toy=fractal-kite-garden`. |
 
-## Standalone HTML visualizers
-These pages embed their own module scripts. Use the imports below to find the main logic.
-
-- **brand.html** → imports `assets/js/core/web-toy.ts`, `assets/js/core/animation-loop.ts`, `assets/js/utils/error-display.ts`, `assets/js/utils/start-audio.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/brand/fun-adapter.ts`.
-- **clay.html** → imports `assets/js/utils/webgl-check.ts`.
-- **defrag.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/error-display.ts`.
-- **evol.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/canvas-resize.ts`.
-- **geom.html** → uses inline canvas and Web Audio logic only (no repo modules).
-- **holy.html** → imports `assets/js/utils/webgl-check.ts` alongside Three.js helpers.
-- **index.html** → uses `assets/js/main.js` to render the toy library.
-- **legible.html** → contains only inline logic plus `particles.js` from a CDN.
-- **lights.html** → loads `assets/js/app.js` as the entry module.
-- **multi.html** → imports `assets/js/core/web-toy.ts`, `assets/js/core/animation-loop.ts`, `assets/js/utils/peak-detector.ts`, `assets/js/utils/audio-handler.ts`, `assets/js/utils/error-display.ts`, `assets/js/utils/start-audio.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/multi/fun-adapter.ts`.
-- **seary.html** → imports `assets/js/utils/audio-handler.ts`, `assets/js/utils/peak-detector.ts`, `assets/js/utils/error-display.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, `assets/seary/fun-adapter.ts`, and `assets/js/utils/canvas-resize.ts`.
-- **sgpat.html** → executes `assets/js/toys/sgpat.ts` directly.
-- **svgtest.html** → imports `assets/js/utils/webgl-check.ts` and `assets/js/utils/audio-handler.ts` alongside Three.js.
-- **symph.html** → imports `assets/js/utils/audio-handler.ts`, `assets/js/utils/canvas-resize.ts`, `assets/js/utils/error-display.ts`, `assets/ui/hints.ts`, `assets/ui/fun-controls.ts`, and `assets/symph/fun-adapter.ts`.
-- **toy.html** → uses `assets/js/toyMain.js`, which delegates to the loader to import modules listed above.
-- **words.html** → imports `assets/js/utils/audio-handler.ts` and `assets/js/utils/error-display.ts` (alongside `wordcloud2` from CDN).
+## Standalone HTML entry points
+All iframe-backed toys can still be visited directly via their HTML pages (for example, `brand.html` or `holy.html`). The library view now embeds those same pages for consistency with query-loaded modules.


### PR DESCRIPTION
## Summary
- update the main README toy catalog to cover the current slugs and note WebGPU requirements
- rewrite the toy script index to map every slug to its module and iframe-backed entry point
- document how to wrap standalone HTML pages via `startIframeToy` when exposing them through `toy.html`

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439438ce048332aa854bc49c12befc)