### PR TITLE
Refactor toy lifecycle and audio pooling

### DIFF
--- a/assets/js/__mocks__/fake-module.js
+++ b/assets/js/__mocks__/fake-module.js
@@ -1,3 +1,5 @@
+import { defaultToyLifecycle } from '../core/toy-lifecycle.ts';
+
 export default function noop() {}
 
 export function start({ container } = {}) {
@@ -6,6 +8,6 @@ export function start({ container } = {}) {
   container?.appendChild(placeholder);
 
   const active = { dispose: () => placeholder.remove() };
-  globalThis.__activeWebToy = active;
+  defaultToyLifecycle.adoptActiveToy(active);
   return active;
 }

--- a/assets/js/core/toy-lifecycle.ts
+++ b/assets/js/core/toy-lifecycle.ts
@@ -1,0 +1,107 @@
+export type ActiveToyCandidate = { dispose?: () => void } | (() => void);
+
+type ActiveToyRecord = { ref: ActiveToyCandidate; dispose?: () => void } | null;
+
+function normalizeActiveToy(candidate: unknown): ActiveToyRecord {
+  if (!candidate) return null;
+
+  if (typeof candidate === 'function') {
+    return { ref: candidate, dispose: candidate };
+  }
+
+  if (typeof candidate === 'object') {
+    const dispose = (candidate as { dispose?: unknown }).dispose;
+    return {
+      ref: candidate as ActiveToyCandidate,
+      dispose: typeof dispose === 'function' ? dispose.bind(candidate) : undefined,
+    };
+  }
+
+  return null;
+}
+
+export type ToyLifecycle = {
+  getActiveToy: () => ActiveToyRecord;
+  adoptActiveToy: (candidate?: unknown) => ActiveToyRecord;
+  disposeActiveToy: () => void;
+  unregisterActiveToy: (candidate?: unknown) => void;
+  attachEscapeHandler: (onBack?: () => void) => void;
+  removeEscapeHandler: () => void;
+  reset: () => void;
+};
+
+export function createToyLifecycle(): ToyLifecycle {
+  let activeToy: ActiveToyRecord = null;
+  let escapeHandler: ((event: KeyboardEvent) => void) | null = null;
+
+  const getWindow = () => (typeof window === 'undefined' ? null : window);
+
+  const setActiveToy = (candidate?: unknown) => {
+    activeToy = normalizeActiveToy(candidate ?? null);
+    return activeToy;
+  };
+
+  const disposeActiveToy = () => {
+    const current = activeToy;
+    activeToy = null;
+
+    if (current?.dispose) {
+      try {
+        current.dispose();
+      } catch (error) {
+        console.error('Error disposing active toy', error);
+      }
+    }
+  };
+
+  const unregisterActiveToy = (candidate?: unknown) => {
+    const normalized = normalizeActiveToy(candidate ?? null);
+    if (activeToy && normalized && normalized.ref === activeToy.ref) {
+      activeToy = null;
+    }
+  };
+
+  const attachEscapeHandler = (onBack?: () => void) => {
+    const win = getWindow();
+    if (!win) return;
+
+    if (escapeHandler) {
+      win.removeEventListener('keydown', escapeHandler);
+      escapeHandler = null;
+    }
+
+    if (!onBack) return;
+
+    escapeHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onBack();
+      }
+    };
+
+    win.addEventListener('keydown', escapeHandler);
+  };
+
+  const removeEscapeHandler = () => {
+    const win = getWindow();
+    if (escapeHandler && win) {
+      win.removeEventListener('keydown', escapeHandler);
+    }
+    escapeHandler = null;
+  };
+
+  return {
+    getActiveToy: () => activeToy,
+    adoptActiveToy: (candidate?: unknown) => (candidate !== undefined ? setActiveToy(candidate) : activeToy),
+    disposeActiveToy,
+    unregisterActiveToy,
+    attachEscapeHandler,
+    removeEscapeHandler,
+    reset: () => {
+      removeEscapeHandler();
+      activeToy = null;
+    },
+  };
+}
+
+export const defaultToyLifecycle = createToyLifecycle();

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -12,6 +12,7 @@ import {
 } from './services/audio-service.ts';
 import type { RendererInitConfig } from './renderer-setup.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
+import { defaultToyLifecycle } from './toy-lifecycle.ts';
 
 export default class WebToy {
   canvas: HTMLCanvasElement;
@@ -82,7 +83,7 @@ export default class WebToy {
     this.resizeHandler = () => this.handleResize();
     window.addEventListener('resize', this.resizeHandler);
 
-    (globalThis as Record<string, unknown>).__activeWebToy = this;
+    defaultToyLifecycle.adoptActiveToy(this);
   }
 
   handleResize() {
@@ -165,8 +166,6 @@ export default class WebToy {
     this.rendererInfo = null;
     this.rendererBackend = null;
 
-    if ((globalThis as Record<string, unknown>).__activeWebToy === this) {
-      delete (globalThis as Record<string, unknown>).__activeWebToy;
-    }
+    defaultToyLifecycle.unregisterActiveToy(this);
   }
 }

--- a/assets/js/toys/iframe-toy.ts
+++ b/assets/js/toys/iframe-toy.ts
@@ -4,6 +4,7 @@ import {
   getSettingsPanel,
   type QualityPreset,
 } from '../core/settings-panel';
+import { defaultToyLifecycle } from '../core/toy-lifecycle.ts';
 
 type StartOptions = {
   container?: HTMLElement | null;
@@ -72,13 +73,11 @@ export function startIframeToy({
     dispose() {
       iframe.remove();
       window.removeEventListener('message', handleMessage);
-      if ((globalThis as Record<string, unknown>).__activeWebToy === activeToy) {
-        delete (globalThis as Record<string, unknown>).__activeWebToy;
-      }
+      defaultToyLifecycle.unregisterActiveToy(activeToy);
     },
   };
 
-  (globalThis as Record<string, unknown>).__activeWebToy = activeToy;
+  defaultToyLifecycle.adoptActiveToy(activeToy);
   target.appendChild(iframe);
 
   return activeToy;

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createRouter } from '../assets/js/router.ts';
 import { createToyView } from '../assets/js/toy-view.ts';
+import { defaultToyLifecycle } from '../assets/js/core/toy-lifecycle.ts';
 
 const originalLocation = window.location;
 const originalHistory = window.history;
@@ -122,7 +123,7 @@ beforeEach(() => {
 afterEach(() => {
   mock.restore();
   document.body.innerHTML = '';
-  delete globalThis.__activeWebToy;
+  defaultToyLifecycle.reset();
   Object.defineProperty(window, 'location', {
     writable: true,
     configurable: true,
@@ -162,7 +163,7 @@ describe('loadToy', () => {
 
     backControl?.dispatchEvent(new Event('click', { bubbles: true }));
 
-    expect(globalThis.__activeWebToy).toBeUndefined();
+    expect(defaultToyLifecycle.getActiveToy()).toBeNull();
     expect(document.getElementById('toy-list')?.classList.contains('is-hidden')).toBe(false);
     expect(window.location.search).toBe('');
     expect(servicesMock.resetAudioPool).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- introduce a shared toy lifecycle manager to own active toy tracking and escape handling while cleaning up loader interactions
- centralize toy view rendering into a single state-driven renderer for nav, statuses, and capability/import errors
- add reference-counted microphone pooling teardown with opt-in release behavior and updated coverage

## Testing
- bun run lint
- bun run typecheck *(fails: existing TypeScript errors in legacy files)*
- bun run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5b139de48332948acf72372eeb69)