### PR TITLE
Add capability preflight UI for toy entry

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -764,3 +764,82 @@ body {
   z-index: 1200;
   font-weight: 600;
 }
+
+.preflight-panel {
+  max-width: 420px;
+  gap: 8px;
+}
+
+.preflight-panel__statuses {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  margin: 8px 0;
+}
+
+.preflight-status {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);
+}
+
+.preflight-status__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(233, 251, 255, 0.72);
+  margin: 0 0 4px;
+}
+
+.preflight-status__value {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+
+.preflight-status__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(233, 251, 255, 0.78);
+}
+
+.preflight-status[data-variant='ok'] {
+  border-color: rgba(111, 247, 255, 0.45);
+  box-shadow: 0 0 12px rgba(111, 247, 255, 0.2);
+}
+
+.preflight-status[data-variant='warn'] {
+  border-color: rgba(255, 196, 105, 0.5);
+}
+
+.preflight-status[data-variant='error'] {
+  border-color: rgba(255, 105, 150, 0.55);
+}
+
+.preflight-panel__issues-container {
+  margin-top: 4px;
+}
+
+.preflight-panel__eyebrow {
+  margin: 0 0 4px;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 196, 105, 0.85);
+}
+
+.preflight-panel__issues {
+  margin: 0;
+  padding-left: 16px;
+  color: rgba(233, 251, 255, 0.86);
+  display: grid;
+  gap: 4px;
+}
+
+.preflight-panel__success {
+  margin: 0;
+  color: rgba(111, 247, 255, 0.96);
+  font-weight: 700;
+}

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -1,0 +1,327 @@
+import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+import { getRendererCapabilities } from './renderer-capabilities.ts';
+
+export type CapabilityPreflightResult = {
+  rendering: {
+    hasWebGL: boolean;
+    rendererBackend: 'webgl' | 'webgpu' | null;
+    webgpuFallbackReason: string | null;
+    triedWebGPU: boolean;
+    shouldRetryWebGPU: boolean;
+  };
+  microphone: {
+    supported: boolean;
+    state: PermissionState | 'unsupported' | 'error';
+    reason: string | null;
+  };
+  environment: {
+    secureContext: boolean;
+    reducedMotion: boolean;
+    hardwareConcurrency: number | null;
+  };
+  blockingIssues: string[];
+  warnings: string[];
+  canProceed: boolean;
+};
+
+async function getMicrophonePermissionState() {
+  if (typeof navigator === 'undefined') {
+    return {
+      supported: false,
+      state: 'unsupported' as const,
+      reason: 'Navigator unavailable in this environment.',
+    };
+  }
+
+  if (!navigator.mediaDevices?.getUserMedia) {
+    return {
+      supported: false,
+      state: 'unsupported' as const,
+      reason: 'This browser cannot capture microphone audio.',
+    };
+  }
+
+  if (!navigator.permissions?.query) {
+    return {
+      supported: true,
+      state: 'prompt' as const,
+      reason: null,
+    };
+  }
+
+  try {
+    const result = await navigator.permissions.query({
+      // Firefox throws unless this is cast to PermissionName.
+      name: 'microphone' as PermissionName,
+    });
+    return {
+      supported: true,
+      state: result.state,
+      reason: result.state === 'denied' ? 'Microphone access is blocked for this site.' : null,
+    };
+  } catch (error) {
+    console.warn('Microphone permission probe failed', error);
+    return {
+      supported: true,
+      state: 'error' as const,
+      reason: 'Unable to read microphone permission state. The browser will still prompt when needed.',
+    };
+  }
+}
+
+function checkWebGLAvailability() {
+  const hasWebGL =
+    typeof WebGL !== 'undefined' &&
+    (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
+
+  return Boolean(hasWebGL);
+}
+
+export async function runCapabilityPreflight(): Promise<CapabilityPreflightResult> {
+  const [capabilities, microphone] = await Promise.all([
+    getRendererCapabilities().catch((error) => {
+      console.warn('Renderer capability probe failed', error);
+      return null;
+    }),
+    getMicrophonePermissionState(),
+  ]);
+
+  const hasWebGL = checkWebGLAvailability();
+
+  const renderingBackend = capabilities?.preferredBackend ?? (hasWebGL ? 'webgl' : null);
+  const webgpuFallbackReason = capabilities?.fallbackReason ?? null;
+
+  const blockingIssues: string[] = [];
+  const warnings: string[] = [];
+
+  if (!renderingBackend) {
+    blockingIssues.push('Graphics acceleration is unavailable (WebGL/WebGPU).');
+  } else if (renderingBackend === 'webgl' && webgpuFallbackReason) {
+    warnings.push(webgpuFallbackReason);
+  }
+
+  if (!microphone.supported) {
+    warnings.push('Microphone APIs are unavailable in this browser.');
+  } else if (microphone.state === 'denied') {
+    warnings.push('Microphone access is blocked; visuals will fall back to demo audio.');
+  }
+
+  const reducedMotionQuery =
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+
+  const environment = {
+    secureContext: typeof window !== 'undefined' ? Boolean(window.isSecureContext) : false,
+    reducedMotion: reducedMotionQuery,
+    hardwareConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency ?? null : null,
+  };
+
+  const canProceed = blockingIssues.length === 0;
+
+  return {
+    rendering: {
+      hasWebGL,
+      rendererBackend: renderingBackend,
+      webgpuFallbackReason,
+      triedWebGPU: capabilities?.triedWebGPU ?? false,
+      shouldRetryWebGPU: capabilities?.shouldRetryWebGPU ?? false,
+    },
+    microphone,
+    environment,
+    blockingIssues,
+    warnings,
+    canProceed,
+  };
+}
+
+function buildStatusBadge(label: string, value: string, variant: 'ok' | 'warn' | 'error') {
+  const badge = document.createElement('div');
+  badge.className = 'preflight-status';
+  badge.dataset.variant = variant;
+
+  const title = document.createElement('p');
+  title.className = 'preflight-status__label';
+  title.textContent = label;
+  badge.appendChild(title);
+
+  const state = document.createElement('p');
+  state.className = 'preflight-status__value';
+  state.textContent = value;
+  badge.appendChild(state);
+
+  return badge;
+}
+
+function updateStatusList(container: HTMLElement, result: CapabilityPreflightResult) {
+  container.innerHTML = '';
+
+  const rendererStatus = buildStatusBadge(
+    'Rendering',
+    result.rendering.rendererBackend === 'webgpu'
+      ? 'Ready (WebGPU)'
+      : result.rendering.rendererBackend === 'webgl'
+        ? 'WebGL fallback'
+        : 'Unavailable',
+    result.rendering.rendererBackend ? (result.rendering.rendererBackend === 'webgpu' ? 'ok' : 'warn') : 'error'
+  );
+
+  const rendererNote = document.createElement('p');
+  rendererNote.className = 'preflight-status__note';
+  rendererNote.textContent =
+    result.rendering.rendererBackend === 'webgpu'
+      ? 'Best fidelity enabled.'
+      : result.rendering.rendererBackend === 'webgl'
+        ? result.rendering.webgpuFallbackReason ?? 'WebGPU was not available; using WebGL.'
+        : 'GPU acceleration was not detected. Enable hardware acceleration or update your browser.';
+  rendererStatus.appendChild(rendererNote);
+
+  const microphoneStatus = buildStatusBadge(
+    'Microphone',
+    !result.microphone.supported
+      ? 'Unavailable'
+      : result.microphone.state === 'granted'
+        ? 'Ready'
+        : result.microphone.state === 'denied'
+          ? 'Blocked'
+          : 'Will prompt on start',
+    !result.microphone.supported || result.microphone.state === 'denied'
+      ? 'warn'
+      : result.microphone.state === 'granted'
+        ? 'ok'
+        : 'warn'
+  );
+
+  const microphoneNote = document.createElement('p');
+  microphoneNote.className = 'preflight-status__note';
+  microphoneNote.textContent =
+    result.microphone.reason ??
+    (result.microphone.state === 'granted'
+      ? 'We will start listening when you click Start audio.'
+      : 'The browser will prompt for microphone access when audio starts.');
+  microphoneStatus.appendChild(microphoneNote);
+
+  const environmentStatus = buildStatusBadge(
+    'Environment',
+    result.environment.secureContext ? 'Secure context' : 'Insecure context',
+    result.environment.secureContext ? 'ok' : 'warn'
+  );
+
+  const environmentNote = document.createElement('p');
+  environmentNote.className = 'preflight-status__note';
+  const hardwareCopy = result.environment.hardwareConcurrency
+    ? `Cores detected: ${result.environment.hardwareConcurrency}.`
+    : 'Hardware concurrency unknown.';
+  const motionCopy = result.environment.reducedMotion
+    ? 'Reduced motion preference detected.'
+    : 'Full motion effects enabled.';
+  environmentNote.textContent = `${hardwareCopy} ${motionCopy}`;
+  environmentStatus.appendChild(environmentNote);
+
+  [rendererStatus, microphoneStatus, environmentStatus].forEach((status) => {
+    container.appendChild(status);
+  });
+}
+
+function renderIssueList(container: HTMLElement, result: CapabilityPreflightResult) {
+  container.innerHTML = '';
+  const issues = result.blockingIssues.length ? result.blockingIssues : result.warnings;
+  if (!issues.length) {
+    const success = document.createElement('p');
+    success.className = 'preflight-panel__success';
+    success.textContent = 'System check passed. Loading the toy now.';
+    container.appendChild(success);
+    return;
+  }
+
+  const heading = document.createElement('p');
+  heading.className = 'preflight-panel__eyebrow';
+  heading.textContent = result.blockingIssues.length ? 'Action needed before loading' : 'Heads up';
+  container.appendChild(heading);
+
+  const list = document.createElement('ul');
+  list.className = 'preflight-panel__issues';
+  issues.forEach((issue) => {
+    const item = document.createElement('li');
+    item.textContent = issue;
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+}
+
+export function attachCapabilityPreflight({
+  host = document.body,
+  heading = 'Quick system check',
+  onComplete,
+  onRetry,
+}: {
+  host?: HTMLElement;
+  heading?: string;
+  onComplete?: (result: CapabilityPreflightResult) => void;
+  onRetry?: (result: CapabilityPreflightResult) => void;
+} = {}) {
+  const panel = document.createElement('section');
+  panel.className = 'control-panel control-panel--floating preflight-panel';
+  panel.setAttribute('aria-live', 'polite');
+
+  const title = document.createElement('div');
+  title.className = 'control-panel__heading';
+  title.textContent = heading;
+  panel.appendChild(title);
+
+  const description = document.createElement('p');
+  description.className = 'control-panel__description';
+  description.textContent = 'We check graphics and microphone support before loading heavy scenes.';
+  panel.appendChild(description);
+
+  const statusContainer = document.createElement('div');
+  statusContainer.className = 'preflight-panel__statuses';
+  panel.appendChild(statusContainer);
+
+  const issueContainer = document.createElement('div');
+  issueContainer.className = 'preflight-panel__issues-container';
+  panel.appendChild(issueContainer);
+
+  const actions = document.createElement('div');
+  actions.className = 'control-panel__actions control-panel__actions--inline';
+  const retryButton = document.createElement('button');
+  retryButton.className = 'cta-button';
+  retryButton.type = 'button';
+  retryButton.textContent = 'Retry checks';
+  actions.appendChild(retryButton);
+  panel.appendChild(actions);
+
+  const run = async (isRetry = false) => {
+    panel.dataset.state = 'running';
+    retryButton.disabled = true;
+    const result = await runCapabilityPreflight();
+    panel.dataset.state = result.canProceed ? 'ready' : 'blocked';
+    retryButton.disabled = false;
+    updateStatusList(statusContainer, result);
+    renderIssueList(issueContainer, result);
+    if (isRetry) {
+      onRetry?.(result);
+    } else {
+      onComplete?.(result);
+    }
+    return result;
+  };
+
+  retryButton.addEventListener('click', () => {
+    void run(true);
+  });
+
+  const attach = () => host.appendChild(panel);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attach, { once: true });
+  } else {
+    attach();
+  }
+
+  void run();
+
+  return {
+    run,
+    destroy: () => panel.remove(),
+  };
+}

--- a/assets/js/toyMain.js
+++ b/assets/js/toyMain.js
@@ -1,4 +1,0 @@
-import { initNavigation, loadFromQuery } from './loader.ts';
-
-initNavigation();
-loadFromQuery();

--- a/assets/js/toyMain.ts
+++ b/assets/js/toyMain.ts
@@ -1,0 +1,6 @@
+import { initNavigation, loadFromQuery } from './loader.ts';
+
+export function startToyPage() {
+  initNavigation();
+  void loadFromQuery();
+}

--- a/toy.html
+++ b/toy.html
@@ -31,13 +31,50 @@
         </button>
       </div>
     </div>
-    <script type="module" src="assets/js/toyMain.js"></script>
+    <script type="module" src="assets/js/toyMain.ts"></script>
     <script type="module">
+      import { attachCapabilityPreflight } from './assets/js/core/capability-preflight.ts';
       import { setupMicrophonePermissionFlow } from './assets/js/core/microphone-flow.ts';
+      import { startToyPage } from './assets/js/toyMain.ts';
 
       const startButton = document.getElementById('start-audio-btn');
       const fallbackButton = document.getElementById('use-demo-audio');
       const statusElement = document.getElementById('audio-status');
+
+      let loaderStarted = false;
+      const startLoaderIfNeeded = () => {
+        if (loaderStarted) return;
+        loaderStarted = true;
+        startToyPage();
+      };
+
+      const updateStatus = (message, variant = 'error') => {
+        if (!statusElement) return;
+        statusElement.hidden = false;
+        statusElement.dataset.variant = variant;
+        statusElement.textContent = message;
+      };
+
+      attachCapabilityPreflight({
+        heading: 'Capability check',
+        onComplete: (result) => {
+          if (result.canProceed) {
+            updateStatus('Loading toy...', 'success');
+            startLoaderIfNeeded();
+          } else {
+            updateStatus(
+              'Rendering is unavailable. Enable hardware acceleration or update your browser, then retry the checks.'
+            );
+          }
+        },
+        onRetry: (result) => {
+          if (result.canProceed) {
+            updateStatus('Loading toy...', 'success');
+            startLoaderIfNeeded();
+          }
+        },
+        host: document.body,
+      });
 
       const getStarter = (fallback = false) => {
         const globalStart = window.startAudio;


### PR DESCRIPTION
## Summary
- add a shared capability preflight helper to probe rendering, microphone, and environment flags
- render a floating preflight panel on the toy entry page and delay loading until checks pass
- style the preflight widget and expose a start function for the toy loader bootstrap

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b53f78bec8332ab42d345511a4dd8)