### PR TITLE
Add bunfig defaults for tests

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["./tests/setup.ts"]
+importmap = "./tests/importmap.json"


### PR DESCRIPTION
## Summary
- configure bun test defaults in bunfig.toml to preload the DOM setup and import map automatically

## Testing
- bun test
- bun run lint

## Checklist
- [x] Linting (`npm run lint`) if applicable
- [x] Tests (`npm test`) if applicable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f384a63c8332955f38f2712ba73d)