### PR TITLE
Document MCP stdio server entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
 For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
+If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,41 @@
+# MCP stdio server guide
+
+The repository includes a Model Context Protocol (MCP) stdio server at [`scripts/mcp-server.ts`](../scripts/mcp-server.ts). It exposes documentation, toy metadata, loader behavior, and development command references so MCP-compatible clients can retrieve structured information without scraping markdown.
+
+## Starting the server
+
+- Install dependencies (`bun install`).
+- Run the stdio server from the repo root:
+  ```bash
+  bun run mcp
+  ```
+  MCP clients should launch the command above with the working directory set to the repository root so the server can read `README.md` and `assets/js/toys-data.js`. The server writes responses over stdio using the MCP protocol.
+
+## Registered tools
+
+All tools are registered on the `stim-webtoys-mcp` server name and use zod-based schemas for validation.
+
+- **`list_docs`**
+  - **Input:** none.
+  - **Output:** `text` response with quick-start pointers, runtime notes, repository layout, and toy catalog references pulled from `README.md` with line ranges.
+- **`get_toys`**
+  - **Input:** optional `slug` (string) to fetch a single toy and optional `requiresWebGPU` (boolean) to filter by WebGPU requirements.
+  - **Output:** `json` array of `{ slug, title, description, requiresWebGPU, url }` entries. Returns a helpful text message when no toys match the filters.
+- **`describe_loader`**
+  - **Input:** none.
+  - **Output:** `text` summary of how the toy loader resolves entries and errors, including manifest resolution (`/.vite/manifest.json`), URL/history handling, WebGPU gating, and the recovery states shown when imports fail.
+- **`dev_commands`**
+  - **Input:** optional `scope` enum (`setup`, `dev`, `build`, `test`, `lint`) to narrow the result.
+  - **Output:** `text` response containing the requested setup or workflow commands from `README.md`. Without a scope, the tool returns all development snippets.
+
+## Inputs, outputs, and client expectations
+
+- All tool calls follow MCP stdio conventions. Successful calls return a `content` array with either `text` or `json` entries.
+- Validation errors surface when inputs don’t satisfy the schemas above (for example, passing a number for `slug`).
+- `get_toys` reads from `assets/js/toys-data.js`; keep that file up to date so MCP clients surface accurate metadata.
+
+## Troubleshooting tips
+
+- **Manifest resolution:** The loader summary references `/.vite/manifest.json`; when discussing loader behavior with `describe_loader`, ensure a Vite dev server or build has produced the manifest so paths resolve correctly.
+- **Slug filters:** If `get_toys` returns “No toys matched the requested filters,” double-check the slug in `assets/js/toys-data.js` or omit filters to retrieve the full catalog.
+- **Client invocation:** MCP clients must launch `bun run mcp` in the repository root; running elsewhere can block access to `README.md`, the toy data file, or the Vite manifest.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,6 @@ This folder contains resources for contributors who are building or maintaining 
 - [`DEVELOPMENT.md`](./DEVELOPMENT.md): day-to-day setup, scripts, workflow, and performance/testing expectations.
 - [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): playbook for creating or updating toy experiences, including audio, rendering, and debugging tips.
 - [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): map from each toy/visualizer to the JS/TS entry points it uses.
+- [`MCP_SERVER.md`](./MCP_SERVER.md): how to launch and use the MCP stdio server (`scripts/mcp-server.ts`) and its registered tools.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.


### PR DESCRIPTION
## Summary
- add a dedicated MCP stdio server guide covering setup, tools, and troubleshooting
- link the new documentation from the docs index and the project README for easy discovery

## Testing
- eslint .
- prettier --write .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461223cb0883328b9639e56acc4ddc)