### PR TITLE
Update docs to prefer Bun for installs and scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,48 +4,43 @@ Thanks for helping build and refine the Stim Webtoys Library! This guide covers 
 
 ## Environment Setup
 
-- Use **Bun 1.2+** for the fastest installs and test runs (the repo records this in `package.json`). **Node.js 22** (see `.nvmrc`) is also supported if you prefer npm for Vite or tooling.
+- Use **Bun 1.2+** for the fastest installs and test runs (the repo records this in `package.json`). **Node.js 22** (see `.nvmrc`) is available as a fallback if you prefer npm for Vite or tooling.
 - Install dependencies with:
   ```bash
-  npm install
-  # or
   bun install
   ```
-  Bun does not automatically run `prepare` scripts, so a `postinstall` script installs Husky when your user agent starts with `bun`. If that misses your setup, run `bun x husky install` (or `npx husky install`) after installing dependencies.
+  Bun does not automatically run `prepare` scripts, so a `postinstall` script installs Husky when your user agent starts with `bun`. If that misses your setup, run `bun x husky install`. If you must use Node, `npm install` works as a backup.
 
 ## Running the Dev Server
 
 Start the local development server and open the site at `http://localhost:5173`:
 ```bash
-npm run dev
-# or
 bun run dev
 ```
+
+If you’re using Node as a fallback, run `npm run dev` instead.
 
 ## Testing, Linting, and Formatting
 
 - Run all tests:
   ```bash
   bun test
-  # or
-  npm run test
   ```
+  (`npm run test` proxies to Bun when available.)
 - Run the Bun test runner with filters (for example, targeting specific files):
   ```bash
   bun test tests/path/to/spec.test.js
   ```
 - Lint the project:
   ```bash
-  npm run lint
-  # or
   bun run lint
   ```
+  (`npm run lint` is available as an optional fallback.)
 - Format the codebase:
   ```bash
-  npm run format
-  # or
   bun run format
   ```
+  (`npm run format` is available as an optional fallback.)
 
 ## Branching and Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what
 ## Quick Start
 
 1. Clone the repo and `cd` into it.
-2. Choose your runtime (the repo records `bun@1.2.14` in `package.json` via `packageManager`):
-   - **Bun 1.2+**: install from [bun.sh](https://bun.sh/) for the fastest install/test cycle.
-   - **Node.js 22** (see `.nvmrc`): still supported for Vite and general tooling if you prefer npm.
-3. Install dependencies with `npm install` or `bun install`. Bun will write to `bun.lock` so you can pin installs with `bun install --frozen-lockfile`.
-4. Start the dev server with `npm run dev` or `bun run dev`, then open `http://localhost:5173` in your browser.
+2. Install **Bun 1.2+** (recorded in `package.json` via `packageManager`) from [bun.sh](https://bun.sh/) for the fastest install/test cycle. **Node.js 22** (see `.nvmrc`) remains available as a fallback if you prefer npm.
+3. Install dependencies with `bun install`. Bun writes to `bun.lock`, so you can pin installs with `bun install --frozen-lockfile`. If you need a fallback, use `npm install` with Node 22.
+4. Start the dev server with `bun run dev`, then open `http://localhost:5173` in your browser. If you’re on Node, `npm run dev` works as a backup.
 
 ## Getting Started
 
@@ -110,55 +108,54 @@ To play with the toys locally you’ll need to run them from a local web server.
    cd stims
    ```
 
-2. Use Bun 1.2+ (recorded in `package.json`) or Node.js 22 (see `.nvmrc`). If you have nvm installed, run `nvm use` to select the correct Node version.
+2. Use Bun 1.2+ (recorded in `package.json`). Node.js 22 (see `.nvmrc`) is available as an optional fallback; if you have nvm installed, run `nvm use` to select it.
 
-3. Install dependencies:
+3. Install dependencies with Bun:
 
    ```bash
-   npm install
-   # or
    bun install
    ```
 
-   Bun does not automatically run `prepare` scripts, so the repo includes a `postinstall` hook that installs Husky when `npm_config_user_agent` starts with `bun`. If that step fails for any reason, fall back to `bun x husky install` (or `npx husky install`).
+   Bun does not automatically run `prepare` scripts, so the repo includes a `postinstall` hook that installs Husky when `npm_config_user_agent` starts with `bun`. If that step fails for any reason, run `bun x husky install`. If you must use Node, `npm install` is an acceptable fallback.
 
-4. Start the development server:
+4. Start the development server (Bun by default):
 
    ```bash
-   npm run dev
-   # or
    bun run dev
    ```
+
+   If you’re on Node, use `npm run dev` instead.
 
 Open `http://localhost:5173` in your browser.
 
 To serve a static build instead of the dev server, run:
 
 ```bash
-npm run build
-npm run preview
-# or
 bun run build
+bun run preview
 
 bun run serve:dist
 # or use Python as a fallback
 python3 -m http.server dist
-bun run preview
+
+# Node fallback
+npm run build
+npm run preview
 ```
 
 The preview server hosts the contents of `dist/` on port `4173` using Vite's `--host` flag, so you can load the build from other devices on your LAN if needed.
 
 All JavaScript dependencies are installed via npm (or Bun) and bundled locally with Vite, so everything works offline without hitting a CDN.
 
-### Helpful Scripts (npm or Bun)
+### Helpful Scripts (Bun-first)
 
-- `npm run dev` / `bun run dev`: Start the Vite development server for local exploration.
-- `npm run build` / `bun run build`: Produce a production build in `dist/`.
-- `npm run preview` / `bun run preview`: Serve the production build locally (Vite preview with `--host` for LAN testing) to validate the output before deploying.
-- `bun test` (or `bun run test`): Run the Bun-native test suite. `npm run test` will also proxy to Bun if you have it installed.
+- `bun run dev`: Start the Vite development server for local exploration. (`npm run dev` works if you’re on Node.)
+- `bun run build`: Produce a production build in `dist/`. (`npm run build` is available as a fallback.)
+- `bun run preview`: Serve the production build locally (Vite preview with `--host` for LAN testing) to validate the output before deploying. (`npm run preview` is the Node fallback.)
+- `bun test` (or `bun run test`): Run the Bun-native test suite. `npm run test` will proxy to Bun when available.
 - `bun run test:watch`: Keep the Bun test runner active while you iterate on specs.
-- `npm run lint` / `bun run lint`: Check code quality with ESLint.
-- `npm run format` / `bun run format`: Format files with Prettier.
+- `bun run lint`: Check code quality with ESLint. (`npm run lint` is an optional fallback.)
+- `bun run format`: Format files with Prettier. (`npm run format` is an optional fallback.)
 - `bun run serve:dist`: Serve the `dist/` build with Bun (preferred for local production previews).
 
 ## Code of Conduct and Contributions
@@ -174,16 +171,16 @@ dependencies and run the tests:
 
    ```bash
    bun install
-   # or
-   npm install
    ```
+
+   (`npm install` is available if you’re using Node.)
 
 2. Run the tests:
    ```bash
    bun test
-   # or
-   npm run test
    ```
+
+   (`npm run test` proxies to Bun when present.)
 
 For quick iteration, use the watch mode:
 
@@ -193,7 +190,7 @@ bun run test:watch
 
 ### Linting and Formatting
 
-Before committing, run `npm run lint` to check code style and `npm run format` to automatically format your files. This keeps the project consistent.
+Before committing, run `bun run lint` to check code style and `bun run format` to automatically format your files. If you’re on Node, the `npm run lint` and `npm run format` fallbacks are available. This keeps the project consistent.
 
 ## Contributing
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,33 +4,30 @@ This guide focuses on day-to-day development tasks for the Stim Webtoys Library.
 
 ## Tooling and Environment
 
-- **Bun 1.2+** is the fastest path for local installs and testing. The repo also supports **Node.js 22** (see `.nvmrc`) if you prefer npm for Vite or tooling.
-- Install dependencies once per clone:
+- **Bun 1.2+** is the default for installs and testing. **Node.js 22** (see `.nvmrc`) is supported as an optional fallback if you prefer npm for Vite or tooling.
+- Install dependencies once per clone with Bun:
   ```bash
-  npm install
-  # or
   bun install
   ```
-  If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install` (or `npx husky install`).
+  If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install`. When using Node, `npm install` is a backup option.
 - The project uses **TypeScript**, **Vite**, **Three.js**, and the Bun test runner. No extra ESM flags are required when running `bun test`.
-- Run the dev server locally:
+- Run the dev server locally with Bun:
   ```bash
-  npm run dev
-  # or
   bun run dev
   ```
+  If you’re on Node, use `npm run dev` instead.
   The site serves from `http://localhost:5173`.
 
-## Common Scripts
+## Common Scripts (Bun-first)
 
-| Task | Command (npm / Bun) |
-| ---- | ------------------ |
-| Start dev server | `npm run dev` / `bun run dev` |
-| Production build | `npm run build` / `bun run build` |
-| Preview build locally | `npm run preview` / `bun run preview` |
-| Run test suite | `bun test` / `bun run test` |
-| Lint | `npm run lint` / `bun run lint` |
-| Format with Prettier | `npm run format` / `bun run format` |
+| Task | Command (Bun / optional Node fallback) |
+| ---- | ------------------------------------- |
+| Start dev server | `bun run dev` (`npm run dev`) |
+| Production build | `bun run build` (`npm run build`) |
+| Preview build locally | `bun run preview` (`npm run preview`) |
+| Run test suite | `bun test` (`npm run test` proxies to Bun) |
+| Lint | `bun run lint` (`npm run lint`) |
+| Format with Prettier | `bun run format` (`npm run format`) |
 
 When debugging a single test file, run:
 ```bash
@@ -81,7 +78,7 @@ bun test tests/filename.test.js
 
 ## Deployment Checklist
 
-- `npm run build` completes without errors.
-- Verify the generated `dist/` assets load via `npm run preview` or a simple static server.
+- `bun run build` completes without errors. (`npm run build` is available if you’re on Node.)
+- Verify the generated `dist/` assets load via `bun run preview` or a simple static server. (`npm run preview` remains a fallback.)
 - Spot-check microphone prompts and toy selection flows in the production build.
 


### PR DESCRIPTION
## Summary
- set Bun as the default install/runtime path in the README with Node noted as a fallback
- update development and contributing guides to show Bun-first commands for installs, scripts, and testing

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447f2bf3f88332941df97a55ea536a)