### PR TITLE
Document assessment and toy note references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
-For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns (including current assessments and per-toy notes).
+For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns, including current assessments and per-toy notes.
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
-For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
+For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns (including current assessments and per-toy notes).
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,7 @@ This folder contains resources for contributors who are building or maintaining 
 - [`DEVELOPMENT.md`](./DEVELOPMENT.md): day-to-day setup, scripts, workflow, and performance/testing expectations.
 - [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): playbook for creating or updating toy experiences, including audio, rendering, and debugging tips.
 - [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): map from each toy/visualizer to the JS/TS entry points it uses.
+- [`stim-assessment.md`](./stim-assessment.md): current findings and the remediation plan for the Stim Webtoys Library.
+- [`toys.md`](./toys.md): per-toy notes, presets, and other focused references.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains resources for contributors who are building or maintaining 
 - [`DEVELOPMENT.md`](./DEVELOPMENT.md): day-to-day setup, scripts, workflow, and performance/testing expectations.
 - [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): playbook for creating or updating toy experiences, including audio, rendering, and debugging tips.
 - [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): map from each toy/visualizer to the JS/TS entry points it uses.
-- [`stim-assessment.md`](./stim-assessment.md): current findings and the remediation plan for the Stim Webtoys Library.
+- [`stim-assessment.md`](./stim-assessment.md): Assessment findings and remediation plans.
 - [`toys.md`](./toys.md): per-toy notes, presets, and other focused references.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.


### PR DESCRIPTION
## Summary
- add entries for stim-assessment and toy note docs to the developer docs index
- update the main README developer-doc blurb to mention assessments and per-toy notes

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461228d61c8332ab3e1c2df9455715)