### PR TITLE
Use Bun in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm install
-      - run: npm run lint
-      - run: npm test
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun test


### PR DESCRIPTION
## Summary
- install Bun in CI using oven-sh/setup-bun
- use Bun to install dependencies and run lint/tests for bun.lock consistency

## Testing
- not run (CI only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445da47be88332ab386a128fbc9da4)