### PR TITLE
Restore window global after loader resolveModulePath tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,8 +45,6 @@ export default [
         CustomEvent: 'readonly',
         define: 'readonly',
         module: 'readonly',
-        process: 'readonly',
-        Bun: 'readonly',
       },
     },
   },

--- a/scripts/serve-dist.ts
+++ b/scripts/serve-dist.ts
@@ -1,4 +1,3 @@
-/* global Bun */
 import process from "node:process";
 import { stat } from "node:fs/promises";
 import path from "node:path";

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -8,6 +8,7 @@ import {
 } from 'bun:test';
 
 const loaderModule = '../assets/js/loader.js';
+const originalWindow = global.window;
 const originalLocation = window.location;
 const originalHistory = window.history;
 const originalNavigator = global.navigator;
@@ -245,7 +246,7 @@ describe('resolveModulePath', () => {
   afterEach(() => {
     mock.restore();
     delete global.fetch;
-    delete global.window;
+    global.window = originalWindow;
   });
 
   test('uses manifest entry when available', async () => {


### PR DESCRIPTION
## Summary
- restore the original window instance after resolveModulePath tests so subsequent suites retain DOM globals
- clean up duplicate Bun/process globals in ESLint config and remove redundant Bun declaration in the dist server script

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694445ee97c48332a5a78e1143730c56)