### PR TITLE
Add manifest fallbacks for toy loader

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,9 @@ const moduleInputs = Object.fromEntries(
 export default defineConfig({
   build: {
     outDir: 'dist',
-    manifest: true,
+    // Emit a top-level manifest so runtime lookups work even when the .vite
+    // directory is hidden or stripped by static hosts.
+    manifest: 'manifest.json',
     rollupOptions: {
       input: {
         main: path.resolve(rootDir, 'index.html'),


### PR DESCRIPTION
## Summary
- adjust loader to look for both top-level and .vite manifests when resolving toy bundles
- emit the Vite manifest at the top level so deployments that hide dot-directories can still load toys

## Testing
- bun run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448373490083329639b960a72d17ed)