### PR TITLE
Add MCP agent workflow guidance

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -27,6 +27,9 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
 - **`dev_commands`**
   - **Input:** optional `scope` enum (`setup`, `dev`, `build`, `test`, `lint`) to narrow the result.
   - **Output:** `text` response containing the requested setup or workflow commands from `README.md`. Without a scope, the tool returns all development snippets.
+- **`agent_workflow`**
+  - **Input:** none.
+  - **Output:** `text` list of best practices for MCP-driven development in this repository, including when to use other tools and how to keep context fresh.
 
 ## Inputs, outputs, and client expectations
 

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -135,6 +135,28 @@ server.registerTool(
   },
 );
 
+server.registerTool(
+  'agent_workflow',
+  {
+    description:
+      'Surface best practices for MCP-driven development in this repo, including quick context and tool usage tips.',
+    inputSchema: z.object({}).strict(),
+  },
+  async () => {
+    const guidance = [
+      '- Run `bun run mcp` from the repository root so README and toy metadata are available to tools.',
+      '- Start with `list_docs` to pull quick-start, runtime, layout, and toy catalog context before making changes.',
+      '- Use `dev_commands` with scopes (setup, dev, build, test, lint) to copy-paste the exact commands for your workflow.',
+      '- Call `get_toys` with `slug` or `requiresWebGPU` when you need precise toy metadata for docs or debugging.',
+      '- Reach for `describe_loader` when investigating loader behavior, entry resolution, or WebGPU gating.',
+      '- Keep the repo synchronized with Bun installs and Vite artifacts (manifest) when testing loader paths.',
+      '- Use the MCP outputs as citations in PRs or reviews so changes reference specific README sections or toy data.',
+    ];
+
+    return asTextResponse(guidance.join('\n'));
+  },
+);
+
 const transport = new StdioServerTransport();
 await server.connect(transport);
 console.error('Stim Webtoys MCP server is running on stdio.');


### PR DESCRIPTION
## Summary
- add an `agent_workflow` MCP tool that outlines best practices for MCP-driven development
- document the new tool in the MCP server guide alongside existing utilities

## Testing
- npm test *(fails: control panel and settings panel tests currently failing in main)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694614d937ec833288989268f7dae634)