### PR TITLE
Document test script requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ If you’re using Node as a fallback, run `npm run dev` instead.
 
 - Run all tests:
   ```bash
-  bun test
+  bun run test
   ```
-  (`npm run test` proxies to Bun when available.)
+  Always invoke the script so the pinned `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags apply, loading happy-dom globals and a Three.js stub needed for headless specs. (`npm test` proxies to the same script when available.)
 - Run the Bun test runner with filters (for example, targeting specific files):
   ```bash
   bun test tests/path/to/spec.test.js

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ All JavaScript dependencies are installed via npm (or Bun) and bundled locally w
 - `bun run dev`: Start the Vite development server for local exploration. (`npm run dev` works if you’re on Node.)
 - `bun run build`: Produce a production build in `dist/`. (`npm run build` is available as a fallback.)
 - `bun run preview`: Serve the production build locally (Vite preview with `--host` for LAN testing) to validate the output before deploying. (`npm run preview` is the Node fallback.)
-- `bun test` (or `bun run test`): Run the Bun-native test suite. `npm run test` will proxy to Bun when available.
+- `bun run test`: Run the Bun-native test suite with the required `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags applied. These load happy-dom globals and a Three.js stub so specs run headlessly. `npm test` proxies to the same script when you’re on Node.
 - `bun run test:watch`: Keep the Bun test runner active while you iterate on specs.
 - `bun run lint`: Check code quality with ESLint. (`npm run lint` is an optional fallback.)
 - `bun run format`: Format files with Prettier. (`npm run format` is an optional fallback.)
@@ -183,12 +183,12 @@ dependencies and run the tests:
 
    (`npm install` is available if you’re using Node.)
 
-2. Run the tests:
+2. Run the tests (via the script so required flags are applied):
    ```bash
-   bun test
+   bun run test
    ```
 
-   (`npm run test` proxies to Bun when present.)
+   This script pins `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` to load happy-dom globals and a Three.js stub for headless execution. Use `npm test` as the Node equivalent.
 
 For quick iteration, use the watch mode:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,7 @@ This guide focuses on day-to-day development tasks for the Stim Webtoys Library.
 | Start dev server | `bun run dev` (`npm run dev`) |
 | Production build | `bun run build` (`npm run build`) |
 | Preview build locally | `bun run preview` (`npm run preview`) |
-| Run test suite | `bun test` (`npm run test` proxies to Bun) |
+| Run test suite | `bun run test` (`npm test` proxies to Bun) |
 | Lint | `bun run lint` (`npm run lint`) |
 | Format with Prettier | `bun run format` (`npm run format`) |
 
@@ -33,6 +33,8 @@ When debugging a single test file, run:
 ```bash
 bun test tests/filename.test.js
 ```
+
+Use the `bun run test` (or `npm test`) script instead of raw `bun test` so the `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags are always applied; they load happy-dom globals and a Three.js stub to keep specs headless and fast.
 
 ## Project Structure
 
@@ -86,4 +88,3 @@ bun test tests/filename.test.js
 - `bun run build` completes without errors. (`npm run build` is available if you’re on Node.)
 - Verify the generated `dist/` assets load via `bun run preview` or a simple static server. (`npm run preview` remains a fallback.)
 - Spot-check microphone prompts and toy selection flows in the production build.
-


### PR DESCRIPTION
## Summary
- direct contributors to run `bun run test`/`npm test` so the scripted preload and import map always apply
- explain the need for the happy-dom globals and Three.js stub when running the suite headlessly in the docs/README/contributing guides

## Testing
- bun run test *(fails: settings-panel quality preset expectations currently broken in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462ab07a688332868ede7c1e99f804)