### PR TITLE
Ensure homepage library renders after DOM is ready

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,5 +16,13 @@ const libraryView = createLibraryView({
   themeToggleId: 'theme-toggle',
 });
 
-libraryView.init();
-initRepoStatusWidget();
+const startApp = () => {
+  libraryView.init();
+  void initRepoStatusWidget();
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', startApp, { once: true });
+} else {
+  startApp();
+}


### PR DESCRIPTION
## Summary
- wait for the DOM to be ready before initializing the library view and repo status widget

## Testing
- bun run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450ada14c08332bd759af13bfc8297)