### PR TITLE
Fix control panel state reset and lighting dependency injection

### DIFF
--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -59,6 +59,7 @@ export const QUALITY_STORAGE_KEY = 'stims:quality-preset';
 
 const qualitySubscribers = new Set<QualitySubscriber>();
 let activeQualityPreset: QualityPreset | null = null;
+let activeQualityPresetStorageKey: string | null = null;
 
 function getStorage(): Storage | null {
   try {
@@ -92,12 +93,13 @@ export function getActiveQualityPreset({
   defaultPresetId = 'balanced',
   storageKey = QUALITY_STORAGE_KEY,
 }: StoredPresetOptions = {}): QualityPreset {
-  if (activeQualityPreset) {
+  if (activeQualityPreset && activeQualityPresetStorageKey === storageKey) {
     const match = presets.find((preset) => preset.id === activeQualityPreset?.id);
     if (match) return match;
   }
 
   activeQualityPreset = getStoredQualityPreset({ presets, defaultPresetId, storageKey });
+  activeQualityPresetStorageKey = storageKey;
   return activeQualityPreset;
 }
 
@@ -135,6 +137,10 @@ class PersistentSettingsPanel {
     this.container.appendChild(this.sectionHost);
 
     document.body.appendChild(this.container);
+  }
+
+  getElement() {
+    return this.container;
   }
 
   configure(config: PanelConfig = {}) {
@@ -267,6 +273,7 @@ class PersistentSettingsPanel {
 
     getStorage()?.setItem(this.qualityStorageKey, preset.id);
     activeQualityPreset = preset;
+    activeQualityPresetStorageKey = this.qualityStorageKey;
     qualitySubscribers.forEach((subscriber) => subscriber(preset));
     this.qualityChangeHandler?.(preset);
   }

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -71,10 +71,10 @@ export default class WebToy {
       });
 
     if (ambientLightOptions) {
-      initAmbientLight(this.scene, ambientLightOptions);
+      initAmbientLight(this.scene, ambientLightOptions, THREE);
     }
     if (lightingOptions) {
-      initLighting(this.scene, lightingOptions);
+      initLighting(this.scene, lightingOptions, THREE);
     }
 
     this.analyser = null;

--- a/assets/js/lighting/lighting-setup.ts
+++ b/assets/js/lighting/lighting-setup.ts
@@ -1,8 +1,7 @@
-import {
+import type {
   AmbientLight,
   DirectionalLight,
   HemisphereLight,
-  Light,
   PointLight,
   Scene,
   SpotLight,
@@ -21,16 +20,22 @@ export interface AmbientLightConfig {
   intensity?: number;
 }
 
-// Initialize a point light with configurable options
-type ThreeLighting = {
+type LightingModule = {
   DirectionalLight: typeof DirectionalLight;
   SpotLight: typeof SpotLight;
   HemisphereLight: typeof HemisphereLight;
   PointLight: typeof PointLight;
 };
 
+type AmbientLightingModule = {
+  AmbientLight: typeof AmbientLight;
+};
+
+type SceneLike = Pick<Scene, 'add'>;
+type LightingInstance = InstanceType<LightingModule[keyof LightingModule]>;
+
 export function initLighting(
-  scene: Scene,
+  scene: SceneLike,
   config: LightConfig = {
     type: 'PointLight',
     color: 0xffffff,
@@ -38,12 +43,7 @@ export function initLighting(
     position: { x: 10, y: 10, z: 10 },
     castShadow: false,
   },
-  lighting: ThreeLighting = {
-    DirectionalLight,
-    SpotLight,
-    HemisphereLight,
-    PointLight,
-  }
+  lighting: LightingModule
 ): void {
   const {
     type = 'PointLight',
@@ -54,7 +54,7 @@ export function initLighting(
   } = config ?? {};
 
   const { x, y, z } = { x: 10, y: 10, z: 10, ...(position ?? {}) };
-  let light: Light;
+  let light: LightingInstance;
 
   switch (type) {
     case 'DirectionalLight':
@@ -87,9 +87,10 @@ export function initLighting(
 }
 
 export function initAmbientLight(
-  scene: Scene,
-  config: AmbientLightConfig = { color: 0x404040, intensity: 0.5 }
+  scene: SceneLike,
+  config: AmbientLightConfig = { color: 0x404040, intensity: 0.5 },
+  lighting: AmbientLightingModule
 ): void {
-  const ambientLight = new AmbientLight(config.color, config.intensity);
+  const ambientLight = new lighting.AmbientLight(config.color, config.intensity);
   scene.add(ambientLight);
 }

--- a/assets/js/utils/control-panel.ts
+++ b/assets/js/utils/control-panel.ts
@@ -21,6 +21,11 @@ export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
 
   const listeners: ChangeHandler[] = [];
   const settingsPanel = getSettingsPanel();
+  const panel = settingsPanel.getElement();
+
+  settingsPanel.configure({
+    title: 'Toy settings',
+  });
 
   settingsPanel.addToggle({
     label: 'Idle visuals',
@@ -65,5 +70,5 @@ export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
     return { ...state };
   }
 
-  return { getState, onChange };
+  return { panel, getState, onChange };
 }


### PR DESCRIPTION
## Summary
- expose the settings panel element for control panel callers and reset toggles on creation to match expected defaults
- scope quality preset memoization to the active storage key so cached presets stay aligned with their source
- inject lighting/ambient light dependencies from callers to avoid runtime imports and make lighting setup testable with stubs

## Testing
- bun test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946277d41348332a154522420669067)