### PR TITLE
Include standalone HTML pages in Vite build

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -15,7 +15,7 @@
     <div id="error-message" style="display: none"></div>
     <script type="module">
       import * as THREE from 'three';
-      import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+      import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
       import WebToy from './assets/js/core/web-toy.ts';
       import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
       import { ensureWebGL } from './assets/js/utils/webgl-check.ts';

--- a/clay.html
+++ b/clay.html
@@ -55,7 +55,7 @@
       import * as THREE from 'three';
       import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
       if (!ensureWebGL()) {
-        return;
+        throw new Error('WebGL support is required for the clay toy.');
       }
       // Basic Three.js setup
       let scene, camera, renderer;

--- a/holy.html
+++ b/holy.html
@@ -239,7 +239,7 @@
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
       if (!ensureWebGL()) {
-        return;
+        throw new Error('WebGL support is required for the Holy visualizer.');
       }
       let scene, camera, renderer, composer, bloomPass, fxaaPass;
       let visualizerShape, particles;

--- a/multi.html
+++ b/multi.html
@@ -159,7 +159,7 @@
       }
 
       const adapter = createMultiFunAdapter({
-        torusMaterial: torusKnot.material as THREE.MeshStandardMaterial,
+        torusMaterial: torusKnot.material,
         pointLight,
         particlesMaterial,
         shapes,
@@ -246,11 +246,10 @@
         sparkle.life = sparkle.maxLife = 0.4 + Math.random() * 0.9;
         sparkle.sizeBase = scale;
         sparkle.points.visible = true;
-        (sparkle.points.material as THREE.PointsMaterial).color.setHSL(
-          hue,
-          0.8,
-          0.6
-        );
+        const sparkleMaterial = sparkle.points.material;
+        if (sparkleMaterial instanceof THREE.PointsMaterial) {
+          sparkleMaterial.color.setHSL(hue, 0.8, 0.6);
+        }
       }
 
       function triggerSparkles(count = 12) {
@@ -265,9 +264,11 @@
           if (sparkle.life <= 0) return;
           sparkle.life -= delta;
           const t = Math.max(sparkle.life / sparkle.maxLife, 0);
-          const material = sparkle.points.material as THREE.PointsMaterial;
-          material.opacity = t;
-          material.size = sparkle.sizeBase * (0.75 + t * 0.75);
+          const material = sparkle.points.material;
+          if (material instanceof THREE.PointsMaterial) {
+            material.opacity = t;
+            material.size = sparkle.sizeBase * (0.75 + t * 0.75);
+          }
           sparkle.points.position.addScaledVector(sparkle.velocity, delta * 60);
           sparkle.velocity.multiplyScalar(0.98);
           if (sparkle.life <= 0) {
@@ -301,9 +302,13 @@
 
       const sensitivitySlider = funControls.container.querySelector(
         '.fun-sensitivity'
-      ) as HTMLInputElement;
+      );
       sensitivitySlider?.addEventListener('input', (event) => {
-        const nextValue = Number((event.target as HTMLInputElement).value);
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+          return;
+        }
+        const nextValue = Number(target.value);
         peakSensitivity = nextValue;
         peakDetector = createPeakDetector({
           getData: () => lastFrequencyData,
@@ -315,16 +320,24 @@
 
       const sparklesToggle = funControls.container.querySelector(
         '.fun-sparkles'
-      ) as HTMLInputElement;
+      );
       sparklesToggle?.addEventListener('change', (event) => {
-        sparklesEnabled = (event.target as HTMLInputElement).checked;
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+          return;
+        }
+        sparklesEnabled = target.checked;
       });
 
       const burstsToggle = funControls.container.querySelector(
         '.fun-bursts'
-      ) as HTMLInputElement;
+      );
       burstsToggle?.addEventListener('change', (event) => {
-        burstsEnabled = (event.target as HTMLInputElement).checked;
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+          return;
+        }
+        burstsEnabled = target.checked;
       });
 
       function animate(ctx) {

--- a/seary.html
+++ b/seary.html
@@ -362,7 +362,7 @@
         'u_burst_intensity'
       );
 
-      let currentFreqs = adapter.transformFrequencies({
+      currentFreqs = adapter.transformFrequencies({
         low: 0,
         mid: 0,
         high: 0,
@@ -482,20 +482,6 @@
         burstState.intensity *= 0.5;
       }
 
-      function rebuildPeakDetector() {
-        if (!analyser) {
-          peakDetector = null;
-          return;
-        }
-
-        peakDetector = createPeakDetector({
-          getData: () => getFrequencyData(analyser),
-          sensitivity: peakSensitivity,
-          onPeak: handlePeak,
-          onRelease: handlePeakRelease,
-        });
-      }
-
       // Audio setup for beat detection and frequency analysis
       let peakDetector = null;
       let lastVibrateTime = 0;
@@ -531,13 +517,14 @@
       }
 
       function rebuildPeakDetector(ctx) {
-        if (!ctx.analyser) {
+        const analyserNode = ctx?.analyser;
+        if (!analyserNode) {
           peakDetector = null;
           return;
         }
 
         peakDetector = createPeakDetector({
-          getData: () => getFrequencyData(ctx.analyser),
+          getData: () => getFrequencyData(analyserNode),
           sensitivity: peakSensitivity,
           onPeak: handlePeak,
           onRelease: handlePeakRelease,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,17 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import toysData from './assets/js/toys-data.js';
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
+const htmlInputs = Object.fromEntries(
+  fs
+    .readdirSync(rootDir)
+    .filter((entry) => entry.endsWith('.html'))
+    .sort()
+    .map((file) => [path.parse(file).name, path.resolve(rootDir, file)])
+);
 const moduleInputs = Object.fromEntries(
   toysData
     .filter((toy) => toy.type === 'module')
@@ -26,7 +34,8 @@ export default defineConfig({
       // can find the `start` functions even when they look unused at build time.
       preserveEntrySignatures: 'strict',
       input: {
-        main: path.resolve(rootDir, 'index.html'),
+        main: htmlInputs.index ?? path.resolve(rootDir, 'index.html'),
+        ...htmlInputs,
         ...moduleInputs,
       },
     },

--- a/words.html
+++ b/words.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <title>Interactive Word Cloud & Visualizer</title>
-    <script src="assets/js/lib/wordcloud2.min.js"></script>
+    <script type="module" src="assets/js/lib/wordcloud2.min.js"></script>
     <link rel="stylesheet" href="assets/css/base.css" />
     <style>
       * {


### PR DESCRIPTION
## Summary
- dynamically include standalone HTML entry points in the Vite rollup inputs
- fix inline toy pages so WebGL checks and imports are build-safe
- remove TypeScript-only syntax and ensure supporting scripts bundle correctly

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b38fc3b748332922b58958f21680b)