### PR TITLE
Fix canvas resize pixel ratio calculation

### DIFF
--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -20,7 +20,9 @@ export function setupCanvasResize(
   { maxPixelRatio, onResize }: CanvasResizeOptions = {}
 ) {
   const resize = () => {
-    const pixelRatio = Math.min(window.devicePixelRatio || 1, maxPixelRatio ?? window.devicePixelRatio || 1);
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const maxSupportedPixelRatio = maxPixelRatio ?? devicePixelRatio;
+    const pixelRatio = Math.min(devicePixelRatio, maxSupportedPixelRatio);
     const cssWidth = window.innerWidth;
     const cssHeight = window.innerHeight;
     const width = Math.max(1, Math.floor(cssWidth * pixelRatio));


### PR DESCRIPTION
## Summary
- adjust canvas resize pixel ratio calculation to avoid invalid operator mixing
- keep pixel ratio within provided max while respecting device pixel ratio defaults

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944499ed3908332b6da34a1e1d30309)