### PR TITLE
Fix iframe scaffold metadata paths

### DIFF
--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -11,7 +11,7 @@ type Toy = {
   slug: string;
   title?: string;
   module: string;
-  type: 'module' | 'page';
+  type: 'module' | 'page' | 'iframe';
   requiresWebGPU?: boolean;
   allowWebGLFallback?: boolean;
 };

--- a/scripts/scaffold-toy.ts
+++ b/scripts/scaffold-toy.ts
@@ -312,13 +312,15 @@ async function appendToyMetadata(
     throw new Error(`Slug "${slug}" already exists in assets/js/toys-data.js.`);
   }
 
+  const modulePath = type === 'iframe' ? `${slug}.html` : `assets/js/toys/${slug}.ts`;
+
   const newEntry = [
     '  {',
     `    slug: '${slug}',`,
     `    title: '${title.replace(/'/g, "\\'")}',`,
     '    description:',
     `      '${description.replace(/'/g, "\\'")}',`,
-    `    module: 'assets/js/toys/${slug}.ts',`,
+    `    module: '${modulePath}',`,
     `    type: '${type}',`,
     '    requiresWebGPU: false,',
     '  },',
@@ -351,8 +353,10 @@ async function validateMetadataEntry(
     throw new Error(`Failed to register ${slug} in assets/js/toys-data.js.`);
   }
 
-  if (entry.module !== `assets/js/toys/${slug}.ts`) {
-    throw new Error(`Module path for ${slug} must be assets/js/toys/${slug}.ts.`);
+  const expectedModule = type === 'iframe' ? `${slug}.html` : `assets/js/toys/${slug}.ts`;
+
+  if (entry.module !== expectedModule) {
+    throw new Error(`Module path for ${slug} must be ${expectedModule}.`);
   }
 
   if (entry.type !== type) {
@@ -372,7 +376,8 @@ async function updateToyIndex(slug: string, type: ToyType, root = repoRoot) {
   const indexPath = path.join(root, 'docs/TOY_SCRIPT_INDEX.md');
   const current = await fs.readFile(indexPath, 'utf8');
 
-  const row = `| \`${slug}\` | \`assets/js/toys/${slug}.ts\` | ${
+  const modulePath = type === 'iframe' ? `${slug}.html` : `assets/js/toys/${slug}.ts`;
+  const row = `| \`${slug}\` | \`${modulePath}\` | ${
     type === 'iframe'
       ? `Iframe wrapper around \`${slug}.html\`.`
       : `Direct module; load with \`toy.html?toy=${slug}\`.`

--- a/tests/check-toys.test.ts
+++ b/tests/check-toys.test.ts
@@ -30,11 +30,11 @@ describe('check-toys script', () => {
     await fs.writeFile(path.join(root, `${slug}.html`), '<!doctype html>');
     await fs.writeFile(
       path.join(root, 'assets/js/toys-data.js'),
-      `export default [{ slug: '${slug}', title: 'Aligned', description: 'ok', module: 'assets/js/toys/${slug}.ts', type: 'iframe' }];\n`
+      `export default [{ slug: '${slug}', title: 'Aligned', description: 'ok', module: '${slug}.html', type: 'iframe' }];\n`
     );
     await fs.appendFile(
       path.join(root, 'docs/TOY_SCRIPT_INDEX.md'),
-      `| \`${slug}\` | \`assets/js/toys/${slug}.ts\` | Iframe wrapper |\n`
+      `| \`${slug}\` | \`${slug}.html\` | Iframe wrapper |\n`
     );
 
     const result = await runToyChecks(root);
@@ -48,7 +48,7 @@ describe('check-toys script', () => {
     await writeToyModule(root, slug);
     await fs.writeFile(
       path.join(root, 'assets/js/toys-data.js'),
-      `export default [{ slug: '${slug}', title: 'Missing Entry', description: 'oops', module: 'assets/js/toys/${slug}.ts', type: 'iframe' }];\n`
+      `export default [{ slug: '${slug}', title: 'Missing Entry', description: 'oops', module: '${slug}.html', type: 'iframe' }];\n`
     );
 
     const result = await runToyChecks(root);

--- a/tests/scaffold-toy.test.ts
+++ b/tests/scaffold-toy.test.ts
@@ -112,6 +112,7 @@ describe('scaffold-toy CLI helpers', () => {
     const data = await import(pathToFileURL(path.join(root, 'assets/js/toys-data.js')).href);
     const entry = data.default.find((item: { slug: string }) => item.slug === slug);
     expect(entry).toBeDefined();
+    expect(entry.module).toBe(`${slug}.html`);
     expect(entry.type).toBe('iframe');
   });
 });


### PR DESCRIPTION
## Summary
- point iframe scaffold metadata to the generated HTML entry instead of the TypeScript module
- tighten toy validation to expect iframe entries to reference their HTML and still allow module detection
- allow iframe entries in the loader and refresh associated tests

## Testing
- bun test tests/scaffold-toy.test.ts tests/check-toys.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b5aed4ea88332b42898635dc87d8b)