### PR TITLE
Handle remote manifest base URLs

### DIFF
--- a/tests/manifest-client.test.js
+++ b/tests/manifest-client.test.js
@@ -1,8 +1,12 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createManifestClient } from '../assets/js/utils/manifest-client.ts';
 
 describe('manifest client', () => {
   const moduleEntry = 'assets/js/toys/example.ts';
+
+  beforeEach(() => {
+    window.location.href = 'http://example.com/';
+  });
 
   afterEach(() => {
     mock.restore();
@@ -48,5 +52,42 @@ describe('manifest client', () => {
     await client.resolveModulePath(moduleEntry);
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('fetches manifest and modules from remote base origin', async () => {
+    window.location.href = 'http://localhost/';
+
+    const manifest = {
+      [moduleEntry]: { file: 'assets/js/toys/example.123.js' },
+    };
+
+    const fetchImpl = mock(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(manifest) })
+    );
+
+    const client = createManifestClient({
+      fetchImpl,
+      baseUrl: 'https://cdn.example.com/app/',
+    });
+
+    const modulePath = await client.resolveModulePath(moduleEntry);
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://cdn.example.com/app/manifest.json');
+    expect(modulePath).toBe('https://cdn.example.com/app/assets/js/toys/example.123.js');
+  });
+
+  test('falls back to remote base for missing manifest entry', async () => {
+    window.location.href = 'http://localhost/';
+
+    const fetchImpl = mock(() => Promise.resolve({ ok: false }));
+
+    const client = createManifestClient({
+      fetchImpl,
+      baseUrl: 'https://cdn.example.com/app/',
+    });
+
+    const modulePath = await client.resolveModulePath(moduleEntry);
+
+    expect(modulePath).toBe('https://cdn.example.com/app/assets/js/toys/example.ts');
   });
 });


### PR DESCRIPTION
## Summary
- ensure manifest path resolution emits absolute URLs when the configured base uses a different origin
- update module resolution and manifest fetch paths to honor remote bases while keeping same-origin relative paths
- add tests covering remote base URL fetch and fallback behaviors

## Testing
- bun run test tests/manifest-client.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946625ec830833299ca5c49e3a9f928)