### PR TITLE
Adopt shared audio helper in holy and legible stims

### DIFF
--- a/holy.html
+++ b/holy.html
@@ -232,14 +232,20 @@
       import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
       import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
       import { FXAAShader } from 'three/examples/jsm/shaders/FXAAShader.js';
+      import {
+        getFrequencyData,
+        initAudio,
+      } from './assets/js/utils/audio-handler.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
       if (!ensureWebGL()) {
         return;
       }
       let scene, camera, renderer, composer, bloomPass, fxaaPass;
       let visualizerShape, particles;
-      let audioContext, audioAnalyser, dataArray;
-      let isAudioInitialized = false;
+      let dataArray = new Uint8Array(0);
+      let analyser = null;
+      let sampleRate = 44100;
       let lastTap = 0;
       let zoomDistance = 5;
       const shapes = ['sphere', 'cube', 'torus', 'dodecahedron'];
@@ -482,37 +488,19 @@
         createShape();
       }
 
-      // Setup Audio Processing
-      async function setupAudio() {
-        try {
-          audioContext = new (window.AudioContext ||
-            window.webkitAudioContext)();
-          const stream = await navigator.mediaDevices.getUserMedia({
-            audio: true,
-          });
-          const source = audioContext.createMediaStreamSource(stream);
-          audioAnalyser = audioContext.createAnalyser();
-          audioAnalyser.fftSize = 1024;
-          source.connect(audioAnalyser);
-          dataArray = new Uint8Array(audioAnalyser.frequencyBinCount);
-          isAudioInitialized = true;
-          hideError();
-        } catch (err) {
-          console.error('Error accessing microphone:', err);
-          showError(
-            'Microphone access is required for the visualizer to work.'
-          );
-        }
-      }
-
       // Animation Loop
-      function animate() {
+      function animate(ctx) {
         const delta = clock.getDelta();
         const elapsed = clock.getElapsedTime();
 
-        if (isAudioInitialized) {
-          audioAnalyser.getByteFrequencyData(dataArray);
+        if (ctx.analyser) {
+          analyser = ctx.analyser;
+          sampleRate = ctx.analyser.context.sampleRate;
+          dataArray = getFrequencyData(ctx.analyser);
           updateVisualizer(elapsed);
+        } else {
+          analyser = null;
+          dataArray = new Uint8Array(0);
         }
 
         // Update Dynamic Background
@@ -578,8 +566,8 @@
 
       // Get Frequencies within a Range
       function getFrequencyRange(low, high) {
-        if (!audioAnalyser) return [];
-        const nyquist = audioContext.sampleRate / 2;
+        if (!analyser || dataArray.length === 0) return [];
+        const nyquist = sampleRate / 2;
         const lowIndex = Math.floor((low / nyquist) * dataArray.length);
         const highIndex = Math.floor((high / nyquist) * dataArray.length);
         return dataArray.slice(lowIndex, highIndex);
@@ -711,9 +699,36 @@
       startButton.addEventListener('click', async () => {
         startButton.style.display = 'none';
         init();
-        await setupAudio();
-        loadingOverlay.style.display = 'none';
-        renderer.setAnimationLoop(animate);
+
+        const toy = {
+          renderer,
+          analyser: null,
+          audioCleanup: null,
+          async initAudio(options = {}) {
+            const audio = await initAudio(options);
+            this.analyser = audio.analyser;
+            this.audioCleanup = audio.cleanup;
+            return audio;
+          },
+          dispose() {
+            this.audioCleanup?.();
+          },
+        };
+
+        try {
+          await startToyAudio(toy, animate, {
+            fftSize: 1024,
+            fallbackToSynthetic: true,
+          });
+          hideError();
+          loadingOverlay.style.display = 'none';
+        } catch (err) {
+          console.error('Error accessing microphone:', err);
+          showError(
+            'Microphone access is required for the visualizer to work.'
+          );
+          startButton.style.display = 'block';
+        }
       });
 
       // Settings Panel Initialization

--- a/legible.html
+++ b/legible.html
@@ -158,11 +158,12 @@
     <div id="particles-js"></div>
     <div class="grid" id="grid"></div>
 
-    <script>
-      let audioContext,
-        analyser,
-        dataArray,
-        micStream,
+    <script type="module">
+      import { getFrequencyData, initAudio } from './assets/js/utils/audio-handler.ts';
+      import { startToyAudio } from './assets/js/utils/start-audio.ts';
+
+      let analyser,
+        dataArray = new Uint8Array(0),
         isMicrophoneEnabled = false;
       const startButton = document.getElementById('start-button');
       const resetButton = document.getElementById('reset-button');
@@ -340,35 +341,65 @@
 
       cycleRandomCharacters(); // Start cycling the characters
 
+      class GridToy {
+        constructor() {
+          this.analyser = null;
+          this.audioCleanup = null;
+          this.loopId = null;
+          this.renderer = {
+            setAnimationLoop: (loop) => {
+              if (this.loopId) {
+                cancelAnimationFrame(this.loopId);
+              }
+
+              const tick = () => {
+                loop();
+                this.loopId = requestAnimationFrame(tick);
+              };
+
+              tick();
+            },
+          };
+        }
+
+        async initAudio(options = {}) {
+          const audio = await initAudio(options);
+          this.analyser = audio.analyser;
+          this.audioCleanup = audio.cleanup;
+          analyser = this.analyser;
+          return audio;
+        }
+
+        dispose() {
+          if (this.loopId) {
+            cancelAnimationFrame(this.loopId);
+          }
+
+          this.audioCleanup?.();
+        }
+      }
+
+      const toy = new GridToy();
+
       function startMicAudio() {
-        navigator.mediaDevices
-          .getUserMedia({ audio: true, video: false })
-          .then((stream) => {
-            audioContext = new (window.AudioContext ||
-              window.webkitAudioContext)();
-            analyser = audioContext.createAnalyser();
-            analyser.fftSize = 512;
-            dataArray = new Uint8Array(analyser.frequencyBinCount);
-
-            micStream = audioContext.createMediaStreamSource(stream);
-            micStream.connect(analyser);
+        startButton.disabled = true;
+        startToyAudio(toy, render, { fftSize: 512, fallbackToSynthetic: true })
+          .then(() => {
             isMicrophoneEnabled = true;
-
-            hideError();
-
             startButton.textContent = 'Microphone Active';
-            startButton.disabled = true;
-            render(); // Start the visualizer
+            hideError();
           })
-          .catch((err) => {
+          .catch(() => {
             showError(
               'Microphone access denied. Please allow microphone access to enable the visualizer.'
             );
+            startButton.disabled = false;
+            startButton.textContent = 'Enable Microphone';
           });
       }
 
       function getBeat() {
-        analyser.getByteFrequencyData(dataArray);
+        if (!dataArray.length) return 0;
         let sumLow = 0;
         const lowEnd = Math.floor(dataArray.length * 0.2);
 
@@ -445,10 +476,11 @@
         cycleRandomCharacters(); // Restart cycling after reset
       }
 
-      function render(time) {
-        requestAnimationFrame(render);
-
-        if (isMicrophoneEnabled) {
+      function render(ctx) {
+        if (ctx.analyser) {
+          analyser = ctx.analyser;
+          dataArray = getFrequencyData(ctx.analyser);
+          isMicrophoneEnabled = true;
           const beatStrength = getBeat();
 
           if (beatStrength > sensitivity) {
@@ -457,13 +489,9 @@
           } else {
             gridElement.style.transform = 'scale(1)';
           }
+        } else {
+          isMicrophoneEnabled = false;
         }
-      }
-
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        showError(
-          'Your browser does not support microphone access. Please update to a modern browser.'
-        );
       }
 
       // Initialize color scheme


### PR DESCRIPTION
## Summary
- replace direct getUserMedia setup in holy and legible stims with the shared startToyAudio helper and audio-handler utilities
- introduce toy wrappers to drive animation loops while reusing centralized audio initialization and cleanup
- preserve existing UI flows while enabling synthetic fallback support through the shared helper

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439cf42e64833299e27407d7e329d3)