### PR TITLE
Fix library rendering by serving WebGL check as JS

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,7 +3,7 @@ import { initScene } from './core/scene-setup.ts';
 import { initCamera } from './core/camera-setup.ts';
 import { initRenderer } from './core/renderer-setup.ts';
 import { setupMicrophonePermissionFlow } from './core/microphone-flow.ts';
-import { ensureWebGL } from './utils/webgl-check.ts';
+import { ensureWebGL } from './utils/webgl-check.js';
 import { initLighting, initAmbientLight } from './lighting/lighting-setup';
 import {
   createSyntheticAudioStream,

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,7 +1,7 @@
 /* global GPUAdapter, GPUDevice, GPU */
 import * as THREE from 'three';
 import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
-import { ensureWebGL } from '../utils/webgl-check.ts';
+import { ensureWebGL } from '../utils/webgl-check.js';
 
 type RendererBackend = 'webgl' | 'webgpu';
 

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -8,7 +8,7 @@ import {
 } from './renderer-setup.ts';
 import { initLighting, initAmbientLight } from '../lighting/lighting-setup';
 import { initAudio } from '../utils/audio-handler.ts';
-import { ensureWebGL } from '../utils/webgl-check.ts';
+import { ensureWebGL } from '../utils/webgl-check.js';
 
 export default class WebToy {
   canvas: HTMLCanvasElement;

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,5 +1,5 @@
 import toysData from './toys-data.js';
-import { ensureWebGL } from './utils/webgl-check.ts';
+import { ensureWebGL } from './utils/webgl-check.js';
 
 const TOY_QUERY_PARAM = 'toy';
 let manifestPromise;

--- a/assets/js/utils/webgl-check.js
+++ b/assets/js/utils/webgl-check.js
@@ -2,27 +2,33 @@ import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 const OVERLAY_ID = 'rendering-capability-overlay';
 
-type TroubleshootingLink = {
-  label: string;
-  href: string;
-};
+/**
+ * @typedef {Object} TroubleshootingLink
+ * @property {string} label
+ * @property {string} href
+ */
 
-type OverlayContent = {
-  title: string;
-  description: string;
-  steps: string[];
-  links: TroubleshootingLink[];
-  previewLabel: string;
-};
+/**
+ * @typedef {Object} OverlayContent
+ * @property {string} title
+ * @property {string} description
+ * @property {string[]} steps
+ * @property {TroubleshootingLink[]} links
+ * @property {string} previewLabel
+ */
 
+/**
+ * Remove any previously rendered capability overlay.
+ */
 function removeExistingOverlay() {
-  const existing = typeof document !== 'undefined'
-    ? document.getElementById(OVERLAY_ID)
-    : null;
+  const existing = typeof document !== 'undefined' ? document.getElementById(OVERLAY_ID) : null;
   existing?.remove();
 }
 
-function buildOverlay(content: OverlayContent) {
+/**
+ * @param {OverlayContent} content
+ */
+function buildOverlay(content) {
   if (typeof document === 'undefined') return null;
 
   const overlay = document.createElement('div');
@@ -86,7 +92,10 @@ function buildOverlay(content: OverlayContent) {
   return overlay;
 }
 
-function addCapabilityOverlay(content: OverlayContent) {
+/**
+ * @param {OverlayContent} content
+ */
+function addCapabilityOverlay(content) {
   if (typeof document === 'undefined' || typeof document.body === 'undefined') {
     return;
   }
@@ -106,10 +115,19 @@ function addCapabilityOverlay(content: OverlayContent) {
   }
 }
 
-type EnsureOptions = Partial<Pick<OverlayContent, 'title' | 'description' | 'previewLabel'>>;
+/**
+ * @typedef {Partial<Pick<OverlayContent, 'title' | 'description' | 'previewLabel'>>} EnsureOptions
+ */
 
-export function ensureWebGL(options: EnsureOptions = {}): boolean {
-  const defaultContent: OverlayContent = {
+/**
+ * Ensure the current environment supports WebGL or WebGPU.
+ * If not, show an overlay explaining what to do.
+ * @param {EnsureOptions} [options]
+ * @returns {boolean}
+ */
+export function ensureWebGL(options = {}) {
+  /** @type {OverlayContent} */
+  const defaultContent = {
     title: 'WebGL or WebGPU is required',
     description:
       'This visual needs GPU acceleration to draw its 3D graphics. Update your browser or enable hardware acceleration to continue.',
@@ -131,8 +149,7 @@ export function ensureWebGL(options: EnsureOptions = {}): boolean {
     return false;
   }
 
-  const { gpu } = navigator as Navigator & { gpu?: unknown };
-  const hasWebGPU = Boolean(gpu);
+  const hasWebGPU = Boolean(navigator?.gpu);
   const hasWebGL = typeof WebGL !== 'undefined' && WebGL.isWebGLAvailable();
 
   if (hasWebGPU || hasWebGL) {


### PR DESCRIPTION
## Summary
- convert the WebGL capability helper to plain JavaScript and update imports
- ensure library scripts load without TypeScript parsing errors in the browser

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694486643e9c8332b76c7ed62c5e6799)