### PR TITLE
Optimize audio frequency buffer handling

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -42,6 +42,8 @@ export async function startAudioLoop(
 /**
  * Get frequency data from the animation context, with fallback to empty array.
  */
+const EMPTY_FREQUENCY_DATA = new Uint8Array(0);
+
 export function getContextFrequencyData(ctx: AnimationContext): Uint8Array {
-  return ctx.analyser ? getFrequencyData(ctx.analyser) : new Uint8Array(0);
+  return ctx.analyser ? getFrequencyData(ctx.analyser) : EMPTY_FREQUENCY_DATA;
 }


### PR DESCRIPTION
## Summary
- reuse the FrequencyAnalyser buffer when receiving worklet frequency updates to reduce allocations
- avoid creating new empty arrays when frequency data is unavailable
- add coverage to ensure the worklet path reuses its buffer and retains RMS updates

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462b8d52988332ad818034a6c4045b)