### PR TITLE
Use ResizeObserver for canvas resize

### DIFF
--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -52,7 +52,8 @@ export function setupCanvasResize(
   };
 
   resize();
-  window.addEventListener('resize', resize);
+  const observer = new ResizeObserver(() => resize());
+  observer.observe(canvas.parentElement ?? canvas);
 
-  return () => window.removeEventListener('resize', resize);
+  return () => observer.disconnect();
 }


### PR DESCRIPTION
## Summary
- replace the canvas window resize listener with a ResizeObserver that triggers the existing resize logic
- clean up the ResizeObserver during teardown to match the previous lifecycle behavior

## Testing
- npm test -- --runInBand *(terminated after ~10 minutes due to hang)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447bb9c2ac8332a07622910c0c5e5b)