### PR TITLE
Unify idle controls with settings panel (restore control panel DOM handle)

### DIFF
--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -153,7 +153,12 @@ class PersistentSettingsPanel {
       this.description = undefined;
     }
 
+    this.clearSections();
+  }
+
+  clearSections() {
     this.sectionHost.replaceChildren();
+    this.toggleCount = 0;
   }
 
   setQualityPresets(options: QualityOptions = {}) {
@@ -259,6 +264,10 @@ class PersistentSettingsPanel {
       defaultPresetId,
       storageKey: this.qualityStorageKey,
     });
+  }
+
+  getElement(): HTMLDivElement {
+    return this.container;
   }
 
   private handleQualityChange(presetId: string) {

--- a/assets/js/utils/control-panel.ts
+++ b/assets/js/utils/control-panel.ts
@@ -21,6 +21,8 @@ export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
 
   const listeners: ChangeHandler[] = [];
   const settingsPanel = getSettingsPanel();
+  const panel = settingsPanel.getElement();
+  settingsPanel.clearSections();
 
   settingsPanel.addToggle({
     label: 'Idle visuals',
@@ -65,5 +67,5 @@ export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
     return { ...state };
   }
 
-  return { getState, onChange };
+  return { panel, getState, onChange };
 }


### PR DESCRIPTION
## Summary
- add toggle support to the persistent settings panel and inline actions styling
- build idle/palette/mobile toggles through the shared settings panel helper
- move the 3D toy’s idle controls into the unified floating panel alongside quality presets
- expose the control panel DOM handle and clear sections before rebuilding toggles for repeated setups

## Testing
- bun test tests/control-panel.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460d2d5a9c8332a1c7561d3c0bbd53)