### PR TITLE
Fix iframe quality sync initialization

### DIFF
--- a/geom.html
+++ b/geom.html
@@ -76,12 +76,10 @@
           },
         });
 
-        const densityScale = Math.max(baseDensity, preset.particleScale ?? 1);
-        particleCount = Math.max(200, Math.round(baseParticleCount * densityScale));
-        rebuildParticles();
+      const densityScale = Math.max(baseDensity, preset.particleScale ?? 1);
+      particleCount = Math.max(200, Math.round(baseParticleCount * densityScale));
+      rebuildParticles();
       }
-
-      setupIframeQualitySync(applyQualityPreset);
 
       class CanvasToy {
         constructor(canvasEl) {
@@ -155,6 +153,8 @@
           particles.push(createParticle());
         }
       }
+
+      setupIframeQualitySync(applyQualityPreset);
 
       function animate(ctxAudio) {
         const frequencyData = getContextFrequencyData(ctxAudio);


### PR DESCRIPTION
## Summary
- defer iframe quality sync setup in the geometry toy until particle constants are available to avoid TDZ errors on load

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460d2de4a8833284cb1fbbc5278ca8)