### PR TITLE
Prioritize public manifest when resolving manifest paths

### DIFF
--- a/assets/js/utils/manifest-client.ts
+++ b/assets/js/utils/manifest-client.ts
@@ -7,7 +7,8 @@ type ManifestEntry = {
   url?: string;
 };
 
-const MANIFEST_CANDIDATES = ['./.vite/manifest.json', './manifest.json'];
+// Prefer the public manifest first; fall back to the hidden Vite output when present.
+const MANIFEST_CANDIDATES = ['./manifest.json', './.vite/manifest.json'];
 
 function getCurrentOrigin() {
   const origin = typeof window !== 'undefined' ? window.location?.origin : null;


### PR DESCRIPTION
## Summary
- prioritize the public `manifest.json` over the hidden `.vite/manifest.json` when fetching build manifests
- keep module resolution using the provided base URL so manifest fetches and compiled asset URLs align with deployment roots

## Testing
- `bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3aa0d2808332aa51ad00db69d33b)