### PR TITLE
Add shared WebGL bootstrap helper and apply to entry points

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -459,6 +459,32 @@ body {
   animation: hueShift 12s linear infinite;
 }
 
+.rendering-fallback {
+  margin: 32px auto;
+  padding: 20px 22px;
+  width: min(640px, 92vw);
+  background: rgba(4, 8, 18, 0.8);
+  border: 1px solid rgba(111, 247, 255, 0.45);
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35), 0 0 18px rgba(17, 216, 255, 0.25);
+  color: #e9fbff;
+}
+
+.rendering-fallback h2 {
+  margin: 6px 0 10px;
+  font-size: 1.35rem;
+  letter-spacing: 0.01em;
+}
+
+.rendering-fallback__description {
+  margin: 0 0 12px;
+  color: rgba(233, 251, 255, 0.82);
+}
+
+.rendering-fallback__preview {
+  margin-top: 6px;
+}
+
 .control-panel {
   position: fixed;
   bottom: 16px;

--- a/assets/js/utils/webgl-bootstrap.ts
+++ b/assets/js/utils/webgl-bootstrap.ts
@@ -87,6 +87,7 @@ export function bootstrapWebGL(options: BootstrapOptions = {}) {
     title: content.title,
     description: content.description,
     previewLabel: content.previewLabel,
+    renderOverlay: false,
   });
 
   if (supported) {

--- a/assets/js/utils/webgl-bootstrap.ts
+++ b/assets/js/utils/webgl-bootstrap.ts
@@ -1,0 +1,99 @@
+import { ensureWebGL } from './webgl-check.ts';
+
+type BootstrapOptions = {
+  mountSelector?: string;
+  overlayTitle?: string;
+  overlayDescription?: string;
+  previewLabel?: string;
+};
+
+type FallbackContent = {
+  title: string;
+  description: string;
+  previewLabel: string;
+};
+
+const FALLBACK_ID = 'rendering-fallback';
+
+const defaultContent: FallbackContent = {
+  title: 'WebGL or WebGPU is required',
+  description:
+    'This visual needs GPU acceleration to draw its 3D graphics. Update your browser or enable hardware acceleration to continue.',
+  previewLabel: 'Static preview (visuals paused without GPU support)',
+};
+
+function getFallbackMount(mountSelector?: string) {
+  if (typeof document === 'undefined') return null;
+  if (mountSelector) {
+    const mount = document.querySelector<HTMLElement>(mountSelector);
+    if (mount) return mount;
+  }
+  return document.body;
+}
+
+function removeFallback(mountSelector?: string) {
+  const mount = getFallbackMount(mountSelector);
+  const existing = mount?.querySelector(`#${FALLBACK_ID}`);
+  existing?.remove();
+}
+
+function renderFallback(content: FallbackContent, mountSelector?: string) {
+  const mount = getFallbackMount(mountSelector);
+  if (!mount) return;
+
+  if (mount.querySelector(`#${FALLBACK_ID}`)) return;
+
+  const container = document.createElement('section');
+  container.id = FALLBACK_ID;
+  container.className = 'rendering-fallback';
+  container.setAttribute('role', 'status');
+
+  const eyebrow = document.createElement('p');
+  eyebrow.className = 'rendering-overlay__eyebrow';
+  eyebrow.textContent = 'Playback unavailable';
+  container.appendChild(eyebrow);
+
+  const heading = document.createElement('h2');
+  heading.textContent = content.title;
+  container.appendChild(heading);
+
+  const description = document.createElement('p');
+  description.className = 'rendering-fallback__description';
+  description.textContent = content.description;
+  container.appendChild(description);
+
+  const preview = document.createElement('div');
+  preview.className = 'rendering-overlay__preview rendering-fallback__preview';
+  const previewLabel = document.createElement('p');
+  previewLabel.textContent = content.previewLabel;
+  preview.appendChild(previewLabel);
+  const previewPane = document.createElement('div');
+  previewPane.className = 'rendering-overlay__preview-pane';
+  previewPane.setAttribute('aria-hidden', 'true');
+  preview.appendChild(previewPane);
+  container.appendChild(preview);
+
+  mount.appendChild(container);
+}
+
+export function bootstrapWebGL(options: BootstrapOptions = {}) {
+  const content: FallbackContent = {
+    title: options.overlayTitle ?? defaultContent.title,
+    description: options.overlayDescription ?? defaultContent.description,
+    previewLabel: options.previewLabel ?? defaultContent.previewLabel,
+  };
+
+  const supported = ensureWebGL({
+    title: content.title,
+    description: content.description,
+    previewLabel: content.previewLabel,
+  });
+
+  if (supported) {
+    removeFallback(options.mountSelector);
+    return true;
+  }
+
+  renderFallback(content, options.mountSelector);
+  return false;
+}

--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -15,7 +15,11 @@ type OverlayContent = {
   previewLabel: string;
 };
 
-type EnsureOptions = Partial<Pick<OverlayContent, 'title' | 'description' | 'previewLabel'>>;
+type EnsureOptions = Partial<
+  Pick<OverlayContent, 'title' | 'description' | 'previewLabel'>
+> & {
+  renderOverlay?: boolean;
+};
 
 function removeExistingOverlay() {
   const existing = typeof document !== 'undefined' ? document.getElementById(OVERLAY_ID) : null;
@@ -107,6 +111,8 @@ function addCapabilityOverlay(content: OverlayContent) {
 }
 
 export function ensureWebGL(options: EnsureOptions = {}) {
+  const { renderOverlay, ...overlayOverrides } = options;
+
   const defaultContent: OverlayContent = {
     title: 'WebGL or WebGPU is required',
     description:
@@ -125,10 +131,12 @@ export function ensureWebGL(options: EnsureOptions = {}) {
 
   const content: OverlayContent = {
     ...defaultContent,
-    ...options,
+    ...overlayOverrides,
     steps: defaultContent.steps,
     links: defaultContent.links,
   };
+
+  const shouldRenderOverlay = renderOverlay ?? true;
 
   if (typeof navigator === 'undefined' || typeof document === 'undefined') {
     return false;
@@ -142,6 +150,8 @@ export function ensureWebGL(options: EnsureOptions = {}) {
     return true;
   }
 
-  addCapabilityOverlay(content);
+  if (shouldRenderOverlay) {
+    addCapabilityOverlay(content);
+  }
   return false;
 }

--- a/brand.html
+++ b/brand.html
@@ -12,32 +12,33 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <canvas id="vizCanvas" class="toy-canvas"></canvas>
-    <div id="error-message" style="display: none"></div>
+    <div id="fallback-root"></div>
+    <div id="error-message"></div>
     <script type="module">
       import * as THREE from 'three';
       import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
       import WebToy from './assets/js/core/web-toy.ts';
       import { getContextFrequencyData } from './assets/js/core/animation-loop.ts';
-      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      import { bootstrapWebGL } from './assets/js/utils/webgl-bootstrap.ts';
       import { showError } from './assets/js/utils/error-display.ts';
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
       import { initHints } from './assets/ui/hints.ts';
       import { initFunControls } from './assets/ui/fun-controls.ts';
       import { createBrandFunAdapter } from './assets/brand/fun-adapter.ts';
 
-      const hasRenderingSupport = ensureWebGL({
-        title: 'WebGL/WebGPU required for the Star Guitar visualizer',
-        description:
+      const hasRenderingSupport = bootstrapWebGL({
+        mountSelector: '#fallback-root',
+        overlayTitle: 'WebGL/WebGPU required for the Star Guitar visualizer',
+        overlayDescription:
           'This scene uses GPU acceleration for its neon skyline. Enable hardware acceleration or try a modern browser to continue.',
         previewLabel: 'Static preview (audio-reactive motion paused)',
       });
 
-      if (!hasRenderingSupport) {
-        showError(
-          'error-message',
-          'This visualizer needs WebGL or WebGPU. Try switching browsers or enabling hardware acceleration.'
-        );
-      } else {
+      if (hasRenderingSupport) {
+        startVisualizer();
+      }
+
+      function startVisualizer() {
         const canvas = document.getElementById('vizCanvas');
 
       initHints({

--- a/clay.html
+++ b/clay.html
@@ -51,25 +51,32 @@
         <button data-tool="pinch">Pinch</button>
       </div>
     </div>
+    <div id="fallback-root"></div>
     <script type="module">
       import * as THREE from 'three';
-      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
-      if (!ensureWebGL()) {
-        throw new Error('WebGL support is required for the clay toy.');
-      }
-      // Basic Three.js setup
-      let scene, camera, renderer;
-      let potteryMesh, wheelMesh;
-      let isInteracting = false;
-      let previousTouches = [];
-      const maxRadius = 5;
-      const minRadius = 0.5;
-      const height = 12;
-      const segments = 100; // Increased for better detail
-      let currentTool = 'smooth';
+      import { bootstrapWebGL } from './assets/js/utils/webgl-bootstrap.ts';
 
-      init();
-      animate();
+      const hasRenderingSupport = bootstrapWebGL({ mountSelector: '#fallback-root' });
+      if (!hasRenderingSupport) {
+        document.body.classList.add('rendering-disabled');
+      } else {
+        startClayToy();
+      }
+
+      function startClayToy() {
+        // Basic Three.js setup
+        let scene, camera, renderer;
+        let potteryMesh, wheelMesh;
+        let isInteracting = false;
+        let previousTouches = [];
+        const maxRadius = 5;
+        const minRadius = 0.5;
+        const height = 12;
+        const segments = 100; // Increased for better detail
+        let currentTool = 'smooth';
+
+        init();
+        animate();
 
       function init() {
         // Scene and Camera
@@ -307,6 +314,8 @@
         camera.updateProjectionMatrix();
 
         renderer.setSize(window.innerWidth, window.innerHeight);
+      }
+
       }
     </script>
   </body>

--- a/holy.html
+++ b/holy.html
@@ -223,6 +223,7 @@
         />
       </div>
     </div>
+    <div id="fallback-root"></div>
 
     <!-- Main Visualizer Script -->
     <script type="module">
@@ -237,10 +238,16 @@
         initAudio,
       } from './assets/js/utils/audio-handler.ts';
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
-      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
-      if (!ensureWebGL()) {
-        throw new Error('WebGL support is required for the Holy visualizer.');
+      import { bootstrapWebGL } from './assets/js/utils/webgl-bootstrap.ts';
+
+      const hasRenderingSupport = bootstrapWebGL({ mountSelector: '#fallback-root' });
+      if (!hasRenderingSupport) {
+        document.body.classList.add('rendering-disabled');
+      } else {
+        startHolyVisualizer();
       }
+
+      function startHolyVisualizer() {
       let scene, camera, renderer, composer, bloomPass, fxaaPass;
       let visualizerShape, particles;
       let dataArray = new Uint8Array(0);
@@ -742,6 +749,7 @@
         e.stopPropagation();
         return false;
       };
+      }
     </script>
   </body>
 </html>

--- a/svgtest.html
+++ b/svgtest.html
@@ -59,6 +59,7 @@
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
     <div id="error-message" style="display: none"></div>
+    <div id="fallback-root"></div>
     <!-- The SVG element for the CSS displacement map -->
     <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
       <defs>
@@ -150,7 +151,7 @@
     <!-- Include Three.js -->
     <script type="module">
       import * as THREE from 'three';
-      import { ensureWebGL } from './assets/js/utils/webgl-check.ts';
+      import { bootstrapWebGL } from './assets/js/utils/webgl-bootstrap.ts';
       import {
         initAudio,
         getFrequencyData,
@@ -172,10 +173,14 @@
         }
       }
 
-      if (!ensureWebGL()) {
+      const hasRenderingSupport = bootstrapWebGL({ mountSelector: '#fallback-root' });
+      if (!hasRenderingSupport) {
         displayError('WebGL is not supported in your browser.');
+      } else {
+        startVisualizer();
       }
 
+      function startVisualizer() {
       // Set up the Three.js scene
       const scene = new THREE.Scene();
       const camera = new THREE.PerspectiveCamera(
@@ -396,6 +401,7 @@
         });
 
       window.addEventListener('pagehide', () => toy.dispose());
+      }
     </script>
   </body>
 </html>

--- a/svgtest.html
+++ b/svgtest.html
@@ -44,21 +44,11 @@
           opacity: 1;
         }
       }
-      #error-message {
-        position: absolute;
-        top: 20px;
-        left: 20px;
-        color: #ff0000;
-        background: rgba(0, 0, 0, 0.7);
-        padding: 10px;
-        border-radius: 5px;
-        z-index: 10;
-      }
     </style>
   </head>
   <body>
     <a href="index.html" class="home-link">Back to Library</a>
-    <div id="error-message" style="display: none"></div>
+    <div id="error-message"></div>
     <div id="fallback-root"></div>
     <!-- The SVG element for the CSS displacement map -->
     <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
@@ -157,26 +147,10 @@
         getFrequencyData,
       } from './assets/js/utils/audio-handler.ts';
       import { startToyAudio } from './assets/js/utils/start-audio.ts';
-
-      const errorEl = document.getElementById('error-message');
-
-      function displayError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
-
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-        }
-      }
+      import { showError, clearError } from './assets/js/utils/error-display.ts';
 
       const hasRenderingSupport = bootstrapWebGL({ mountSelector: '#fallback-root' });
-      if (!hasRenderingSupport) {
-        displayError('WebGL is not supported in your browser.');
-      } else {
+      if (hasRenderingSupport) {
         startVisualizer();
       }
 
@@ -391,10 +365,11 @@
       }
 
       startToyAudio(toy, animate, { fftSize: 256, fallbackToSynthetic: true })
-        .then(() => hideError())
+        .then(() => clearError('error-message'))
         .catch((err) => {
           console.error('Error capturing audio: ', err);
-          displayError(
+          showError(
+            'error-message',
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));


### PR DESCRIPTION
## Summary
- add a shared WebGL bootstrap helper that wraps capability checks and renders a fallback preview
- update HTML entry points to use the bootstrap helper for consistent unsupported messaging
- style the reusable fallback panel to align with the existing overlay preview

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ccea32fb48332a5e69fe8b15413f0)