### PR TITLE
Refactor lights visual to use WebToy architecture

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,339 +1,348 @@
+/* global HTMLButtonElement, HTMLCanvasElement, HTMLSelectElement */
 import * as THREE from 'three';
-import { initScene } from './core/scene-setup.ts';
-import { initCamera } from './core/camera-setup.ts';
-import { initRenderer } from './core/renderer-setup.ts';
+import WebToy from './core/web-toy';
+import { getContextFrequencyData } from './core/animation-loop';
 import { setupMicrophonePermissionFlow } from './core/microphone-flow.ts';
 import { ensureWebGL } from './utils/webgl-check.ts';
-import { initLighting, initAmbientLight } from './lighting/lighting-setup';
-import {
-  createSyntheticAudioStream,
-  initAudio,
-  getFrequencyData,
-} from './utils/audio-handler.ts';
-import {
-  applyAudioRotation,
-  applyAudioScale,
-} from './utils/animation-utils.ts';
+import { applyAudioRotation, applyAudioScale } from './utils/animation-utils.ts';
+import { startToyAudio } from './utils/start-audio.ts';
 import PatternRecognizer from './utils/patternRecognition.ts';
 
 const DEFAULT_RENDERER_OPTIONS = { maxPixelRatio: 2 };
 
-class VisualizationController {
-  constructor() {
-    this.scene = null;
-    this.camera = null;
-    this.renderer = null;
-    this.rendererBackend = null;
-    this.cube = null;
-    this.analyser = null;
-    this.patternRecognizer = null;
-    this.audioCleanup = null;
-    this.syntheticCleanup = null;
-    this.rendererReadyPromise = null;
-    this.currentLightType = document.getElementById('light-type')?.value || 'PointLight';
-    this.animationFrameId = null;
-    this.isAnimating = false;
-    this.audioListener = null;
-    this.hasRequestedAudio = false;
-    this.prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-    this.isReducedMotionPreferred = this.prefersReducedMotion.matches;
+const LIGHT_CONFIGS = {
+  PointLight: { type: 'PointLight', position: { x: 10, y: 10, z: 20 }, intensity: 1 },
+  DirectionalLight: { type: 'DirectionalLight', position: { x: 10, y: 10, z: 20 }, intensity: 1 },
+  SpotLight: { type: 'SpotLight', position: { x: 10, y: 15, z: 18 }, intensity: 1.25 },
+  HemisphereLight: { type: 'HemisphereLight', position: { x: 0, y: 10, z: 0 }, intensity: 1 },
+};
 
-    this.handleResize = this.handleResize.bind(this);
-    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
-    this.handleReducedMotionChange = this.handleReducedMotionChange.bind(this);
-    this.handleLightChange = this.handleLightChange.bind(this);
-    this.handlePageHide = this.handlePageHide.bind(this);
-    this.animate = this.animate.bind(this);
-  }
+function createLightsExperience({
+  documentRef = typeof document !== 'undefined' ? document : null,
+  windowRef = typeof window !== 'undefined' ? window : null,
+} = {}) {
+  const doc = documentRef;
+  const win = windowRef;
 
-  init() {
-    this.rendererReadyPromise = this.initVisualization();
+  const prefersReducedMotion = win?.matchMedia?.('(prefers-reduced-motion: reduce)') ?? null;
 
-    this.prefersReducedMotion.addEventListener('change', this.handleReducedMotionChange);
-    window.addEventListener('resize', this.handleResize);
-    document.addEventListener('visibilitychange', this.handleVisibilityChange);
-    window.addEventListener('pagehide', this.handlePageHide);
-    const lightTypeSelect = document.getElementById('light-type');
-    lightTypeSelect?.addEventListener('change', this.handleLightChange);
+  let isReducedMotionPreferred = prefersReducedMotion?.matches ?? false;
+  let shouldAnimate = true;
+  /** @type {WebToy | null} */
+  let toy = null;
+  /** @type {THREE.Group | null} */
+  let lightingGroup = null;
+  /** @type {THREE.Mesh | null} */
+  let cube = null;
+  /** @type {AnimationContext | null} */
+  let animationContext = null;
+  /** @type {PatternRecognizer | null} */
+  let patternRecognizer = null;
+  /** @type {'microphone' | 'sample' | null} */
+  let audioMode = null;
 
-    setupMicrophonePermissionFlow({
-      startButton: document.getElementById('start-audio-btn'),
-      fallbackButton: document.getElementById('use-sample-audio'),
-      statusElement: document.getElementById('audio-status'),
-      requestMicrophone: () => this.startAudioAndAnimation(false),
-      requestSampleAudio: () => this.startAudioAndAnimation(true),
-      analytics: {
-        log: (event, detail) => console.info(`[audio-flow] ${event}`, detail ?? {}),
-      },
-      onSuccess: () => {
-        const startButton = document.getElementById('start-audio-btn');
-        if (startButton instanceof window.HTMLButtonElement) {
-          startButton.style.display = 'none';
-        }
+  const elements = {
+    startButton: doc?.getElementById('start-audio-btn'),
+    fallbackButton: doc?.getElementById('use-sample-audio'),
+    statusElement: doc?.getElementById('audio-status'),
+    lightSelect: doc?.getElementById('light-type'),
+  };
 
-        const fallbackButton = document.getElementById('use-sample-audio');
-        if (fallbackButton instanceof window.HTMLButtonElement) {
-          fallbackButton.hidden = true;
-        }
-      },
-    });
-  }
+  const setStatus = (message, variant = 'info') => {
+    if (!elements.statusElement) return;
+    elements.statusElement.textContent = message;
+    elements.statusElement.dataset.variant = variant;
+    elements.statusElement.hidden = !message;
+  };
 
-  async initVisualization() {
-    if (!ensureWebGL()) {
-      this.displayError('WebGL support is required to render this visual.');
-      return null;
+  const getSelectedLightType = () => {
+    if (elements.lightSelect instanceof HTMLSelectElement) {
+      return elements.lightSelect.value;
+    }
+    return 'PointLight';
+  };
+
+  const renderOnce = () => {
+    if (toy) {
+      toy.render();
+    }
+  };
+
+  const clearAnimationLoop = () => {
+    if (toy?.renderer?.setAnimationLoop) {
+      toy.renderer.setAnimationLoop(null);
+    }
+  };
+
+  const applyLighting = (lightType) => {
+    if (!toy || !lightingGroup) return;
+
+    while (lightingGroup.children.length > 0) {
+      lightingGroup.remove(lightingGroup.children[0]);
     }
 
-    this.stopAnimationLoop();
-    this.disposeScene();
+    const config = LIGHT_CONFIGS[lightType] ?? LIGHT_CONFIGS.PointLight;
+    const { type, intensity, position } = config;
 
-    const canvas = document.getElementById('toy-canvas');
-    if (!canvas) {
-      this.displayError('Canvas element not found.');
-      return null;
+    /** @type {THREE.Light} */
+    let light;
+    switch (type) {
+      case 'DirectionalLight':
+        light = new THREE.DirectionalLight(0xffffff, intensity);
+        break;
+      case 'SpotLight':
+        light = new THREE.SpotLight(0xffffff, intensity);
+        break;
+      case 'HemisphereLight':
+        light = new THREE.HemisphereLight(0xffffff, 0x444444, intensity);
+        break;
+      default:
+        light = new THREE.PointLight(0xffffff, intensity);
+        break;
     }
 
-    this.scene = initScene();
-    this.camera = initCamera();
+    light.position.set(position.x, position.y, position.z);
+    lightingGroup.add(light);
+  };
 
-    const rendererResult = await initRenderer(canvas, DEFAULT_RENDERER_OPTIONS);
-    if (!rendererResult) {
-      this.displayError('Unable to initialize a renderer on this device.');
-      return null;
+  /** @param {import('./core/animation-loop').AnimationContext} ctx */
+  const animate = (ctx) => {
+    if (!toy || !cube) return;
+
+    if (!shouldAnimate) {
+      renderOnce();
+      clearAnimationLoop();
+      return;
     }
 
-    this.renderer = rendererResult.renderer;
-    this.rendererBackend = rendererResult.backend;
-    console.info(`Using renderer backend: ${this.rendererBackend}`);
+    const audioData = getContextFrequencyData(ctx);
+    applyAudioRotation(cube, audioData, 0.05);
+    applyAudioScale(cube, audioData, 50);
 
-    initLighting(this.scene, {
-      type: this.currentLightType,
-      color: 0xffffff,
-      intensity: 1,
-      position: { x: 10, y: 10, z: 20 },
-    });
-    initAmbientLight(this.scene, { color: 0x404040, intensity: 0.5 });
+    patternRecognizer?.updatePatternBuffer();
+    const detectedPattern = patternRecognizer?.detectPattern();
 
-    const geometry = new THREE.BoxGeometry();
-    const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-    this.cube = new THREE.Mesh(geometry, material);
-    this.scene.add(this.cube);
-
-    this.renderSceneOnce();
-
-    if (this.analyser && !this.isReducedMotionPreferred) {
-      this.startAnimationLoop();
-    }
-
-    return this.renderer;
-  }
-
-  disposeScene() {
-    if (this.renderer) {
-      this.renderer.dispose();
-      this.renderer = null;
-    }
-
-    if (this.scene) {
-      this.scene.traverse((object) => {
-        if (object.isMesh) {
-          object.geometry?.dispose?.();
-          if (Array.isArray(object.material)) {
-            object.material.forEach((material) => material.dispose?.());
-          } else {
-            object.material?.dispose?.();
-          }
+    if (Array.isArray(cube.material)) {
+      cube.material.forEach((material) => {
+        if ('color' in material && material.color) {
+          material.color.setHex(detectedPattern ? 0xff0000 : 0x00ff00);
         }
       });
-
-      while (this.scene.children.length > 0) {
-        this.scene.remove(this.scene.children[0]);
-      }
-
-      this.scene = null;
+    } else if ('color' in cube.material && cube.material.color) {
+      cube.material.color.setHex(detectedPattern ? 0xff0000 : 0x00ff00);
     }
 
-    this.camera = null;
-    this.cube = null;
-    this.rendererBackend = null;
-  }
+    renderOnce();
+  };
 
-  startAnimationLoop() {
-    if (this.isAnimating || this.isReducedMotionPreferred) return;
+  const restartAnimationLoop = () => {
+    if (!toy?.renderer || !animationContext || !shouldAnimate) return;
+    toy.renderer.setAnimationLoop(() => animate(animationContext));
+  };
 
-    this.isAnimating = true;
-    this.animationFrameId = requestAnimationFrame(this.animate);
-  }
-
-  stopAnimationLoop() {
-    if (!this.isAnimating) return;
-
-    this.isAnimating = false;
-    if (this.animationFrameId !== null) {
-      window.cancelAnimationFrame(this.animationFrameId);
-      this.animationFrameId = null;
+  const cleanupAudio = () => {
+    clearAnimationLoop();
+    toy?.audioCleanup?.();
+    if (toy) {
+      toy.analyser = null;
+      toy.audioListener = null;
+      toy.audio = null;
+      toy.audioStream = null;
+      toy.audioCleanup = null;
     }
-  }
+    animationContext = null;
+    patternRecognizer = null;
+  };
 
-  cleanupAudio() {
-    if (this.audioCleanup) {
-      this.audioCleanup();
+  const initializeToy = async () => {
+    if (!doc) return;
+
+    const canvas = doc.getElementById('toy-canvas');
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      setStatus('Canvas element not found.', 'error');
+      return;
     }
-    if (this.syntheticCleanup) {
-      this.syntheticCleanup();
-    }
 
-    this.audioCleanup = null;
-    this.syntheticCleanup = null;
-    this.analyser = null;
-    this.patternRecognizer = null;
-    this.audioListener = null;
-  }
-
-  async startAudioAndAnimation(useSampleAudio = false) {
-    this.hasRequestedAudio = true;
     try {
-      if (this.rendererReadyPromise) {
-        await this.rendererReadyPromise;
-      }
-      if (!this.renderer) {
-        throw new Error('Unable to start because no renderer is available.');
-      }
-
-      this.cleanupAudio();
-      const syntheticStream = useSampleAudio ? createSyntheticAudioStream() : null;
-      const audioData = await initAudio({ stream: syntheticStream?.stream });
-      this.analyser = audioData.analyser;
-      this.audioListener = audioData.listener ?? null;
-      this.audioCleanup = () => audioData.cleanup();
-      this.syntheticCleanup = syntheticStream?.cleanup ?? null;
-      this.patternRecognizer = new PatternRecognizer(this.analyser);
-
-      if (this.isReducedMotionPreferred) {
-        this.renderSceneOnce();
-      } else {
-        this.startAnimationLoop();
-      }
-      return true;
+      toy = new WebToy({
+        rendererOptions: DEFAULT_RENDERER_OPTIONS,
+        ambientLightOptions: { color: 0x404040, intensity: 0.5 },
+        cameraOptions: { position: { x: 0, y: 0, z: 5 } },
+        canvas,
+      });
     } catch (error) {
-      console.error('initAudio failed:', error);
-      this.syntheticCleanup?.();
-      this.syntheticCleanup = null;
+      console.error('Unable to create WebToy instance', error);
+      setStatus('WebGL support is required to render this visual.', 'error');
+      toy = null;
+      return;
+    }
+
+    lightingGroup = new THREE.Group();
+    toy.scene.add(lightingGroup);
+    applyLighting(getSelectedLightType());
+
+    cube = new THREE.Mesh(
+      new THREE.BoxGeometry(),
+      new THREE.MeshStandardMaterial({ color: 0x00ff00, metalness: 0.3, roughness: 0.4 })
+    );
+    toy.scene.add(cube);
+
+    await toy.rendererReady;
+    renderOnce();
+  };
+
+  const startAudio = async (mode) => {
+    if (!toy) {
+      setStatus('Renderer is not ready yet. Please retry.', 'error');
+      return;
+    }
+
+    shouldAnimate = !isReducedMotionPreferred;
+    audioMode = mode;
+
+    try {
+      animationContext = await startToyAudio(toy, animate, {
+        fallbackToSynthetic: mode === 'microphone',
+        preferSynthetic: mode === 'sample',
+      });
+
+      if (animationContext.analyser) {
+        patternRecognizer = new PatternRecognizer(animationContext.analyser);
+      }
+
+      if (isReducedMotionPreferred) {
+        renderOnce();
+      }
+    } catch (error) {
+      audioMode = null;
+      clearAnimationLoop();
       throw error;
     }
-  }
+  };
 
-  animate() {
-    if (!this.isAnimating) return;
+  const handleVisibilityChange = async () => {
+    if (!doc || !toy) return;
 
-    if (this.analyser && this.cube) {
-      const audioData = getFrequencyData(this.analyser);
-
-      if (!this.isReducedMotionPreferred) {
-        applyAudioRotation(this.cube, audioData, 0.05);
-        applyAudioScale(this.cube, audioData, 50);
-      }
-
-      this.patternRecognizer?.updatePatternBuffer();
-      const detectedPattern = this.patternRecognizer?.detectPattern();
-
-      if (detectedPattern) {
-        this.cube.material.color.setHex(0xff0000); // Detected pattern color
-      } else {
-        this.cube.material.color.setHex(0x00ff00); // Normal color
-      }
-    }
-
-    this.renderer?.render(this.scene, this.camera);
-    this.animationFrameId = requestAnimationFrame(this.animate);
-  }
-
-  handleResize() {
-    if (!this.camera || !this.renderer) return;
-
-    this.camera.aspect = window.innerWidth / window.innerHeight;
-    this.camera.updateProjectionMatrix();
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-  }
-
-  renderSceneOnce() {
-    if (this.renderer && this.scene && this.camera) {
-      this.renderer.render(this.scene, this.camera);
-    }
-  }
-
-  displayError(message) {
-    const errorElement = document.getElementById('audio-status');
-    if (!errorElement) return;
-
-    errorElement.innerText = message;
-    errorElement.dataset.variant = 'error';
-    errorElement.hidden = !message;
-  }
-
-  handleLightChange(event) {
-    this.currentLightType = event.target?.value || this.currentLightType;
-    this.rendererReadyPromise = this.initVisualization();
-  }
-
-  async handleVisibilityChange() {
-    if (document.visibilityState === 'hidden') {
-      this.stopAnimationLoop();
-
-      if (this.audioListener?.context?.state === 'running') {
+    if (doc.visibilityState === 'hidden') {
+      clearAnimationLoop();
+      if (toy.audioListener?.context?.state === 'running') {
         try {
-          await this.audioListener.context.suspend();
+          await toy.audioListener.context.suspend();
         } catch (error) {
           console.error('Error suspending audio context:', error);
         }
       } else {
-        this.cleanupAudio();
+        cleanupAudio();
       }
-
       return;
     }
 
-    if (document.visibilityState === 'visible') {
-      if (this.audioListener?.context?.state === 'suspended') {
+    if (doc.visibilityState === 'visible') {
+      if (toy.audioListener?.context?.state === 'suspended') {
         try {
-          await this.audioListener.context.resume();
+          await toy.audioListener.context.resume();
         } catch (error) {
           console.error('Error resuming audio context:', error);
         }
-      } else if (this.hasRequestedAudio && !this.analyser) {
+      } else if (audioMode && !animationContext) {
         try {
-          await this.startAudioAndAnimation();
+          await startAudio(audioMode);
         } catch (error) {
-          this.displayError(
-            'Microphone access is required for the visualization to work. Please allow microphone access.',
+          setStatus(
+            'Microphone or sample audio is required for the visualization to work. Please try again.',
+            'error'
           );
           console.error('Unable to restart audio after visibility change', error);
         }
       }
 
-      if (this.analyser) {
-        this.startAnimationLoop();
+      if (animationContext) {
+        restartAnimationLoop();
       }
     }
-  }
+  };
 
-  handleReducedMotionChange(event) {
-    this.isReducedMotionPreferred = event.matches;
+  const handleLightChange = () => {
+    applyLighting(getSelectedLightType());
+    renderOnce();
+  };
 
-    if (this.isReducedMotionPreferred) {
-      this.stopAnimationLoop();
-      this.renderSceneOnce();
-    } else if (this.analyser) {
-      this.startAnimationLoop();
+  const handleReducedMotionChange = (event) => {
+    isReducedMotionPreferred = event.matches;
+    shouldAnimate = !isReducedMotionPreferred;
+
+    if (isReducedMotionPreferred) {
+      clearAnimationLoop();
+      renderOnce();
+    } else {
+      restartAnimationLoop();
     }
-  }
+  };
 
-  handlePageHide() {
-    this.cleanupAudio();
-    this.stopAnimationLoop();
-  }
+  const handlePageHide = () => {
+    cleanupAudio();
+    clearAnimationLoop();
+  };
+
+  const init = async () => {
+    if (!doc || !win) return;
+
+    const supportsRendering = ensureWebGL({
+      title: 'Graphics support required',
+      description:
+        'This visualizer needs WebGL or WebGPU to render. Enable hardware acceleration or update your browser to continue.',
+    });
+
+    if (!supportsRendering) return;
+
+    await initializeToy();
+
+    setupMicrophonePermissionFlow({
+      startButton: elements.startButton,
+      fallbackButton: elements.fallbackButton,
+      statusElement: elements.statusElement,
+      requestMicrophone: () => startAudio('microphone'),
+      requestSampleAudio: () => startAudio('sample'),
+      analytics: {
+        log: (event, detail) => console.info(`[audio-flow] ${event}`, detail ?? {}),
+      },
+      onSuccess: (mode) => {
+        if (elements.startButton instanceof HTMLButtonElement) {
+          elements.startButton.style.display = 'none';
+        }
+
+        if (mode === 'microphone' && elements.fallbackButton instanceof HTMLButtonElement) {
+          elements.fallbackButton.hidden = true;
+        }
+      },
+    });
+
+    elements.lightSelect?.addEventListener('change', handleLightChange);
+    prefersReducedMotion?.addEventListener('change', handleReducedMotionChange);
+    doc.addEventListener('visibilitychange', handleVisibilityChange);
+    win.addEventListener('pagehide', handlePageHide);
+  };
+
+  const dispose = () => {
+    cleanupAudio();
+    clearAnimationLoop();
+    elements.lightSelect?.removeEventListener('change', handleLightChange);
+    prefersReducedMotion?.removeEventListener('change', handleReducedMotionChange);
+    doc?.removeEventListener('visibilitychange', handleVisibilityChange);
+    win?.removeEventListener('pagehide', handlePageHide);
+    toy?.dispose();
+    toy = null;
+    cube = null;
+    lightingGroup = null;
+  };
+
+  return { init, dispose };
 }
 
-const controller = new VisualizationController();
-controller.init();
+const experience = createLightsExperience();
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => experience.init(), { once: true });
+} else {
+  void experience.init();
+}


### PR DESCRIPTION
## Summary
- refactor the lights visual to build on the shared WebToy lifecycle instead of bespoke setup logic
- centralize light configuration/presets and WebGL/WebGPU readiness checks for the lights entry point
- align audio start/stop, reduced-motion handling, and capability messaging with shared helpers

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694514177d608332950c322a243b502b)