### PR TITLE
Refactor loader into manifest, router, and view modules

### DIFF
--- a/assets/js/core/manifest.ts
+++ b/assets/js/core/manifest.ts
@@ -1,0 +1,114 @@
+type FetchLike = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+type ManifestEntry = { file?: string; url?: string };
+type ManifestData = Record<string, ManifestEntry>;
+type BaseUrlOption = URL | string | null | undefined | (() => URL | string | null | undefined);
+
+function resolveBaseUrl(option?: BaseUrlOption) {
+  if (typeof option === 'function') {
+    return option();
+  }
+
+  if (option) {
+    return option;
+  }
+
+  if (typeof window === 'undefined') return null;
+
+  const href = window.location?.href;
+  if (href) return new URL(href);
+
+  const origin = window.location?.origin;
+  if (origin) return new URL(origin);
+
+  return null;
+}
+
+function resolveRelativePath(relativePath: string, baseUrl: string | URL | null) {
+  return baseUrl ? new URL(relativePath, baseUrl).pathname : relativePath.replace(/^\.\//, '/');
+}
+
+export function createManifestClient({
+  fetchImpl = typeof fetch !== 'undefined' ? fetch : undefined,
+  baseUrl,
+}: {
+  fetchImpl?: FetchLike;
+  baseUrl?: BaseUrlOption;
+} = {}) {
+  let manifestPromise: Promise<ManifestData | null> | null = null;
+  const getBaseUrl = () => resolveBaseUrl(baseUrl);
+
+  const getManifestPaths = () => {
+    const resolvedBase = getBaseUrl();
+    return [resolveRelativePath('./manifest.json', resolvedBase), resolveRelativePath('./.vite/manifest.json', resolvedBase)];
+  };
+
+  const fetchManifest = async () => {
+    if (!manifestPromise) {
+      const fetcher = fetchImpl;
+      manifestPromise = (async () => {
+        for (const path of getManifestPaths()) {
+          if (!fetcher) break;
+
+          try {
+            const response = await fetcher(path);
+            if (response?.ok) {
+              return response.json();
+            }
+          } catch (error) {
+            console.warn('Error fetching manifest from', path, error);
+          }
+        }
+
+        return null;
+      })();
+    }
+
+    return manifestPromise;
+  };
+
+  const resolveModulePath = async (entry: string) => {
+    const manifest = await fetchManifest();
+    const manifestEntry = manifest?.[entry];
+    const base = getBaseUrl();
+
+    if (manifestEntry) {
+      const compiledFile = manifestEntry.file || manifestEntry.url;
+      if (compiledFile) {
+        if (base) {
+          return new URL(compiledFile, base).pathname;
+        }
+
+        if (typeof window !== 'undefined' && window.location?.origin) {
+          return new URL(compiledFile, window.location.origin).pathname;
+        }
+
+        return compiledFile;
+      }
+    }
+
+    if (entry.startsWith('./')) {
+      try {
+        return new URL(entry, import.meta.url).pathname;
+      } catch (error) {
+        console.error('Error resolving module path from import.meta.url:', error);
+      }
+    }
+
+    if (base) {
+      return new URL(entry, base).pathname;
+    }
+
+    return entry.startsWith('/') || entry.startsWith('.') ? entry : `/${entry}`;
+  };
+
+  return {
+    fetchManifest,
+    resolveModulePath,
+    getManifestPaths,
+  };
+}
+
+const defaultClient = createManifestClient();
+
+export const fetchManifest = () => defaultClient.fetchManifest();
+export const resolveModulePath = (entry: string) => defaultClient.resolveModulePath(entry);

--- a/assets/js/core/router.ts
+++ b/assets/js/core/router.ts
@@ -1,0 +1,69 @@
+type WindowLike = Window & typeof globalThis;
+
+export function createRouter({
+  window: providedWindow = typeof window !== 'undefined' ? window : null,
+  queryParam = 'toy',
+  loadToy,
+  onLibraryRoute,
+}: {
+  window?: WindowLike | null;
+  queryParam?: string;
+  loadToy?: (slug: string) => Promise<void> | void;
+  onLibraryRoute?: () => void;
+} = {}) {
+  let navigationInitialized = false;
+  const getWindow = () => providedWindow ?? null;
+
+  const pushToyState = (slug: string) => {
+    const win = getWindow();
+    if (!win?.history) return;
+
+    const url = new URL(win.location.href);
+    url.searchParams.set(queryParam, slug);
+    win.history.pushState({ [queryParam]: slug }, '', url);
+  };
+
+  const updateHistoryToLibraryView = () => {
+    const win = getWindow();
+    if (!win?.history) return;
+
+    const url = new URL(win.location.href);
+    if (!url.searchParams.has(queryParam)) {
+      return;
+    }
+
+    url.searchParams.delete(queryParam);
+    win.history.pushState({}, '', url);
+  };
+
+  const loadFromQuery = async () => {
+    const win = getWindow();
+    if (!win?.location) return;
+
+    const params = new URLSearchParams(win.location.search);
+    const slug = params.get(queryParam);
+
+    if (slug && typeof loadToy === 'function') {
+      await loadToy(slug);
+    } else if (!slug && typeof onLibraryRoute === 'function') {
+      onLibraryRoute();
+    }
+  };
+
+  const initNavigation = () => {
+    const win = getWindow();
+    if (!win || navigationInitialized) return;
+
+    navigationInitialized = true;
+    win.addEventListener('popstate', () => {
+      void loadFromQuery();
+    });
+  };
+
+  return {
+    pushToyState,
+    loadFromQuery,
+    initNavigation,
+    updateHistoryToLibraryView,
+  };
+}

--- a/assets/js/core/view.ts
+++ b/assets/js/core/view.ts
@@ -1,0 +1,238 @@
+type DocumentLike = Document | null;
+type WindowLike = Window & typeof globalThis;
+
+type ToyInfo = {
+  title?: string;
+  slug?: string;
+};
+
+function toggleHidden(element: Element | null, hidden: boolean) {
+  if (!element) return;
+
+  if (hidden) {
+    element.classList.add('is-hidden');
+  } else {
+    element.classList.remove('is-hidden');
+  }
+}
+
+function buildImportErrorMessage(
+  toy: ToyInfo | undefined,
+  win: WindowLike | null,
+  { moduleUrl, importError }: { moduleUrl?: string; importError?: Error } = {}
+) {
+  if (win?.location?.protocol === 'file:') {
+    return 'This toy needs a local web server to compile its TypeScript modules. Run `npm run dev` (or `bun run dev`) and reload from `http://localhost:5173`.';
+  }
+
+  const message = importError?.message ?? '';
+  if (typeof moduleUrl === 'string' && moduleUrl.endsWith('.ts')) {
+    return `${toy?.title ?? 'This toy'} could not be compiled. Make sure you are running through the dev server or a production build so the TypeScript bundle is available.`;
+  }
+
+  if (message.toLowerCase().includes('mime')) {
+    return `${toy?.title ?? 'This toy'} could not be loaded because the server is returning an unexpected file type. Try reloading from the dev server or production build.`;
+  }
+
+  return toy?.title
+    ? `${toy.title} hit a snag while loading. Try again or return to the library.`
+    : 'Something went wrong while loading this toy. Try again or return to the library.';
+}
+
+export function createToyView({
+  document: doc = typeof document !== 'undefined' ? document : null,
+  window: win = typeof window !== 'undefined' ? window : null,
+  host = doc?.body ?? null,
+  toyList,
+  onBackToLibrary,
+}: {
+  document?: DocumentLike;
+  window?: WindowLike | null;
+  host?: HTMLElement | null;
+  toyList?: HTMLElement | null;
+  onBackToLibrary?: () => void;
+} = {}) {
+  let activeContainer: HTMLElement | null = null;
+
+  const getToyList = () => toyList ?? doc?.getElementById('toy-list') ?? null;
+
+  const ensureActiveToyContainer = () => {
+    if (activeContainer?.isConnected) return activeContainer;
+    if (!doc || !host) return null;
+
+    activeContainer = doc.createElement('div');
+    activeContainer.id = 'active-toy-container';
+    activeContainer.className = 'active-toy-container is-hidden';
+    host.appendChild(activeContainer);
+
+    return activeContainer;
+  };
+
+  const clearActiveToyContainer = () => {
+    const container = ensureActiveToyContainer();
+    if (!container) return;
+
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
+    }
+  };
+
+  const createStatusElement = (
+    container: HTMLElement | null,
+    { title, message, type }: { title: string; message: string; type: 'loading' | 'error' }
+  ) => {
+    if (!doc || !container) return null;
+
+    const existing = container.querySelector('.active-toy-status');
+    if (existing) {
+      existing.remove();
+    }
+
+    const status = doc.createElement('div');
+    status.className = `active-toy-status ${type === 'error' ? 'is-error' : 'is-loading'}`;
+
+    const glow = doc.createElement('div');
+    glow.className = 'active-toy-status__glow';
+    status.appendChild(glow);
+
+    const content = doc.createElement('div');
+    content.className = 'active-toy-status__content';
+    status.appendChild(content);
+
+    if (type === 'loading') {
+      const spinner = doc.createElement('div');
+      spinner.className = 'toy-loading-spinner';
+      content.appendChild(spinner);
+    }
+
+    const heading = doc.createElement('h2');
+    heading.textContent = title;
+    content.appendChild(heading);
+
+    const body = doc.createElement('p');
+    body.textContent = message;
+    content.appendChild(body);
+
+    container.appendChild(status);
+    return status;
+  };
+
+  const showLoadingIndicator = (toyTitle?: string) => {
+    const container = ensureActiveToyContainer();
+    return createStatusElement(container, {
+      type: 'loading',
+      title: 'Preparing toy...',
+      message: toyTitle ? `${toyTitle} is loading.` : 'Loading toy...',
+    });
+  };
+
+  const removeStatusElement = () => {
+    const container = ensureActiveToyContainer();
+    const status = container?.querySelector('.active-toy-status');
+    if (status) {
+      status.remove();
+    }
+  };
+
+  const ensureBackToLibraryControl = () => {
+    const container = ensureActiveToyContainer();
+    if (!doc || !container) return null;
+
+    let control = container.querySelector<HTMLButtonElement>('[data-back-to-library]');
+    if (control) return control;
+
+    control = doc.createElement('button');
+    control.type = 'button';
+    control.className = 'home-link';
+    control.textContent = 'Back to Library';
+    control.setAttribute('data-back-to-library', 'true');
+    control.addEventListener('click', () => {
+      onBackToLibrary?.();
+    });
+
+    container.appendChild(control);
+    return control;
+  };
+
+  const showLibraryView = () => {
+    toggleHidden(getToyList(), false);
+    toggleHidden(ensureActiveToyContainer(), true);
+  };
+
+  const showActiveToyView = () => {
+    toggleHidden(getToyList(), true);
+    const container = ensureActiveToyContainer();
+    ensureBackToLibraryControl();
+    toggleHidden(container, false);
+    return container;
+  };
+
+  const showImportError = (
+    toy: ToyInfo | undefined,
+    { moduleUrl, importError }: { moduleUrl?: string; importError?: Error } = {}
+  ) => {
+    clearActiveToyContainer();
+    const container = ensureActiveToyContainer();
+    const status = createStatusElement(container, {
+      type: 'error',
+      title: 'Unable to load this toy',
+      message: buildImportErrorMessage(toy, win, { moduleUrl, importError }),
+    });
+
+    if (!status || !doc) return;
+
+    const actions = doc.createElement('div');
+    actions.className = 'active-toy-status__actions';
+
+    const retry = doc.createElement('button');
+    retry.className = 'cta-button primary';
+    retry.type = 'button';
+    retry.textContent = 'Back to library';
+    retry.addEventListener('click', () => {
+      onBackToLibrary?.();
+    });
+
+    actions.appendChild(retry);
+    status.querySelector('.active-toy-status__content')?.appendChild(actions);
+  };
+
+  const showCapabilityError = (toy?: ToyInfo) => {
+    clearActiveToyContainer();
+    const container = ensureActiveToyContainer();
+    const status = createStatusElement(container, {
+      type: 'error',
+      title: 'WebGPU not available',
+      message: toy?.title
+        ? `${toy.title} needs WebGPU, which is not supported in this browser.`
+        : 'This toy requires WebGPU, which is not supported in this browser.',
+    });
+
+    if (!status || !doc) return;
+
+    const actions = doc.createElement('div');
+    actions.className = 'active-toy-actions';
+
+    const back = doc.createElement('button');
+    back.type = 'button';
+    back.className = 'cta-button';
+    back.textContent = 'Back to Library';
+    back.addEventListener('click', () => {
+      onBackToLibrary?.();
+    });
+
+    actions.appendChild(back);
+    status.querySelector('.active-toy-status__content')?.appendChild(actions);
+  };
+
+  return {
+    ensureActiveToyContainer,
+    ensureBackToLibraryControl,
+    showLibraryView,
+    showActiveToyView,
+    showLoadingIndicator,
+    removeStatusElement,
+    showImportError,
+    showCapabilityError,
+    clearActiveToyContainer,
+  };
+}

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { createManifestClient } from '../assets/js/core/manifest.ts';
+
+describe('manifest client', () => {
+  test('prefers manifest entries using provided fetch and base URL', async () => {
+    const manifest = {
+      'assets/js/toys/example.ts': { file: 'assets/js/toys/example.123.js' },
+    };
+    const fetchImpl = mock(async () => ({
+      ok: true,
+      json: () => Promise.resolve(manifest),
+    }));
+
+    const client = createManifestClient({
+      fetchImpl,
+      baseUrl: 'http://example.com/site/',
+    });
+
+    const modulePath = await client.resolveModulePath('assets/js/toys/example.ts');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(modulePath).toBe('/site/assets/js/toys/example.123.js');
+  });
+
+  test('falls back when manifest is missing and caches requests', async () => {
+    const fetchImpl = mock(async () => ({ ok: false }));
+    const client = createManifestClient({
+      fetchImpl,
+      baseUrl: 'http://example.com',
+    });
+
+    const modulePath = await client.resolveModulePath('assets/js/toys/example.ts');
+    const cachedManifest = await client.fetchManifest();
+
+    expect(modulePath).toBe('/assets/js/toys/example.ts');
+    expect(cachedManifest).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { createRouter } from '../assets/js/core/router.ts';
+
+function createMockLocation(href: string) {
+  const url = new URL(href);
+  return {
+    get href() {
+      return url.href;
+    },
+    set href(value: string) {
+      url.href = new URL(value, url.href).href;
+    },
+    get search() {
+      return url.search;
+    },
+    set search(value: string) {
+      url.search = value;
+    },
+    get origin() {
+      return url.origin;
+    },
+  };
+}
+
+function createMockHistory(locationObject: { href: string }) {
+  return {
+    pushState: (_state: unknown, _title: string, nextUrl: string | URL) => {
+      const targetUrl = typeof nextUrl === 'string' ? new URL(nextUrl, locationObject.href) : nextUrl;
+      locationObject.href = targetUrl.href;
+    },
+  };
+}
+
+function createMockWindow(href: string) {
+  const listeners: Record<string, () => void> = {};
+  const location = createMockLocation(href);
+  return {
+    location,
+    history: createMockHistory(location),
+    addEventListener: (type: string, callback: () => void) => {
+      listeners[type] = callback;
+    },
+    trigger: (type: string) => listeners[type]?.(),
+  };
+}
+
+describe('router', () => {
+  test('pushToyState updates the query param', () => {
+    const win = createMockWindow('http://example.com/library');
+    const router = createRouter({ window: win });
+
+    router.pushToyState('aurora-painter');
+
+    expect(win.location.search).toBe('?toy=aurora-painter');
+  });
+
+  test('loadFromQuery dispatches to loaders and library handler', async () => {
+    const win = createMockWindow('http://example.com/library?toy=aurora-painter');
+    const loadToy = mock();
+    const onLibraryRoute = mock();
+    const router = createRouter({ window: win, loadToy, onLibraryRoute });
+
+    await router.loadFromQuery();
+    expect(loadToy).toHaveBeenCalledWith('aurora-painter');
+
+    win.location.search = '';
+    await router.loadFromQuery();
+    expect(onLibraryRoute).toHaveBeenCalledTimes(1);
+  });
+
+  test('initNavigation registers popstate once', async () => {
+    const win = createMockWindow('http://example.com/library?toy=aurora-painter');
+    const loadToy = mock();
+    const router = createRouter({ window: win, loadToy });
+
+    router.initNavigation();
+    router.initNavigation();
+
+    win.trigger('popstate');
+    expect(loadToy).toHaveBeenCalledWith('aurora-painter');
+  });
+});

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { createToyView } from '../assets/js/core/view.ts';
+
+function createDocument() {
+  const doc = document.implementation.createHTMLDocument('view');
+  const toyList = doc.createElement('div');
+  toyList.id = 'toy-list';
+  doc.body.appendChild(toyList);
+  return { doc, toyList };
+}
+
+describe('toy view helper', () => {
+  test('shows active toy view and wires back control', () => {
+    const { doc, toyList } = createDocument();
+    const onBack = mock();
+    const view = createToyView({
+      document: doc,
+      host: doc.body,
+      toyList,
+      onBackToLibrary: onBack,
+    });
+
+    const container = view.showActiveToyView();
+    const backControl = container?.querySelector('[data-back-to-library]');
+
+    expect(container?.classList.contains('is-hidden')).toBe(false);
+    expect(toyList.classList.contains('is-hidden')).toBe(true);
+    expect(backControl).not.toBeNull();
+
+    backControl?.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders import errors with retry affordance', () => {
+    const { doc, toyList } = createDocument();
+    const onBack = mock();
+    const view = createToyView({
+      document: doc,
+      host: doc.body,
+      toyList,
+      onBackToLibrary: onBack,
+    });
+
+    view.showImportError(
+      { title: 'Example Toy' },
+      { moduleUrl: 'assets/js/toys/example.ts', importError: new Error('MIME') }
+    );
+
+    const status = doc.querySelector('.active-toy-status.is-error');
+    expect(status?.querySelector('h2')?.textContent).toContain('Unable to load this toy');
+    expect(status?.querySelector('p')?.textContent).toContain('Example Toy');
+
+    const retry = status?.querySelector('button');
+    retry?.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows capability errors', () => {
+    const { doc, toyList } = createDocument();
+    const view = createToyView({
+      document: doc,
+      host: doc.body,
+      toyList,
+    });
+
+    view.showCapabilityError({ title: 'Fancy WebGPU' });
+
+    const status = doc.querySelector('.active-toy-status.is-error');
+    expect(status?.querySelector('h2')?.textContent).toContain('WebGPU not available');
+    expect(status?.querySelector('p')?.textContent).toContain('Fancy WebGPU');
+  });
+});

--- a/tests/webgl-check.test.js
+++ b/tests/webgl-check.test.js
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const freshImport = async () =>
-  import(`../assets/js/utils/webgl-check.ts?ts=${Date.now()}-${Math.random()}`);
+  import(`../assets/js/utils/webgl-check.js?ts=${Date.now()}-${Math.random()}`);
 
 const originalGpu = Object.getOwnPropertyDescriptor(navigator, 'gpu');
 


### PR DESCRIPTION
## Summary
- extract manifest resolution into an injectable core manifest client for better testability
- add reusable router and view helpers while refactoring loader orchestration around them
- expand unit coverage for manifest resolution, navigation, view rendering, and loader flows

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/loader.test.js tests/manifest.test.ts tests/audio-handler.test.js tests/animation-utils.test.js tests/microphone-flow.test.js tests/pattern-recognizer.test.js tests/webgl-check.test.js
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/app-shell.test.js tests/control-panel.test.js tests/router.test.ts tests/view.test.ts tests/lighting-setup.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694489cd8cf48332881d1d156d7b7891)