### PR TITLE
Add renderer capability caching and WebGPU gating updates

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -1,0 +1,142 @@
+/* global GPUAdapter, GPUDevice, GPU */
+
+export type RendererBackend = 'webgl' | 'webgpu';
+
+export type RendererCapabilities = {
+  preferredBackend: RendererBackend;
+  adapter: GPUAdapter | null;
+  device: GPUDevice | null;
+  triedWebGPU: boolean;
+  fallbackReason: string | null;
+  shouldRetryWebGPU: boolean;
+};
+
+type FallbackOptions = {
+  triedWebGPU?: boolean;
+  shouldRetryWebGPU?: boolean;
+};
+
+let capabilitiesPromise: Promise<RendererCapabilities> | null = null;
+let cachedCapabilities: RendererCapabilities | null = null;
+
+const buildFallback = (
+  fallbackReason: string,
+  { triedWebGPU = false, shouldRetryWebGPU = false }: FallbackOptions = {}
+): RendererCapabilities => ({
+  preferredBackend: 'webgl',
+  adapter: null,
+  device: null,
+  triedWebGPU,
+  fallbackReason,
+  shouldRetryWebGPU,
+});
+
+const cacheResult = (result: RendererCapabilities) => {
+  cachedCapabilities = result;
+  return result;
+};
+
+async function probeRendererCapabilities(): Promise<RendererCapabilities> {
+  if (typeof navigator === 'undefined') {
+    return cacheResult(buildFallback('Renderer capabilities are unavailable.'));
+  }
+
+  const { gpu } = navigator as Navigator & { gpu?: GPU };
+  if (!gpu?.requestAdapter) {
+    return cacheResult(
+      buildFallback('WebGPU is not available in this browser.', {
+        triedWebGPU: false,
+        shouldRetryWebGPU: false,
+      })
+    );
+  }
+
+  try {
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) {
+      return cacheResult(
+        buildFallback('No compatible WebGPU adapter was found.', {
+          triedWebGPU: true,
+          shouldRetryWebGPU: true,
+        })
+      );
+    }
+
+    let device: GPUDevice | null = null;
+    try {
+      device = await adapter.requestDevice();
+    } catch (error) {
+      console.warn('WebGPU device request failed. Falling back to WebGL.', error);
+      return cacheResult(
+        buildFallback('Unable to acquire a WebGPU device.', {
+          triedWebGPU: true,
+          shouldRetryWebGPU: true,
+        })
+      );
+    }
+
+    if (!device) {
+      return cacheResult(
+        buildFallback('WebGPU device request returned no device.', {
+          triedWebGPU: true,
+          shouldRetryWebGPU: true,
+        })
+      );
+    }
+
+    return cacheResult({
+      preferredBackend: 'webgpu',
+      adapter,
+      device,
+      triedWebGPU: true,
+      fallbackReason: null,
+      shouldRetryWebGPU: false,
+    });
+  } catch (error) {
+    console.warn('WebGPU initialization failed. Falling back to WebGL.', error);
+    return cacheResult(
+      buildFallback('WebGPU initialization failed.', {
+        triedWebGPU: true,
+        shouldRetryWebGPU: true,
+      })
+    );
+  }
+}
+
+export function resetRendererCapabilities() {
+  capabilitiesPromise = null;
+  cachedCapabilities = null;
+}
+
+export function rememberRendererFallback(
+  fallbackReason: string,
+  {
+    shouldRetryWebGPU = false,
+    triedWebGPU = true,
+  }: { shouldRetryWebGPU?: boolean; triedWebGPU?: boolean } = {}
+) {
+  const result = cacheResult(
+    buildFallback(fallbackReason, {
+      triedWebGPU,
+      shouldRetryWebGPU,
+    })
+  );
+  capabilitiesPromise = Promise.resolve(result);
+  return result;
+}
+
+export async function getRendererCapabilities({ forceRetry = false } = {}) {
+  if (forceRetry) {
+    capabilitiesPromise = null;
+  }
+
+  if (!capabilitiesPromise) {
+    capabilitiesPromise = probeRendererCapabilities();
+  }
+
+  return capabilitiesPromise;
+}
+
+export function getCachedRendererCapabilities() {
+  return cachedCapabilities;
+}

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -15,6 +15,7 @@ type CapabilityOptions = {
   allowFallback?: boolean;
   onBack?: () => void;
   onContinue?: () => void;
+  details?: string | null;
 };
 
 type ImportErrorOptions = {
@@ -212,13 +213,15 @@ export function createToyView({
     const status = buildStatusElement(doc, container, {
       type: options.allowFallback ? 'warning' : 'error',
       title: options.allowFallback ? 'WebGPU is unavailable' : 'WebGPU not available',
-      message: options.allowFallback
+      message: `${
+        options.allowFallback
         ? toy?.title
           ? `${toy.title} works best with WebGPU. We can try a lighter WebGL version instead.`
           : 'This toy works best with WebGPU. We can try a lighter WebGL version instead.'
         : toy?.title
           ? `${toy.title} needs WebGPU, which is not supported in this browser.`
-          : 'This toy requires WebGPU, which is not supported in this browser.',
+          : 'This toy requires WebGPU, which is not supported in this browser.'
+      }${options.details ? ` (${options.details})` : ''}`,
     });
 
     if (!status) return null;

--- a/tests/renderer-capabilities.test.js
+++ b/tests/renderer-capabilities.test.js
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import {
+  getRendererCapabilities,
+  rememberRendererFallback,
+  resetRendererCapabilities,
+} from '../assets/js/core/renderer-capabilities.ts';
+
+const originalNavigator = global.navigator;
+
+function mockNavigatorWithGPU({ device = {} } = {}) {
+  const requestDevice = mock(async () => device);
+  const requestAdapter = mock(async () => ({ requestDevice }));
+  Object.defineProperty(global, 'navigator', {
+    writable: true,
+    configurable: true,
+    value: { gpu: { requestAdapter } },
+  });
+  return { requestAdapter, requestDevice };
+}
+
+afterEach(() => {
+  resetRendererCapabilities();
+  mock.restore();
+  Object.defineProperty(global, 'navigator', {
+    writable: true,
+    configurable: true,
+    value: originalNavigator,
+  });
+});
+
+describe('renderer capabilities', () => {
+  test('caches adapter probing across calls', async () => {
+    const { requestAdapter, requestDevice } = mockNavigatorWithGPU({ device: { label: 'device' } });
+
+    const first = await getRendererCapabilities();
+    const second = await getRendererCapabilities();
+
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+    expect(requestDevice).toHaveBeenCalledTimes(1);
+    expect(first.adapter).toBe(second.adapter);
+    expect(first.device).toBe(second.device);
+    expect(second.preferredBackend).toBe('webgpu');
+  });
+
+  test('falls back to WebGL when WebGPU is missing', async () => {
+    Object.defineProperty(global, 'navigator', {
+      writable: true,
+      configurable: true,
+      value: {},
+    });
+
+    const result = await getRendererCapabilities({ forceRetry: true });
+
+    expect(result.preferredBackend).toBe('webgl');
+    expect(result.fallbackReason).toContain('WebGPU');
+    expect(result.shouldRetryWebGPU).toBe(false);
+  });
+
+  test('retains fallback preference when renderer creation fails', async () => {
+    mockNavigatorWithGPU({ device: { label: 'device' } });
+
+    await getRendererCapabilities({ forceRetry: true });
+    const recorded = rememberRendererFallback('Renderer creation failed.', { shouldRetryWebGPU: true });
+
+    expect(recorded.preferredBackend).toBe('webgl');
+    const replay = await getRendererCapabilities();
+    expect(replay.fallbackReason).toContain('Renderer creation failed.');
+    expect(replay.shouldRetryWebGPU).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a renderer-capabilities service to probe WebGPU/WebGL once, cache the preferred backend, and expose fallback metadata
- update renderer initialization, loader gating, and toy flows to honor cached adapter/backend choices and reduce redundant adapter requests
- harden manifest resolution and expand tests to cover cached decisions and manifest fetch reuse

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944f7fbd2288332a6f10044aeaa6b59)