### PR TITLE
Fix Pages wrangler config validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,11 @@ Cloudflare Pages can build this project with Bun using the `wrangler.toml` in th
 
 - Project name: `stims` (top-level `name` in `wrangler.toml`)
 - Build output directory: `dist/` (set via `pages_build_output_dir` in `wrangler.toml`)
-- Build command: `bun run build` (set in the Pages UI under **Settings → Builds & deployments → Build command**; Pages ignores a `[build]` table in `wrangler.toml`)
+- Build command: `bun run build` (set in the Pages UI under **Settings → Builds & deployments → Build command**; Pages rejects a `[build]` table in `wrangler.toml`)
 - Set the `BUN_VERSION` environment variable (for example, `BUN_VERSION=1.2.14`) in your Pages project so the hosted runtime matches local installs.
 - Enable Pages’ **Bun runtime** so the build runs under Bun instead of Node.
 - The `compatibility_date` in `wrangler.toml` keeps Pages aligned with the Cloudflare Workers API version.
+- Do not add a `[pages]` table in `wrangler.toml`; Cloudflare Pages expects project linkage to be configured in the dashboard.
 
 To verify the preview locally, run `bun run build` and inspect the generated `dist/` folder; it matches the assets Pages will serve when the Bun runtime is enabled and the build output directory is `dist/`.
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,9 +1,3 @@
 name = "stims"
 compatibility_date = "2024-10-20"
 pages_build_output_dir = "dist"
-
-[build]
-command = "bun run build"
-
-[pages]
-project_name = "stims"


### PR DESCRIPTION
## Summary
- remove unsupported `build` and `pages` tables from `wrangler.toml` so Cloudflare Pages validation succeeds
- clarify README guidance that Pages rejects `[build]`/`[pages]` tables and the build command must be configured in the dashboard

## Testing
- not run (config/docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462dc5816083329c3a4327428cf379)