### PR TITLE
Add Bun build pipeline for hashed static bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ To serve a static build instead of the dev server, run:
 npm run build
 # or
 bun run build
+# or build with Bun's bundler (code-splitting + hashed assets)
+bun run bun-build
 
 python3 -m http.server dist
 ```
@@ -148,6 +150,7 @@ All JavaScript dependencies are installed via npm (or Bun) and bundled locally w
 
 - `npm run dev` / `bun run dev`: Start the Vite development server for local exploration.
 - `npm run build` / `bun run build`: Produce a production build in `dist/`.
+- `bun run bun-build`: Build the site with Bun's bundler, enabling code-splitting and hashed assets for static hosting in `dist/`.
 - `npm run preview` / `bun run preview`: Serve the production build locally to validate the output before deploying.
 - `bun test` (or `bun run test`): Run the Bun-native test suite. `npm run test` will also proxy to Bun if you have it installed.
 - `bun run test:watch`: Keep the Bun test runner active while you iterate on specs.

--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -20,7 +20,9 @@ export function setupCanvasResize(
   { maxPixelRatio, onResize }: CanvasResizeOptions = {}
 ) {
   const resize = () => {
-    const pixelRatio = Math.min(window.devicePixelRatio || 1, maxPixelRatio ?? window.devicePixelRatio || 1);
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const pixelRatioCeiling = maxPixelRatio ?? devicePixelRatio;
+    const pixelRatio = Math.min(devicePixelRatio, pixelRatioCeiling);
     const cssWidth = window.innerWidth;
     const cssHeight = window.innerHeight;
     const width = Math.max(1, Math.floor(cssWidth * pixelRatio));

--- a/bun.build.ts
+++ b/bun.build.ts
@@ -1,0 +1,40 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url));
+
+const htmlEntrypoints = (await readdir(rootDir))
+  .filter((file) => file.endsWith('.html'))
+  .map((file) => path.join(rootDir, file));
+
+if (htmlEntrypoints.length === 0) {
+  console.error('No HTML entry points found in the project root.');
+  process.exit(1);
+}
+
+const result = await Bun.build({
+  entrypoints: htmlEntrypoints,
+  outdir: path.join(rootDir, 'dist'),
+  minify: true,
+  sourcemap: 'external',
+  splitting: true,
+  target: 'browser',
+  publicPath: '/',
+  naming: {
+    entry: '[name]-[hash].[ext]',
+    chunk: 'chunks/[name]-[hash].[ext]',
+    asset: 'assets/[name]-[hash].[ext]',
+  },
+});
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}
+
+for (const output of result.outputs) {
+  console.info(`built ${path.relative(rootDir, output.path)}`);
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write .",
     "dev": "vite",
     "build": "vite build",
+    "bun-build": "bun bun.build.ts",
     "prepare": "husky install",
     "postinstall": "if [ \"${npm_config_user_agent%%/*}\" = \"bun\" ]; then husky install; fi"
   },


### PR DESCRIPTION
## Summary
- add a Bun-powered build script that bundles all HTML entry points with code-splitting and hashed outputs
- wire the new bun-build command into package.json and document it alongside existing build steps
- clarify pixel ratio calculation in the canvas resize helper for bundler compatibility

## Testing
- bun run bun-build
- python3 -m http.server 8000 --directory dist (curl -I index-4wgxzzwj.html)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694395eac994833288ed6d8c83c6a5da)