### PR TITLE
Add deployment guide and link from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what
 3. Install dependencies with `bun install` (preferred). The repository tracks `bun.lock` for reproducible installs—use `bun install --frozen-lockfile` to respect it. If you use npm, run `npm install` locally; a `package-lock.json` will be generated but is not committed.
 4. Start the dev server with `npm run dev` or `bun run dev`, then open `http://localhost:5173` in your browser. The dev server already binds to all interfaces for easy forwarding and mobile checks; `bun run dev:host` (or `npm run dev:host`) remains available as an explicit alternative.
 
+See the [Deployment Guide](./docs/DEPLOYMENT.md) for build, preview, static hosting, and Cloudflare Worker instructions.
+
 ## Getting Started
 
 ### What You’ll Need:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,80 @@
+# Deployment Guide
+
+This guide covers how to build the Stim Webtoys Library, validate the production bundle locally, and ship the site and MCP Worker to production targets. Commands reference the scripts in `package.json` so you can copy/paste without drift.
+
+## Build the Site
+
+Run the production build to emit optimized assets:
+
+```bash
+bun run build
+```
+
+The Vite build outputs to `dist/` and also writes a `.vite/manifest.json` file. Keep the manifest alongside the hashed assets—it powers any server-side integrations or debug tooling that map back to the compiled files.
+
+### Artifact Layout
+
+After `bun run build`, expect the following structure:
+
+- `dist/`: HTML entry points and hashed JS/CSS assets under `dist/assets/`.
+- `dist/.vite/manifest.json`: Vite manifest mapping original sources to their output filenames.
+
+When deploying to static hosting, serve the contents of `dist/` directly. Do not strip the `.vite` directory or rename the asset paths.
+
+## Verify Locally
+
+Use the same scripts defined in `package.json` to validate the production output:
+
+- Preview the build with Vite’s preview server (binds to all interfaces):
+
+  ```bash
+  bun run preview
+  ```
+
+- Serve the built assets with the Bun helper if you want a minimal static server:
+
+  ```bash
+  bun run serve:dist
+  ```
+
+Both commands expect a fresh `bun run build` and read from `dist/`.
+
+## Static Hosting Expectations
+
+Any static host should point its document root to the `dist/` directory and preserve the following:
+
+- `dist/index.html` (and other HTML entry points).
+- `dist/assets/**` for hashed JS/CSS.
+- `dist/.vite/manifest.json` for asset lookups.
+
+If your platform supports immutable caching, enable it for `dist/assets/**`; keep HTML un-cached or lightly cached so updates propagate.
+
+## Cloudflare Worker (MCP) Deployment
+
+The MCP HTTP/WebSocket endpoint lives in [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Deploy it with Wrangler using the existing [`wrangler.toml`](../wrangler.toml) (name, compatibility date, and Pages output dir are already defined).
+
+Common commands (Bun-first):
+
+- Run locally with live reload and the configured compatibility date:
+
+  ```bash
+  bunx wrangler dev scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
+  ```
+
+- Deploy to Cloudflare Workers:
+
+  ```bash
+  bunx wrangler deploy scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
+  ```
+
+Flags and bindings to keep in mind:
+
+- `--name` should match or override the `name` in `wrangler.toml` if you need a different environment-specific Worker name.
+- `--compatibility-date` should stay aligned with `wrangler.toml` (`2024-10-20`) to ensure the MCP server runs with the intended platform APIs.
+- No KV, Durable Objects, or secrets are required for the current worker; it only needs standard Worker APIs plus WebSocket support enabled by the compatibility date.
+
+## Release Checklist
+
+- Update [`CHANGELOG.md`](../CHANGELOG.md) with user-facing notes for the release.
+- Tag the version in Git after merging (e.g., `git tag vX.Y.Z && git push origin --tags`).
+- Smoke test the production URL at [https://no.toil.fyi](https://no.toil.fyi) after deploy (basic load, a few toys, and audio input checks).

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This folder contains resources for contributors who are building or maintaining 
 - [`stim-assessment.md`](./stim-assessment.md): Assessment findings and remediation plans.
 - [`toys.md`](./toys.md): per-toy notes, presets, and other focused references.
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md): end-to-end app architecture, loader flow, and core runtime composition with diagrams.
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md): build, preview, static hosting layout, and Cloudflare Worker deployment steps.
 - [`MCP_SERVER.md`](./MCP_SERVER.md): how to launch and use the MCP stdio server (`scripts/mcp-server.ts`) and its registered tools.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.


### PR DESCRIPTION
## Summary
- add a deployment guide detailing build/preview steps, static hosting layout, and Cloudflare Worker deployment commands
- include a release checklist for tagging and production smoke tests
- link the new deployment doc from the top-level README and docs index for easier discovery

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a09588cac8332a710525c4825cc10)