### PR TITLE
Improve toy search metadata and audio options

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -690,6 +690,20 @@ h1 {
   margin-top: 1rem;
 }
 
+.search-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: var(--text-muted);
+}
+
+.search-meta__results {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-color);
+}
+
 .search-field {
   display: flex;
   align-items: center;
@@ -731,6 +745,25 @@ h1 {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: calc(var(--section-gap) * 0.7);
   margin: 0 auto;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  border: 1px dashed var(--surface-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  background: var(--surface-strong);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.empty-state__message {
+  margin: 0;
+  color: var(--text-muted);
 }
 
 .webtoy-card {

--- a/index.html
+++ b/index.html
@@ -235,11 +235,16 @@
                 id="toy-search"
                 type="search"
                 name="toy-search"
-                placeholder="Search by name or vibe (e.g., aurora, fractal, WebGPU)"
+                placeholder="Search by name, tags, moods, or capabilities (try: calm, motion, demo audio)"
                 autocomplete="off"
                 inputmode="search"
               />
-              <span aria-hidden="true" class="search-field__hint">⌘/Ctrl + F to search</span>
+              <span aria-hidden="true" class="search-field__hint">Search name, tags, mood, mic/motion/demo audio</span>
+            </div>
+            <div class="search-meta">
+              <p class="search-meta__results" data-search-results role="status" aria-live="polite">
+                Loading library…
+              </p>
             </div>
           </div>
         </div>
@@ -287,8 +292,51 @@
         const list = document.getElementById('toy-list');
         if (!list || list.childElementCount > 0) return;
 
-        const renderCards = (toys) => {
+        const search = document.getElementById('toy-search');
+        const searchResults = document.querySelector('[data-search-results]');
+        let cachedQuery = '';
+        let allToys = [];
+
+        const updateResultsMeta = (count, total, query = '') => {
+          if (!(searchResults instanceof HTMLElement)) return;
+          const countLabel = `${count} ${count === 1 ? 'match' : 'matches'}`;
+          const totalLabel = `${total} ${total === 1 ? 'stim' : 'stims'}`;
+          searchResults.textContent = query
+            ? `${countLabel} for “${query}”`
+            : `Showing all ${totalLabel}`;
+        };
+
+        const renderEmptyState = () => {
+          const empty = document.createElement('div');
+          empty.className = 'empty-state';
+          const message = document.createElement('p');
+          message.className = 'empty-state__message';
+          message.textContent = 'No stims match your search.';
+
+          const reset = document.createElement('button');
+          reset.type = 'button';
+          reset.className = 'cta-button ghost';
+          reset.textContent = 'Clear search';
+          reset.addEventListener('click', () => {
+            if (search instanceof HTMLInputElement) {
+              search.value = '';
+              cachedQuery = '';
+            }
+            renderCards(allToys, '');
+          });
+
+          empty.append(message, reset);
+          list.appendChild(empty);
+        };
+
+        const renderCards = (toys, query = '') => {
           list.innerHTML = '';
+          updateResultsMeta(toys.length, allToys.length, query || cachedQuery);
+
+          if (toys.length === 0) {
+            renderEmptyState();
+            return;
+          }
 
           toys.forEach((toy) => {
             const href =
@@ -309,16 +357,45 @@
 
             card.append(title, desc);
 
+            const badgeRow = document.createElement('div');
+            badgeRow.className = 'webtoy-card-meta';
+
+            const badges = [];
+
             if (toy.requiresWebGPU) {
-              const badgeRow = document.createElement('div');
-              badgeRow.className = 'webtoy-card-meta';
+              badges.push({ label: 'WebGPU', title: 'Requires WebGPU to run.' });
+            }
 
-              const badge = document.createElement('span');
-              badge.className = 'capability-badge';
-              badge.textContent = 'WebGPU';
-              badge.title = 'Requires WebGPU to run.';
+            if (toy.capabilities?.microphone) {
+              badges.push({
+                label: 'Microphone',
+                title: 'Uses live microphone input for audio.',
+              });
+            }
 
-              badgeRow.appendChild(badge);
+            if (toy.capabilities?.demoAudio) {
+              badges.push({
+                label: 'Demo audio',
+                title: 'Includes a demo track if you skip the mic.',
+              });
+            }
+
+            if (toy.capabilities?.motion) {
+              badges.push({
+                label: 'Motion',
+                title: 'Responds to device motion or tilt.',
+              });
+            }
+
+            if (badges.length > 0) {
+              badges.forEach((badgeData) => {
+                const badge = document.createElement('span');
+                badge.className = 'capability-badge';
+                badge.textContent = badgeData.label;
+                badge.title = badgeData.title;
+                badgeRow.appendChild(badge);
+              });
+
               card.appendChild(badgeRow);
             }
 
@@ -331,23 +408,41 @@
           .then((toys) => {
             if (!toys || list.childElementCount > 0) return;
 
-            const search = document.getElementById('toy-search');
-            renderCards(toys);
+            allToys = toys;
+            renderCards(allToys);
 
             if (search instanceof HTMLInputElement) {
               search.addEventListener('input', () => {
                 const query = search.value.toLowerCase().trim();
+                cachedQuery = query;
+
                 if (!query) {
-                  renderCards(toys);
+                  renderCards(allToys);
                   return;
                 }
 
-                const filtered = toys.filter(
-                  (toy) =>
-                    toy.title?.toLowerCase().includes(query) ||
-                    toy.description?.toLowerCase().includes(query),
-                );
-                renderCards(filtered);
+                const filtered = allToys.filter((toy) => {
+                  const capabilityTerms = Object.entries(toy.capabilities || {})
+                    .filter(([, enabled]) => !!enabled)
+                    .map(([key]) => key.toLowerCase());
+
+                  const haystack = [
+                    toy.title,
+                    toy.slug,
+                    toy.description,
+                    ...(toy.tags ?? []),
+                    ...(toy.moods ?? []),
+                    ...capabilityTerms,
+                    toy.requiresWebGPU ? 'webgpu' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')
+                    .toLowerCase();
+
+                  return haystack.includes(query);
+                });
+
+                renderCards(filtered, query);
               });
             }
           })

--- a/public/toys.json
+++ b/public/toys.json
@@ -5,7 +5,10 @@
     "description": "Dive into a twisting 3D tunnel that responds to sound.",
     "module": "assets/js/toys/three-d-toy.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["3d", "tunnel", "pulse"],
+    "moods": ["trippy", "energetic"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "aurora-painter",
@@ -13,7 +16,10 @@
     "description": "Paint flowing aurora ribbons that react to your microphone in layered waves.",
     "module": "assets/js/toys/aurora-painter.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["aurora", "painting", "ribbons"],
+    "moods": ["calm", "flow"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "brand",
@@ -21,7 +27,10 @@
     "description": "A visual journey inspired by an iconic music video, synced to your music.",
     "module": "assets/js/toys/brand.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["retro", "music-video", "sparkle"],
+    "moods": ["nostalgic", "party"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "clay",
@@ -29,7 +38,10 @@
     "description": "Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.",
     "module": "assets/js/toys/clay.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["sculpt", "clay", "tactile"],
+    "moods": ["focused", "soothing"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "defrag",
@@ -37,7 +49,10 @@
     "description": "A nostalgic, sound-reactive visualizer evoking old defragmentation screens.",
     "module": "assets/js/toys/defrag.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["retro", "grid", "scan"],
+    "moods": ["nostalgic", "steady"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "evol",
@@ -45,7 +60,10 @@
     "description": "Watch surreal landscapes evolve with fractals and glitches that react to music.",
     "module": "assets/js/toys/evol.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["fractal", "glitch", "surreal"],
+    "moods": ["dreamy", "experimental"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "geom",
@@ -53,7 +71,10 @@
     "description": "Push shifting geometric forms directly from live mic input with responsive controls.",
     "module": "assets/js/toys/geom.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["geometry", "lines", "responsive"],
+    "moods": ["focused", "technical"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "holy",
@@ -61,7 +82,10 @@
     "description": "Layered halos, particles, and morphing shapes that respond to your music.",
     "module": "assets/js/toys/holy.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["halo", "particles", "soft"],
+    "moods": ["soothing", "uplifting"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "multi",
@@ -70,7 +94,10 @@
     "module": "assets/js/toys/multi.ts",
     "type": "module",
     "requiresWebGPU": true,
-    "allowWebGLFallback": true
+    "allowWebGLFallback": true,
+    "tags": ["motion", "lights", "reactive"],
+    "moods": ["energetic", "immersive"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": true }
   },
   {
     "slug": "seary",
@@ -78,7 +105,10 @@
     "description": "Blend audio and visuals in a rich synesthetic experience.",
     "module": "assets/js/toys/seary.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["synesthetic", "gradient", "pulse"],
+    "moods": ["trippy", "immersive"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "sgpat",
@@ -86,7 +116,10 @@
     "description": "See patterns form dynamically in response to sound.",
     "module": "assets/js/toys/sgpat.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["patterns", "grid", "reactive"],
+    "moods": ["focused", "rhythmic"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "legible",
@@ -94,7 +127,10 @@
     "description": "A retro green text grid that pulses to audio and surfaces fresh words as you play.",
     "module": "assets/js/toys/legible.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["text", "grid", "terminal"],
+    "moods": ["nostalgic", "steady"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "svgtest",
@@ -102,7 +138,10 @@
     "description": "A hybrid visualizer blending 2D and 3D elements, reacting in real time.",
     "module": "assets/js/toys/svgtest.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["hybrid", "svg", "threejs"],
+    "moods": ["experimental", "bold"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "symph",
@@ -110,7 +149,10 @@
     "description": "A relaxing spectrograph that moves gently with your audio.",
     "module": "assets/js/toys/symph.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["spectrograph", "soft", "color"],
+    "moods": ["dreamy", "gentle"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "words",
@@ -118,7 +160,10 @@
     "description": "Speak and watch the word cloud react and shift with your voice.",
     "module": "assets/js/toys/words.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["words", "voice", "cloud"],
+    "moods": ["playful", "responsive"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "cube-wave",
@@ -126,7 +171,10 @@
     "description": "Swap between cube waves and bouncing spheres without stopping the music.",
     "module": "assets/js/toys/cube-wave.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["grid", "cubes", "waves"],
+    "moods": ["rhythmic", "energetic"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "bubble-harmonics",
@@ -134,7 +182,10 @@
     "description": "Translucent, audio-inflated bubbles that split into harmonics on high frequencies.",
     "module": "assets/js/toys/bubble-harmonics.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["bubbles", "harmonics", "liquid"],
+    "moods": ["playful", "glossy"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "cosmic-particles",
@@ -142,7 +193,10 @@
     "description": "Jump between orbiting swirls and nebula fly-throughs with a single toggle.",
     "module": "assets/js/toys/cosmic-particles.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["cosmic", "particles", "nebula"],
+    "moods": ["vast", "cinematic"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "lights",
@@ -150,7 +204,10 @@
     "description": "Swap shader styles and color palettes while lights ripple with your microphone input.",
     "module": "assets/js/toys/lights.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["lights", "shaders", "palette"],
+    "moods": ["vivid", "energetic"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "spiral-burst",
@@ -158,7 +215,10 @@
     "description": "Colorful spirals rotate and expand with every beat.",
     "module": "assets/js/toys/spiral-burst.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["spiral", "burst", "color"],
+    "moods": ["vivid", "excited"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "rainbow-tunnel",
@@ -166,7 +226,10 @@
     "description": "Fly through colorful rings that spin to your music.",
     "module": "assets/js/toys/rainbow-tunnel.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["tunnel", "rainbow", "rings"],
+    "moods": ["uplifting", "bright"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "star-field",
@@ -174,7 +237,10 @@
     "description": "A field of shimmering stars reacts to the beat.",
     "module": "assets/js/toys/star-field.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["stars", "space", "shimmer"],
+    "moods": ["calm", "dreamy"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "fractal-kite-garden",
@@ -182,7 +248,10 @@
     "description": "Grow branching kite fractals that sway with mids and shimmer with crisp highs.",
     "module": "assets/js/toys/fractal-kite-garden.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["fractal", "kite", "garden"],
+    "moods": ["organic", "delicate"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
     "slug": "tactile-sand-table",
@@ -190,7 +259,10 @@
     "description": "Heightfield sand ripples that respond to bass, mids, and device tilt.",
     "module": "assets/js/toys/tactile-sand-table.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["sand", "ripples", "tilt"],
+    "moods": ["tactile", "meditative"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": true }
   },
   {
     "slug": "bioluminescent-tidepools",
@@ -198,6 +270,9 @@
     "description": "Sketch glowing currents that bloom with high-frequency sparkle from your music.",
     "module": "assets/js/toys/bioluminescent-tidepools.ts",
     "type": "module",
-    "requiresWebGPU": false
+    "requiresWebGPU": false,
+    "tags": ["ocean", "bioluminescent", "currents"],
+    "moods": ["serene", "glowing"],
+    "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   }
 ]

--- a/toy.html
+++ b/toy.html
@@ -11,13 +11,22 @@
     <a href="index.html" class="home-link">Back to Library</a>
     <div class="control-panel">
       <div class="control-panel__heading">Audio controls</div>
-      <p class="control-panel__description">Start microphone input to play the toy.</p>
+      <p class="control-panel__description">
+        Choose how to feed audio: use your microphone for live input, or load our demo track to preview instantly.
+      </p>
       <div class="control-panel__row">
         <div class="control-panel__text">
           <span class="control-panel__label">Microphone</span>
-          <small>Enable audio to begin the experience.</small>
+          <small>Uses your device mic for the most responsive visuals.</small>
         </div>
-        <button id="start-audio-btn" class="cta-button primary">Start audio</button>
+        <button id="start-audio-btn" class="cta-button primary">Use microphone</button>
+      </div>
+      <div class="control-panel__row">
+        <div class="control-panel__text">
+          <span class="control-panel__label">Demo audio</span>
+          <small>No mic needed—start with a built-in track.</small>
+        </div>
+        <button id="use-demo-audio" class="cta-button">Use demo audio</button>
       </div>
       <div
         id="audio-status"
@@ -25,11 +34,6 @@
         role="status"
         hidden
       ></div>
-      <div class="control-panel__actions">
-        <button id="use-demo-audio" class="cta-button" hidden>
-          Load demo audio
-        </button>
-      </div>
     </div>
     <script type="module" src="assets/js/toyMain.ts"></script>
     <script type="module">
@@ -92,11 +96,13 @@
         fallbackButton,
         statusElement,
         requestMicrophone: () => {
+          startLoaderIfNeeded();
           const starter = getStarter();
           if (!starter) throw new Error('Microphone starter unavailable.');
           return starter(false);
         },
         requestSampleAudio: () => {
+          startLoaderIfNeeded();
           const starter = getStarter(true) ?? getStarter();
           if (!starter) throw new Error('Demo audio unavailable.');
           return starter(true);


### PR DESCRIPTION
## Summary
- enrich toy metadata with tags, moods, and capability flags for search and card badges
- expand the library search UX with capability-aware filtering, counts, and an empty-state reset helper
- surface microphone and demo-audio controls on toy pages so either path can start immediately

## Testing
- bun run lint
- bun run typecheck *(fails due to existing TypeScript errors in three.js typings and test setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d70883fdc8332b18d0849185a8b4c)