### PR TITLE
Refactor toy pages to use startToyAudio

### DIFF
--- a/defrag.html
+++ b/defrag.html
@@ -39,6 +39,7 @@
         getAverageFrequency,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { showError } from './assets/js/utils/error-display.ts';
       const canvas = document.getElementById('canvas');
       const ctx = canvas.getContext('2d');
@@ -73,7 +74,6 @@
         }
       }
 
-      let analyser;
       let audioDataArray = neutralSpectrum.slice();
       let idleState = true;
       let movingAverageLevel = 0;
@@ -95,20 +95,52 @@
 
       updateStatusIndicator('waiting');
 
-      async function setupAudio() {
-        try {
-          const result = await initAudio({ fftSize: DEFAULT_FFT_SIZE });
-          analyser = result.analyser;
-          updateStatusIndicator('listening');
-        } catch (err) {
-          console.error('Error capturing audio: ', err);
-          showError(
-            'error-message',
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
-          );
-          updateStatusIndicator('waiting');
+      class CanvasToy {
+        constructor(canvasEl) {
+          this.canvas = canvasEl;
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderLoop = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              this.renderLoop = loop;
+
+              if (!loop) return;
+
+              const tick = () => {
+                this.renderLoop?.();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.renderLoop = null;
+          this.loopId = null;
+          this.audioCleanup?.();
         }
       }
+
+      const toy = new CanvasToy(canvas);
 
       function drawBlocks() {
         const frequencyData = audioDataArray.length
@@ -149,24 +181,35 @@
         }
       }
 
-      function defragLoop() {
-        if (analyser) {
-          audioDataArray = getFrequencyData(analyser);
+      function defragLoop(ctxAudio) {
+        if (ctxAudio.analyser) {
+          audioDataArray = getFrequencyData(ctxAudio.analyser);
           const averageLevel = getAverageFrequency(audioDataArray);
           movingAverageLevel =
             movingAverageLevel * 0.7 + averageLevel * 0.3;
           idleState = movingAverageLevel < idleThreshold;
           updateStatusIndicator(idleState ? 'idle' : 'listening');
         } else {
+          audioDataArray = neutralSpectrum;
           updateStatusIndicator('waiting');
         }
         drawBlocks();
         defragTextAnimation();
-        requestAnimationFrame(defragLoop);
       }
 
-      setupAudio();
-      defragLoop();
+      startToyAudio(toy, defragLoop, {
+        fftSize: DEFAULT_FFT_SIZE,
+        fallbackToSynthetic: true,
+        onCleanup: () => updateStatusIndicator('waiting'),
+      }).catch((err) => {
+        console.error('Error capturing audio: ', err);
+        showError(
+          'error-message',
+          'Microphone access is required for the visualization to work. Please allow microphone access.'
+        );
+        updateStatusIndicator('waiting');
+        toy.renderer.setAnimationLoop(() => defragLoop({ toy, analyser: null }));
+      });
     </script>
   </body>
 </html>

--- a/evol.html
+++ b/evol.html
@@ -26,11 +26,9 @@
       </div>
     </div>
     <script type="module">
-      import {
-        initAudio,
-        getFrequencyData,
-      } from './assets/js/utils/audio-handler.ts';
+      import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from './assets/js/utils/canvas-resize.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const errorEl = document.getElementById('error-message');
@@ -233,36 +231,56 @@
         },
       });
 
+      class CanvasToy {
+        constructor(canvasEl) {
+          this.canvas = canvasEl;
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderLoop = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              this.renderLoop = loop;
+
+              if (!loop) return;
+
+              const tick = () => {
+                this.renderLoop?.();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.renderLoop = null;
+          this.loopId = null;
+          this.audioCleanup?.();
+        }
+      }
+
+      const toy = new CanvasToy(canvas);
+
       let time = 0.0;
       let audioData = 0.0;
       let fractalIntensity = 1.0;
-      let analyser;
-
-      async function setupAudio() {
-        try {
-          const result = await initAudio();
-          analyser = result.analyser;
-          hideError();
-          getAudioData();
-        } catch (err) {
-          console.error('Error capturing audio: ', err);
-          displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
-          );
-        }
-      }
-
-      function getAudioData() {
-        requestAnimationFrame(getAudioData);
-        if (analyser) {
-          const dataArray = getFrequencyData(analyser);
-          const average =
-            dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
-          audioData = average / 128.0;
-        }
-      }
-
-      setupAudio();
 
       document
         .getElementById('fractalIntensity')
@@ -270,7 +288,17 @@
           fractalIntensity = event.target.value;
         });
 
-      function render() {
+      function render(ctxAudio) {
+        if (ctxAudio.analyser) {
+          const dataArray = getFrequencyData(ctxAudio.analyser);
+          const average =
+            dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
+          audioData = average / 128.0;
+          hideError();
+        } else {
+          audioData = 0;
+        }
+
         time += 0.02;
         gl.uniform1f(timeUniformLocation, time);
         gl.uniform1f(audioDataUniformLocation, audioData);
@@ -278,12 +306,22 @@
 
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
-
-        requestAnimationFrame(render);
       }
 
-      requestAnimationFrame(render);
-      window.addEventListener('pagehide', disposeResize);
+      startToyAudio(toy, render, { fallbackToSynthetic: true })
+        .then(() => hideError())
+        .catch((err) => {
+          console.error('Error capturing audio: ', err);
+          displayError(
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
+          );
+          toy.renderer.setAnimationLoop(() => render({ toy, analyser: null }));
+        });
+
+      window.addEventListener('pagehide', () => {
+        disposeResize();
+        toy.dispose?.();
+      });
     </script>
   </body>
 </html>

--- a/seary.html
+++ b/seary.html
@@ -45,6 +45,7 @@
     </div>
     <script type="module">
       import {
+        initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
       import { createPeakDetector } from './assets/js/utils/peak-detector.ts';
@@ -53,6 +54,7 @@
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSearyFunAdapter } from './assets/seary/fun-adapter.ts';
       import { setupCanvasResize } from './assets/js/utils/canvas-resize.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
       const sparkleCanvas = document.getElementById('sparkleCanvas');
@@ -67,6 +69,7 @@
       let burstsEnabled = true;
       let peakSensitivity = 0.35;
       let lastRenderTime = 0;
+      let renderElapsed = 0;
 
       function displayError(message) {
         const el = document.getElementById('error-message');
@@ -144,6 +147,54 @@
       window.addEventListener('resize', resizeCanvas);
       resizeCanvas();
       const disposeResize = setupCanvasResize(canvas, gl, { maxPixelRatio: 2 });
+
+      class CanvasToy {
+        constructor(canvasEl) {
+          this.canvas = canvasEl;
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderLoop = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              this.renderLoop = loop;
+
+              if (!loop) return;
+
+              const tick = () => {
+                this.renderLoop?.();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.renderLoop = null;
+          this.loopId = null;
+          this.audioCleanup?.();
+          this.analyser = null;
+        }
+      }
+
+      const toy = new CanvasToy(canvas);
 
       // Compile shader
       function compileShader(source, type) {
@@ -446,175 +497,174 @@
       }
 
       // Audio setup for beat detection and frequency analysis
-      let audioContext, analyser, source;
       let peakDetector = null;
-      let bufferLength, dataArray;
+      let lastVibrateTime = 0;
+      let currentFreqs = adapter.transformFrequencies({
+        low: 0,
+        mid: 0,
+        high: 0,
+      });
       const audioSelect = document.getElementById('audioSelect');
+
+      function vibrateBasedOnAudio(lowFreq, midFreq, highFreq) {
+        const intensity = Math.max(lowFreq, midFreq, highFreq);
+        const currentTime = Date.now();
+
+        if (intensity > 0.7 && currentTime - lastVibrateTime > 500) {
+          if (navigator.vibrate) {
+            navigator.vibrate([intensity * 100, 50, intensity * 100]);
+          }
+          lastVibrateTime = currentTime;
+        }
+      }
+
+      function vibrateBasedOnVisuals(lowFreq, midFreq, highFreq, dist) {
+        const vibrateIntensity =
+          Math.max(lowFreq, midFreq, highFreq) * (1.0 - dist);
+        if (navigator.vibrate && vibrateIntensity > 0.5) {
+          navigator.vibrate([
+            Math.floor(vibrateIntensity * 200),
+            50,
+            Math.floor(vibrateIntensity * 200),
+          ]);
+        }
+      }
+
+      function rebuildPeakDetector(ctx) {
+        if (!ctx.analyser) {
+          peakDetector = null;
+          return;
+        }
+
+        peakDetector = createPeakDetector({
+          getData: () => getFrequencyData(ctx.analyser),
+          sensitivity: peakSensitivity,
+          onPeak: handlePeak,
+          onRelease: handlePeakRelease,
+        });
+      }
+
+      window.addEventListener('deviceorientation', (event) => {
+        orientation.alpha = event.alpha;
+        orientation.beta = event.beta;
+        orientation.gamma = event.gamma;
+      });
+
+      function processAudio(ctxAudio) {
+        if (!ctxAudio.analyser) {
+          peakDetector = null;
+          currentFreqs = adapter.transformFrequencies({
+            low: 0,
+            mid: 0,
+            high: 0,
+          });
+          return { lowFreq: 0, midFreq: 0, highFreq: 0 };
+        }
+
+        const dataArray = getFrequencyData(ctxAudio.analyser);
+        const bufferLength = dataArray.length || 1;
+        const bucketSize = bufferLength / 3;
+        const lowFreq =
+          dataArray
+            .slice(0, bucketSize)
+            .reduce((sum, value) => sum + value, 0) /
+          bucketSize /
+          256.0;
+        const midFreq =
+          dataArray
+            .slice(bucketSize, 2 * bucketSize)
+            .reduce((sum, value) => sum + value, 0) /
+          bucketSize /
+          256.0;
+        const highFreq =
+          dataArray
+            .slice(2 * bucketSize)
+            .reduce((sum, value) => sum + value, 0) /
+          bucketSize /
+          256.0;
+
+        currentFreqs = adapter.transformFrequencies({
+          low: lowFreq,
+          mid: midFreq,
+          high: highFreq,
+        });
+
+        if (!peakDetector) {
+          rebuildPeakDetector(ctxAudio);
+        }
+
+        peakDetector?.update(dataArray);
+
+        vibrateBasedOnAudio(
+          currentFreqs.low,
+          currentFreqs.mid,
+          currentFreqs.high
+        );
+        vibrateBasedOnVisuals(
+          currentFreqs.low,
+          currentFreqs.mid,
+          currentFreqs.high,
+          Math.random()
+        );
+
+        return { lowFreq, midFreq, highFreq };
+      }
+
+      async function initializeAudio() {
+        lastRenderTime = 0;
+        renderElapsed = 0;
+        const options =
+          audioSelect.value === 'device'
+            ? { preferSynthetic: true, fftSize: 256 }
+            : { fftSize: 256, fallbackToSynthetic: true };
+
+        try {
+          await startToyAudio(toy, animate, options);
+          funControls.setAudioAvailable(true);
+          rebuildPeakDetector(toy);
+        } catch (err) {
+          console.error('Error accessing microphone: ' + err);
+          funControls.setAudioAvailable(false);
+          peakDetector = null;
+          currentFreqs = adapter.transformFrequencies({
+            low: 0,
+            mid: 0,
+            high: 0,
+          });
+          showError(
+            'error-message',
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
+          );
+          toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));
+        }
+      }
 
       audioSelect.addEventListener('change', initializeAudio);
       initializeAudio();
 
-      function initializeAudio() {
-        if (audioContext) {
-          audioContext.close();
-        }
-        peakDetector = null;
-
-        navigator.mediaDevices
-          .getUserMedia({ audio: true })
-          .then((stream) => {
-            funControls.setAudioAvailable(true);
-            audioContext = new (window.AudioContext ||
-              window.webkitAudioContext)();
-            analyser = audioContext.createAnalyser();
-            analyser.fftSize = 256;
-            if (audioSelect.value === 'mic') {
-              initAudio()
-                .then(({ analyser: a, dataArray: d }) => {
-                  analyser = a;
-                  source = audioContext.createMediaStreamSource(stream);
-                  source.connect(analyser);
-                  startProcessing(d);
-                })
-                .catch((err) => {
-                  console.error('Error capturing audio: ', err);
-                  showError(
-                    'error-message',
-                    'Microphone access is required for the visualization to work. Please allow microphone access.'
-                  );
-                });
-            } else {
-              // Use the audio context's `createMediaElementSource` to capture device audio
-              const audioElement = new Audio();
-              audioElement.crossOrigin = 'anonymous';
-              source = audioContext.createMediaElementSource(audioElement);
-              source.connect(audioContext.destination); // To allow playback
-              audioElement.play();
-            }
-            source.connect(analyser);
-            rebuildPeakDetector();
-            bufferLength = analyser.frequencyBinCount;
-            dataArray = new Uint8Array(bufferLength);
-            startProcessing(dataArray);
-
-            let lastVibrateTime = 0;
-
-            function vibrateBasedOnAudio(lowFreq, midFreq, highFreq) {
-              const intensity = Math.max(lowFreq, midFreq, highFreq);
-              const currentTime = Date.now();
-
-              // Vibrate only during significant visual events and not too frequently
-              if (intensity > 0.7 && currentTime - lastVibrateTime > 500) {
-                if (navigator.vibrate) {
-                  navigator.vibrate([intensity * 100, 50, intensity * 100]);
-                }
-                lastVibrateTime = currentTime;
-              }
-            }
-
-            function vibrateBasedOnVisuals(lowFreq, midFreq, highFreq, dist) {
-              const vibrateIntensity =
-                Math.max(lowFreq, midFreq, highFreq) * (1.0 - dist);
-              if (navigator.vibrate && vibrateIntensity > 0.5) {
-                navigator.vibrate([
-                  Math.floor(vibrateIntensity * 200),
-                  50,
-                  Math.floor(vibrateIntensity * 200),
-                ]);
-              }
-            }
-
-            // Device orientation-based distortion
-            window.addEventListener('deviceorientation', (event) => {
-              orientation.alpha = event.alpha;
-              orientation.beta = event.beta;
-              orientation.gamma = event.gamma;
-            });
-
-            function startProcessing(arr) {
-              dataArray = arr;
-              bufferLength = analyser.frequencyBinCount;
-              updateAudioData();
-            }
-
-            function updateAudioData() {
-              dataArray = getFrequencyData(analyser);
-              const lowFreq =
-                dataArray
-                  .slice(0, bufferLength / 3)
-                  .reduce((sum, value) => sum + value, 0) /
-                (bufferLength / 3) /
-                256.0;
-              const midFreq =
-                dataArray
-                  .slice(bufferLength / 3, (2 * bufferLength) / 3)
-                  .reduce((sum, value) => sum + value, 0) /
-                (bufferLength / 3) /
-                256.0;
-              const highFreq =
-                dataArray
-                  .slice((2 * bufferLength) / 3, bufferLength)
-                  .reduce((sum, value) => sum + value, 0) /
-                (bufferLength / 3) /
-                256.0;
-
-              // Beat detection based on low frequency threshold
-              if (lowFreq > 0.5) {
-                canvas.style.transform = 'scale(1.1)';
-                setTimeout(() => {
-                  canvas.style.transform = 'scale(1)';
-                }, 100);
-              }
-
-              currentFreqs = adapter.transformFrequencies({
-                low: lowFreq,
-                mid: midFreq,
-                high: highFreq,
-              });
-
-              peakDetector?.update(dataArray);
-
-              vibrateBasedOnAudio(
-                currentFreqs.low,
-                currentFreqs.mid,
-                currentFreqs.high
-              );
-              vibrateBasedOnVisuals(
-                currentFreqs.low,
-                currentFreqs.mid,
-                currentFreqs.high,
-                Math.random()
-              );
-
-              requestAnimationFrame(updateAudioData);
-            }
-            updateAudioData();
-          })
-          .catch((err) => {
-            console.error('Error accessing microphone: ' + err);
-            funControls.setAudioAvailable(false);
-            peakDetector = null;
-            currentFreqs = adapter.transformFrequencies({
-              low: 0,
-              mid: 0,
-              high: 0,
-            });
-          });
-      }
-
       // Render loop
-      function render(time) {
-        time *= 0.001; // Convert time to seconds
-        const delta = lastRenderTime === 0 ? 0 : time - lastRenderTime;
+      function animate(ctxAudio) {
+        const now = performance.now();
+        const delta = lastRenderTime === 0 ? 0 : (now - lastRenderTime) / 1000;
         const dt = Math.min(delta, 0.1);
-        lastRenderTime = time;
+        lastRenderTime = now;
+        renderElapsed += dt;
+
+        const audioMetrics = processAudio(ctxAudio);
+
+        if (audioMetrics?.lowFreq > 0.5) {
+          canvas.style.transform = 'scale(1.1)';
+          setTimeout(() => {
+            canvas.style.transform = 'scale(1)';
+          }, 100);
+        }
 
         burstState.scale += (1 - burstState.scale) * Math.min(1, dt * 2.25);
         burstState.rotation *= Math.max(0, 1 - dt * 1.35);
         burstState.intensity = Math.max(0, burstState.intensity - dt * 1.2);
 
         // Set uniforms
-        gl.uniform1f(timeLocation, time);
+        gl.uniform1f(timeLocation, renderElapsed);
         gl.uniform1f(lowFreqLocation, currentFreqs.low);
         gl.uniform1f(midFreqLocation, currentFreqs.mid);
         gl.uniform1f(highFreqLocation, currentFreqs.high);
@@ -648,11 +698,12 @@
         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
         updateSparkles(dt || 0.016);
-
-        requestAnimationFrame(render);
       }
-      requestAnimationFrame(render);
-      window.addEventListener('pagehide', disposeResize);
+
+      window.addEventListener('pagehide', () => {
+        disposeResize();
+        toy.dispose?.();
+      });
     </script>
   </body>
 </html>

--- a/svgtest.html
+++ b/svgtest.html
@@ -155,6 +155,7 @@
         initAudio,
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
 
       const errorEl = document.getElementById('error-message');
 
@@ -252,6 +253,26 @@
 
       camera.position.z = 20;
 
+      const toy = {
+        camera,
+        renderer,
+        analyser: null,
+        audioCleanup: null,
+        async initAudio(options = {}) {
+          const audio = await initAudio({ ...options, camera });
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        },
+        dispose() {
+          if (this.renderer?.setAnimationLoop) {
+            this.renderer.setAnimationLoop(null);
+          }
+
+          this.audioCleanup?.();
+        },
+      };
+
       // Handle window resize
       window.addEventListener('resize', () => {
         renderer.setSize(window.innerWidth, window.innerHeight);
@@ -260,23 +281,7 @@
       });
 
       // Set up audio using the shared audio handler
-      let analyser;
       let audioDataArray = new Uint8Array(128);
-
-      async function setupAudio() {
-        try {
-          const result = await initAudio({ fftSize: 256 });
-          analyser = result.analyser;
-          hideError();
-        } catch (err) {
-          console.error('Error capturing audio: ', err);
-          displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.'
-          );
-        }
-      }
-
-      setupAudio();
 
       // SVG elements for reactive effects
       const turbulence = document.getElementById('turbulence');
@@ -288,16 +293,15 @@
       let time = 0;
 
       // Main animation loop
-      function animate() {
-        requestAnimationFrame(animate);
+      function animate(ctxAudio) {
         time += 0.016;
 
         let avgFrequency = 0;
         let bassFrequency = 0;
         let highFrequency = 0;
 
-        if (analyser) {
-          audioDataArray = getFrequencyData(analyser);
+        if (ctxAudio.analyser) {
+          audioDataArray = getFrequencyData(ctxAudio.analyser);
           avgFrequency =
             audioDataArray.reduce((sum, val) => sum + val, 0) /
             audioDataArray.length;
@@ -381,7 +385,17 @@
         renderer.render(scene, camera);
       }
 
-      animate();
+      startToyAudio(toy, animate, { fftSize: 256, fallbackToSynthetic: true })
+        .then(() => hideError())
+        .catch((err) => {
+          console.error('Error capturing audio: ', err);
+          displayError(
+            'Microphone access is required for the visualization to work. Please allow microphone access.'
+          );
+          toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));
+        });
+
+      window.addEventListener('pagehide', () => toy.dispose());
     </script>
   </body>
 </html>

--- a/symph.html
+++ b/symph.html
@@ -43,6 +43,7 @@
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createSymphFunAdapter } from './assets/symph/fun-adapter.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
       const ctx2d = canvas.getContext('2d');
@@ -232,12 +233,58 @@
       `;
       funControls.appendControl(extraControls);
 
+      class CanvasToy {
+        constructor(canvasEl) {
+          this.canvas = canvasEl;
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderLoop = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              this.renderLoop = loop;
+
+              if (!loop) return;
+
+              const tick = () => {
+                this.renderLoop?.();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.renderLoop = null;
+          this.loopId = null;
+          this.audioCleanup?.();
+        }
+      }
+
+      const toy = new CanvasToy(canvas);
+
       let gradientStops = adapter.paletteOptions.bright;
       let time = 0.0;
       let audioData = adapter.transformAudioValue(0);
       let colorOffset = [...adapter.paletteAccent];
       let touchPoint = [0.0, 0.0];
-      let analyser;
       let smoothedLevel = 0;
       let burstEnergy = 0;
       let lastTransientTime = 0;
@@ -281,54 +328,6 @@
           event.target.setAttribute('aria-valuenow', transientSensitivity.toString());
         }
       });
-
-      async function setupAudio() {
-        try {
-          const { analyser: a } = await initAudio();
-          analyser = a;
-          clearError('error-message');
-          getAudioData();
-          funControls.setAudioAvailable(true);
-        } catch (err) {
-          showError(
-            'error-message',
-            'Microphone access is unavailable. Visuals will run without audio reactivity.'
-          );
-          funControls.setAudioAvailable(false);
-          audioData = adapter.transformAudioValue(0);
-          console.error('Error capturing audio: ', err);
-        }
-      }
-
-      function getAudioData() {
-        requestAnimationFrame(getAudioData);
-        if (analyser) {
-          const dataArray = getFrequencyData(analyser);
-          const average = getAverageFrequency(dataArray);
-          const normalized = average / 255;
-          smoothedLevel = smoothedLevel
-            ? smoothedLevel * 0.9 + normalized * 0.1
-            : normalized;
-          const threshold = 0.08 + (1 - transientSensitivity) * 0.25;
-          const transientDelta = normalized - smoothedLevel;
-          const now = performance.now();
-          if (
-            transientDelta > threshold &&
-            now - lastTransientTime > 110 &&
-            normalized > 0.05
-          ) {
-            const strength = Math.min(
-              1,
-              (transientDelta - threshold) * 3 + normalized * 0.35
-            );
-            lastTransientTime = now;
-            triggerBurst(strength);
-          }
-
-          audioData = adapter.transformAudioValue(average);
-          updateSpectrograph(dataArray);
-        }
-      }
 
       function updateSpectrograph(dataArray) {
         if (!ctx2d) return;
@@ -422,9 +421,38 @@
         }
       }
 
-      setupAudio();
+      function animate(ctxAudio) {
+        if (ctxAudio.analyser) {
+          const dataArray = getFrequencyData(ctxAudio.analyser);
+          const average = getAverageFrequency(dataArray);
+          const normalized = average / 255;
+          smoothedLevel = smoothedLevel
+            ? smoothedLevel * 0.9 + normalized * 0.1
+            : normalized;
+          const threshold = 0.08 + (1 - transientSensitivity) * 0.25;
+          const transientDelta = normalized - smoothedLevel;
+          const now = performance.now();
+          if (
+            transientDelta > threshold &&
+            now - lastTransientTime > 110 &&
+            normalized > 0.05
+          ) {
+            const strength = Math.min(
+              1,
+              (transientDelta - threshold) * 3 + normalized * 0.35
+            );
+            lastTransientTime = now;
+            triggerBurst(strength);
+          }
 
-      function render() {
+          audioData = adapter.transformAudioValue(average);
+          updateSpectrograph(dataArray);
+          funControls.setAudioAvailable(true);
+        } else {
+          audioData = adapter.transformAudioValue(0);
+          funControls.setAudioAvailable(false);
+        }
+
         time += 0.02;
         gl.uniform1f(timeUniformLocation, time);
         gl.uniform1f(audioDataUniformLocation, audioData);
@@ -446,10 +474,21 @@
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
-        requestAnimationFrame(render);
+        updateSparkles();
       }
 
-      requestAnimationFrame(render);
+      startToyAudio(toy, animate, { fallbackToSynthetic: true })
+        .then(() => clearError('error-message'))
+        .catch((err) => {
+          showError(
+            'error-message',
+            'Microphone access is unavailable. Visuals will run without audio reactivity.'
+          );
+          funControls.setAudioAvailable(false);
+          audioData = adapter.transformAudioValue(0);
+          console.error('Error capturing audio: ', err);
+          toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));
+        });
 
       // Handle pointer input
       canvas.addEventListener('pointerdown', (event) => {
@@ -463,7 +502,10 @@
         const y = -(event.clientY / canvas.clientHeight) * 2.0 + 1.0;
         touchPoint = [x, y];
       });
-      window.addEventListener('pagehide', disposeResize);
+      window.addEventListener('pagehide', () => {
+        disposeResize();
+        toy.dispose?.();
+      });
     </script>
   </body>
 </html>

--- a/words.html
+++ b/words.html
@@ -187,10 +187,8 @@
     </div>
 
     <script type="module">
-      import {
-        initAudio,
-        getFrequencyData,
-      } from './assets/js/utils/audio-handler.ts';
+      import { initAudio, getFrequencyData } from './assets/js/utils/audio-handler.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { showError } from './assets/js/utils/error-display.ts';
       const wordCloudCanvas = document.getElementById('word-cloud-canvas');
       const unmuteButton = document.getElementById('unmute-button');
@@ -218,15 +216,57 @@
         'rhythm',
       ];
 
+      class AudioToy {
+        constructor() {
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderLoop = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              this.renderLoop = loop;
+
+              if (!loop) return;
+
+              const tick = () => {
+                this.renderLoop?.();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.renderLoop = null;
+          this.loopId = null;
+          this.audioCleanup?.();
+          this.analyser = null;
+        }
+      }
+
+      let toy = null;
+
       let isUnmuted = false;
       let isAddingWords = false;
       let wordsArray = [...seedWords];
       let wordCloudData = [];
-
-      let audioContext = null;
-      let analyser = null;
-      let microphone = null;
-      let mediaStream = null;
 
       // Word cloud shapes for randomness
       const shapes = ['circle', 'star', 'triangle', 'diamond'];
@@ -315,13 +355,8 @@
 
       async function activateVisualizer() {
         try {
-          const { analyser: a, audioContext: ctx, stream } = await initAudio();
-          analyser = a;
-          audioContext = ctx;
-          mediaStream = stream;
-          microphone = audioContext.createMediaStreamSource(stream);
-          microphone.connect(analyser);
-          visualize();
+          toy = toy ?? new AudioToy();
+          await startToyAudio(toy, animate, { fallbackToSynthetic: true });
         } catch (error) {
           console.error('Error accessing microphone for visualizer:', error);
           showError(
@@ -335,36 +370,21 @@
         }
       }
 
-      function visualize() {
-        let dataArray = new Uint8Array(analyser.frequencyBinCount);
+      function animate(ctxAudio) {
+        if (!isUnmuted) return;
 
-        function draw() {
-          if (!isUnmuted) return;
+        const dataArray = ctxAudio.analyser
+          ? getFrequencyData(ctxAudio.analyser)
+          : new Uint8Array(0);
+        const maxVolume = dataArray.length ? Math.max(...dataArray) : 0;
 
-          dataArray = getFrequencyData(analyser);
-          const maxVolume = Math.max(...dataArray);
-
-          updateWordCloudWithVisualizer(maxVolume);
-          createParticleEffects(maxVolume);
-
-          requestAnimationFrame(draw);
-        }
-        draw();
+        updateWordCloudWithVisualizer(maxVolume);
+        createParticleEffects(maxVolume);
       }
 
       function deactivateVisualizer() {
-        if (audioContext) {
-          audioContext.close();
-          audioContext = null;
-          analyser = null;
-          microphone = null;
-
-          // Explicitly stop all tracks of the media stream
-          if (mediaStream) {
-            mediaStream.getTracks().forEach((track) => track.stop());
-            mediaStream = null;
-          }
-        }
+        toy?.dispose();
+        toy = null;
         document.querySelectorAll('.particle').forEach((p) => p.remove());
       }
 


### PR DESCRIPTION
## Summary
- replace manual microphone setup in defrag, evol, symph, words, seary, and svgtest entries with the shared startToyAudio helper
- update animation loops to consume the shared animation context and support synthetic audio fallbacks
- add lightweight toy wrappers to manage audio cleanup and renderer loops across the standalone HTML entry points

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944395d7c948332b3a95c3e700bbdd4)