### PR TITLE
Clarify documentation maintenance triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use these entry points to find the right docs quickly:
 
 - [`docs/README.md`](./docs/README.md): overview of all project docs plus onboarding highlights.
 - [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md): day-to-day setup, tooling, scripts, and workflow expectations.
-- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md) and [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md): how to build or modify toys, plus a map from toy slugs to their TypeScript entry points.
+- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md), and [`docs/toys.md`](./docs/toys.md): how to build or modify toys, toy script index, and per-toy notes.
 - [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md): production build/preview steps, Cloudflare Pages/Workers notes, and static hosting tips.
 - [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md): runtime composition, loaders, and diagrams for the core systems.
 - [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md): Model Context Protocol stdio server usage and available tools.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,31 @@
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to provide some fun sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play, or as a form of sensory exploration, especially for neurodiverse folks.
 
-For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns.
-If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
+For setup, testing, and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns. If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.
+
+## Documentation map
+
+Use these entry points to find the right docs quickly:
+
+- [`docs/README.md`](./docs/README.md): overview of all project docs plus onboarding highlights.
+- [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md): day-to-day setup, tooling, scripts, and workflow expectations.
+- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md) and [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md): how to build or modify toys, plus a map from toy slugs to their TypeScript entry points.
+- [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md): production build/preview steps, Cloudflare Pages/Workers notes, and static hosting tips.
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md): runtime composition, loaders, and diagrams for the core systems.
+- [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md): Model Context Protocol stdio server usage and available tools.
+
+If you add new scripts, toys, or deployment options, update the relevant doc above so the workflows stay discoverable.
+
+**When to update docs**
+
+| Change type | Docs to touch |
+| --- | --- |
+| New toy or renamed slug | `docs/TOY_DEVELOPMENT.md`, `docs/TOY_SCRIPT_INDEX.md`, `docs/toys.md` |
+| New script or workflow change | `docs/DEVELOPMENT.md` |
+| Hosting or CI change | `docs/DEPLOYMENT.md`, `docs/ARCHITECTURE.md` (if it alters runtime/data flow) |
+| MCP server updates | `docs/MCP_SERVER.md` |
 
 ## Quick Start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,29 @@ This folder contains resources for contributors who are building or maintaining 
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.
 
+### How to add a new guide
+
+1. Create the Markdown file under `docs/` with a clear title and a short purpose statement in the first paragraph.
+2. Add a bullet link in this README under the list above so others can find it.
+3. Cross-link the guide from the relevant primary doc (for example, reference new build steps from `DEVELOPMENT.md`).
+4. If the guide introduces new scripts, toy entry points, or deployment steps, update the checklists and indexes they depend on.
+
 ## Onboarding highlights
 
 - Use **Bun 1.2+** for installs and scripts (Node 22 is available as a fallback). Run `bun install` in a fresh clone to populate `bun.lock`-aligned dependencies.
 - Run a **dev server smoke test** without opening a browser via `bun run dev:check` (or `npm run dev:check`) to confirm Vite wiring before you start coding.
 - When adding or renaming toys, run `bun run check:toys` to ensure `assets/js/toys-data.js` entries, TypeScript modules, iframe HTML files, and `docs/TOY_SCRIPT_INDEX.md` stay in sync.
+
+## Navigation tips
+
+- Start with [`DEVELOPMENT.md`](./DEVELOPMENT.md) if you’re getting your environment ready; it mirrors the quick start in the repo root but adds tooling details and command matrices.
+- Jump to [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) when you’re building or adjusting an experience; it links back to reusable components in `assets/js/core/` and the toy index.
+- Check [`DEPLOYMENT.md`](./DEPLOYMENT.md) before shipping changes to production so your build/preview/Pages flow matches the current configuration.
+- Review [`ARCHITECTURE.md`](./ARCHITECTURE.md) when you need a refresher on renderer wiring, data flow, or how audio/motion inputs are shared.
+
+## Doc maintenance checklist
+
+- Add or update a link here whenever you create a new guide under `docs/` so contributors can discover it.
+- Cross-link new scripts or workflows from the relevant guide (for example, record new npm/bun scripts in `DEVELOPMENT.md` and toy-scaffolding changes in `TOY_DEVELOPMENT.md`).
+- Keep toy-related documentation synchronized: update `TOY_SCRIPT_INDEX.md` and `toys.md` when adding, renaming, or removing a toy entry point.
+- Before shipping a PR, skim the docs above for stale script names, flags, or file paths introduced by your change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,5 +37,5 @@ If you add new tooling or patterns, update these docs so the next contributor ha
 
 - Add or update a link here whenever you create a new guide under `docs/` so contributors can discover it.
 - Cross-link new scripts or workflows from the relevant guide (for example, record new npm/bun scripts in `DEVELOPMENT.md` and toy-scaffolding changes in `TOY_DEVELOPMENT.md`).
-- Keep toy-related documentation synchronized: update `TOY_SCRIPT_INDEX.md` and `toys.md` when adding, renaming, or removing a toy entry point.
+- Keep toy-related documentation synchronized: update `TOY_DEVELOPMENT.md`, `TOY_SCRIPT_INDEX.md`, and `toys.md` when adding, renaming, or removing a toy entry point.
 - Before shipping a PR, skim the docs above for stale script names, flags, or file paths introduced by your change.


### PR DESCRIPTION
## Summary
- add a quick table in the root README that maps common change types to the docs that must be updated
- document the steps for adding a new guide and add a pre-PR doc freshness check in docs/README

## Testing
- not run (docs-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cab8862b88332812fb02a0af5bfa7)