### PR TITLE
Add audio worklet analyser for audio handling

### DIFF
--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -2,6 +2,133 @@ import * as THREE from 'three';
 
 type AudioAccessReason = 'unsupported' | 'denied' | 'unavailable';
 
+const FREQUENCY_ANALYSER_PROCESSOR = new URL(
+  './frequency-analyser-processor.ts',
+  import.meta.url
+);
+
+export class FrequencyAnalyser {
+  frequencyBinCount: number;
+  private frequencyData: Uint8Array;
+  private rms = 0;
+  private readonly context: AudioContext;
+  private readonly sourceNode: MediaStreamAudioSourceNode;
+  private readonly silentGain: GainNode;
+  private readonly workletNode?: AudioWorkletNode;
+  private readonly analyserNode?: AnalyserNode;
+
+  private constructor({
+    context,
+    sourceNode,
+    workletNode,
+    analyserNode,
+    fftSize,
+    silentGain,
+  }: {
+    context: AudioContext;
+    sourceNode: MediaStreamAudioSourceNode;
+    workletNode?: AudioWorkletNode;
+    analyserNode?: AnalyserNode;
+    fftSize: number;
+    silentGain: GainNode;
+  }) {
+    this.context = context;
+    this.sourceNode = sourceNode;
+    this.workletNode = workletNode;
+    this.analyserNode = analyserNode;
+    this.frequencyBinCount = fftSize / 2;
+    this.frequencyData = new Uint8Array(this.frequencyBinCount);
+    this.silentGain = silentGain;
+
+    if (this.workletNode) {
+      this.workletNode.port.onmessage = (event: MessageEvent) => {
+        const { frequencyData, rms } = event.data ?? {};
+        if (frequencyData) {
+          this.frequencyData = new Uint8Array(frequencyData);
+        }
+        if (typeof rms === 'number') {
+          this.rms = rms;
+        }
+      };
+    }
+  }
+
+  static async create(
+    context: AudioContext,
+    stream: MediaStream,
+    fftSize: number
+  ): Promise<FrequencyAnalyser> {
+    const sourceNode = context.createMediaStreamSource(stream);
+    const silentGain = context.createGain();
+    silentGain.gain.value = 0;
+
+    if (context.audioWorklet?.addModule) {
+      try {
+        await context.audioWorklet.addModule(FREQUENCY_ANALYSER_PROCESSOR);
+
+        const workletNode = new AudioWorkletNode(context, 'frequency-analyser', {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          outputChannelCount: [1],
+          processorOptions: { fftSize },
+        });
+
+        sourceNode.connect(workletNode);
+        workletNode.connect(silentGain);
+        silentGain.connect(context.destination);
+
+        return new FrequencyAnalyser({
+          context,
+          sourceNode,
+          workletNode,
+          fftSize,
+          silentGain,
+        });
+      } catch (error) {
+        console.warn('Falling back to AnalyserNode after AudioWorklet failure', error);
+      }
+    }
+
+    const analyserNode = context.createAnalyser();
+    analyserNode.fftSize = fftSize;
+    sourceNode.connect(analyserNode);
+    analyserNode.connect(silentGain);
+    silentGain.connect(context.destination);
+
+    return new FrequencyAnalyser({
+      context,
+      sourceNode,
+      analyserNode,
+      fftSize,
+      silentGain,
+    });
+  }
+
+  getFrequencyData() {
+    if (this.analyserNode) {
+      this.analyserNode.getByteFrequencyData(this.frequencyData);
+    }
+
+    return this.frequencyData;
+  }
+
+  getRmsLevel() {
+    return this.rms;
+  }
+
+  disconnect() {
+    if (this.workletNode) {
+      this.workletNode.port.onmessage = null;
+      this.workletNode.disconnect();
+    }
+    if (this.analyserNode) {
+      this.analyserNode.disconnect();
+    }
+    this.sourceNode.disconnect();
+    this.silentGain.disconnect();
+  }
+}
+
 async function queryMicrophonePermissionState(): Promise<PermissionState | undefined> {
   if (typeof navigator === 'undefined') return undefined;
   if (!navigator.permissions?.query) return undefined;
@@ -36,7 +163,7 @@ export type AudioInitOptions = {
   constraints?: MediaStreamConstraints;
   stream?: MediaStream;
   onCleanup?: (ctx: {
-    analyser: THREE.AudioAnalyser;
+    analyser: FrequencyAnalyser;
     listener: THREE.AudioListener;
     audio: THREE.Audio | THREE.PositionalAudio;
     stream?: MediaStream;
@@ -153,7 +280,11 @@ export async function initAudio(options: AudioInitOptions = {}) {
     if (positional && object) {
       object.add(audio);
     }
-    const analyser = new THREE.AudioAnalyser(audio, fftSize);
+    const analyser = await FrequencyAnalyser.create(
+      listener.context,
+      streamSource,
+      fftSize
+    );
 
     let cleanedUp = false;
     const cleanup = () => {
@@ -172,9 +303,7 @@ export async function initAudio(options: AudioInitOptions = {}) {
         audio.disconnect();
       }
 
-      if (analyser?.analyser) {
-        analyser.analyser.disconnect();
-      }
+      analyser?.disconnect();
 
       if (streamSource) {
         streamSource.getTracks().forEach((track) => track.stop());
@@ -250,7 +379,7 @@ export async function initAudio(options: AudioInitOptions = {}) {
   }
 }
 
-export function getFrequencyData(analyser: THREE.AudioAnalyser) {
+export function getFrequencyData(analyser: FrequencyAnalyser) {
   return analyser.getFrequencyData();
 }
 

--- a/assets/js/utils/frequency-analyser-processor.ts
+++ b/assets/js/utils/frequency-analyser-processor.ts
@@ -1,0 +1,139 @@
+/* global AudioWorkletProcessor, registerProcessor */
+
+const TWO_PI = Math.PI * 2;
+
+function buildHannWindow(length: number): Float32Array {
+  const window = new Float32Array(length);
+  for (let i = 0; i < length; i += 1) {
+    window[i] = 0.5 * (1 - Math.cos((TWO_PI * i) / (length - 1)));
+  }
+  return window;
+}
+
+function reverseBits(value: number, bits: number): number {
+  let reversed = 0;
+  for (let i = 0; i < bits; i += 1) {
+    reversed = (reversed << 1) | ((value >>> i) & 1);
+  }
+  return reversed;
+}
+
+function fft(real: Float32Array, imag: Float32Array): void {
+  const n = real.length;
+  const bits = Math.log2(n);
+
+  for (let i = 0; i < n; i += 1) {
+    const j = reverseBits(i, bits);
+    if (j > i) {
+      [real[i], real[j]] = [real[j], real[i]];
+      [imag[i], imag[j]] = [imag[j], imag[i]];
+    }
+  }
+
+  for (let size = 2; size <= n; size <<= 1) {
+    const halfSize = size >> 1;
+    const phaseStep = -TWO_PI / size;
+
+    for (let start = 0; start < n; start += size) {
+      for (let i = 0; i < halfSize; i += 1) {
+        const phase = phaseStep * i;
+        const cos = Math.cos(phase);
+        const sin = Math.sin(phase);
+
+        const evenReal = real[start + i];
+        const evenImag = imag[start + i];
+        const oddReal = real[start + i + halfSize];
+        const oddImag = imag[start + i + halfSize];
+
+        const tempReal = oddReal * cos - oddImag * sin;
+        const tempImag = oddReal * sin + oddImag * cos;
+
+        real[start + i] = evenReal + tempReal;
+        imag[start + i] = evenImag + tempImag;
+        real[start + i + halfSize] = evenReal - tempReal;
+        imag[start + i + halfSize] = evenImag - tempImag;
+      }
+    }
+  }
+}
+
+class FrequencyAnalyserProcessor extends AudioWorkletProcessor {
+  private readonly fftSize: number;
+  private readonly frequencyBinCount: number;
+  private readonly window: Float32Array;
+  private readonly buffer: Float32Array;
+  private bufferIndex = 0;
+  private readonly outputReal: Float32Array;
+  private readonly outputImag: Float32Array;
+
+  constructor(options: AudioWorkletNodeOptions) {
+    super();
+    this.fftSize = options.processorOptions?.fftSize ?? 256;
+    this.frequencyBinCount = this.fftSize / 2;
+    this.window = buildHannWindow(this.fftSize);
+    this.buffer = new Float32Array(this.fftSize);
+    this.outputReal = new Float32Array(this.fftSize);
+    this.outputImag = new Float32Array(this.fftSize);
+  }
+
+  private analyse() {
+    for (let i = 0; i < this.fftSize; i += 1) {
+      this.outputReal[i] = this.buffer[i] * this.window[i];
+      this.outputImag[i] = 0;
+    }
+
+    let sumSquares = 0;
+    for (let i = 0; i < this.fftSize; i += 1) {
+      const sample = this.buffer[i];
+      sumSquares += sample * sample;
+    }
+    const rms = Math.sqrt(sumSquares / this.fftSize);
+
+    fft(this.outputReal, this.outputImag);
+
+    const frequencyData = new Uint8Array(this.frequencyBinCount);
+    for (let i = 0; i < this.frequencyBinCount; i += 1) {
+      const magnitude =
+        Math.sqrt(
+          this.outputReal[i] * this.outputReal[i] +
+            this.outputImag[i] * this.outputImag[i]
+        ) /
+        this.frequencyBinCount;
+      frequencyData[i] = Math.min(255, Math.max(0, Math.round(magnitude * 255)));
+    }
+
+    this.port.postMessage(
+      { frequencyData, rms },
+      [frequencyData.buffer]
+    );
+  }
+
+  process(inputs: Float32Array[][], outputs: Float32Array[][]) {
+    const input = inputs[0]?.[0];
+    const outputChannel = outputs[0]?.[0];
+
+    if (!input) {
+      return true;
+    }
+
+    for (let i = 0; i < input.length; i += 1) {
+      this.buffer[this.bufferIndex] = input[i];
+      this.bufferIndex += 1;
+
+      if (this.bufferIndex >= this.fftSize) {
+        this.bufferIndex = 0;
+        this.analyse();
+      }
+    }
+
+    if (outputChannel) {
+      outputChannel.fill(0);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('frequency-analyser', FrequencyAnalyserProcessor);
+
+export {};


### PR DESCRIPTION
## Summary
- replace the Three.js analyser with a FrequencyAnalyser built on an AudioWorklet and silent routing
- add a worklet processor that performs windowed FFT and RMS calculations for microphone data
- refresh audio handler tests to mock the AudioWorklet flow and media stream tracks

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447e3eac9883328aed1fad1c2e0fa8)