### PR TITLE
Expand MCP server metadata and docs tooling

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -20,7 +20,10 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
   - **Output:** `text` response with quick-start pointers, runtime notes, repository layout, and toy catalog references pulled from `README.md` with line ranges.
 - **`get_toys`**
   - **Input:** optional `slug` (string) to fetch a single toy and optional `requiresWebGPU` (boolean) to filter by WebGPU requirements.
-  - **Output:** `json` array of `{ slug, title, description, requiresWebGPU, url }` entries. Returns a helpful text message when no toys match the filters.
+  - **Output:** `json` array of `{ slug, title, description, requiresWebGPU, controls, module, type, allowWebGLFallback, url }` entries. Returns a helpful text message when no toys match the filters. Optional fields default to sensible fallbacks when missing from `assets/js/toys-data.js`.
+- **`read_doc_section`**
+  - **Input:** required `file` enum (e.g., `README.md`, `docs/MCP_SERVER.md`) and optional `heading` string.
+  - **Output:** `text` response containing the full markdown file when no heading is provided, or the matching section beginning at the requested heading. Returns a friendly error when the file or heading cannot be found.
 - **`describe_loader`**
   - **Input:** none.
   - **Output:** `text` summary of how the toy loader resolves entries and errors, including manifest resolution (`/.vite/manifest.json`), URL/history handling, WebGPU gating, and the recovery states shown when imports fail.

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { getDocSectionContent, normalizeToys } from '../scripts/mcp-server.ts';
+
+describe('normalizeToys', () => {
+  test('preserves optional metadata fields when provided', () => {
+    const [toy] = normalizeToys([
+      {
+        slug: 'example',
+        description: 'example toy',
+        requiresWebGPU: true,
+        module: 'assets/example.ts',
+        type: 'module',
+        allowWebGLFallback: true,
+        controls: ['alpha', 'beta', 1],
+      },
+    ]);
+
+    expect(toy).toBeDefined();
+    expect(toy?.module).toBe('assets/example.ts');
+    expect(toy?.type).toBe('module');
+    expect(toy?.allowWebGLFallback).toBe(true);
+    expect(toy?.controls).toEqual(['alpha', 'beta']);
+  });
+
+  test('defaults optional metadata when fields are missing', () => {
+    const [toy] = normalizeToys([{ slug: 'fallback' }]);
+
+    expect(toy).toBeDefined();
+    expect(toy?.title).toBe('fallback');
+    expect(toy?.description).toBe('');
+    expect(toy?.requiresWebGPU).toBe(false);
+    expect(toy?.controls).toEqual([]);
+    expect(toy?.module).toBeNull();
+    expect(toy?.type).toBeNull();
+    expect(toy?.allowWebGLFallback).toBe(false);
+    expect(toy?.url).toContain('toy=fallback');
+  });
+});
+
+describe('getDocSectionContent', () => {
+  test('returns a specific heading section when present', async () => {
+    const result = await getDocSectionContent('docs/MCP_SERVER.md', 'Registered tools');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.content).toContain('Registered tools');
+      expect(result.content).toContain('list_docs');
+    }
+  });
+
+  test('returns a friendly error when a heading is missing', async () => {
+    const result = await getDocSectionContent('docs/MCP_SERVER.md', 'This heading does not exist');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('was not found');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- include controls, module path, type, and WebGL fallback flags in get_toys responses via normalized metadata
- add read_doc_section tool to return full markdown files or specific headings across repo docs
- document the new tool and cover toy metadata normalization and doc section lookups with tests

## Testing
- bun test tests/mcp-server.test.ts --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694627f221888332bd5b93a922644c21)