### PR TITLE
Align MCP server deploy commands with deployment guide

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -65,11 +65,11 @@ compatibility_flags = ["nodejs_compat"]
 1. Install dependencies (`bun install`), ensuring `@cfworker/json-schema` is available for the Worker build.
 2. Deploy with Wrangler:
    ```bash
-   bunx wrangler deploy
+   bunx wrangler deploy scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
    ```
 3. Local preview (Worker fetch + WebSocket support):
    ```bash
-   bunx wrangler dev
+   bunx wrangler dev scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
    ```
 
 ### Client endpoints


### PR DESCRIPTION
## Summary
- update MCP server deployment steps to match the concrete Wrangler commands used in the deployment guide
- include entry path, worker name, and compatibility date flags for both local dev and deploy flows

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db4d2b2308332ad309a2489443dd5)