### PR TITLE
Improve WebGPU fallback and speechless word cloud flow

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -90,10 +90,17 @@ body {
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45), 0 0 24px rgba(255, 120, 150, 0.35);
 }
 
+.active-toy-status.is-warning .active-toy-status__content {
+  border-color: rgba(255, 196, 105, 0.8);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45), 0 0 24px rgba(255, 196, 105, 0.35);
+}
+
 .active-toy-status__actions {
   margin-top: 16px;
   display: flex;
   justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .toy-loading-spinner {

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -76,7 +76,8 @@ export default [
     description: 'Shapes and lights move with both sound and device motion.',
     module: 'assets/js/toys/multi.ts',
     type: 'module',
-    requiresWebGPU: false,
+    requiresWebGPU: true,
+    allowWebGLFallback: true,
   },
   {
     slug: 'seary',

--- a/docs/stim-assessment.md
+++ b/docs/stim-assessment.md
@@ -1,0 +1,22 @@
+# Stim assessment and remediation plan
+
+## Findings
+
+- **Multi-Capability Visualizer (`multi`)**
+  - The library manifest lists `multi` as an iframe that requires WebGPU, but the toy metadata leaves `requiresWebGPU` set to `false`, so the loader never shows the capability warning or aborts on unsupported devices.
+  - Result: users on browsers without WebGPU attempt to load `multi` with no notice about degraded visuals.
+- **Interactive Word Cloud (`words`)**
+  - Speech input depends on `SpeechRecognition`/`webkitSpeechRecognition`; when unsupported, the UI simply disables the toggle and posts an error message while keeping the experience locked to the seed words.
+  - Result: on Safari/Firefox (no speech API) the stim effectively loses its main interaction and exposes a prominent error banner instead of offering a fallback way to add words.
+
+## Fix plan
+
+- **Multi-Capability Visualizer (`multi`)**
+  - Align toy metadata with the documented requirement by marking the toy as `requiresWebGPU` so the loader surfaces the WebGPU capability screen instead of failing silently.
+  - Expand the iframe entry (`multi.html`) to present a friendlier WebGPU warning plus a tuned WebGL fallback preset (reduced particles/light bounces) for unsupported browsers.
+  - Add a lightweight telemetry hook in the loader to track WebGPU support rates so we can tune defaults before forcing WebGPU-only paths.
+
+- **Interactive Word Cloud (`words`)**
+  - Replace the hard failure path for missing `SpeechRecognition` with a fallback text input drawer that lets users seed new words manually and replay previous captures.
+  - Defer showing the speech toggle entirely when the API is unavailable; instead, promote the manual entry flow and ensure the audio visualizer still starts without blocking on speech features.
+  - Add a recorded-audio sample or keyboard shortcut to verify the word cloud rendering loop even when microphones or speech APIs are blocked (useful for CI/browser-testing too).

--- a/multi.html
+++ b/multi.html
@@ -14,11 +14,30 @@
         height: 100%;
         background-color: #000000;
       }
+
+      .capability-banner {
+        position: fixed;
+        top: 70px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(255, 196, 105, 0.12);
+        color: #ffe5bd;
+        border: 1px solid rgba(255, 196, 105, 0.5);
+        padding: 10px 14px;
+        border-radius: 10px;
+        font-size: 0.95rem;
+        letter-spacing: 0.01em;
+        backdrop-filter: blur(8px);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+        display: none;
+        z-index: 5;
+      }
     </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="webglCanvas" class="toy-canvas"></canvas>
+    <div id="capability-banner" class="capability-banner" aria-live="polite"></div>
     <div id="error-message" style="display: none"></div>
     <script type="module">
       import * as THREE from 'three';
@@ -33,12 +52,13 @@
       import { createMultiFunAdapter } from './assets/multi/fun-adapter.ts';
 
       const canvas = document.getElementById('webglCanvas');
+      const capabilityBanner = document.getElementById('capability-banner');
+      const hasWebGPU = Boolean(navigator.gpu);
 
-      if (!navigator.gpu) {
-        showError(
-          'error-message',
-          'Running in WebGL mode. Optional WebGPU features add extra bloom and lighting polish when available.'
-        );
+      if (!hasWebGPU && capabilityBanner) {
+        capabilityBanner.textContent =
+          'Running in WebGL fallback mode. WebGPU adds extra bloom and lighting polish when supported.';
+        capabilityBanner.style.display = 'block';
       }
 
       initHints({
@@ -56,11 +76,17 @@
           fov: 75,
           position: { x: 0, y: 0, z: 50 },
         },
-        rendererOptions: {
-          antialias: true,
-          exposure: 1,
-          maxPixelRatio: 2,
-        },
+        rendererOptions: hasWebGPU
+          ? {
+              antialias: true,
+              exposure: 1,
+              maxPixelRatio: 2,
+            }
+          : {
+              antialias: false,
+              exposure: 0.9,
+              maxPixelRatio: 1.25,
+            },
         ambientLightOptions: { color: 0xffffff, intensity: 1 },
       });
 
@@ -79,7 +105,7 @@
       toy.scene.add(pointLight);
 
       const particlesGeometry = new THREE.BufferGeometry();
-      const particlesCount = 1000;
+      const particlesCount = hasWebGPU ? 1200 : 450;
       const particlesPosition = new Float32Array(particlesCount * 3);
       for (let i = 0; i < particlesCount * 3; i++) {
         particlesPosition[i] = (Math.random() - 0.5) * 500;

--- a/words.html
+++ b/words.html
@@ -74,6 +74,55 @@
         justify-content: center;
       }
 
+      .manual-panel {
+        background: rgba(0, 0, 0, 0.18);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 16px;
+        padding: 12px 14px;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(12px);
+      }
+
+      .manual-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .manual-input {
+        min-width: 240px;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        background: rgba(255, 255, 255, 0.1);
+        color: #fff;
+        outline: none;
+        font-size: 0.95rem;
+      }
+
+      .pill-button {
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 999px;
+        padding: 10px 14px;
+        background: rgba(255, 255, 255, 0.18);
+        color: #fff;
+        cursor: pointer;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .pill-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+      }
+
+      .pill-button.secondary {
+        border-color: rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.12);
+      }
+
       .control-button {
         background: rgba(255, 255, 255, 0.2);
         padding: 20px;
@@ -179,9 +228,29 @@
           />
         </button>
       </div>
-      <p class="control-hint">
-        Unmute to sync the visuals with your microphone. Enable speech to drop your spoken words into the cloud—if your browser supports it.
+      <p class="control-hint" id="status-message">
+        Unmute to sync the visuals with your microphone. Speech controls appear when your browser supports them.
       </p>
+      <div class="manual-panel" id="manual-panel">
+        <div class="manual-row">
+          <label class="visually-hidden" for="manual-words">Add words manually</label>
+          <input
+            id="manual-words"
+            class="manual-input"
+            name="manual-words"
+            type="text"
+            autocomplete="off"
+            placeholder="Type words, separate with commas or spaces"
+          />
+          <button id="add-words-button" class="pill-button" type="button">Add words</button>
+          <button id="demo-words-button" class="pill-button secondary" type="button">
+            Add sample words
+          </button>
+        </div>
+        <p class="control-hint" style="margin-top: 8px; margin-bottom: 0">
+          Press Enter to submit. Tap "Add sample words" or press Space to pulse the cloud even without a mic.
+        </p>
+      </div>
     </div>
 
     <div id="word-cloud-container">
@@ -200,6 +269,11 @@
       );
       const unmuteIcon = document.getElementById('unmute-icon');
       const toggleSpeechIcon = document.getElementById('toggle-speech-icon');
+      const manualPanel = document.getElementById('manual-panel');
+      const manualInput = document.getElementById('manual-words');
+      const addWordsButton = document.getElementById('add-words-button');
+      const demoWordsButton = document.getElementById('demo-words-button');
+      const statusMessage = document.getElementById('status-message');
       const SpeechRecognition =
         window.SpeechRecognition || window.webkitSpeechRecognition;
       const speechSupported = Boolean(SpeechRecognition);
@@ -218,6 +292,38 @@
         'wave',
         'rhythm',
       ];
+
+      const demoWordSets = [
+        ['vibe', 'cosmos', 'pixel', 'wisp', 'lumen', 'glide'],
+        ['glitter', 'orbital', 'sonic', 'river', 'spark'],
+        ['neon', 'drift', 'hush', 'glow', 'warp', 'pulse'],
+      ];
+
+      function setStatus(text) {
+        if (statusMessage) {
+          statusMessage.textContent = text;
+        }
+      }
+
+      function addWordsToCloud(words) {
+        if (!Array.isArray(words) || !words.length) return;
+
+        wordsArray = wordsArray.concat(words);
+
+        if (wordsArray.length > 1000) {
+          wordsArray = wordsArray.slice(wordsArray.length - 1000);
+        }
+
+        updateWordCloud(wordsArray);
+      }
+
+      function normalizeInputWords(text) {
+        return text
+          .split(/[,\n]+|\s{2,}/)
+          .flatMap((chunk) => chunk.trim().split(/\s+/))
+          .map((word) => word.trim())
+          .filter(Boolean);
+      }
 
       class AudioToy {
         constructor() {
@@ -284,6 +390,8 @@
       }
 
       function updateSpeechIcon() {
+        if (!toggleSpeechIcon) return;
+
         toggleSpeechIcon.src = isAddingWords
           ? './assets/ui/speech-on.svg'
           : './assets/ui/speech-off.svg';
@@ -291,16 +399,22 @@
 
       function disableSpeechToggle(message) {
         isAddingWords = false;
-        toggleSpeechButton.classList.remove('active');
-        toggleSpeechButton.disabled = true;
-        toggleSpeechButton.title = message;
+
+        if (toggleSpeechButton) {
+          toggleSpeechButton.classList.remove('active');
+          toggleSpeechButton.disabled = true;
+          toggleSpeechButton.title = message;
+        }
+
         updateSpeechIcon();
-        showError('error-message', message);
+        setStatus(message);
       }
 
       function initSpeechRecognition() {
         if (!speechSupported) {
           disableSpeechToggle(speechUnavailableMessage);
+          toggleSpeechButton?.remove();
+          updateSpeechIcon();
           return;
         }
 
@@ -340,6 +454,26 @@
         }
       }
 
+      function handleManualWordSubmit() {
+        const manualText = manualInput?.value ?? '';
+        const words = normalizeInputWords(manualText);
+
+        if (!words.length) return;
+
+        addWordsToCloud(words);
+
+        if (manualInput) {
+          manualInput.value = '';
+        }
+      }
+
+      function addDemoWords() {
+        const sample = demoWordSets[Math.floor(Math.random() * demoWordSets.length)];
+        addWordsToCloud(sample);
+        updateWordCloudWithVisualizer(90);
+        createParticleEffects(90);
+      }
+
       // Unmute button logic for music visualizer activation
       unmuteButton.addEventListener('click', () => {
         if (!isUnmuted) {
@@ -353,6 +487,26 @@
           unmuteButton.classList.remove('active');
           updateUnmuteIcon();
           deactivateVisualizer();
+        }
+      });
+
+      addWordsButton?.addEventListener('click', handleManualWordSubmit);
+      demoWordsButton?.addEventListener('click', addDemoWords);
+
+      manualInput?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          handleManualWordSubmit();
+        }
+      });
+
+      window.addEventListener('keydown', (event) => {
+        const target = event.target;
+        const isTypingTarget = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+
+        if (event.code === 'Space' && !isTypingTarget) {
+          event.preventDefault();
+          addDemoWords();
         }
       });
 
@@ -431,7 +585,7 @@
       }
 
       // Toggle speech button logic for speech detection
-      toggleSpeechButton.addEventListener('click', () => {
+      toggleSpeechButton?.addEventListener('click', () => {
         if (!recognition) {
           disableSpeechToggle(speechUnavailableMessage);
           return;
@@ -442,6 +596,7 @@
           toggleSpeechButton.classList.add('active');
           updateSpeechIcon();
           deactivateVisualizer(); // Ensure visualizer is turned off before starting speech recognition
+          setStatus('Listening for words…');
           try {
             recognition.start();
           } catch (error) {
@@ -455,6 +610,7 @@
           toggleSpeechButton.classList.remove('active');
           updateSpeechIcon();
           recognition.stop();
+          setStatus('Speech paused. Keep typing or add sample words to grow the cloud.');
         }
       });
 
@@ -469,18 +625,17 @@
 
       initSpeechRecognition();
 
+      if (speechSupported) {
+        setStatus('Unmute to sync with your mic. Enable speech to sprinkle your words into the cloud.');
+      } else {
+        setStatus('Speech recognition is unavailable. Type words or use sample words to keep playing.');
+      }
+
       if (recognition) {
         recognition.onresult = (event) => {
           const transcript = event.results[0][0].transcript;
           const newWords = transcript.split(' ');
-
-          wordsArray = wordsArray.concat(newWords);
-
-          if (wordsArray.length > 1000) {
-            wordsArray = wordsArray.slice(wordsArray.length - 1000);
-          }
-
-          updateWordCloud(wordsArray);
+          addWordsToCloud(newWords);
         };
 
         recognition.onspeechend = () => {
@@ -498,8 +653,11 @@
             disableSpeechToggle(
               'Speech recognition permission was denied. You can keep using the default word cloud.'
             );
+            setStatus('Speech recognition permission was denied. Type words or use sample words instead.');
             return;
           }
+
+          setStatus('Speech recognition hiccuped. Keep typing or try toggling speech again.');
 
           if (isAddingWords) {
             recognition.start();


### PR DESCRIPTION
## Summary
- gate WebGPU-only toys with an explicit fallback option so unsupported browsers can proceed in WebGL
- tune the multi visualizer with a fallback banner and lighter rendering defaults when WebGPU is missing
- add manual entry and sample-word flows to keep the words toy playable without speech recognition

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944861910fc83329b060f276e2a7fca)