### PR TITLE
Add build step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun test
+      - run: bun run build


### PR DESCRIPTION
## Summary
- add a bun build step to the CI workflow following lint and test phases
- keep the build using the existing Bun-based install to match other steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446628545c83328fe8143db7d095af)