### PR TITLE
Improve toy scaffold tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ All JavaScript dependencies are installed via npm (or Bun) and bundled locally w
 - `bun run test:watch`: Keep the Bun test runner active while you iterate on specs.
 - `bun run lint`: Check code quality with ESLint. (`npm run lint` is an optional fallback.)
 - `bun run format`: Format files with Prettier. (`npm run format` is an optional fallback.)
-- `bun run scripts/scaffold-toy.ts`: Interactive scaffolder that prompts for a slug/title/type, creates a starter module from [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), appends metadata to `assets/js/toys-data.js`, updates `docs/TOY_SCRIPT_INDEX.md`, and can optionally drop a minimal Bun spec.
+- `bun run scripts/scaffold-toy.ts`: Interactive (or flag-driven) scaffolder that prompts for a slug/title/type, creates a starter module from [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), appends metadata to `assets/js/toys-data.js`, updates `docs/TOY_SCRIPT_INDEX.md`, and can optionally drop a minimal Bun spec. Pass flags such as `--slug ripple-orb --title "Ripple Orb" --type module --with-test` for non-interactive runs.
 - `bun run serve:dist`: Serve the `dist/` build with Bun (preferred for local production previews).
 
 ## Code of Conduct and Contributions

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -11,7 +11,7 @@ Use this playbook when adding or modifying toys so new experiences integrate cle
 
 ## Add-and-test checklist (fast path)
 
-Use this sequence when you want to stand up a fresh toy quickly:
+Use this sequence when you want to stand up a fresh toy quickly (you can also run `bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test` to automate steps 1–3):
 
 1. **Create a module** in `assets/js/toys/<slug>.ts` using the starter template below. Export `start({ container, canvas?, audioContext? })`. Prefer `canvas` from the loader if you need a fullscreen surface; otherwise mount your own elements inside `container`.
 2. **Register the slug** in `assets/js/toys-data.js` with a short title/description. Set `requiresWebGPU` or `allowWebGLFallback` if you depend on WebGPU features.

--- a/tests/scaffold-toy.test.ts
+++ b/tests/scaffold-toy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { scaffoldToy } from '../scripts/scaffold-toy.ts';
+
+async function createTempRepo() {
+  const root = await fs.mkdtemp(path.join(tmpdir(), 'toy-scaffold-'));
+
+  await fs.mkdir(path.join(root, 'assets/js'), { recursive: true });
+  await fs.writeFile(path.join(root, 'assets/js/toys-data.js'), 'export default [\n];\n');
+
+  await fs.mkdir(path.join(root, 'docs'), { recursive: true });
+  await fs.writeFile(
+    path.join(root, 'docs/TOY_SCRIPT_INDEX.md'),
+    `# Toy and Visualizer Script Index
+
+## Query-driven toys (\`toy.html\`)
+| Slug | Entry module | How it loads |
+| --- | --- | --- |
+
+## Standalone HTML entry points
+`
+  );
+
+  await fs.mkdir(path.join(root, 'tests'), { recursive: true });
+
+  return root;
+}
+
+describe('scaffold-toy CLI helpers', () => {
+  test('writes module, metadata, index row, and test file when requested', async () => {
+    const root = await createTempRepo();
+    const slug = 'ripple-orb';
+    const title = 'Ripple Orb';
+    const description = 'Gentle rippling spheres.';
+
+    const log = mock(() => {});
+    const originalConsoleLog = console.log;
+    console.log = (...args) => {
+      log(args);
+    };
+
+    await scaffoldToy({
+      slug,
+      title,
+      description,
+      type: 'module',
+      createTest: true,
+      root,
+    });
+
+    const modulePath = path.join(root, 'assets/js/toys', `${slug}.ts`);
+    const moduleContents = await fs.readFile(modulePath, 'utf8');
+    expect(moduleContents).toContain('export async function start');
+
+    const data = await fs.readFile(path.join(root, 'assets/js/toys-data.js'), 'utf8');
+    expect(data).toContain(`slug: '${slug}'`);
+    expect(data).toContain(`title: '${title}'`);
+    expect(data).toContain(description);
+
+    const index = await fs.readFile(path.join(root, 'docs/TOY_SCRIPT_INDEX.md'), 'utf8');
+    expect(index).toContain(`| \`${slug}\``);
+    expect(index.indexOf(slug)).toBeLessThan(index.indexOf('## Standalone HTML entry points'));
+
+    const testSpec = await fs.readFile(path.join(root, 'tests', `${slug}.test.ts`), 'utf8');
+    expect(testSpec).toContain(`describe('${slug} toy scaffold'`);
+
+    console.log = originalConsoleLog;
+  });
+
+  test('throws when a duplicate slug exists in metadata', async () => {
+    const root = await createTempRepo();
+    await fs.writeFile(
+      path.join(root, 'assets/js/toys-data.js'),
+      "export default [\n  { slug: 'dupe', title: 'Existing', module: 'assets/js/toys/dupe.ts', type: 'module' },\n];\n"
+    );
+
+    await expect(
+      scaffoldToy({
+        slug: 'dupe',
+        title: 'Duplicate',
+        description: 'Existing slug',
+        type: 'module',
+        createTest: false,
+        root,
+      })
+    ).rejects.toThrow(/already exists/);
+  });
+});


### PR DESCRIPTION
## Summary
- add CLI flags and duplicate safeguards to the toy scaffold script so it can run non-interactively or against a custom root
- export the scaffold routine for programmatic use and document the faster flag-driven workflow
- cover the scaffold flow with a Bun test to ensure modules, metadata, and index rows are created

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694501dcbb788332aefc2ae1c370739a)