### PR TITLE
Add toy runtime state machine and event-driven views

### DIFF
--- a/assets/js/core/toy-runtime.ts
+++ b/assets/js/core/toy-runtime.ts
@@ -1,0 +1,167 @@
+type RuntimeState = 'idle' | 'loading' | 'active' | 'error';
+
+type Toy = {
+  slug: string;
+  title?: string;
+};
+
+type ActiveToyCandidate = { dispose?: () => void } | (() => void);
+
+type RuntimeError =
+  | { type: 'capability'; toy?: Toy; options?: Record<string, unknown> }
+  | { type: 'import'; toy?: Toy; options?: Record<string, unknown> };
+
+type LoadingEvent = { toy?: Toy; onBack?: () => void };
+type ActiveEvent = { toy?: Toy; activeRef?: ActiveToyCandidate | null; container?: HTMLElement | null };
+type ErrorEvent = { toy?: Toy; error: RuntimeError };
+type DisposedEvent = { reason: 'swap' | 'library' | 'error'; toy?: Toy };
+
+type ListenerPayloads = {
+  onLoading: LoadingEvent;
+  onActive: ActiveEvent;
+  onError: ErrorEvent;
+  onDisposed: DisposedEvent;
+};
+
+type ListenerMap = {
+  [K in keyof ListenerPayloads]: Set<(event: ListenerPayloads[K]) => void>;
+};
+
+type ToyRuntime = {
+  getState: () => RuntimeState;
+  getActiveToy: () => ActiveToyCandidate | null;
+  getContainer: () => HTMLElement | null;
+  setContainer: (container: HTMLElement | null) => void;
+  startLoading: (event: LoadingEvent) => void;
+  setActiveToy: (candidate: unknown) => ActiveToyCandidate | null;
+  setError: (error: RuntimeError) => void;
+  dispose: (event?: { reason?: DisposedEvent['reason'] }) => void;
+  onLoading: (listener: (event: LoadingEvent) => void) => () => void;
+  onActive: (listener: (event: ActiveEvent) => void) => () => void;
+  onError: (listener: (event: ErrorEvent) => void) => () => void;
+  onDisposed: (listener: (event: DisposedEvent) => void) => () => void;
+};
+
+const globalKey = '__activeWebToy';
+
+const normalizeActiveToy = (
+  candidate: unknown
+): { ref: ActiveToyCandidate; dispose?: () => void } | null => {
+  if (!candidate) return null;
+
+  if (typeof candidate === 'function') {
+    return { ref: candidate, dispose: candidate };
+  }
+
+  if (typeof candidate === 'object') {
+    const dispose = (candidate as { dispose?: unknown }).dispose;
+    return {
+      ref: candidate as ActiveToyCandidate,
+      dispose: typeof dispose === 'function' ? dispose.bind(candidate) : undefined,
+    };
+  }
+
+  return null;
+};
+
+const setGlobalActiveToy = (candidate: ActiveToyCandidate | null) => {
+  if (candidate) {
+    (globalThis as Record<string, unknown>)[globalKey] = candidate;
+  } else {
+    delete (globalThis as Record<string, unknown>)[globalKey];
+  }
+};
+
+export function createToyRuntime(): ToyRuntime {
+  let state: RuntimeState = 'idle';
+  let activeToy: { ref: ActiveToyCandidate; dispose?: () => void } | null = null;
+  let container: HTMLElement | null = null;
+  let currentToy: Toy | undefined;
+  const listeners: ListenerMap = {
+    onLoading: new Set(),
+    onActive: new Set(),
+    onError: new Set(),
+    onDisposed: new Set(),
+  };
+
+  const emit = <K extends keyof ListenerMap>(event: K, payload: ListenerPayloads[K]) => {
+    listeners[event].forEach((listener) => listener(payload as never));
+  };
+
+  const getGlobalActiveToy = () =>
+    (globalThis as typeof globalThis & { __activeWebToy?: ActiveToyCandidate }).__activeWebToy;
+
+  const setActiveToy = (candidate: unknown) => {
+    const normalized = normalizeActiveToy(candidate ?? getGlobalActiveToy());
+    activeToy = normalized;
+    setGlobalActiveToy(normalized?.ref ?? null);
+    return normalized?.ref ?? null;
+  };
+
+  const startLoading = (event: LoadingEvent) => {
+    currentToy = event.toy ?? currentToy;
+    container = null;
+    state = 'loading';
+    emit('onLoading', { toy: currentToy, onBack: event.onBack });
+  };
+
+  const setError = (error: RuntimeError) => {
+    state = 'error';
+    emit('onError', { toy: currentToy, error });
+  };
+
+  const setContainer = (next: HTMLElement | null) => {
+    container = next;
+  };
+
+  const dispose = (event: { reason?: DisposedEvent['reason'] } = {}) => {
+    const reason = event.reason ?? 'library';
+    const current = activeToy ?? normalizeActiveToy(getGlobalActiveToy());
+
+    if (current?.dispose) {
+      try {
+        current.dispose();
+      } catch (error) {
+        console.error('Error disposing active toy', error);
+      }
+    }
+
+    activeToy = null;
+    setGlobalActiveToy(null);
+    const previousToy = currentToy;
+    currentToy = undefined;
+    container = null;
+
+    if (state !== 'idle') {
+      state = 'idle';
+      emit('onDisposed', { reason, toy: previousToy });
+    }
+  };
+
+  const setActive = (candidate: unknown) => {
+    const normalized = setActiveToy(candidate);
+    state = 'active';
+    emit('onActive', { toy: currentToy, activeRef: normalized, container });
+    return normalized;
+  };
+
+  const addListener = <K extends keyof ListenerMap>(event: K, listener: (event: ListenerPayloads[K]) => void) => {
+    listeners[event].add(listener as never);
+    return () => listeners[event].delete(listener as never);
+  };
+
+  return {
+    getState: () => state,
+    getActiveToy: () => activeToy?.ref ?? null,
+    getContainer: () => container,
+    setContainer,
+    startLoading,
+    setActiveToy: setActive,
+    setError,
+    dispose,
+    onLoading: (listener) => addListener('onLoading', listener),
+    onActive: (listener) => addListener('onActive', listener),
+    onError: (listener) => addListener('onError', listener),
+    onDisposed: (listener) => addListener('onDisposed', listener),
+  };
+}

--- a/tests/toy-runtime.test.ts
+++ b/tests/toy-runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { createToyRuntime } from '../assets/js/core/toy-runtime.ts';
+
+describe('toy runtime state machine', () => {
+  test('emits navigation events when switching toys', () => {
+    const runtime = createToyRuntime();
+    const states: string[] = [];
+
+    runtime.onLoading(({ toy }) => states.push(`loading:${toy?.slug}`));
+    runtime.onActive(({ toy }) => states.push(`active:${toy?.slug}`));
+    runtime.onDisposed(({ reason, toy }) => states.push(`disposed:${reason}:${toy?.slug ?? ''}`));
+
+    runtime.startLoading({ toy: { slug: 'alpha' } });
+    runtime.setActiveToy(() => {});
+    runtime.dispose({ reason: 'swap' });
+    runtime.startLoading({ toy: { slug: 'beta' } });
+
+    expect(states).toEqual(['loading:alpha', 'active:alpha', 'disposed:swap:alpha', 'loading:beta']);
+  });
+
+  test('guards against double dispose', () => {
+    const runtime = createToyRuntime();
+    const disposeFn = mock();
+
+    runtime.setActiveToy({ dispose: disposeFn });
+    runtime.dispose();
+    runtime.dispose();
+
+    expect(disposeFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('recovers from errors with a new loading cycle', () => {
+    const runtime = createToyRuntime();
+    const events: string[] = [];
+
+    runtime.onError(({ error }) => events.push(`error:${error.type}`));
+    runtime.onActive(({ toy }) => events.push(`active:${toy?.slug}`));
+    runtime.onLoading(({ toy }) => events.push(`loading:${toy?.slug}`));
+
+    runtime.startLoading({ toy: { slug: 'broken' } });
+    runtime.setError({ type: 'import', toy: { slug: 'broken' } });
+    runtime.startLoading({ toy: { slug: 'recovered' } });
+    runtime.setActiveToy(() => {});
+
+    expect(events).toEqual(['loading:broken', 'error:import', 'loading:recovered', 'active:recovered']);
+    expect(runtime.getState()).toBe('active');
+  });
+});

--- a/tests/toy-view.test.js
+++ b/tests/toy-view.test.js
@@ -1,6 +1,39 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createToyView } from '../assets/js/toy-view.ts';
 
+function createMockRuntime() {
+  const listeners = {
+    onLoading: new Set(),
+    onActive: new Set(),
+    onError: new Set(),
+    onDisposed: new Set(),
+  };
+
+  const emit = (event, payload) => listeners[event].forEach((listener) => listener(payload));
+
+  return {
+    listeners,
+    emit,
+    setContainer: mock(),
+    onLoading: (listener) => {
+      listeners.onLoading.add(listener);
+      return () => listeners.onLoading.delete(listener);
+    },
+    onActive: (listener) => {
+      listeners.onActive.add(listener);
+      return () => listeners.onActive.delete(listener);
+    },
+    onError: (listener) => {
+      listeners.onError.add(listener);
+      return () => listeners.onError.delete(listener);
+    },
+    onDisposed: (listener) => {
+      listeners.onDisposed.add(listener);
+      return () => listeners.onDisposed.delete(listener);
+    },
+  };
+}
+
 describe('toy view helpers', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="toy-list"></div>';
@@ -10,11 +43,15 @@ describe('toy view helpers', () => {
     document.body.innerHTML = '';
   });
 
-  test('shows active view and registers back control once', () => {
+  test('binds runtime events and registers back control once', () => {
     const view = createToyView();
+    const runtime = createMockRuntime();
     const onBack = mock();
 
-    const container = view.showActiveToyView(onBack, { slug: 'demo', title: 'Demo Toy' });
+    view.bindRuntime(runtime);
+
+    runtime.emit('onLoading', { toy: { slug: 'demo', title: 'Demo Toy' }, onBack });
+    const container = document.querySelector('.active-toy-container');
 
     expect(container?.classList.contains('is-hidden')).toBe(false);
     const backControl = container?.querySelector('[data-back-to-library]');
@@ -22,21 +59,27 @@ describe('toy view helpers', () => {
     expect(container?.querySelectorAll('[data-back-to-library]')).toHaveLength(1);
     expect(container?.querySelector('.active-toy-nav__title')?.textContent).toBe('Demo Toy');
 
+    runtime.emit('onActive', { toy: { slug: 'demo' }, container });
+
     backControl?.dispatchEvent(new Event('click', { bubbles: true }));
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  test('renders capability error with fallback actions', () => {
+  test('renders capability error with fallback actions from runtime event', () => {
     const view = createToyView();
+    const runtime = createMockRuntime();
     const onBack = mock();
     const onContinue = mock();
 
-    const status = view.showCapabilityError(
-      { slug: 'webgpu-toy', title: 'Fancy WebGPU' },
-      { allowFallback: true, onBack, onContinue }
-    );
+    view.bindRuntime(runtime);
 
-    expect(status?.classList.contains('is-warning')).toBe(true);
+    runtime.emit('onError', {
+      toy: { slug: 'webgpu-toy', title: 'Fancy WebGPU' },
+      error: { type: 'capability', options: { allowFallback: true, onBack, onContinue } },
+    });
+
+    const status = document.querySelector('.active-toy-status.is-warning');
+    expect(status).not.toBeNull();
 
     const buttons = status?.querySelectorAll('button');
     expect(buttons?.length).toBe(2);
@@ -48,13 +91,18 @@ describe('toy view helpers', () => {
     expect(onContinue).toHaveBeenCalledTimes(1);
   });
 
-  test('renders import error message for TypeScript modules', () => {
+  test('renders import error message for TypeScript modules through runtime', () => {
     const view = createToyView();
-    const status = view.showImportError(
-      { slug: 'import-error', title: 'Broken Toy' },
-      { moduleUrl: 'assets/js/toys/broken.ts' }
-    );
+    const runtime = createMockRuntime();
 
+    view.bindRuntime(runtime);
+
+    runtime.emit('onError', {
+      toy: { slug: 'import-error', title: 'Broken Toy' },
+      error: { type: 'import', options: { moduleUrl: 'assets/js/toys/broken.ts' } },
+    });
+
+    const status = document.querySelector('.active-toy-status.is-error');
     expect(status?.textContent).toContain('could not be compiled');
     expect(status?.querySelector('.active-toy-status__actions button')).not.toBeNull();
   });


### PR DESCRIPTION
## Summary
- add a ToyRuntime state machine that centralizes toy lifecycle state, active references, and event emissions
- refactor the loader and toy view to subscribe to runtime events for navigation, cleanup, loading, and error handling
- extend documentation and tests to cover runtime states, view integration, navigation, and double-dispose safety

## Testing
- npm run lint -- --max-warnings=0
- bun test tests/loader.test.js tests/toy-view.test.js tests/toy-runtime.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946da6311048332976653cc38b42bc9)