### PR TITLE
Allow multi toy to run without WebGPU requirement

### DIFF
--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -76,7 +76,7 @@ export default [
     description: 'Shapes and lights move with both sound and device motion.',
     module: 'assets/js/toys/multi.ts',
     type: 'module',
-    requiresWebGPU: true,
+    requiresWebGPU: false,
   },
   {
     slug: 'seary',

--- a/multi.html
+++ b/multi.html
@@ -33,6 +33,14 @@
       import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
+
+      if (!navigator.gpu) {
+        showError(
+          'error-message',
+          'Running in WebGL mode. Optional WebGPU features add extra bloom and lighting polish when available.'
+        );
+      }
+
       initHints({
         id: 'multi-visualizer',
         tips: [


### PR DESCRIPTION
## Summary
- allow the multi toy to load through the library without blocking on WebGPU support
- display a WebGL-mode hint in the multi toy that explains the optional WebGPU enhancements

## Testing
- Not run (not requested).

## Checklist
- [ ] Linting (`npm run lint`) if applicable
- [ ] Tests (`npm test`) if applicable


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694483862df083329c5a6db3139cac19)