### PR TITLE
Add Bun cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           node-version: 22
       - uses: oven-sh/setup-bun@v1
+      - name: Cache Bun and node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun test


### PR DESCRIPTION
## Summary
- add an actions/cache step to reuse the Bun installation and node_modules in CI
- key the cache on bun.lock so lint, test, and build jobs restore dependencies quickly

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3abe9ee0833283d635156bbe63d1)