### PR TITLE
Improve library launch UX with quickstart CTA and search

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -526,6 +526,49 @@ h1 {
   line-height: 1.6;
 }
 
+.library-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: linear-gradient(
+      145deg,
+      rgba(109, 240, 255, 0.08),
+      rgba(155, 123, 255, 0.06),
+      rgba(255, 111, 227, 0.06)
+    );
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-pill);
+  padding: 0.35rem 0.8rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
+
+.search-field input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  font-size: 1rem;
+  padding: 0.55rem 0.35rem;
+  outline: none;
+}
+
+.search-field input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-field__hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 .webtoy-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1106,7 +1106,7 @@ export function createLibraryView({
   loadFromQuery,
   targetId = 'toy-list',
   searchInputId,
-  cardElement = 'button',
+  cardElement = 'a',
   enableIcons = false,
   enableCapabilityBadges = false,
   enableKeyboardHandlers = false,
@@ -1126,8 +1126,15 @@ export function createLibraryView({
   const createCard = (toy) => {
     const card = document.createElement(cardElement);
     card.className = 'webtoy-card';
+    const href =
+      toy.type === 'module'
+        ? `toy.html?toy=${encodeURIComponent(toy.slug)}`
+        : toy.module;
     if (cardElement === 'button') {
       card.type = 'button';
+    } else if (cardElement === 'a') {
+      card.href = href;
+      card.setAttribute('data-toy-href', href);
     }
 
     if (enableIcons) {
@@ -1170,14 +1177,27 @@ export function createLibraryView({
       }
     }
 
-    const handleOpenToy = () => openToy(toy);
+    const handleOpenToy = (event) => {
+      const isModifiedClick = !!(
+        event &&
+        (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button === 1)
+      );
+
+      if (cardElement === 'a' && event) {
+        if (isModifiedClick) return;
+        event.preventDefault();
+      }
+
+      openToy(toy);
+    };
+
     card.addEventListener('click', handleOpenToy);
 
     if (enableKeyboardHandlers) {
       card.addEventListener('keydown', (event) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          handleOpenToy();
+          handleOpenToy(event);
         }
       });
     }

--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -26,6 +26,9 @@ export function createLoader({
   ensureWebGLCheck = ensureWebGL,
   rendererCapabilities = getRendererCapabilities,
   toys = toysData as Toy[],
+  prewarmRendererCapabilitiesFn = prewarmRendererCapabilities,
+  prewarmMicrophoneFn = prewarmMicrophone,
+  resetAudioPoolFn = resetAudioPool,
 }: {
   manifestClient?: ReturnType<typeof createManifestClient>;
   router?: ReturnType<typeof createRouter>;
@@ -33,6 +36,9 @@ export function createLoader({
   ensureWebGLCheck?: typeof ensureWebGL;
   rendererCapabilities?: typeof getRendererCapabilities;
   toys?: Toy[];
+  prewarmRendererCapabilitiesFn?: typeof prewarmRendererCapabilities;
+  prewarmMicrophoneFn?: typeof prewarmMicrophone;
+  resetAudioPoolFn?: typeof resetAudioPool;
   } = {}) {
   let navigationInitialized = false;
   let escapeHandler: ((event: KeyboardEvent) => void) | null = null;
@@ -120,7 +126,7 @@ export function createLoader({
     view.showLibraryView();
     router.goToLibrary();
     updateRendererStatus(null);
-    void resetAudioPool({ stopStreams: true });
+    void resetAudioPoolFn({ stopStreams: true });
   };
 
   const registerEscapeHandler = () => {
@@ -142,8 +148,8 @@ export function createLoader({
     pushState: boolean,
     initialCapabilities?: Awaited<ReturnType<typeof rendererCapabilities>>
   ) => {
-    void prewarmRendererCapabilities();
-    void prewarmMicrophone();
+    void prewarmRendererCapabilitiesFn();
+    void prewarmMicrophoneFn();
     let capabilities = initialCapabilities ?? (await rendererCapabilities());
 
     const supportsRendering = ensureWebGLCheck({

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,6 +9,8 @@ const libraryView = createLibraryView({
   initNavigation,
   loadFromQuery,
   targetId: 'toy-list',
+  searchInputId: 'toy-search',
+  cardElement: 'a',
   enableIcons: true,
   enableCapabilityBadges: true,
   enableKeyboardHandlers: true,
@@ -16,8 +18,26 @@ const libraryView = createLibraryView({
   themeToggleId: 'theme-toggle',
 });
 
+const bindQuickstartCta = () => {
+  const quickstart = document.querySelector('[data-quickstart-slug]');
+  if (!quickstart || !('dataset' in quickstart)) return;
+
+  const { quickstartSlug } = quickstart.dataset;
+  if (!quickstartSlug) return;
+
+  quickstart.addEventListener('click', (event) => {
+    const isModifiedClick =
+      event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button === 1;
+    if (isModifiedClick) return;
+
+    event.preventDefault();
+    loadToy(quickstartSlug, { pushState: true });
+  });
+};
+
 const startApp = () => {
   libraryView.init();
+  bindQuickstartCta();
   void initRepoStatusWidget();
 };
 

--- a/index.html
+++ b/index.html
@@ -58,10 +58,19 @@
             <h1>Launch an interactive webtoy in seconds.</h1>
             <p class="tagline">
               Explore audio, color, and motion without setup. Every stim opens
-              fast, works with mic and touch, and ships with clear controls.
+              fast, works with mic and touch, and ships with clear controls. When
+              you launch a toy, we’ll ask for microphone access so visuals can
+              react to your sound.
             </p>
             <div class="cta-row">
-              <a href="#toy-list" class="cta-button primary">Browse library</a>
+              <a
+                href="toy.html?toy=holy"
+                class="cta-button primary"
+                data-quickstart-slug="holy"
+              >
+                Start with Halo Flow
+              </a>
+              <a href="#toy-list" class="cta-button ghost">Browse library</a>
               <a
                 href="https://github.com/zz-plant/stims"
                 target="_blank"
@@ -71,7 +80,8 @@
               >
             </div>
               <p class="cta-helper">
-              No installs or accounts. Code and contribution notes live on GitHub.
+              No installs or accounts. Enable your mic when prompted to see the
+              visuals react. Code and contribution notes live on GitHub.
             </p>
             <div class="repo-status" data-repo-status aria-live="polite">
               <div class="repo-status__header">
@@ -114,6 +124,20 @@
             and Lights sit alongside the module-based set so everything is easy
             to reach.
           </p>
+          <div class="library-search">
+            <label class="sr-only" for="toy-search">Search the library</label>
+            <div class="search-field">
+              <input
+                id="toy-search"
+                type="search"
+                name="toy-search"
+                placeholder="Search by name or vibe (e.g., aurora, fractal, WebGPU)"
+                autocomplete="off"
+                inputmode="search"
+              />
+              <span aria-hidden="true" class="search-field__hint">⌘/Ctrl + F to search</span>
+            </div>
+          </div>
         </div>
         <main id="toy-list" class="webtoy-container"></main>
       </section>
@@ -159,45 +183,69 @@
         const list = document.getElementById('toy-list');
         if (!list || list.childElementCount > 0) return;
 
+        const renderCards = (toys) => {
+          list.innerHTML = '';
+
+          toys.forEach((toy) => {
+            const href =
+              toy.type === 'page'
+                ? toy.module
+                : `toy.html?toy=${encodeURIComponent(toy.slug)}`;
+
+            const card = document.createElement('a');
+            card.className = 'webtoy-card';
+            card.href = href;
+            card.setAttribute('data-toy-fallback', 'true');
+
+            const title = document.createElement('h3');
+            title.textContent = toy.title;
+
+            const desc = document.createElement('p');
+            desc.textContent = toy.description;
+
+            card.append(title, desc);
+
+            if (toy.requiresWebGPU) {
+              const badgeRow = document.createElement('div');
+              badgeRow.className = 'webtoy-card-meta';
+
+              const badge = document.createElement('span');
+              badge.className = 'capability-badge';
+              badge.textContent = 'WebGPU';
+              badge.title = 'Requires WebGPU to run.';
+
+              badgeRow.appendChild(badge);
+              card.appendChild(badgeRow);
+            }
+
+            list.appendChild(card);
+          });
+        };
+
         fetch('./toys.json')
           .then((response) => (response.ok ? response.json() : null))
           .then((toys) => {
             if (!toys || list.childElementCount > 0) return;
 
-            toys.forEach((toy) => {
-              const href =
-                toy.type === 'page'
-                  ? toy.module
-                  : `toy.html?toy=${encodeURIComponent(toy.slug)}`;
+            const search = document.getElementById('toy-search');
+            renderCards(toys);
 
-              const card = document.createElement('a');
-              card.className = 'webtoy-card';
-              card.href = href;
-              card.setAttribute('data-toy-fallback', 'true');
+            if (search instanceof HTMLInputElement) {
+              search.addEventListener('input', () => {
+                const query = search.value.toLowerCase().trim();
+                if (!query) {
+                  renderCards(toys);
+                  return;
+                }
 
-              const title = document.createElement('h3');
-              title.textContent = toy.title;
-
-              const desc = document.createElement('p');
-              desc.textContent = toy.description;
-
-              card.append(title, desc);
-
-              if (toy.requiresWebGPU) {
-                const badgeRow = document.createElement('div');
-                badgeRow.className = 'webtoy-card-meta';
-
-                const badge = document.createElement('span');
-                badge.className = 'capability-badge';
-                badge.textContent = 'WebGPU';
-                badge.title = 'Requires WebGPU to run.';
-
-                badgeRow.appendChild(badge);
-                card.appendChild(badgeRow);
-              }
-
-              list.appendChild(card);
-            });
+                const filtered = toys.filter(
+                  (toy) =>
+                    toy.title?.toLowerCase().includes(query) ||
+                    toy.description?.toLowerCase().includes(query),
+                );
+                renderCards(filtered);
+              });
+            }
           })
           .catch((error) => {
             console.error('Unable to render library fallback', error);


### PR DESCRIPTION
## Summary
- add a quick-start hero CTA that deep-links into a featured toy with microphone guidance
- add an inline library search field and fallback filtering so toys are easier to find
- make library cards shareable links while keeping in-app navigation, and inject loader dependencies to drop cross-test module mocks

## Testing
- bun run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694993fb03b883329caef4cd741c9e5d)