### PR TITLE
Add troubleshooting guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ The preview server hosts the contents of `dist/` on port `4173` using Vite's `--
 
 All JavaScript dependencies are installed via npm (or Bun) and bundled locally with Vite, so everything works offline without hitting a CDN.
 
+### Troubleshooting
+
+#### Microphone permissions
+
+- If the browser denied microphone access, re-allow it via the address bar/site settings and click the start button again. Hard-refreshing the page will re-trigger the prompt on most browsers.
+- Switch to demo audio if you keep seeing timeouts or “blocked” errors—the UI exposes a fallback button for a pre-mixed track so you can keep exploring without mic input.
+- For deeper debugging (including timeouts and permission-state checks), see the microphone flow helper in [`assets/js/core/microphone-flow.ts`](./assets/js/core/microphone-flow.ts).
+
+#### WebGPU gating
+
+- A WebGPU fallback warning means the browser lacked a compatible adapter or device at startup; toys will fall back to WebGL when possible.
+- To force a retry (for example, after toggling a browser flag or switching GPUs), refresh the page—WebGPU detection resets and will attempt the adapter/device handshake again.
+- WebGPU-only toys (like [`multi`](./multi.html)) won’t run without WebGPU; expect them to stay idle or prompt you to pick another toy until the capability probe succeeds. The renderer capability probe and fallback reasons live in [`assets/js/core/renderer-capabilities.ts`](./assets/js/core/renderer-capabilities.ts) if you need to trace the gating logic.
+
+#### Dev-server hosting
+
+- Use `bun run dev:host` (or `npm run dev:host`) to bind the dev server to your LAN interface for mobile/device testing; the script mirrors the default `dev` command but with explicit hosting.
+- Check the served port in the terminal output (Vite defaults to `5173`; preview uses `4173`). Connect from other devices via `http://<your-ip>:<port>`.
+- Avoid loading toys over `file://`; the modules and JSON fetches require an HTTP server, so always use the dev server, preview server, or another static host.
+
 ### Helpful Scripts (Bun-first)
 
 - `bun run dev`: Start the Vite development server for local exploration. (`npm run dev` works if you’re on Node.)


### PR DESCRIPTION
## Summary
- add an early troubleshooting section near Local Setup
- document microphone permission recovery, WebGPU fallback expectations, and dev-server hosting tips
- link to microphone and renderer helpers for deeper debugging

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0951ae048332a5cb16decb3af4bf)