### PR TITLE
Refresh landing page experience

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -22,6 +22,7 @@
   --surface-border: rgba(255, 255, 255, 0.1);
   --shadow-strong: 0 24px 60px rgba(0, 0, 0, 0.35);
   --shadow-soft: 0 14px 36px rgba(0, 0, 0, 0.28);
+  --shadow-surface: 0 14px 38px rgba(2, 4, 13, 0.65);
   --radius-lg: 20px;
   --radius-md: 14px;
   --radius-pill: 999px;
@@ -183,8 +184,10 @@ header.hero {
   padding: clamp(2.4rem, 2vw + 1.4rem, 3.2rem);
   overflow: hidden;
   border-radius: 24px;
-  background: linear-gradient(150deg, rgba(100, 244, 255, 0.12), rgba(255, 111, 227, 0.08));
-  box-shadow: var(--shadow-soft);
+  background: linear-gradient(150deg, rgba(100, 244, 255, 0.14), rgba(255, 111, 227, 0.12)),
+    radial-gradient(circle at 18% 10%, rgba(109, 240, 255, 0.16), transparent 40%),
+    radial-gradient(circle at 90% 30%, rgba(255, 111, 227, 0.14), transparent 45%);
+  box-shadow: var(--shadow-surface);
   border: 1px solid var(--surface-border);
   backdrop-filter: blur(14px) saturate(125%);
 }
@@ -227,6 +230,36 @@ header.hero {
   text-align: left;
   display: grid;
   gap: 0.85rem;
+}
+
+.signal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.7rem;
+  margin: 0.25rem 0 0.25rem;
+}
+
+.signal-card {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(109, 240, 255, 0.12), rgba(155, 123, 255, 0.12));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(10px);
+}
+
+.signal-label {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  color: var(--text-color);
+  font-weight: 700;
+}
+
+.signal-value {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
 .hero-visual {
@@ -453,15 +486,13 @@ header.hero {
 }
 
 .hero-highlights {
-  list-style: none;
-  padding: 0;
   margin: 0.5rem 0 0;
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
 }
 
-.hero-highlights li {
+.highlight-chip {
   background: var(--surface-gradient);
   border-radius: var(--radius-pill);
   padding: 0.65rem 0.9rem;
@@ -474,7 +505,7 @@ header.hero {
   font-weight: 600;
 }
 
-.hero-highlights li span {
+.highlight-chip span {
   font-size: 1.05rem;
 }
 
@@ -814,6 +845,63 @@ footer {
 
 .footer-helper {
   margin: 0.25rem 0 0;
+}
+
+.feature-bands {
+  margin-top: -0.5rem;
+  padding: clamp(1.2rem, 1vw + 1rem, 2rem);
+  border-radius: 24px;
+  background: linear-gradient(160deg, rgba(10, 16, 40, 0.9), rgba(14, 20, 48, 0.92));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-surface);
+  backdrop-filter: blur(12px) saturate(120%);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.feature-card {
+  background: linear-gradient(135deg, rgba(109, 240, 255, 0.14), rgba(155, 123, 255, 0.1));
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  align-items: start;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(10px);
+}
+
+.feature-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  background: linear-gradient(145deg, rgba(109, 240, 255, 0.22), rgba(255, 111, 227, 0.18));
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+}
+
+.feature-body h3 {
+  margin: 0 0 0.35rem;
+}
+
+.feature-body p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.feature-meta {
+  font-size: 0.9rem;
+  color: var(--text-color);
+  opacity: 0.8;
 }
 
 .theme-toggle {

--- a/index.html
+++ b/index.html
@@ -55,13 +55,22 @@
         <div class="hero-grid">
           <div class="hero-copy">
             <p class="eyebrow">Open-source stims • Quick to try • No accounts</p>
-            <h1>Launch an interactive webtoy in seconds.</h1>
+            <h1>Feel-first visuals that breathe with your audio.</h1>
             <p class="tagline">
-              Explore audio, color, and motion without setup. Every stim opens
-              fast, works with mic and touch, and ships with clear controls. When
-              you launch a toy, we’ll ask for microphone access so visuals can
-              react to your sound.
+              Explore audio, color, and motion without setup. Every stim opens fast, responds to mic and touch,
+              and comes with sensible defaults that keep you in flow. When you launch a toy, we’ll ask for
+              microphone access so visuals can react to your sound.
             </p>
+            <div class="signal-grid" role="list">
+              <div class="signal-card" role="listitem">
+                <p class="signal-label">Cinematic by default</p>
+                <p class="signal-value">Layered gradients, softened edges, and light/dark palettes that respect your theme.</p>
+              </div>
+              <div class="signal-card" role="listitem">
+                <p class="signal-label">Responsive everywhere</p>
+                <p class="signal-value">Keyboard, touch, and reduced-motion aware so focus stays on the sensation, not the setup.</p>
+              </div>
+            </div>
             <div class="cta-row">
               <a
                 href="toy.html?toy=holy"
@@ -106,11 +115,12 @@
                 Loading GitHub stats…
               </p>
             </div>
-            <ul class="hero-highlights">
-              <li><span aria-hidden="true">🪩</span> Audio-reactive scenes and tactile controls.</li>
-              <li><span aria-hidden="true">⚡</span> Zero-install links that open instantly.</li>
-              <li><span aria-hidden="true">🌗</span> Light/dark mode remembers your choice.</li>
-            </ul>
+            <div class="hero-highlights">
+              <div class="highlight-chip"><span aria-hidden="true">🪩</span> Audio-reactive scenes and tactile controls.</div>
+              <div class="highlight-chip"><span aria-hidden="true">⚡</span> Zero-install links that open instantly.</div>
+              <div class="highlight-chip"><span aria-hidden="true">🌗</span> Light/dark mode remembers your choice.</div>
+              <div class="highlight-chip"><span aria-hidden="true">🧭</span> Curated paths help you find a vibe fast.</div>
+            </div>
           </div>
           <div class="hero-visual" aria-hidden="true">
             <div class="orbital">
@@ -136,6 +146,43 @@
           </div>
         </div>
       </header>
+
+      <section class="feature-bands">
+        <div class="section-heading">
+          <p class="eyebrow">Design refresh</p>
+          <h2>Curated paths make discovery calmer</h2>
+          <p class="section-description">
+            We rebuilt the landing layout with layered glass, new gradients, and cushioned cards. Spotlights and sound-first
+            tips now sit above the full library so you can either follow a vibe or dive straight into every toy.
+          </p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">🌈</div>
+            <div class="feature-body">
+              <h3>Color-first spotlights</h3>
+              <p>New highlight cards pair atmospheric gradients with clear descriptions so you can pick a palette that matches your mood.</p>
+              <p class="feature-meta">Glassy borders, subtle glow, and rounded corners that feel tactile.</p>
+            </div>
+          </article>
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">🎧</div>
+            <div class="feature-body">
+              <h3>Audio-aware guidance</h3>
+              <p>Callouts explain how to start with microphone input, demos, or device motion without ever feeling technical.</p>
+              <p class="feature-meta">Lightweight help text with improved readability on both themes.</p>
+            </div>
+          </article>
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">🧭</div>
+            <div class="feature-body">
+              <h3>Wayfinding that hugs the grid</h3>
+              <p>New section spacing, pill-shaped highlights, and soft dividers keep the experience airy even with dozens of entries.</p>
+              <p class="feature-meta">Library search and cards inherit the refreshed styling automatically.</p>
+            </div>
+          </article>
+        </div>
+      </section>
 
       <section class="library">
         <div class="section-heading">


### PR DESCRIPTION
## Summary
- Refresh landing hero messaging with signal cards and tactile highlight chips for clearer guidance
- Add a design-refresh feature band that surfaces curated pathways before the full library
- Update styling with deeper gradients, glass panels, and accent shadows to match the elevated layout

## Testing
- bun run dev --host --port 4173


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ccb7aaf508332a6dd9cb9ae44a7e7)