### PR TITLE
Add GitHub status widget with resilient caching

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -433,6 +433,77 @@ h1 {
   transform-style: preserve-3d;
 }
 
+.repo-status {
+  margin: 1.25rem 0 0.25rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, rgba(109, 240, 255, 0.12), rgba(155, 123, 255, 0.08));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.repo-status__header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.repo-status__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.repo-status__description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.repo-status__repo-name {
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.repo-status__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+}
+
+.repo-status__metric {
+  list-style: none;
+  padding: 0.85rem 0.95rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+
+.repo-status__metric dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.repo-status__metric dd {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.repo-status__message {
+  margin: 0.1rem 0 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
 .webtoy-card:hover .toy-icon {
   transform: translateY(-3px) rotateX(6deg) rotateY(-6deg) scale(1.04);
   filter: drop-shadow(0 0 16px rgba(76, 238, 167, 0.45))

--- a/assets/js/repo-status.js
+++ b/assets/js/repo-status.js
@@ -1,5 +1,6 @@
 const API_URL = 'https://api.github.com/repos/zz-plant/stims';
 const CACHE_KEY = 'repo-status:zz-plant/stims';
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 const formatCount = (count) =>
   typeof count === 'number' ? new Intl.NumberFormat('en-US').format(count) : '—';
@@ -15,19 +16,34 @@ const readCache = () => {
   try {
     const cached = sessionStorage.getItem(CACHE_KEY);
     if (!cached) return null;
-    return JSON.parse(cached);
+    const parsed = JSON.parse(cached);
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const { payload, etag, timestamp } = parsed;
+    if (!payload || typeof timestamp !== 'number') return null;
+
+    return { payload, etag, timestamp };
   } catch (error) {
     return null;
   }
 };
 
-const writeCache = (data) => {
+const writeCache = (payload, etag) => {
   try {
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify(data));
+    sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        payload,
+        etag: etag ?? null,
+        timestamp: Date.now(),
+      }),
+    );
   } catch (error) {
     // Ignore cache write errors
   }
 };
+
+const isCacheFresh = (entry) => !entry || Date.now() - entry.timestamp < CACHE_TTL_MS;
 
 const updateMetrics = (container, data) => {
   const starTarget = container.querySelector('[data-star-count]');
@@ -46,21 +62,51 @@ const showFallback = (container, message) => {
   const fallback = container.querySelector('[data-status-fallback]');
   if (!fallback) return;
   fallback.textContent = message;
-  fallback.hidden = false;
+  fallback.hidden = !message;
 };
 
-const fetchRepoStatus = async () => {
-  const response = await fetch(API_URL, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-    },
-  });
+const fetchRepoStatus = async (etag) => {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+  };
 
-  if (!response.ok) {
-    throw new Error('GitHub API request failed');
+  if (etag) {
+    headers['If-None-Match'] = etag;
   }
 
-  return response.json();
+  const response = await fetch(API_URL, {
+    headers,
+  });
+
+  if (response.status === 304) {
+    return { status: 'not_modified' };
+  }
+
+  if (response.status === 403 && response.headers.get('X-RateLimit-Remaining') === '0') {
+    const resetHeader = response.headers.get('X-RateLimit-Reset');
+    const resetTimestamp = Number.parseInt(resetHeader ?? '', 10);
+    const resetAt = Number.isFinite(resetTimestamp) ? new Date(resetTimestamp * 1000) : null;
+    const error = new Error('GitHub rate limit exceeded');
+    error.code = 'rate_limit';
+    error.resetAt = resetAt;
+    throw error;
+  }
+
+  if (!response.ok) {
+    const error = new Error('GitHub API request failed');
+    error.code = 'http_error';
+    error.status = response.status;
+    throw error;
+  }
+
+  const etagHeader = response.headers.get('ETag');
+  const data = await response.json();
+
+  return {
+    status: 'ok',
+    data,
+    etag: etagHeader ?? etag ?? null,
+  };
 };
 
 export const initRepoStatusWidget = async () => {
@@ -68,16 +114,55 @@ export const initRepoStatusWidget = async () => {
   if (!container) return;
 
   const cached = readCache();
+  const cacheIsFresh = isCacheFresh(cached);
+
   if (cached) {
-    updateMetrics(container, cached);
+    updateMetrics(container, cached.payload);
+    if (!cacheIsFresh) {
+      showFallback(container, 'Showing cached GitHub stats while we refresh…');
+    } else {
+      showFallback(container, '');
+    }
+  } else {
+    showFallback(container, 'Loading GitHub stats…');
+  }
+
+  if (cacheIsFresh && cached) {
     return;
   }
 
   try {
-    const data = await fetchRepoStatus();
-    updateMetrics(container, data);
-    writeCache(data);
+    const result = await fetchRepoStatus(cached?.etag);
+
+    if (result.status === 'not_modified' && cached) {
+      writeCache(cached.payload, cached.etag);
+      showFallback(container, '');
+      return;
+    }
+
+    if (result.status === 'ok') {
+      updateMetrics(container, result.data);
+      writeCache(result.data, result.etag);
+      showFallback(container, '');
+    }
   } catch (error) {
+    if (error?.code === 'rate_limit') {
+      const resetMessage = error.resetAt ? `Retry after ${formatDate(error.resetAt.toISOString())}.` : 'Please try again later.';
+      showFallback(container, `GitHub rate limit reached. ${cached ? 'Showing cached stats for now.' : 'Live metrics are paused.'} ${resetMessage}`);
+      return;
+    }
+
+    if (cached) {
+      showFallback(
+        container,
+        `Connection hiccup. Showing cached GitHub stats from ${formatDate(
+          new Date(cached.timestamp).toISOString(),
+        )}.`,
+      );
+      return;
+    }
+
+    updateMetrics(container, null);
     showFallback(container, 'GitHub status is taking a break. Try again later.');
   }
 };

--- a/index.html
+++ b/index.html
@@ -73,6 +73,29 @@
               <p class="cta-helper">
               No installs or accounts. Code and contribution notes live on GitHub.
             </p>
+            <div class="repo-status" data-repo-status aria-live="polite">
+              <div class="repo-status__header">
+                <p class="eyebrow">Project health</p>
+                <p class="repo-status__title">GitHub status</p>
+                <p class="repo-status__description">
+                  Latest stats for <span class="repo-status__repo-name">zz-plant/stims</span>
+                  with live stars and recent activity.
+                </p>
+              </div>
+              <dl class="repo-status__metrics">
+                <div class="repo-status__metric">
+                  <dt>Stars</dt>
+                  <dd data-star-count aria-label="Stargazers">—</dd>
+                </div>
+                <div class="repo-status__metric">
+                  <dt>Last push</dt>
+                  <dd data-last-commit aria-label="Last commit date">—</dd>
+                </div>
+              </dl>
+              <p class="repo-status__message" data-status-fallback hidden role="status" aria-live="polite">
+                Loading GitHub stats…
+              </p>
+            </div>
             <ul class="hero-highlights">
               <li><span aria-hidden="true">🪩</span> Audio-reactive scenes and tactile controls.</li>
               <li><span aria-hidden="true">⚡</span> Zero-install links that open instantly.</li>


### PR DESCRIPTION
## Summary
- add a GitHub status card to the landing hero with star and last push metrics plus accessible fallback copy
- style the status widget for both light and dark themes to match the existing layout
- refresh the repo status script with TTL-based caching, ETag reuse, and clearer fallback handling for rate limits or offline sessions

## Testing
- Not run (CI will run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462a45723c8332a3e76786e7db184b)