### PR TITLE
Add Bun/Node CI matrix and dev server check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,69 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  quality:
+    name: "${{ matrix.runtime }} / checks"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [bun, node]
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: oven-sh/setup-bun@v1
-      - name: Cache Bun and node_modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.bun
-            node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun test
-      - run: bun run build
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          else
+            npm install --no-package-lock
+          fi
+
+      - name: Dev server check
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun run dev:check
+          else
+            npm run dev:check
+          fi
+
+      - name: Lint
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun run lint
+          else
+            npm run lint
+          fi
+
+      - name: Type check
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun run typecheck
+          else
+            npm run typecheck
+          fi
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun run build
+          else
+            npm run build
+          fi
+
+      - name: Test
+        run: |
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            bun run test
+          else
+            npm test
+          fi

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,11 +5,22 @@ This guide focuses on day-to-day development tasks for the Stim Webtoys Library.
 ## Tooling and Environment
 
 - **Bun 1.2+** is the default for installs and testing. **Node.js 22** (see `.nvmrc`) is supported as an optional fallback if you prefer npm for Vite or tooling.
+- Use the **Bun/Node matrix** below to match local commands to CI:
+  | Task | Bun command | Node 22 command |
+  | ---- | ----------- | --------------- |
+  | Install deps | `bun install --frozen-lockfile` | `npm install --no-package-lock` |
+  | Dev server smoke test | `bun run dev:check` | `npm run dev:check` |
+  | Lint | `bun run lint` | `npm run lint` |
+  | Type check | `bun run typecheck` | `npm run typecheck` |
+  | Build | `bun run build` | `npm run build` |
+  | Tests | `bun run test` | `npm test` |
+  The CI workflows run this same matrix for Bun and Node 22 to ensure both paths stay healthy.
 - Install dependencies once per clone with Bun:
   ```bash
   bun install
   ```
-  If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install`. When using Node, `npm install` is a backup option.
+  If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install`. When using Node, `npm install --no-package-lock` is a backup option.
+  - Keep `bun.lock` authoritative; avoid committing `package-lock.json`. Use `bun install --frozen-lockfile` in CI and prefer Bun locally to keep dependency resolution consistent.
 - The project uses **TypeScript**, **Vite**, **Three.js**, and the Bun test runner. No extra ESM flags are required when running `bun test`.
 - Run the dev server locally with Bun:
   ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "dev": "vite",
     "dev:host": "vite --host",
+    "dev:check": "node scripts/dev-check.mjs",
     "build": "vite build",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",

--- a/scripts/dev-check.mjs
+++ b/scripts/dev-check.mjs
@@ -1,0 +1,37 @@
+/* eslint-env node */
+/* global fetch, console, process */
+import { createServer } from 'vite';
+
+async function main() {
+  const server = await createServer({
+    clearScreen: false,
+    logLevel: 'error',
+    optimizeDeps: {
+      disabled: true,
+    },
+    server: {
+      host: '127.0.0.1',
+      port: 5173,
+      strictPort: true,
+      hmr: false,
+    },
+  });
+
+  const started = await server.listen();
+  const url = started.resolvedUrls?.local?.[0] ?? 'http://127.0.0.1:5173/';
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Dev server responded with status ${response.status}`);
+    }
+  } finally {
+    await server.close();
+  }
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add Bun/Node command matrix and lockfile guidance to the development docs
- introduce a reusable dev server smoke-test script and wire it into package scripts
- expand CI to run dev, lint, typecheck, build, and tests across Bun and Node 22

## Testing
- bun run dev:check
- bun run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b53d15138833294c4e6181a24ffda)