### PR TITLE
Add module existence guard to scaffoldToy

### DIFF
--- a/scripts/scaffold-toy.ts
+++ b/scripts/scaffold-toy.ts
@@ -67,6 +67,10 @@ export async function scaffoldToy({
   createTest = false,
   root = repoRoot,
 }: Required<Omit<ScaffoldOptions, 'root'>> & { root?: string }) {
+  if (await fileExists(toyModulePath(slug, root))) {
+    throw new Error(`A toy module already exists for slug "${slug}".`);
+  }
+
   await createToyModule(slug, title, type, root);
   await appendToyMetadata(slug, title, description, type, root);
   await updateToyIndex(slug, type, root);


### PR DESCRIPTION
## Summary
- prevent scaffoldToy from overwriting an existing toy module in non-interactive runs
- reuse the existing duplicate slug error messaging when a module file already exists

## Testing
- bun test tests/scaffold-toy.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945082090408332a512a0131dd54d4c)