### PR TITLE
Add shared quality presets to remaining toys

### DIFF
--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -8,21 +8,60 @@ import {
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
 import { mapFrequencyToItems } from '../utils/audio-mapper';
+import {
+  DEFAULT_QUALITY_PRESETS,
+  getSettingsPanel,
+  getStoredQualityPreset,
+  type QualityPreset,
+} from '../core/settings-panel';
+
+const settingsPanel = getSettingsPanel();
+let activeQuality: QualityPreset = getStoredQualityPreset();
 
 const toy = new WebToy({
   cameraOptions: { position: { x: 0, y: 0, z: 100 } },
   lightingOptions: { type: 'HemisphereLight' },
   ambientLightOptions: {},
+  rendererOptions: {
+    maxPixelRatio: activeQuality.maxPixelRatio,
+    renderScale: activeQuality.renderScale,
+  },
 } as ToyConfig);
 
 const lines: THREE.Line[] = [];
+const lineGroup = new THREE.Group();
+toy.scene.add(lineGroup);
+
+function getLineConfig() {
+  const scale = activeQuality.particleScale ?? 1;
+  const lineCount = Math.max(12, Math.round(50 * scale));
+  const pointCount = Math.max(12, Math.round(30 * Math.sqrt(scale)));
+  return { lineCount, pointCount };
+}
+
+function disposeLines() {
+  lines.forEach((line) => {
+    lineGroup.remove(line);
+    line.geometry.dispose();
+    (line.material as THREE.Material).dispose();
+  });
+  lines.length = 0;
+}
 
 function init() {
-  const { scene } = toy;
-  for (let i = 0; i < 50; i++) {
+  setupSettingsPanel();
+  if (!lines.length) {
+    buildLines();
+  }
+}
+
+function buildLines() {
+  disposeLines();
+  const { lineCount, pointCount } = getLineConfig();
+  for (let i = 0; i < lineCount; i++) {
     const geometry = new THREE.BufferGeometry();
     const points = [];
-    for (let j = 0; j < 30; j++) {
+    for (let j = 0; j < pointCount; j++) {
       const angle = j * 0.2 + i * 0.1;
       const radius = j * 0.5 + i;
       points.push(
@@ -34,9 +73,30 @@ function init() {
       color: Math.random() * 0xffffff,
     });
     const line = new THREE.Line(geometry, material);
-    scene.add(line);
+    lineGroup.add(line);
     lines.push(line);
   }
+}
+
+function applyQualityPreset(preset: QualityPreset) {
+  activeQuality = preset;
+  toy.updateRendererSettings({
+    maxPixelRatio: preset.maxPixelRatio,
+    renderScale: preset.renderScale,
+  });
+  buildLines();
+}
+
+function setupSettingsPanel() {
+  settingsPanel.configure({
+    title: 'Spiral burst',
+    description: 'Match render scale and line density to your hardware.',
+  });
+  settingsPanel.setQualityPresets({
+    presets: DEFAULT_QUALITY_PRESETS,
+    defaultPresetId: activeQuality.id,
+    onChange: applyQualityPreset,
+  });
 }
 
 function animate(ctx: AnimationContext) {


### PR DESCRIPTION
## Summary
- add a shared helper to load/store quality presets and reuse it across all toys
- wire the settings panel into each remaining toy so renderer options and density/geometry counts scale with the chosen preset
- reapply sizing and counts when presets change so scenes update without reloads

## Testing
- eslint .
- prettier --write .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450ba71d38833292467d6181d1194e)