### PR TITLE
Handle WebGPU initialization fallback

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,10 +13,18 @@ import PatternRecognizer from './utils/patternRecognition.ts';
 
 const DEFAULT_RENDERER_OPTIONS = { maxPixelRatio: 2 };
 
-let scene, camera, renderer, cube, analyser, patternRecognizer, audioCleanup;
+let scene,
+  camera,
+  renderer,
+  rendererBackend,
+  cube,
+  analyser,
+  patternRecognizer,
+  audioCleanup;
+let rendererReadyPromise;
 let currentLightType = 'PointLight'; // Default light type
 
-function initVisualization() {
+async function initVisualization() {
   if (!ensureWebGL()) {
     return;
   }
@@ -45,7 +53,15 @@ function initVisualization() {
   scene = initScene();
   camera = initCamera();
   const canvas = document.getElementById('toy-canvas');
-  renderer = initRenderer(canvas, DEFAULT_RENDERER_OPTIONS);
+  const rendererResult = await initRenderer(canvas, DEFAULT_RENDERER_OPTIONS);
+  if (!rendererResult) {
+    displayError('Unable to initialize a renderer on this device.');
+    return;
+  }
+
+  renderer = rendererResult.renderer;
+  rendererBackend = rendererResult.backend;
+  console.info(`Using renderer backend: ${rendererBackend}`);
 
   // Set up lighting based on user selection
   initLighting(scene, {
@@ -65,6 +81,13 @@ function initVisualization() {
 
 async function startAudioAndAnimation() {
   try {
+    if (rendererReadyPromise) {
+      await rendererReadyPromise;
+    }
+    if (!renderer) {
+      displayError('Unable to start because no renderer is available.');
+      return false;
+    }
     const audioData = await initAudio();
     analyser = audioData.analyser;
     audioCleanup = audioData.cleanup;
@@ -98,13 +121,13 @@ function animate() {
     }
   }
 
-  renderer.render(scene, camera);
+  renderer?.render(scene, camera);
 }
 
 function handleResize() {
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer?.setSize(window.innerWidth, window.innerHeight);
 }
 
 function displayError(message) {
@@ -119,11 +142,11 @@ function displayError(message) {
 document.getElementById('light-type').addEventListener('change', (event) => {
   currentLightType = event.target.value;
   // Reinitialize lighting
-  initVisualization();
+  rendererReadyPromise = initVisualization();
 });
 
 // Start visualization
-initVisualization();
+rendererReadyPromise = initVisualization();
 
 // Handle audio start button click
 document

--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -27,8 +27,14 @@ export async function startAudioLoop(
   animate: (ctx: AnimationContext) => void,
   audioOptions: AudioInitOptions = {}
 ): Promise<AnimationContext> {
+  if (toy.rendererReady) {
+    await toy.rendererReady;
+  }
   await toy.initAudio(audioOptions);
   const ctx: AnimationContext = { toy, analyser: toy.analyser };
+  if (!toy.renderer?.setAnimationLoop) {
+    throw new Error('Renderer is not available to start the animation loop.');
+  }
   toy.renderer.setAnimationLoop(() => animate(ctx));
   return ctx;
 }

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,9 +1,19 @@
+/* global GPUAdapter, GPUDevice, GPU */
 import * as THREE from 'three';
 import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
 import { ensureWebGL } from '../utils/webgl-check.ts';
 
-export function initRenderer(
-  canvas,
+type RendererBackend = 'webgl' | 'webgpu';
+
+export type RendererInitResult = {
+  renderer: THREE.WebGLRenderer | WebGPURenderer;
+  backend: RendererBackend;
+  adapter?: GPUAdapter | null;
+  device?: GPUDevice | null;
+};
+
+export async function initRenderer(
+  canvas: HTMLCanvasElement,
   config: {
     antialias?: boolean;
     exposure?: number;
@@ -15,7 +25,7 @@ export function initRenderer(
     maxPixelRatio: 2,
     alpha: false,
   }
-) {
+): Promise<RendererInitResult | null> {
   if (!ensureWebGL()) {
     return null;
   }
@@ -27,20 +37,58 @@ export function initRenderer(
     alpha = false,
   } = config;
 
-  let renderer;
-  if (navigator.gpu) {
-    renderer = new WebGPURenderer({ canvas, antialias, alpha });
-  } else {
-    renderer = new THREE.WebGLRenderer({
-      canvas,
-      antialias,
-      alpha,
-    });
+  const finalize = (
+    renderer: THREE.WebGLRenderer | WebGPURenderer,
+    backend: RendererBackend,
+    adapter: GPUAdapter | null,
+    device: GPUDevice | null
+  ): RendererInitResult => {
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, maxPixelRatio));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = exposure;
+    return { renderer, backend, adapter, device };
+  };
+
+  const fallbackToWebGL = (reason: string, error?: unknown) => {
+    console.info(`Falling back to WebGL renderer: ${reason}`);
+    if (error) {
+      console.debug(error);
+    }
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias, alpha });
+    return finalize(renderer, 'webgl', null, null);
+  };
+
+  const { gpu } = navigator as Navigator & { gpu?: GPU }; 
+  if (!gpu?.requestAdapter) {
+    return fallbackToWebGL('WebGPU is not available in this browser.');
   }
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio, maxPixelRatio));
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  renderer.outputColorSpace = THREE.SRGBColorSpace;
-  renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = exposure;
-  return renderer;
+
+  try {
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) {
+      return fallbackToWebGL('No compatible WebGPU adapter was found.');
+    }
+
+    let device: GPUDevice | null = null;
+    try {
+      device = await adapter.requestDevice();
+    } catch (error) {
+      return fallbackToWebGL('Unable to acquire a WebGPU device.', error);
+    }
+
+    if (!device) {
+      return fallbackToWebGL('WebGPU device request returned no device.');
+    }
+
+    try {
+      const renderer = new WebGPURenderer({ canvas, antialias, alpha, adapter, device });
+      return finalize(renderer, 'webgpu', adapter, device);
+    } catch (error) {
+      return fallbackToWebGL('Failed to create a WebGPU renderer.', error);
+    }
+  } catch (error) {
+    return fallbackToWebGL('WebGPU initialization failed.', error);
+  }
 }

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -299,7 +299,9 @@ function createControls() {
 
 function init() {
   toy.scene.fog = new THREE.FogExp2(0x030712, 0.028);
-  toy.renderer?.setClearColor(0x030712, 1);
+  toy.rendererReady.then((result) => {
+    result?.renderer.setClearColor?.(0x030712, 1);
+  });
   createControls();
   buildGarden();
 }

--- a/assets/js/toys/sgpat.ts
+++ b/assets/js/toys/sgpat.ts
@@ -18,16 +18,18 @@ const toy = new WebToy({
   },
 });
 
-toy.renderer?.domElement.classList.add('sgpat-canvas');
-if (toy.renderer?.domElement) {
-  Object.assign(toy.renderer.domElement.style, {
+toy.rendererReady.then((result) => {
+  const canvasElement = result?.renderer.domElement;
+  if (!canvasElement) return;
+  canvasElement.classList.add('sgpat-canvas');
+  Object.assign(canvasElement.style, {
     position: 'fixed',
     top: '0',
     left: '0',
     width: '100vw',
     height: '100vh',
   });
-}
+});
 
 type SpectroContext = CanvasRenderingContext2D;
 
@@ -260,7 +262,8 @@ async function start() {
   if (isStarting) return;
   isStarting = true;
   updateStartButton(hasAudioStarted ? 'Restarting...' : 'Starting...', true);
-  if (!toy.renderer) {
+  const rendererResult = await toy.rendererReady;
+  if (!rendererResult?.renderer) {
     displayError('WebGL is not supported in this browser.');
     updateStartButton('Start / Retry Audio', false);
     isStarting = false;

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -58,7 +58,9 @@ function createStarField(): StarFieldBuffers {
   toy.scene.add(points);
 
   toy.scene.fog = new THREE.FogExp2(0x030712, 0.0008);
-  toy.renderer?.setClearColor(0x030712, 1);
+  toy.rendererReady.then((result) => {
+    result?.renderer.setClearColor?.(0x030712, 1);
+  });
 
   return { geometry, material, velocities };
 }


### PR DESCRIPTION
## Summary
- add async renderer initialization that requests a WebGPU adapter/device and falls back to WebGL when unavailable
- surface renderer backend metadata and readiness promises for consumers before starting animation loops
- update toy entry points to wait for renderer availability and maintain visuals when WebGPU is not supported

## Testing
- npm run lint -- --max-warnings=0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447ba277f48332bdee9e992a160ce9)