### PR TITLE
Update manifest client tests for .vite path

### DIFF
--- a/tests/manifest-client.test.js
+++ b/tests/manifest-client.test.js
@@ -34,6 +34,8 @@ describe('manifest client', () => {
     const client = createManifestClient({ fetchImpl, baseUrl: 'http://example.com/' });
     const modulePath = await client.resolveModulePath(moduleEntry);
 
+    expect(fetchImpl).toHaveBeenNthCalledWith(1, '/.vite/manifest.json');
+    expect(fetchImpl).toHaveBeenNthCalledWith(2, '/manifest.json');
     expect(modulePath).toBe('/assets/js/toys/example.ts');
   });
 

--- a/tests/manifest-client.test.js
+++ b/tests/manifest-client.test.js
@@ -24,7 +24,7 @@ describe('manifest client', () => {
     const client = createManifestClient({ fetchImpl, baseUrl: 'http://example.com/app/' });
     const modulePath = await client.resolveModulePath(moduleEntry);
 
-    expect(fetchImpl).toHaveBeenCalledWith('/app/manifest.json');
+    expect(fetchImpl).toHaveBeenCalledWith('/app/.vite/manifest.json');
     expect(modulePath).toBe('/app/assets/js/toys/example.123.js');
   });
 
@@ -72,7 +72,7 @@ describe('manifest client', () => {
 
     const modulePath = await client.resolveModulePath(moduleEntry);
 
-    expect(fetchImpl).toHaveBeenCalledWith('https://cdn.example.com/app/manifest.json');
+    expect(fetchImpl).toHaveBeenCalledWith('https://cdn.example.com/app/.vite/manifest.json');
     expect(modulePath).toBe('https://cdn.example.com/app/assets/js/toys/example.123.js');
   });
 


### PR DESCRIPTION
## Summary
- update manifest client tests to expect the .vite manifest path when a base URL is provided

## Testing
- bun test tests/manifest-client.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3b5b72588332b44745fb153f8424)