### PR TITLE
Add Cloudflare Pages helper scripts

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,6 +49,20 @@ Any static host should point its document root to the `dist/` directory and pres
 
 If your platform supports immutable caching, enable it for `dist/assets/**`; keep HTML un-cached or lightly cached so updates propagate.
 
+## Cloudflare Pages Configuration
+
+Cloudflare Pages reads the build command from the project settings in the dashboard, so keep `wrangler.toml` limited to the shared metadata (`name`, `compatibility_date`, and `pages_build_output_dir`). Do **not** add a `[build]` table—Pages rejects it and will surface a configuration validation error. Configure the build command (for example, `bun run build`) directly in Pages, or rely on `CF_PAGES=1` with the existing install script to generate `dist/` during install.
+
+For local CLI flows, run the bundled scripts so Wrangler always sees a built `dist/` folder and avoids the "output directory not found" error:
+
+```bash
+# Build and serve locally with wrangler pages dev
+bun run pages:dev
+
+# Build and deploy static assets to Cloudflare Pages
+bun run pages:deploy
+```
+
 ## Cloudflare Worker (MCP) Deployment
 
 The MCP HTTP/WebSocket endpoint lives in [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Deploy it with Wrangler using the existing [`wrangler.toml`](../wrangler.toml) (name, compatibility date, and Pages output dir are already defined).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build": "vite build",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",
+    "pages:dev": "bun run build && bunx wrangler pages dev dist --compatibility-date=2024-10-20",
+    "pages:deploy": "bun run build && bunx wrangler pages deploy dist",
     "mcp": "bun run scripts/mcp-server.ts",
     "prepare": "husky install",
     "postinstall": "node scripts/postinstall.mjs || bun scripts/postinstall.mjs"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "vite build",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",
-    "pages:dev": "bun run build && bunx wrangler pages dev dist --compatibility-date=2024-10-20",
+    "pages:dev": "bun run build && bunx wrangler pages dev dist",
     "pages:deploy": "bun run build && bunx wrangler pages deploy dist",
     "mcp": "bun run scripts/mcp-server.ts",
     "prepare": "husky install",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,3 @@
 name = "stims"
 compatibility_date = "2024-10-20"
 pages_build_output_dir = "dist"
-
-[build]
-command = "npm run build"


### PR DESCRIPTION
## Summary
- add helper scripts to build and run/deploy Cloudflare Pages via Wrangler while ensuring dist exists
- document the new scripts to avoid missing output directory errors in local CLI flows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b234d5bbc8332ab21c70b5eb7d97d)