### PR TITLE
Make dev server reachable for forwarded browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what
    - **Bun 1.2+**: install from [bun.sh](https://bun.sh/) for the fastest install/test cycle.
    - **Node.js 22** (see `.nvmrc`): still supported for Vite and general tooling if you prefer npm.
 3. Install dependencies with `bun install` (preferred). The repository tracks `bun.lock` for reproducible installs—use `bun install --frozen-lockfile` to respect it. If you use npm, run `npm install` locally; a `package-lock.json` will be generated but is not committed.
-4. Start the dev server with `npm run dev` or `bun run dev`, then open `http://localhost:5173` in your browser. If you need to load the dev server from another device on your network (for mobile checks), use `bun run dev:host` (or `npm run dev:host`) to bind the Vite server to all interfaces.
+4. Start the dev server with `npm run dev` or `bun run dev`, then open `http://localhost:5173` in your browser. The dev server already binds to all interfaces for easy forwarding and mobile checks; `bun run dev:host` (or `npm run dev:host`) remains available as an explicit alternative.
 
 ## Getting Started
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,11 @@ const moduleInputs = Object.fromEntries(
 );
 
 export default defineConfig({
+  server: {
+    // Bind to all interfaces so forwarded browsers (e.g., Playwright) can reach
+    // the dev server instead of seeing connection refused.
+    host: true,
+  },
   build: {
     outDir: 'dist',
     // Emit a top-level manifest so runtime lookups work even when the .vite


### PR DESCRIPTION
## Summary
- bind the Vite dev server to all interfaces so forwarded browsers (e.g., Playwright) can reach it without connection refusals
- clarify in the quick start docs that the dev server already binds to all interfaces and the host script is optional

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949bb0454e88332a5f92542a3cf2df0)