### PR TITLE
Ensure Pages installs dev dependencies for Vite build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Ensure devDependencies (e.g., Vite) are installed in CI and Pages builds
+production=false

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -53,6 +53,8 @@ If your platform supports immutable caching, enable it for `dist/assets/**`; kee
 
 Cloudflare Pages reads the build command from the project settings in the dashboard, so keep `wrangler.toml` limited to the shared metadata (`name`, `compatibility_date`, and `pages_build_output_dir`). Do **not** add a `[build]` table—Pages rejects it and will surface a configuration validation error. Configure the build command (for example, `bun run build`) directly in Pages, or rely on `CF_PAGES=1` with the existing install script to generate `dist/` during install.
 
+> **Install step:** Make sure devDependencies are present so `vite` exists at build time. In Cloudflare Pages, set the install command to `bun install` (or `npm install`) and keep `NPM_CONFIG_PRODUCTION=false` (the repo ships `.npmrc` with `production=false` for this). If you prefer Bun, set `BUN_INSTALL_DEV=true` to mirror local installs.
+
 ### Pages CLI flows
 
 Use the dedicated scripts to avoid drift between local and CI deployments:


### PR DESCRIPTION
## Summary
- add .npmrc to keep devDependencies during installs so Vite is available for builds
- document Cloudflare Pages install command guidance and environment vars for dev dependency installation

## Testing
- bun run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b588983908332bb16e886cb7ee553)