### PR TITLE
Align MCP Worker docs with compatibility date pin

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -52,10 +52,12 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
 
 ### `wrangler.toml` example
 
+The Worker uses the repository’s pinned compatibility date (`2024-10-20`) to keep WebSocket support consistent with `wrangler.toml` and the deployment snippets in `docs/DEPLOYMENT.md`.
+
 ```toml
 name = "stim-webtoys-mcp"
 main = "scripts/mcp-worker.ts"
-compatibility_date = "2025-02-20"
+compatibility_date = "2024-10-20"
 workers_dev = true
 compatibility_flags = ["nodejs_compat"]
 ```


### PR DESCRIPTION
## Summary
- update the MCP server guide to pin the Worker compatibility date to 2024-10-20
- add narrative tying the example to the wrangler.toml and deployment snippets

## Testing
- not run (documentation change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db4cf560c833288577ec21c3132f1)