### PR TITLE
Style control panel inputs

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -607,7 +607,8 @@ body {
   cursor: pointer;
 }
 
-.control-panel select {
+.control-panel select,
+.control-panel__select {
   background: linear-gradient(135deg, rgba(16, 24, 40, 0.9), rgba(11, 17, 29, 0.92));
   color: #e9fbff;
   border: 1px solid rgba(111, 247, 255, 0.8);
@@ -619,7 +620,89 @@ body {
   box-shadow: 0 0 14px rgba(17, 216, 255, 0.25), inset 0 0 12px rgba(255, 0, 153, 0.18);
 }
 
-.control-panel select:focus {
+.control-panel select:focus,
+.control-panel__select:focus {
+  outline: 2px solid rgba(255, 0, 153, 0.65);
+  outline-offset: 2px;
+  box-shadow: 0 0 18px rgba(255, 0, 153, 0.4), 0 0 10px rgba(111, 247, 255, 0.35);
+}
+
+.control-panel input[type='range'],
+.control-panel__slider {
+  appearance: none;
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 216, 255, 0.16), rgba(255, 0, 153, 0.12));
+  border: 1px solid rgba(111, 247, 255, 0.65);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55), 0 0 14px rgba(17, 216, 255, 0.25);
+  cursor: pointer;
+  flex: 1;
+}
+
+.control-panel input[type='range']:focus-visible,
+.control-panel__slider:focus-visible {
+  outline: 2px solid rgba(255, 0, 153, 0.65);
+  outline-offset: 3px;
+  box-shadow: 0 0 18px rgba(255, 0, 153, 0.4), 0 0 10px rgba(111, 247, 255, 0.35);
+}
+
+.control-panel input[type='range']::-webkit-slider-runnable-track,
+.control-panel__slider::-webkit-slider-runnable-track {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 216, 255, 0.18), rgba(255, 0, 153, 0.14));
+  border: 1px solid rgba(111, 247, 255, 0.55);
+}
+
+.control-panel input[type='range']::-webkit-slider-thumb,
+.control-panel__slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(17, 216, 255, 0.8));
+  border: 1px solid rgba(111, 247, 255, 0.85);
+  box-shadow: 0 0 16px rgba(17, 216, 255, 0.5), 0 0 8px rgba(255, 0, 153, 0.25);
+  margin-top: -4px;
+}
+
+.control-panel input[type='range']::-moz-range-track,
+.control-panel__slider::-moz-range-track {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 216, 255, 0.18), rgba(255, 0, 153, 0.14));
+  border: 1px solid rgba(111, 247, 255, 0.55);
+}
+
+.control-panel input[type='range']::-moz-range-thumb,
+.control-panel__slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(17, 216, 255, 0.8));
+  border: 1px solid rgba(111, 247, 255, 0.85);
+  box-shadow: 0 0 16px rgba(17, 216, 255, 0.5), 0 0 8px rgba(255, 0, 153, 0.25);
+}
+
+.control-panel__checkbox-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(111, 247, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #e9fbff;
+}
+
+.control-panel__checkbox-inline input[type='checkbox'] {
+  margin: 0;
+}
+
+.control-panel__checkbox-inline:focus-within {
   outline: 2px solid rgba(255, 0, 153, 0.65);
   outline-offset: 2px;
   box-shadow: 0 0 18px rgba(255, 0, 153, 0.4), 0 0 10px rgba(111, 247, 255, 0.35);

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -236,6 +236,7 @@ function createControls() {
   densityInput.max = '1';
   densityInput.step = '0.05';
   densityInput.value = settings.density.toString();
+  densityInput.className = 'control-panel__slider';
   densityInput.addEventListener('input', () => {
     settings.density = Number(densityInput.value);
     buildGarden();

--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -220,6 +220,7 @@ export async function start() {
   grainSlider.step = '0.02';
   grainSlider.value = grainScale.toString();
   grainSlider.setAttribute('aria-label', 'Grain size');
+  grainSlider.className = 'control-panel__slider';
   grainSlider.addEventListener('input', (event) => {
     const value = Number((event.target as HTMLInputElement).value);
     grainScale = value;
@@ -238,6 +239,7 @@ export async function start() {
   dampingSlider.step = '0.001';
   dampingSlider.value = damping.toFixed(3);
   dampingSlider.setAttribute('aria-label', 'Ripple damping');
+  dampingSlider.className = 'control-panel__slider';
   dampingSlider.addEventListener('input', (event) => {
     damping = Number((event.target as HTMLInputElement).value);
   });
@@ -250,9 +252,10 @@ export async function start() {
   const gravityLock = document.createElement('input');
   gravityLock.type = 'checkbox';
   gravityLock.id = 'tactile-gravity-lock';
-  const gravityLabel = document.createElement('label');
-  gravityLabel.htmlFor = gravityLock.id;
-  gravityLabel.textContent = 'Lock gravity';
+  const gravityToggle = document.createElement('label');
+  gravityToggle.className = 'control-panel__checkbox-inline';
+  gravityToggle.htmlFor = gravityLock.id;
+  gravityToggle.textContent = 'Lock gravity';
 
   gravityLock.checked = gravity.locked;
 
@@ -274,7 +277,8 @@ export async function start() {
     gravity.locked = true;
   });
 
-  gravityRow.append(gravityLock, gravityLabel, recenter);
+  gravityToggle.prepend(gravityLock);
+  gravityRow.append(gravityToggle, recenter);
 
   initHints({
     id: 'tactile-sand-table',


### PR DESCRIPTION
## Summary
- add shared control panel styles for selects, sliders, and inline checkboxes
- apply the new slider and checkbox styling to tactile sand table controls
- align the fractal kite garden slider with the shared control panel look

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694606b8b8b08332a4fa2fdc0dfa0708)