### PR TITLE
Tone down homepage copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,12 +54,12 @@
       <header class="hero">
         <div class="hero-grid">
           <div class="hero-copy">
-            <p class="eyebrow">Fresh toys • Built to fidget • Lo-fi friendly</p>
-            <h1>Push buttons, drag sliders, shake your phone—no signups, no jargon.</h1>
+            <p class="eyebrow">Open-source stims • Quick to try • No accounts</p>
+            <h1>Interactive webtoys you can launch in the browser.</h1>
             <p class="tagline">
-              The library stays quick so you can poke at color, audio, and
-              motion right away. Every stim is tuned for touch, mic input, and
-              keyboard play without the "enterprise" gloss.
+              Choose a stim to explore audio, color, or motion. They run with
+              touch, microphone, and keyboard input so you can experiment fast
+              without extra setup.
             </p>
             <div class="cta-row">
               <a href="#toy-list" class="cta-button primary">Browse library</a>
@@ -70,25 +70,10 @@
                 class="cta-button ghost"
                 >View the code</a
               >
-              <a
-                href="https://github.com/zz-plant/stims/issues/new/choose"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="cta-button ghost"
-                >Report an issue</a
-              >
-              <a
-                href="https://github.com/zz-plant/stims/blob/main/CONTRIBUTING.md"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="cta-button ghost"
-                >Contribute</a
-              >
             </div>
             <p class="cta-helper">
-              "Report an issue" opens GitHub’s templates so you can share bugs or
-              feature ideas. "Contribute" takes you to the contribution guide to
-              see what to expect before opening a PR.
+              The GitHub link includes docs, contribution guidelines, and issue
+              templates if you want to suggest fixes.
             </p>
             <div class="hero-marquee" aria-hidden="true">
               <div class="marquee-track">
@@ -124,11 +109,10 @@
             </div>
             <div class="pulse-card">
               <p class="pulse-eyebrow">Live status</p>
-              <p class="pulse-title">Ready when you are</p>
+              <p class="pulse-title">Repository</p>
               <p class="pulse-copy">
-                Tap a card and the stim opens immediately. Icons flag controls
-                and accessibility hints so you can vibe without corporate
-                sparkle.
+                Cards open immediately and show basic controls plus
+                accessibility hints.
               </p>
             </div>
               <div class="status-card" data-repo-status>
@@ -161,9 +145,9 @@
           <p class="eyebrow">Library</p>
           <h2>Browse every stim</h2>
           <p class="section-description">
-            Tap a card to open it instantly. Standalone stims like Clay, Geom,
-            Legible, and Lights sit alongside the module-based set so everything
-            is easy to reach.
+            Tap a card to open it. Standalone stims like Clay, Geom, Legible,
+            and Lights sit alongside the module-based set so everything is easy
+            to reach.
           </p>
         </div>
         <main id="toy-list" class="webtoy-container"></main>
@@ -198,8 +182,8 @@
             >
           </div>
           <p class="cta-helper footer-helper">
-            Jumping to GitHub lets you pick the right issue form or read how we
-            review pull requests before you send one.
+            GitHub links include issue forms plus the contribution guide if
+            you're preparing a pull request.
           </p>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- soften the homepage hero messaging to focus on neutral, informative descriptions
- trim the primary call-to-actions to keep the entry experience straightforward
- align supporting status and footer text with the lower-key tone

## Testing
- not run (copy change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447df9dde48332be04be665627a95b)