### PR TITLE
Improve microphone permission retries and messaging

### DIFF
--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-type AudioAccessReason = 'unsupported' | 'denied' | 'unavailable';
+type AudioAccessReason = 'unsupported' | 'denied' | 'unavailable' | 'timeout';
 
 const FREQUENCY_ANALYSER_PROCESSOR = new URL(
   './frequency-analyser-processor.ts',

--- a/tests/microphone-flow.test.ts
+++ b/tests/microphone-flow.test.ts
@@ -81,6 +81,37 @@ describe('setupMicrophonePermissionFlow', () => {
     expect(statusElement.dataset.variant).toBe('error');
     expect(statusElement.textContent).toContain('blocked');
     expect(fallbackButton.hidden).toBe(false);
+    expect(startButton.textContent).toContain('Retry microphone');
+
+    const toast = document.querySelector('[data-audio-toast="true"]');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('permissions');
+    expect(toast?.getAttribute('role')).toBe('alert');
+  });
+
+  test('communicates timeout guidance and shows retry affordance', async () => {
+    const { startButton, fallbackButton, statusElement } = buildDom();
+
+    mockPermissionState('prompt');
+
+    const timeoutPromise = new Promise(() => {});
+
+    const flow = setupMicrophonePermissionFlow({
+      startButton,
+      fallbackButton,
+      statusElement,
+      requestMicrophone: () => timeoutPromise,
+      timeoutMs: 5,
+    });
+
+    await expect(flow.startMicrophoneRequest()).rejects.toBeInstanceOf(
+      AudioAccessError
+    );
+
+    expect(statusElement.dataset.variant).toBe('error');
+    expect(statusElement.textContent).toContain('timed out');
+    expect(fallbackButton.hidden).toBe(false);
+    expect(startButton.textContent).toContain('Retry microphone');
   });
 
   test('removes event listeners when disposed before reinitializing', async () => {


### PR DESCRIPTION
## Summary
- add clearer microphone denial/timeout guidance with retry messaging and toast fallback hints
- expose toast host option and retry labeling while preserving demo audio fallback handling
- cover denial and timeout flows with new unit tests for the microphone permission helper

## Testing
- bun run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b557543888332915fb21302162535)