### PR TITLE
Enforce toy lifecycle contracts

### DIFF
--- a/assets/js/__mocks__/disposable-module.js
+++ b/assets/js/__mocks__/disposable-module.js
@@ -1,0 +1,19 @@
+export let disposeCalls = 0;
+
+export function resetDisposeCalls() {
+  disposeCalls = 0;
+}
+
+export function start({ container } = {}) {
+  const marker = document.createElement('div');
+  marker.setAttribute('data-fake-toy', 'true');
+  marker.setAttribute('data-module', 'disposable');
+  container?.appendChild(marker);
+
+  return {
+    dispose() {
+      disposeCalls += 1;
+      marker.remove();
+    },
+  };
+}

--- a/assets/js/__mocks__/fake-module.js
+++ b/assets/js/__mocks__/fake-module.js
@@ -5,7 +5,5 @@ export function start({ container } = {}) {
   placeholder.setAttribute('data-fake-toy', 'true');
   container?.appendChild(placeholder);
 
-  const active = { dispose: () => placeholder.remove() };
-  globalThis.__activeWebToy = active;
-  return active;
+  return { dispose: () => placeholder.remove() };
 }

--- a/assets/js/__mocks__/non-conforming-module.js
+++ b/assets/js/__mocks__/non-conforming-module.js
@@ -1,0 +1,8 @@
+export function start({ container } = {}) {
+  const marker = document.createElement('div');
+  marker.setAttribute('data-fake-toy', 'true');
+  marker.setAttribute('data-module', 'non-conforming');
+  container?.appendChild(marker);
+
+  return 'invalid-start-return';
+}

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -9,8 +9,9 @@ import {
 import { initLighting, initAmbientLight } from '../lighting/lighting-setup';
 import { initAudio } from '../utils/audio-handler.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
+import type { ToyInstance } from '../toy-runtime.ts';
 
-export default class WebToy {
+export default class WebToy implements ToyInstance {
   canvas: HTMLCanvasElement;
   scene: THREE.Scene;
   camera: THREE.Camera;
@@ -32,6 +33,7 @@ export default class WebToy {
     rendererOptions = {},
     lightingOptions = null,
     ambientLightOptions = null,
+    container = null,
     canvas = null,
   } = {}) {
     if (!ensureWebGL()) {
@@ -41,7 +43,9 @@ export default class WebToy {
     this.canvas = canvas || document.createElement('canvas');
 
     const host =
-      document.getElementById('active-toy-container') || document.body;
+      container ||
+      document.getElementById('active-toy-container') ||
+      document.body;
     host.appendChild(this.canvas);
 
     this.scene = initScene(sceneOptions);
@@ -84,8 +88,6 @@ export default class WebToy {
     this.audioCleanup = null;
     this.resizeHandler = () => this.handleResize();
     window.addEventListener('resize', this.resizeHandler);
-
-    (globalThis as Record<string, unknown>).__activeWebToy = this;
   }
 
   handleResize() {
@@ -189,10 +191,6 @@ export default class WebToy {
 
     if (this.canvas?.parentElement) {
       this.canvas.parentElement.removeChild(this.canvas);
-    }
-
-    if ((globalThis as Record<string, unknown>).__activeWebToy === this) {
-      delete (globalThis as Record<string, unknown>).__activeWebToy;
     }
   }
 }

--- a/assets/js/toy-runtime.ts
+++ b/assets/js/toy-runtime.ts
@@ -1,0 +1,22 @@
+export interface ToyInstance {
+  dispose?: () => void;
+}
+
+export interface ToyStartOptions {
+  container?: HTMLElement | null;
+  slug: string;
+}
+
+export type ToyStartResult = ToyInstance | void | null | undefined;
+export type ToyStarter = (options: ToyStartOptions) => ToyStartResult | Promise<ToyStartResult>;
+
+export function normalizeToyInstance(candidate: unknown): ToyInstance | null {
+  if (!candidate || typeof candidate !== 'object') return null;
+
+  const dispose = (candidate as { dispose?: unknown }).dispose;
+  if (dispose !== undefined && typeof dispose !== 'function') {
+    return null;
+  }
+
+  return candidate as ToyInstance;
+}

--- a/assets/js/toys/brand.ts
+++ b/assets/js/toys/brand.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './brand.html',

--- a/assets/js/toys/clay.ts
+++ b/assets/js/toys/clay.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './clay.html',

--- a/assets/js/toys/defrag.ts
+++ b/assets/js/toys/defrag.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './toy.html?toy=defrag',

--- a/assets/js/toys/evol.ts
+++ b/assets/js/toys/evol.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './toy.html?toy=evol',

--- a/assets/js/toys/geom.ts
+++ b/assets/js/toys/geom.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './geom.html',

--- a/assets/js/toys/holy.ts
+++ b/assets/js/toys/holy.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './holy.html',

--- a/assets/js/toys/iframe-toy.ts
+++ b/assets/js/toys/iframe-toy.ts
@@ -4,9 +4,9 @@ import {
   getSettingsPanel,
   type QualityPreset,
 } from '../core/settings-panel';
+import type { ToyInstance, ToyStartOptions } from '../toy-runtime.ts';
 
-type StartOptions = {
-  container?: HTMLElement | null;
+type StartOptions = ToyStartOptions & {
   path: string;
   title?: string;
   allow?: string;
@@ -28,7 +28,7 @@ export function startIframeToy({
   title,
   allow,
   description,
-}: StartOptions) {
+}: StartOptions): ToyInstance {
   const target = container ?? document.getElementById('active-toy-container');
 
   if (!target) {
@@ -68,17 +68,13 @@ export function startIframeToy({
   };
   window.addEventListener('message', handleMessage);
 
-  const activeToy = {
+  const activeToy: ToyInstance = {
     dispose() {
       iframe.remove();
       window.removeEventListener('message', handleMessage);
-      if ((globalThis as Record<string, unknown>).__activeWebToy === activeToy) {
-        delete (globalThis as Record<string, unknown>).__activeWebToy;
-      }
     },
   };
 
-  (globalThis as Record<string, unknown>).__activeWebToy = activeToy;
   target.appendChild(iframe);
 
   return activeToy;

--- a/assets/js/toys/legible.ts
+++ b/assets/js/toys/legible.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './legible.html',

--- a/assets/js/toys/lights.ts
+++ b/assets/js/toys/lights.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './lights.html',

--- a/assets/js/toys/multi.ts
+++ b/assets/js/toys/multi.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './multi.html',

--- a/assets/js/toys/seary.ts
+++ b/assets/js/toys/seary.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './seary.html',

--- a/assets/js/toys/svgtest.ts
+++ b/assets/js/toys/svgtest.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './svgtest.html',

--- a/assets/js/toys/symph.ts
+++ b/assets/js/toys/symph.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './symph.html',

--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -6,6 +6,7 @@ import {
 } from '../core/animation-loop';
 import { getAverageFrequency } from '../utils/audio-handler';
 import { startToyAudio } from '../utils/start-audio';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 import {
   DEFAULT_QUALITY_PRESETS,
   getSettingsPanel,
@@ -76,7 +77,7 @@ function mapOrientationToGravity(event: DeviceOrientationEvent, state: GravitySt
   state.target.set(gamma / 70, -1, -0.2 + beta / 90).normalize();
 }
 
-export async function start() {
+export async function start({ container }: ToyStartOptions) {
   const toy = new WebToy({
     cameraOptions: {
       fov: 55,
@@ -94,6 +95,7 @@ export async function start() {
       intensity: 1.1,
       color: 0xffffff,
     },
+    container,
   });
 
   const gravity: GravityState = {

--- a/assets/js/toys/words.ts
+++ b/assets/js/toys/words.ts
@@ -1,6 +1,7 @@
 import { startIframeToy } from './iframe-toy';
+import type { ToyStartOptions } from '../toy-runtime.ts';
 
-export function start({ container } = {}) {
+export function start({ container }: ToyStartOptions) {
   return startIframeToy({
     container,
     path: './toy.html?toy=words',

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@ flowchart TD
 2. **Navigate**: push state with the router when requested, set up Escape-to-library, and clear any previous toy.
 3. **Render shell**: ask `toy-view` to show the active toy container and loading indicator; bubble capability status to the UI.
 4. **Import module**: resolve a Vite-friendly URL via the manifest client and `import()` it.
-5. **Start toy**: call the module’s `start` or default export; normalize the returned reference so `dispose` can be called on navigation.
+5. **Start toy**: call the module’s `start` or default export, which must return a `ToyInstance` (`assets/js/toy-runtime.ts`). The loader runs `normalizeToyInstance` so only objects with an optional `dispose` hook are retained for cleanup.
 6. **Cleanup**: on Escape/back, dispose the active toy, clear the container, and reset renderer status in the view.
 
 ## Rendering and Capability Detection
@@ -95,6 +95,7 @@ graph LR
 
 - **Start from a slug**: register the module in `assets/js/toys-data.js` and ensure there is an HTML entry point (often `toy.html?toy=<slug>`).
 - **Use the core**: instantiate `WebToy` (or its helpers) to get camera/scene/renderer/audio defaults and return a `dispose` function for safe teardown.
+- **Return instances, not globals**: loader cleanup only honors objects shaped like `ToyInstance` (with an optional `dispose` method) returned from `start`. The legacy `globalThis.__activeWebToy` fallback has been removed.
 - **Respect presets**: honor `updateRendererSettings` for max pixel ratio and render scale; avoid hard-coding devicePixelRatio.
 - **Surface errors**: throw or log during init so the loader’s import error UI can respond; avoid swallowing dynamic import failures silently.
 


### PR DESCRIPTION
## Summary
- add a ToyInstance interface and loader normalization to validate module start returns without relying on global fallbacks
- update WebToy-based wrappers to return typed instances with disposable iframe/web toy cleanup
- document the lifecycle contract and add loader coverage for disposable and non-conforming start results

## Testing
- bun test tests/loader.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946da3f98088332ba3fc0957930e0c0)