### PR TITLE
Add standalone typecheck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ All JavaScript dependencies are installed via npm (or Bun) and bundled locally w
 - `bun run test:watch`: Keep the Bun test runner active while you iterate on specs.
 - `bun run lint`: Check code quality with ESLint. (`npm run lint` is an optional fallback.)
 - `bun run format`: Format files with Prettier. (`npm run format` is an optional fallback.)
+- `bun run typecheck`: Run TypeScript’s type checker without emitting files. (`npm run typecheck` is an optional fallback.)
 - `bun run scripts/scaffold-toy.ts`: Interactive (or flag-driven) scaffolder that prompts for a slug/title/type, creates a starter module from [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), appends metadata to `assets/js/toys-data.js`, updates `docs/TOY_SCRIPT_INDEX.md`, and can optionally drop a minimal Bun spec. Pass flags such as `--slug ripple-orb --title "Ripple Orb" --type module --with-test` for non-interactive runs.
 - `bun run serve:dist`: Serve the `dist/` build with Bun (preferred for local production previews).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,6 +28,7 @@ This guide focuses on day-to-day development tasks for the Stim Webtoys Library.
 | Run test suite | `bun test` (`npm run test` proxies to Bun) |
 | Lint | `bun run lint` (`npm run lint`) |
 | Format with Prettier | `bun run format` (`npm run format`) |
+| Type check without emit | `bun run typecheck` (`npm run typecheck`) |
 
 When debugging a single test file, run:
 ```bash
@@ -86,4 +87,3 @@ bun test tests/filename.test.js
 - `bun run build` completes without errors. (`npm run build` is available if you’re on Node.)
 - Verify the generated `dist/` assets load via `bun run preview` or a simple static server. (`npm run preview` remains a fallback.)
 - Spot-check microphone prompts and toy selection flows in the production build.
-

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:watch": "bun test --watch --preload=./tests/setup.ts --importmap=./tests/importmap.json",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
     "dev": "vite",
     "build": "vite build",
     "serve:dist": "bun run scripts/serve-dist.ts",


### PR DESCRIPTION
## Summary
- add a dedicated `typecheck` npm script that runs `tsc --noEmit`
- document the typecheck command alongside other developer scripts in README and docs/DEVELOPMENT

## Testing
- Not run (not requested)

## Checklist
- [ ] Linting (`npm run lint`) if applicable
- [ ] Tests (`npm test`) if applicable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462ac24960833289dacb27ce601ab2)