### PR TITLE
Add repo status widget to landing page

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -656,6 +656,71 @@ footer {
   line-height: 1.5;
 }
 
+.status-card {
+  padding: 1.1rem 1rem;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(109, 240, 255, 0.14), rgba(155, 123, 255, 0.14), rgba(255, 111, 227, 0.12));
+  border: 1px solid var(--accent-soft);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.3), 0 0 24px var(--highlight-glow);
+  backdrop-filter: blur(10px);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.release-link {
+  color: var(--accent-color);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.release-link:hover,
+.release-link:focus-visible {
+  text-decoration: underline;
+}
+
+.status-body {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.status-metric {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.metric-value {
+  font-weight: 700;
+  color: var(--accent-color);
+}
+
+.status-fallback {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ffbf47;
+  background: rgba(255, 191, 71, 0.1);
+  border: 1px solid rgba(255, 191, 71, 0.5);
+  padding: 0.7rem 0.75rem;
+  border-radius: 12px;
+}
+
 @media (max-width: 768px) {
   h1 {
     font-size: 2rem;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,6 @@
 import { initNavigation, loadToy, loadFromQuery } from './loader.js';
 import { createLibraryView } from './library-view.js';
+import { initRepoStatusWidget } from './repo-status.js';
 import toysData from './toys-data.js';
 
 const libraryView = createLibraryView({
@@ -16,3 +17,4 @@ const libraryView = createLibraryView({
 });
 
 libraryView.init();
+initRepoStatusWidget();

--- a/assets/js/repo-status.js
+++ b/assets/js/repo-status.js
@@ -1,0 +1,83 @@
+const API_URL = 'https://api.github.com/repos/zz-plant/stims';
+const CACHE_KEY = 'repo-status:zz-plant/stims';
+
+const formatCount = (count) =>
+  typeof count === 'number' ? new Intl.NumberFormat('en-US').format(count) : '—';
+
+const formatDate = (isoString) => {
+  if (!isoString) return '—';
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+};
+
+const readCache = () => {
+  try {
+    const cached = sessionStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+    return JSON.parse(cached);
+  } catch (error) {
+    return null;
+  }
+};
+
+const writeCache = (data) => {
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  } catch (error) {
+    // Ignore cache write errors
+  }
+};
+
+const updateMetrics = (container, data) => {
+  const starTarget = container.querySelector('[data-star-count]');
+  const commitTarget = container.querySelector('[data-last-commit]');
+
+  if (starTarget) {
+    starTarget.textContent = formatCount(data?.stargazers_count);
+  }
+
+  if (commitTarget) {
+    commitTarget.textContent = formatDate(data?.pushed_at);
+  }
+};
+
+const showFallback = (container, message) => {
+  const fallback = container.querySelector('[data-status-fallback]');
+  if (!fallback) return;
+  fallback.textContent = message;
+  fallback.hidden = false;
+};
+
+const fetchRepoStatus = async () => {
+  const response = await fetch(API_URL, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('GitHub API request failed');
+  }
+
+  return response.json();
+};
+
+export const initRepoStatusWidget = async () => {
+  const container = document.querySelector('[data-repo-status]');
+  if (!container) return;
+
+  const cached = readCache();
+  if (cached) {
+    updateMetrics(container, cached);
+    return;
+  }
+
+  try {
+    const data = await fetchRepoStatus();
+    updateMetrics(container, data);
+    writeCache(data);
+  } catch (error) {
+    showFallback(container, 'GitHub status is taking a break. Try again later.');
+  }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,8 @@ export default [
         URLSearchParams: 'readonly',
         URL: 'readonly',
         localStorage: 'readonly',
+        sessionStorage: 'readonly',
+        Intl: 'readonly',
         requestAnimationFrame: 'readonly',
         CustomEvent: 'readonly',
         define: 'readonly',

--- a/index.html
+++ b/index.html
@@ -112,6 +112,27 @@
                 sparkle.
               </p>
             </div>
+              <div class="status-card" data-repo-status>
+                <div class="status-header">
+                  <p class="eyebrow">Repo status</p>
+                  <a class="release-link" href="./CHANGELOG.md"
+                    >Release notes — check out the CHANGELOG</a
+                  >
+                </div>
+              <div class="status-body">
+                <div class="status-metric">
+                  <span class="metric-label">GitHub stars</span>
+                  <span class="metric-value" data-star-count aria-live="polite">—</span>
+                </div>
+                <div class="status-metric">
+                  <span class="metric-label">Last commit</span>
+                  <span class="metric-value" data-last-commit>—</span>
+                </div>
+              </div>
+              <p class="status-fallback" data-status-fallback hidden>
+                GitHub status is taking a break. Try again in a bit.
+              </p>
+            </div>
           </aside>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add a hero-side repository status card with a release-notes link to the changelog
- fetch and cache GitHub stars and last commit data with graceful fallback messaging
- style the widget to match existing cards and update lint globals for browser APIs

## Testing
- eslint .
- prettier --write .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444e83c9ec8332b35853f7c23b6a52)