### PR TITLE
Add build command for Pages deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,6 @@
 name = "stims"
 compatibility_date = "2024-10-20"
 pages_build_output_dir = "dist"
+
+[build]
+command = "npm run build"


### PR DESCRIPTION
## Summary
- add a Wrangler build command so Pages deployments run the site build and emit the dist output

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0d4f758c833298c23bfaa9b32b4c)