### PR TITLE
Add changelog and link from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+_Current release status: actively developed. The latest tagged release is **1.0.0** and ongoing updates will appear in **Unreleased**._
+
+## [Unreleased]
+### Added
+- Track upcoming tweaks to audio, WebGL, and touch experiences across the library of toys.
+
+## [1.0.0] - 2025-02-04
+### Added
+- Initial release of the Stim Webtoys Library with interactive experiences such as [Aurora Painter](./toy.html?toy=aurora-painter), [Defrag Visualizer](./toy.html?toy=defrag), [Multi-Capability Visualizer](./toy.html?toy=multi), [Audio Light Show](./toy.html?toy=lights), and many more listed in the [README](./README.md#toys-in-the-collection).
+- Core setup for running toys locally via Vite with Bun or Node.js, including build, preview, lint, and test scripts.
+
+### Changed
+- Documented repository layout and contribution guidance to help users navigate assets, utilities, and test suites.
+
+### Fixed
+- Clarified local setup to avoid issues when opening HTML files directly without a dev server.
+
+[Unreleased]: https://github.com/zz-plant/stims/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/zz-plant/stims/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil
 
 For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
 
+Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
+
 ## Quick Start
 
 1. Clone the repo and `cd` into it.


### PR DESCRIPTION
## Summary
- add root-level CHANGELOG using Keep a Changelog format to document releases and current status
- describe initial 1.0.0 release with links to key webtoys and repository setup details
- link the README to the changelog for quick navigation

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694445fa12848332b1e4bf0b2f1e3184)