### PR TITLE
Add issue and contribution calls to action

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -230,6 +230,14 @@ header.hero {
   margin: 1.5rem 0;
 }
 
+.cta-helper {
+  margin: -0.5rem 0 1.5rem;
+  max-width: 720px;
+  font-size: 0.95rem;
+  opacity: 0.8;
+  line-height: 1.5;
+}
+
 .cta-button {
   padding: 0.7rem 1.25rem;
   border-radius: 12px;
@@ -517,6 +525,21 @@ footer {
   text-align: center;
   margin-top: 3rem;
   padding: 1rem;
+}
+
+.footer-actions {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+}
+
+.footer-cta-row {
+  margin: 0.5rem 0 0;
+  justify-content: center;
+}
+
+.footer-helper {
+  margin: 0.25rem 0 0;
 }
 
 .theme-toggle {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,26 @@
                 class="cta-button ghost"
                 >View the code</a
               >
+              <a
+                href="https://github.com/zz-plant/stims/issues/new/choose"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="cta-button ghost"
+                >Report an issue</a
+              >
+              <a
+                href="https://github.com/zz-plant/stims/blob/main/CONTRIBUTING.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="cta-button ghost"
+                >Contribute</a
+              >
             </div>
+            <p class="cta-helper">
+              "Report an issue" opens GitHub’s templates so you can share bugs or
+              feature ideas. "Contribute" takes you to the contribution guide to
+              see what to expect before opening a PR.
+            </p>
             <div class="hero-marquee" aria-hidden="true">
               <div class="marquee-track">
                 <span>⚡ Live audio</span>
@@ -130,16 +149,38 @@
       </section>
 
       <footer>
-        <p>
-          Curious about how these work?
-          <a
-            href="https://github.com/zz-plant/stims"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Check out our open-source project.
-          </a>
-        </p>
+        <div class="footer-actions">
+          <p>
+            Curious about how these work?
+            <a
+              href="https://github.com/zz-plant/stims"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Check out our open-source project.
+            </a>
+          </p>
+          <div class="cta-row footer-cta-row">
+            <a
+              href="https://github.com/zz-plant/stims/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="cta-button ghost"
+              >Report an issue</a
+            >
+            <a
+              href="https://github.com/zz-plant/stims/blob/main/CONTRIBUTING.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="cta-button ghost"
+              >Contribute</a
+            >
+          </div>
+          <p class="cta-helper footer-helper">
+            Jumping to GitHub lets you pick the right issue form or read how we
+            review pull requests before you send one.
+          </p>
+        </div>
       </footer>
     </div>
 


### PR DESCRIPTION
## Summary
- add hero and footer CTAs linking to GitHub issue templates and the contribution guide with helper copy
- style helper text and footer CTA layout to align with existing call-to-action buttons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444e7b8d2083329d26c561a8abe0a2)