### PR TITLE
Replace audio analyser with audio worklet pipeline

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -1,5 +1,5 @@
 import type * as THREE from 'three';
-import { getFrequencyData } from '../utils/audio-handler';
+import { getFrequencyData, type FrequencyAnalyser } from '../utils/audio-handler';
 import type { AudioInitOptions } from '../utils/audio-handler';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,7 +10,7 @@ type WebToyInstance = any;
  */
 export interface AnimationContext {
   toy: WebToyInstance;
-  analyser: THREE.AudioAnalyser | null;
+  analyser: FrequencyAnalyser | null;
 }
 
 /**

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -3,7 +3,7 @@ import { initScene } from './scene-setup.ts';
 import { initCamera } from './camera-setup.ts';
 import { initRenderer } from './renderer-setup.ts';
 import { initLighting, initAmbientLight } from '../lighting/lighting-setup';
-import { initAudio } from '../utils/audio-handler.ts';
+import { initAudio, type FrequencyAnalyser } from '../utils/audio-handler.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
 
 export default class WebToy {
@@ -11,7 +11,7 @@ export default class WebToy {
   scene: THREE.Scene;
   camera: THREE.Camera;
   renderer: ReturnType<typeof initRenderer>;
-  analyser: THREE.AudioAnalyser | null;
+  analyser: FrequencyAnalyser | null;
   audioListener: THREE.AudioListener | null;
   audio: THREE.Audio | THREE.PositionalAudio | null;
   audioStream: MediaStream | null;

--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -1,14 +1,14 @@
 // patternRecognition.js: A pattern recognition and predictive listening script for audio-based visualizers
 
-import type { AudioAnalyser } from 'three';
+import type { FrequencyAnalyser } from './audio-handler';
 
 class PatternRecognizer {
-  analyser: AudioAnalyser;
+  analyser: FrequencyAnalyser;
   bufferSize: number;
   patternBuffer: Uint8Array[];
   writeIndex: number;
   filled: number;
-  constructor(analyser: AudioAnalyser, bufferSize = 30) {
+  constructor(analyser: FrequencyAnalyser, bufferSize = 30) {
     // Reduced buffer size for performance
     this.analyser = analyser;
     this.bufferSize = bufferSize;

--- a/assets/js/utils/peak-detector.ts
+++ b/assets/js/utils/peak-detector.ts
@@ -1,8 +1,8 @@
-import type { AudioAnalyser } from 'three';
+import type { FrequencyAnalyser } from './audio-handler';
 import { getAverageFrequency, getFrequencyData } from './audio-handler';
 
 export interface PeakDetectorOptions {
-  analyser?: AudioAnalyser;
+  analyser?: FrequencyAnalyser;
   /** Custom provider for FFT data; use when you already have a buffer handy. */
   getData?: () => Uint8Array;
   /** How much louder than the baseline the signal must be to trigger a peak. */

--- a/assets/js/worklets/audio-analyser.worklet.ts
+++ b/assets/js/worklets/audio-analyser.worklet.ts
@@ -1,0 +1,129 @@
+const createHannWindow = (size: number) => {
+  const window = new Float32Array(size);
+  const denominator = size - 1;
+  for (let i = 0; i < size; i += 1) {
+    window[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / denominator));
+  }
+  return window;
+};
+
+const bitReverse = (value: number, bits: number) => {
+  let reversed = 0;
+  for (let i = 0; i < bits; i += 1) {
+    reversed = (reversed << 1) | (value & 1);
+    value >>= 1;
+  }
+  return reversed;
+};
+
+const fft = (real: Float32Array, imag: Float32Array) => {
+  const n = real.length;
+  const levels = Math.log2(n);
+  if (Math.floor(levels) !== levels) {
+    throw new Error('FFT size must be a power of 2');
+  }
+
+  const cosTable = new Float32Array(n / 2);
+  const sinTable = new Float32Array(n / 2);
+  for (let i = 0; i < n / 2; i += 1) {
+    cosTable[i] = Math.cos((2 * Math.PI * i) / n);
+    sinTable[i] = Math.sin((2 * Math.PI * i) / n);
+  }
+
+  for (let i = 0; i < n; i += 1) {
+    const j = bitReverse(i, levels);
+    if (j > i) {
+      [real[i], real[j]] = [real[j], real[i]];
+      [imag[i], imag[j]] = [imag[j], imag[i]];
+    }
+  }
+
+  for (let size = 2; size <= n; size <<= 1) {
+    const halfSize = size >> 1;
+    const tableStep = n / size;
+    for (let i = 0; i < n; i += size) {
+      let k = 0;
+      for (let j = i; j < i + halfSize; j += 1) {
+        const l = j + halfSize;
+        const tpre = real[l] * cosTable[k] + imag[l] * sinTable[k];
+        const tpim = -real[l] * sinTable[k] + imag[l] * cosTable[k];
+        real[l] = real[j] - tpre;
+        imag[l] = imag[j] - tpim;
+        real[j] += tpre;
+        imag[j] += tpim;
+        k += tableStep;
+      }
+    }
+  }
+};
+
+class FFTAnalyserProcessor extends AudioWorkletProcessor {
+  fftSize: number;
+  timeDomain: Float32Array;
+  window: Float32Array;
+  writeIndex: number;
+
+  constructor(options: AudioWorkletNodeOptions) {
+    super();
+    this.fftSize = (options.processorOptions?.fftSize as number) || 256;
+    this.timeDomain = new Float32Array(this.fftSize);
+    this.window = createHannWindow(this.fftSize);
+    this.writeIndex = 0;
+  }
+
+  process(inputs: Float32Array[][]) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    const channelData = input[0];
+    if (!channelData) return true;
+
+    for (let i = 0; i < channelData.length; i += 1) {
+      this.timeDomain[this.writeIndex] = channelData[i];
+      this.writeIndex += 1;
+
+      if (this.writeIndex >= this.fftSize) {
+        this.writeIndex = 0;
+        this.computeFFT();
+      }
+    }
+
+    return true;
+  }
+
+  computeFFT() {
+    const real = new Float32Array(this.fftSize);
+    const imag = new Float32Array(this.fftSize);
+
+    let sumSquares = 0;
+    for (let i = 0; i < this.fftSize; i += 1) {
+      const windowed = this.timeDomain[i] * this.window[i];
+      real[i] = windowed;
+      sumSquares += windowed * windowed;
+    }
+
+    fft(real, imag);
+
+    const spectrumSize = this.fftSize / 2;
+    const frequencyData = new Uint8Array(spectrumSize);
+    const normFactor = 1 / this.fftSize;
+
+    for (let i = 0; i < spectrumSize; i += 1) {
+      const magnitude = Math.sqrt(
+        real[i] * real[i] + imag[i] * imag[i]
+      ) * normFactor;
+      const db = 20 * Math.log10(magnitude + 1e-12);
+      const normalized = Math.min(1, Math.max(0, (db + 100) / 100));
+      frequencyData[i] = Math.round(normalized * 255);
+    }
+
+    const rms = Math.sqrt(sumSquares / this.fftSize);
+
+    this.port.postMessage(
+      { type: 'fft', data: frequencyData.buffer, average: rms },
+      [frequencyData.buffer]
+    );
+  }
+}
+
+registerProcessor('audio-analyser', FFTAnalyserProcessor);


### PR DESCRIPTION
## Summary
- add an AudioWorklet-based analyser with FFT and RMS calculations in `initAudio`
- update consumers to use the new `FrequencyAnalyser` shape while keeping existing helper APIs
- expand audio-handler tests to mock audio worklet support

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/audio-handler.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/loader.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/lighting-setup.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/app-shell.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/control-panel.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/animation-utils.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/pattern-recognizer.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447bae80dc833290e667593a4d1c9e)