### PR TITLE
Improve ESLint coverage and clean lint warnings

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,14 +31,6 @@ function setupDarkModeToggle() {
   });
 }
 
-function colorFromSlug(slug) {
-  let hash = 0;
-  for (const char of slug) {
-    hash = (hash * 31 + char.charCodeAt(0)) % 360;
-  }
-  return `hsl(${hash}, 70%, 60%)`;
-}
-
 function createSVGAnimation(slug) {
   const ns = 'http://www.w3.org/2000/svg';
   const svg = document.createElementNS(ns, 'svg');

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,15 @@ import tsParser from '@typescript-eslint/parser';
 const tsconfigRootDir = new URL('.', import.meta.url).pathname;
 
 export default [
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/dist/**',
+      '**/bun.lock',
+      '**/package-lock.json',
+    ],
+  },
   js.configs.recommended,
   {
     files: ['**/*.{js,ts,tsx}'],
@@ -23,7 +32,12 @@ export default [
         window: 'readonly',
         fetch: 'readonly',
         console: 'readonly',
+        navigator: 'readonly',
+        performance: 'readonly',
+        Event: 'readonly',
+        DOMException: 'readonly',
         URLSearchParams: 'readonly',
+        URL: 'readonly',
         localStorage: 'readonly',
         requestAnimationFrame: 'readonly',
         CustomEvent: 'readonly',
@@ -47,5 +61,14 @@ export default [
     rules: {
       ...tsPlugin.configs.recommended.rules,
     },
+  },
+  {
+    files: ['**/*.d.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    ignores: ['assets/js/lib/**'],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "allowImportingTsExtensions": true,
     "jsx": "preserve"
   },
-  "include": ["assets/js/**/*"],
+  "include": ["assets/**/*", "tests/**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
## Summary
- add lint ignores for generated/vendor assets and register browser globals
- expand the TypeScript project scope to include all asset and test sources
- remove an unused helper from the main entry script to satisfy lint rules

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943968242e4833297cb030446d5a972)