### PR TITLE
Improve microphone denial guidance and fallback

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -218,6 +218,44 @@ body {
   gap: 2px;
 }
 
+.control-panel__status {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(111, 247, 255, 0.35);
+}
+
+.control-panel__status[data-variant='error'] {
+  border-color: rgba(255, 82, 130, 0.8);
+  color: #ffd6e6;
+  background: linear-gradient(
+      120deg,
+      rgba(255, 0, 153, 0.15),
+      rgba(255, 255, 255, 0)
+    ),
+    rgba(0, 0, 0, 0.45);
+}
+
+.control-panel__status[data-variant='success'] {
+  border-color: rgba(17, 216, 255, 0.8);
+  color: #e9fbff;
+  background: linear-gradient(
+      120deg,
+      rgba(17, 216, 255, 0.12),
+      rgba(255, 255, 255, 0)
+    ),
+    rgba(0, 0, 0, 0.38);
+}
+
+.control-panel__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .control-panel__label {
   font-weight: 600;
   font-size: 0.95rem;

--- a/assets/js/toys/aurora-painter.ts
+++ b/assets/js/toys/aurora-painter.ts
@@ -142,10 +142,16 @@ function init() {
   }
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, { fftSize: 512 });
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 512,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/bubble-harmonics.ts
+++ b/assets/js/toys/bubble-harmonics.ts
@@ -243,12 +243,16 @@ function animate(ctx: AnimationContext) {
 
 const initPromise = init();
 
-async function startAudio() {
+async function startAudio(useSynthetic = false) {
   await initPromise;
   return startToyAudio(toy, animate, {
     fftSize: 2048,
     smoothingTimeConstant: 0.72,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
   });
 }
 
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -325,9 +325,15 @@ function animate(ctx: AnimationContext) {
   activePreset?.animate(ctx);
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 256,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -322,8 +322,12 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 256,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 function init() {
@@ -334,3 +338,5 @@ function init() {
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -336,9 +336,15 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, 512);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 512,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -178,9 +178,15 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 256,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -58,9 +58,14 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -112,9 +112,15 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
-  return startToyAudio(toy, animate, 256);
+async function startAudio(useSynthetic = false) {
+  return startToyAudio(toy, animate, {
+    fftSize: 256,
+    fallbackToSynthetic: useSynthetic,
+    preferSynthetic: useSynthetic,
+  });
 }
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -202,9 +202,12 @@ function animate(ctx: AnimationContext) {
   ctx.toy.render();
 }
 
-async function startAudio() {
+async function startAudio(useSynthetic = false) {
   try {
-    await startToyAudio(toy, animate);
+    await startToyAudio(toy, animate, {
+      fallbackToSynthetic: useSynthetic,
+      preferSynthetic: useSynthetic,
+    });
     hideError();
     return true;
   } catch (e) {
@@ -215,3 +218,5 @@ async function startAudio() {
 
 init();
 (window as unknown as Record<string, unknown>).startAudio = startAudio;
+(window as unknown as Record<string, unknown>).startAudioFallback = () =>
+  startAudio(true);

--- a/toy.html
+++ b/toy.html
@@ -19,22 +19,85 @@
         </div>
         <button id="start-audio-btn" class="cta-button primary">Start audio</button>
       </div>
+      <div id="audio-status" class="control-panel__status" role="status"></div>
+      <div class="control-panel__actions">
+        <button id="use-demo-audio" class="cta-button" hidden>
+          Use demo audio instead
+        </button>
+      </div>
     </div>
     <script type="module" src="assets/js/toyMain.js"></script>
     <script>
-      const btn = document.getElementById('start-audio-btn');
-      btn.addEventListener('click', async () => {
-        if (window.startAudio) {
-          btn.disabled = true;
-          try {
-            await window.startAudio();
-            btn.style.display = 'none';
-          } catch (error) {
-            console.error('Unable to start audio:', error);
-            btn.disabled = false;
-          }
+      const startButton = document.getElementById('start-audio-btn');
+      const fallbackButton = document.getElementById('use-demo-audio');
+      const statusElement = document.getElementById('audio-status');
+
+      if (statusElement) {
+        statusElement.hidden = true;
+      }
+
+      const setStatus = (message, variant = 'info') => {
+        if (!statusElement) return;
+        statusElement.textContent = message;
+        statusElement.dataset.variant = variant;
+        statusElement.hidden = !message;
+      };
+
+      const enableButtons = () => {
+        startButton.disabled = false;
+        fallbackButton.disabled = false;
+      };
+
+      const disableButtons = () => {
+        startButton.disabled = true;
+        fallbackButton.disabled = true;
+      };
+
+      const describeError = (error) => {
+        const reason = error?.reason;
+        if (reason === 'denied') {
+          return 'Microphone access was blocked. Check your browser address bar or system privacy settings to allow it.';
         }
-      });
+        if (reason === 'unsupported') {
+          return 'This browser cannot capture microphone audio. Try a different browser or load the demo audio below.';
+        }
+        return 'We could not access your microphone. You can retry or continue with demo audio.';
+      };
+
+      const finishSuccess = () => {
+        startButton.style.display = 'none';
+        fallbackButton.hidden = true;
+        setStatus('Microphone connected! Enjoy the visuals.', 'success');
+      };
+
+      const showFallback = () => {
+        fallbackButton.hidden = false;
+        enableButtons();
+      };
+
+      const startWithMode = async (useSyntheticAudio) => {
+        if (!window.startAudio) return;
+
+        disableButtons();
+        setStatus(
+          useSyntheticAudio
+            ? 'Loading demo audio (no microphone needed)...'
+            : 'Requesting microphone access...',
+          'info'
+        );
+
+        try {
+          await window.startAudio(useSyntheticAudio);
+          finishSuccess();
+        } catch (error) {
+          console.error('Unable to start audio:', error);
+          setStatus(describeError(error), 'error');
+          showFallback();
+        }
+      };
+
+      startButton.addEventListener('click', () => startWithMode(false));
+      fallbackButton.addEventListener('click', () => startWithMode(true));
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add inline status messaging and demo-audio option to toy launcher when microphone access fails
- allow WebToy audio startup to fallback to a synthetic stream and expose that toggle across toys
- style control panel status and action rows for clearer permission guidance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439829436c8332bf8bf57f1109a7c2)