### PR TITLE
Improve documentation navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,22 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
-For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
-If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
+For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns. If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
+
+## Documentation map
+
+Use these entry points to find the right docs quickly:
+
+- [`docs/README.md`](./docs/README.md): overview of all project docs plus onboarding highlights.
+- [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md): day-to-day setup, tooling, scripts, and workflow expectations.
+- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md) and [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md): how to build or modify toys, plus a map from toy slugs to their TypeScript entry points.
+- [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md): production build/preview steps, Cloudflare Pages/Workers notes, and static hosting tips.
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md): runtime composition, loaders, and diagrams for the core systems.
+- [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md): Model Context Protocol stdio server usage and available tools.
+
+If you add new scripts, toys, or deployment options, update the relevant doc above so the workflows stay discoverable.
 
 ## Quick Start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,16 @@ If you add new tooling or patterns, update these docs so the next contributor ha
 - Use **Bun 1.2+** for installs and scripts (Node 22 is available as a fallback). Run `bun install` in a fresh clone to populate `bun.lock`-aligned dependencies.
 - Run a **dev server smoke test** without opening a browser via `bun run dev:check` (or `npm run dev:check`) to confirm Vite wiring before you start coding.
 - When adding or renaming toys, run `bun run check:toys` to ensure `assets/js/toys-data.js` entries, TypeScript modules, iframe HTML files, and `docs/TOY_SCRIPT_INDEX.md` stay in sync.
+
+## Navigation tips
+
+- Start with [`DEVELOPMENT.md`](./DEVELOPMENT.md) if you’re getting your environment ready; it mirrors the quick start in the repo root but adds tooling details and command matrices.
+- Jump to [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) when you’re building or adjusting an experience; it links back to reusable components in `assets/js/core/` and the toy index.
+- Check [`DEPLOYMENT.md`](./DEPLOYMENT.md) before shipping changes to production so your build/preview/Pages flow matches the current configuration.
+- Review [`ARCHITECTURE.md`](./ARCHITECTURE.md) when you need a refresher on renderer wiring, data flow, or how audio/motion inputs are shared.
+
+## Doc maintenance checklist
+
+- Add or update a link here whenever you create a new guide under `docs/` so contributors can discover it.
+- Cross-link new scripts or workflows from the relevant guide (for example, record new npm/bun scripts in `DEVELOPMENT.md` and toy-scaffolding changes in `TOY_DEVELOPMENT.md`).
+- Keep toy-related documentation synchronized: update `TOY_SCRIPT_INDEX.md` and `toys.md` when adding, renaming, or removing a toy entry point.


### PR DESCRIPTION
## Summary
- add a documentation map to the root README for quicker doc discovery
- expand docs/README with navigation tips and maintenance checklist to keep guides in sync

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cab8862b88332812fb02a0af5bfa7)