### PR TITLE
Add VS Code workspace tooling configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 node_modules/
 
 # Editor directories
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # Logs
 npm-debug.log*
@@ -14,4 +18,3 @@ yarn-error.log*
 
 # Build directories
 /dist/
-

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "typescript-eslint.typescript-eslint-language-service"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Vite Dev Server",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}",
+      "preLaunchTask": "bun:dev",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Bun Tests",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["test", "--inspect-brk"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "bun:dev",
+      "type": "shell",
+      "command": "bun run dev",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "fileLocation": "absolute",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "vite v",
+          "endsPattern": "ready in"
+        }
+      }
+    },
+    {
+      "label": "bun:test",
+      "type": "shell",
+      "command": "bun test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,6 +34,12 @@ When debugging a single test file, run:
 bun test tests/filename.test.js
 ```
 
+### Editor Tooling
+
+- VS Code users can install recommended extensions via `.vscode/extensions.json` (Prettier, ESLint, and the TypeScript ESLint language service).
+- `.vscode/settings.json` configures Prettier as the default formatter and enables format-on-save for common web languages.
+- `.vscode/launch.json` includes a Vite dev-server debug config (with a Bun-backed prelaunch task) and a Bun test debug config so you can attach the debugger without additional setup.
+
 ## Project Structure
 
 - `assets/js/toys/`: Individual toy implementations. Each module exports a `start` function that receives a DOM canvas/audio context.
@@ -86,4 +92,3 @@ bun test tests/filename.test.js
 - `bun run build` completes without errors. (`npm run build` is available if you’re on Node.)
 - Verify the generated `dist/` assets load via `bun run preview` or a simple static server. (`npm run preview` remains a fallback.)
 - Spot-check microphone prompts and toy selection flows in the production build.
-


### PR DESCRIPTION
## Summary
- add VS Code extension recommendations to mirror Prettier, ESLint, and TypeScript ESLint tooling
- configure workspace defaults for Prettier formatting plus debug launch configs and tasks for Vite dev server and Bun tests
- allow tracking workspace helpers in gitignore and document the VS Code setup in the development guide

## Testing
- git commit (husky ran eslint . and prettier --write .)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462ac919ec8332a69af49b3a01830a)