### PR TITLE
Add toy harness example test and stubs

### DIFF
--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -95,6 +95,7 @@ Manual scenarios to verify:
 - Add Jest specs for math and utility helpers in `assets/js/utils/` as they are shared by multiple toys.
 - For toy-specific logic, prefer unit-testing pure functions (e.g., color pickers, motion curves) rather than WebGL rendering.
 - Keep tests deterministic: mock `performance.now`, random seeds, and any time-based easing functions when needed.
+- Use the shared happy-dom preload in `tests/setup.ts` along with the stub helpers in `tests/toy-test-helpers.ts` (see `tests/sample-toy.test.ts`) to spin up a toy container, fake audio context/analyzer, or mock renderer. Follow that pattern to ensure `start` returns a cleanup function and disposes DOM nodes and audio handles.
 
 ## Documentation
 
@@ -102,4 +103,3 @@ Manual scenarios to verify:
 - Describe user-facing controls or setup steps in the associated HTML entry point if they deviate from existing patterns.
 - Include inline comments for novel shader parameters, math tricks, or input handling quirks.
 - When you wrap an existing HTML page for use in `toy.html`, expose it through `startIframeToy` (see `assets/js/toys/*`) and add the slug to `assets/js/toys-data.js` so the loader can surface it in the library view.
-

--- a/tests/demo-toy.ts
+++ b/tests/demo-toy.ts
@@ -1,0 +1,28 @@
+type StartOptions = {
+  container: HTMLElement;
+  audioContext: {
+    createAnalyser: () => {
+      frequencyBinCount?: number;
+      getByteFrequencyData: (array: Uint8Array) => void;
+    };
+    close?: () => Promise<void> | void;
+  };
+};
+
+export function start({ container, audioContext }: StartOptions) {
+  const mount = document.createElement('section');
+  mount.dataset.toyMount = 'demo-toy';
+  container.appendChild(mount);
+
+  const analyser = audioContext.createAnalyser();
+  const frequencyData = new Uint8Array(analyser.frequencyBinCount ?? 8);
+  analyser.getByteFrequencyData(frequencyData);
+  mount.dataset.frequencySample = String(frequencyData[0] ?? 0);
+
+  return async () => {
+    mount.remove();
+    if (typeof audioContext.close === 'function') {
+      await audioContext.close();
+    }
+  };
+}

--- a/tests/sample-toy.test.ts
+++ b/tests/sample-toy.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { start as startDemoToy } from './demo-toy.ts';
+import { createMockRenderer, createToyContainer, FakeAudioContext } from './toy-test-helpers.ts';
+
+describe('toy harness example', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('runs demo toy with shared stubs and cleans up DOM', async () => {
+    const { container, dispose } = createToyContainer('demo-toy-root');
+    const audioContext = new FakeAudioContext();
+    const initialBodyChildren = document.body.childElementCount;
+
+    const cleanup = startDemoToy({ container, audioContext });
+
+    expect(typeof cleanup).toBe('function');
+    expect(container.querySelector('[data-toy-mount="demo-toy"]')).not.toBeNull();
+
+    await cleanup();
+
+    expect(container.childElementCount).toBe(0);
+    expect(document.querySelector('[data-toy-mount="demo-toy"]')).toBeNull();
+    expect(document.body.childElementCount).toBe(initialBodyChildren);
+    expect(audioContext.closed).toBe(true);
+
+    dispose();
+    expect(document.body.childElementCount).toBe(0);
+  });
+
+  test('exposes reusable helpers for analyzers and renderers', () => {
+    const renderer = createMockRenderer();
+    renderer.renderFrame({ frame: 1 });
+    renderer.renderFrame({ frame: 2 });
+
+    expect(renderer.render).toHaveBeenCalledTimes(2);
+    expect(renderer.render).toHaveBeenLastCalledWith({ frame: 2 });
+
+    const audioContext = new FakeAudioContext();
+    const analyser = audioContext.createAnalyser();
+    const samples = new Uint8Array(analyser.frequencyBinCount);
+    analyser.getByteFrequencyData(samples);
+
+    expect(Array.from(samples)).toEqual(new Array(analyser.frequencyBinCount).fill(128));
+  });
+});

--- a/tests/toy-test-helpers.ts
+++ b/tests/toy-test-helpers.ts
@@ -1,0 +1,57 @@
+import { mock } from 'bun:test';
+
+export class FakeAnalyserNode {
+  frequencyBinCount: number;
+  connected = false;
+
+  constructor(frequencyBinCount = 16) {
+    this.frequencyBinCount = frequencyBinCount;
+  }
+
+  connect() {
+    this.connected = true;
+  }
+
+  disconnect() {
+    this.connected = false;
+  }
+
+  getByteFrequencyData(array: Uint8Array) {
+    array.fill(128);
+  }
+}
+
+export class FakeAudioContext {
+  closed = false;
+  analyzersCreated = 0;
+
+  createAnalyser() {
+    this.analyzersCreated += 1;
+    return new FakeAnalyserNode();
+  }
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+export function createToyContainer(id = 'toy-container') {
+  const container = document.createElement('div');
+  container.id = id;
+  document.body.appendChild(container);
+
+  const dispose = () => {
+    container.remove();
+  };
+
+  return { container, dispose };
+}
+
+export function createMockRenderer() {
+  const render = mock((payload?: unknown) => payload);
+  const dispose = mock(() => {});
+
+  const renderFrame = (payload?: unknown) => render(payload);
+
+  return { render, dispose, renderFrame };
+}


### PR DESCRIPTION
## Summary
- add shared toy test helpers for fake audio contexts, analyzers, renderers, and DOM containers
- add a demo toy module plus sample test that validates cleanup and stub usage
- document toy testing guidance to point to the harness and reuse the stubs

## Testing
- bun test tests/sample-toy.test.ts --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694502895fd8833292949aacde0760d3)