### PR TITLE
Remove Pages build block from wrangler config

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,6 +49,10 @@ Any static host should point its document root to the `dist/` directory and pres
 
 If your platform supports immutable caching, enable it for `dist/assets/**`; keep HTML un-cached or lightly cached so updates propagate.
 
+## Cloudflare Pages Configuration
+
+Cloudflare Pages reads the build command from the project settings in the dashboard, so keep `wrangler.toml` limited to the shared metadata (`name`, `compatibility_date`, and `pages_build_output_dir`). Do **not** add a `[build]` table—Pages rejects it and will surface a configuration validation error. Configure the build command (for example, `bun run build`) directly in Pages, or rely on `CF_PAGES=1` with the existing install script to generate `dist/` during install.
+
 ## Cloudflare Worker (MCP) Deployment
 
 The MCP HTTP/WebSocket endpoint lives in [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Deploy it with Wrangler using the existing [`wrangler.toml`](../wrangler.toml) (name, compatibility date, and Pages output dir are already defined).

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,3 @@
 name = "stims"
 compatibility_date = "2024-10-20"
 pages_build_output_dir = "dist"
-
-[build]
-command = "npm run build"


### PR DESCRIPTION
## Summary
- remove the unsupported Cloudflare Pages build table from `wrangler.toml`
- document how to configure the Pages build command outside Wrangler while keeping shared metadata only

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b234d5bbc8332ab21c70b5eb7d97d)