### PR TITLE
Retry manifest fetch when cached result is null

### DIFF
--- a/assets/js/utils/manifest-client.ts
+++ b/assets/js/utils/manifest-client.ts
@@ -114,13 +114,18 @@ export function createManifestClient({
       })();
     }
 
-    const manifest = await manifestPromise;
+    try {
+      const manifest = await manifestPromise;
 
-    if (manifest === null) {
+      if (manifest === null) {
+        manifestPromise = null;
+      }
+
+      return manifest;
+    } catch (error) {
       manifestPromise = null;
+      throw error;
     }
-
-    return manifest;
   };
 
   const resolveModulePath = async (entry: string) => {


### PR DESCRIPTION
## Summary
- reset the cached manifest promise when a fetch resolves to null and track the base URL to avoid stale cache usage
- guard fallback resolution against invalid base URLs while preserving existing behavior
- add coverage to confirm a null manifest triggers a refetch and subsequent success uses the manifest entry

## Testing
- bun test tests/manifest-client.test.js

## Checklist
- [ ] Linting (`npm run lint`) if applicable
- [x] Tests (`npm test`) if applicable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694663763538833283467c51c8505cac)