### PR TITLE
Add Bun static server for dist builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ npm run build
 # or
 bun run build
 
-python3 -m http.server dist
+bun run serve
 ```
 
-Then open `http://localhost:8000`.
+By default the Bun server binds to `0.0.0.0:4173` (use `PORT`/`HOST` to override) and serves `dist/` with gzip/brotli enabled plus long-lived caching headers for bundled JS/CSS/assets. HTML remains uncached so live reloads and SPA routes keep working. Use this when you want a lightweight production-style host without the Vite middleware layer. `vite preview` still works the same way, but it runs the Vite preview server instead of pure static files if you need closer parity with Vite plugins. Then open `http://localhost:4173` (or your chosen port).
 
 All JavaScript dependencies are installed via npm (or Bun) and bundled locally with Vite, so everything works offline without hitting a CDN.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write .",
     "dev": "vite",
     "build": "vite build",
+    "serve": "bun run server.ts",
     "prepare": "husky install",
     "postinstall": "if [ \"${npm_config_user_agent%%/*}\" = \"bun\" ]; then husky install; fi"
   },

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,73 @@
+import { normalize, join, extname } from "node:path";
+import { stat } from "node:fs/promises";
+
+const distRoot = join(import.meta.dir, "dist");
+const host = process.env.HOST ?? "0.0.0.0";
+const port = Number(process.env.PORT ?? 4173);
+
+const longCache = "public, max-age=31536000, immutable";
+const noCache = "no-cache, no-store, must-revalidate";
+
+async function fileExists(filePath: string) {
+  try {
+    const info = await stat(filePath);
+    return info.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function resolvePath(pathname: string) {
+  const normalized = normalize(pathname).replace(/^\/+/, "");
+  const target = normalized || "index.html";
+  const withSlashIndex = target.endsWith("/") ? `${target}index.html` : target;
+  const candidate = join(distRoot, withSlashIndex);
+
+  if (!candidate.startsWith(distRoot)) return null;
+
+  if (await fileExists(candidate)) return candidate;
+
+  if (!extname(withSlashIndex)) {
+    const htmlCandidate = `${withSlashIndex}.html`;
+    const htmlPath = join(distRoot, htmlCandidate);
+    if (!htmlPath.startsWith(distRoot)) return null;
+    if (await fileExists(htmlPath)) return htmlPath;
+  }
+
+  return null;
+}
+
+function cacheHeader(filePath: string) {
+  const type = Bun.mimeType(filePath) ?? "application/octet-stream";
+  return type.startsWith("text/html") ? noCache : longCache;
+}
+
+async function serveFile(filePath: string) {
+  const headers = new Headers();
+  headers.set("Content-Type", Bun.mimeType(filePath) ?? "application/octet-stream");
+  headers.set("Cache-Control", cacheHeader(filePath));
+  return new Response(Bun.file(filePath), { headers });
+}
+
+const server = Bun.serve({
+  hostname: host,
+  port,
+  compression: true,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const resolved = await resolvePath(decodeURIComponent(url.pathname));
+
+    if (resolved) {
+      return serveFile(resolved);
+    }
+
+    const fallback = join(distRoot, "index.html");
+    if (await fileExists(fallback)) {
+      return serveFile(fallback);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`Serving dist/ at http://${host}:${server.port}`);


### PR DESCRIPTION
## Summary
- add a lightweight Bun server for hosting the built dist directory with compression, caching, and SPA fallback
- wire a `bun run serve` script for locally previewing the production build without Vite middleware
- document the new Bun serving option and how it compares to `vite preview`

## Testing
- `bun run build` *(fails: existing canvas-resize.ts nullish coalescing syntax error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694395faa11c8332a0e9b3aad467c164)