### PR TITLE
Refresh renderer badge after runtime fallback

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,14 @@ flowchart LR
 - **Initialization**: `renderer-setup.ts` builds a renderer using the preferred backend, applies tone mapping, sets pixel ratio/size, and returns metadata consumed by `web-toy.ts`.
 - **Quality presets**: `settings-panel.ts` and `iframe-quality-sync.ts` broadcast max pixel ratio, render scale, and exposure; `WebToy.updateRendererSettings` re-applies them without a reload.
 
+### Renderer status propagation
+
+1. **Probe**: `loader.ts` asks `getRendererCapabilities` for cached-or-probed support before showing a toy view.
+2. **Renderer init**: `renderer-setup.ts` finalizes WebGPU or falls back to WebGL and emits the chosen backend plus any `rememberRendererFallback` reason.
+3. **Status refresh**: after a toy initializes, the loader calls `getCachedRendererCapabilities` to refresh `setRendererStatus`, ensuring the badge reflects runtime fallbacks as well as startup probes.
+
+Runtime fallbacks (anything that calls `rememberRendererFallback` or otherwise changes the cached renderer capability) must refresh the UI so the badge and retry affordances stay accurate.
+
 ## WebToy Composition
 
 ```mermaid

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -150,6 +150,29 @@ describe('loadToy', () => {
     expect(document.getElementById('toy-list')?.classList.contains('is-hidden')).toBe(false);
     expect(window.location.search).toBe('');
   });
+
+  test('refreshes renderer status from cached capabilities after toy init', async () => {
+    const fallbackCapabilities = {
+      preferredBackend: 'webgl',
+      adapter: null,
+      device: null,
+      triedWebGPU: true,
+      fallbackReason: 'Mock WebGPU init failure',
+      shouldRetryWebGPU: true,
+    };
+
+    capabilitiesMock.getRendererCapabilities.mockResolvedValue(defaultCapabilities);
+    capabilitiesMock.getCachedRendererCapabilities.mockImplementation(() => fallbackCapabilities);
+
+    const { loader } = await buildLoader();
+
+    await loader.loadToy('brand');
+
+    const fallbackPill = document.querySelector('.renderer-pill');
+    expect(fallbackPill?.textContent).toContain('WebGL fallback');
+    const detail = document.querySelector('.renderer-pill__detail');
+    expect(detail?.textContent).toContain('Mock WebGPU init failure');
+  });
 });
 
 describe('WebGPU requirements', () => {


### PR DESCRIPTION
## Summary
- emit renderer capability callbacks when initialization completes or falls back
- refresh the loader’s renderer badge from cached capabilities after a toy starts
- document the renderer status propagation flow and add regression coverage for fallback messaging

## Testing
- bun test loader.test.js --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946da3b05248332920d7d41b279a6e8)