### PR TITLE
Use WebGPU renderer helper and prefer manifest lookup

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -1,6 +1,6 @@
 /* global GPUAdapter, GPUDevice */
 import * as THREE from 'three';
-import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
+import { WebGPURenderer } from './webgpu-renderer.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
 import {
   getRendererCapabilities,

--- a/assets/js/core/services/render-service.ts
+++ b/assets/js/core/services/render-service.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js';
+import { WebGPURenderer } from '../webgpu-renderer.ts';
 import {
   getActiveQualityPreset,
   subscribeToQualityPreset,

--- a/assets/js/core/webgpu-renderer.ts
+++ b/assets/js/core/webgpu-renderer.ts
@@ -1,0 +1,15 @@
+import type { WebGPURenderer as ExamplesWebGPURenderer } from 'three/examples/jsm/renderers/webgpu/WebGPURenderer.js';
+
+export type WebGPURendererType = ExamplesWebGPURenderer;
+
+let WebGPURenderer: typeof import('three/src/renderers/webgpu/WebGPURenderer.js').default;
+
+try {
+  const module = await import('three/examples/jsm/renderers/webgpu/WebGPURenderer.js');
+  WebGPURenderer = module.WebGPURenderer ?? (module.default as typeof WebGPURenderer);
+} catch {
+  const module = await import('three/src/renderers/webgpu/WebGPURenderer.js');
+  WebGPURenderer = module.WebGPURenderer ?? (module.default as typeof WebGPURenderer);
+}
+
+export { WebGPURenderer };

--- a/assets/js/utils/manifest-client.ts
+++ b/assets/js/utils/manifest-client.ts
@@ -7,7 +7,7 @@ type ManifestEntry = {
   url?: string;
 };
 
-const MANIFEST_CANDIDATES = ['./.vite/manifest.json', './manifest.json'];
+const MANIFEST_CANDIDATES = ['./manifest.json', './.vite/manifest.json'];
 
 function getCurrentOrigin() {
   const origin = typeof window !== 'undefined' ? window.location?.origin : null;

--- a/tests/importmap.json
+++ b/tests/importmap.json
@@ -1,5 +1,7 @@
 {
   "imports": {
-    "three": "./tests/three-stub.ts"
+    "three": "./tests/three-stub.ts",
+    "three/examples/jsm/renderers/webgpu/WebGPURenderer.js": "./tests/three-webgpu-renderer-stub.ts",
+    "three/src/renderers/webgpu/WebGPURenderer.js": "./tests/three-webgpu-renderer-stub.ts"
   }
 }

--- a/tests/three-webgpu-renderer-stub.ts
+++ b/tests/three-webgpu-renderer-stub.ts
@@ -1,0 +1,24 @@
+export class WebGPURenderer {
+  outputColorSpace = '';
+  toneMapping = 0;
+  toneMappingExposure = 1;
+
+  constructor(options: unknown = {}) {
+    void options;
+  }
+
+  setPixelRatio(ratio: number) {
+    void ratio;
+  }
+
+  setSize(width: number, height: number) {
+    void width;
+    void height;
+  }
+
+  setAnimationLoop(callback: (() => void) | null) {
+    void callback;
+  }
+
+  dispose() {}
+}


### PR DESCRIPTION
## Summary
- add a shared WebGPU renderer helper that favors the examples export with a fallback
- point renderer setup and pooling to the helper and stub the import map for tests
- prefer the standard manifest path before the Vite build artifact when resolving modules

## Testing
- bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3acb06148332a787c989bbe1709f)