### PR TITLE
Add interaction readiness pulse to landing hero

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -262,6 +262,91 @@ header.hero {
   line-height: 1.5;
 }
 
+.readiness-panel {
+  margin-top: 0.4rem;
+  padding: 1.15rem 1.2rem;
+  border-radius: calc(var(--radius-lg) + 2px);
+  background: radial-gradient(circle at 18% 10%, rgba(109, 240, 255, 0.18), transparent 40%),
+    radial-gradient(circle at 82% 30%, rgba(255, 111, 227, 0.18), transparent 40%),
+    linear-gradient(145deg, rgba(109, 240, 255, 0.1), rgba(155, 123, 255, 0.1));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(12px) saturate(120%);
+}
+
+.readiness-header {
+  display: grid;
+  gap: 0.1rem;
+  margin-bottom: 0.65rem;
+}
+
+.readiness-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+  font-weight: 700;
+}
+
+.readiness-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.readiness-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.readiness-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.65rem 0.6rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.readiness-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 700;
+}
+
+.readiness-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(234, 245, 255, 0.6);
+  position: relative;
+  box-shadow: 0 0 0 4px rgba(234, 245, 255, 0.08);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.readiness-dot[data-status='ready'] {
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-purple));
+  box-shadow: 0 0 0 4px rgba(109, 240, 255, 0.2), 0 0 0 10px rgba(109, 240, 255, 0.08);
+}
+
+.readiness-dot[data-status='warn'] {
+  background: linear-gradient(135deg, #f5c768, #ff7b7b);
+  box-shadow: 0 0 0 4px rgba(245, 199, 104, 0.2), 0 0 0 10px rgba(255, 123, 123, 0.08);
+}
+
+.readiness-name {
+  letter-spacing: 0.01em;
+}
+
+.readiness-note {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .hero-visual {
   position: relative;
   display: grid;

--- a/index.html
+++ b/index.html
@@ -106,6 +106,36 @@
                 <p class="signal-value">Keyboard, touch, and reduced-motion aware so focus stays on the sensation, not the setup.</p>
               </div>
             </div>
+            <div class="readiness-panel" role="status" aria-live="polite">
+              <div class="readiness-header">
+                <p class="eyebrow">Interaction readiness</p>
+                <p class="readiness-title">Quick pulse before you launch</p>
+                <p class="readiness-subtitle">We check capabilities without requesting permission so you know what to expect.</p>
+              </div>
+              <ul class="readiness-list">
+                <li class="readiness-item">
+                  <div class="readiness-label">
+                    <span class="readiness-dot" data-status-dot="mic" aria-hidden="true"></span>
+                    <span class="readiness-name">Microphone input</span>
+                  </div>
+                  <p class="readiness-note" data-status-note="mic">Detecting audio support…</p>
+                </li>
+                <li class="readiness-item">
+                  <div class="readiness-label">
+                    <span class="readiness-dot" data-status-dot="motion" aria-hidden="true"></span>
+                    <span class="readiness-name">Motion controls</span>
+                  </div>
+                  <p class="readiness-note" data-status-note="motion">Checking for device motion…</p>
+                </li>
+                <li class="readiness-item">
+                  <div class="readiness-label">
+                    <span class="readiness-dot" data-status-dot="reduced" aria-hidden="true"></span>
+                    <span class="readiness-name">Reduced motion preference</span>
+                  </div>
+                  <p class="readiness-note" data-status-note="reduced">Reading your animation comfort settings…</p>
+                </li>
+              </ul>
+            </div>
             <div class="cta-row">
               <a
                 href="toy.html?toy=holy"
@@ -449,6 +479,76 @@
           .catch((error) => {
             console.error('Unable to render library fallback', error);
           });
+
+        const readinessDots = {
+          mic: document.querySelector('[data-status-dot="mic"]'),
+          motion: document.querySelector('[data-status-dot="motion"]'),
+          reduced: document.querySelector('[data-status-dot="reduced"]'),
+        };
+
+        const readinessNotes = {
+          mic: document.querySelector('[data-status-note="mic"]'),
+          motion: document.querySelector('[data-status-note="motion"]'),
+          reduced: document.querySelector('[data-status-note="reduced"]'),
+        };
+
+        const setReadinessState = (key, state, message) => {
+          const dot = readinessDots[key];
+          const note = readinessNotes[key];
+          if (dot instanceof HTMLElement) {
+            dot.dataset.status = state;
+          }
+          if (note instanceof HTMLElement) {
+            note.textContent = message;
+          }
+        };
+
+        const hasMediaDevices = () => !!navigator.mediaDevices?.getUserMedia;
+        const hasMotionSensors = () =>
+          'DeviceMotionEvent' in window || 'LinearAccelerationSensor' in window;
+
+        const updateMicStatus = () => {
+          if (hasMediaDevices()) {
+            setReadinessState('mic', 'ready', 'Live audio available — you can grant mic access when a toy asks.');
+          } else {
+            setReadinessState(
+              'mic',
+              'warn',
+              'No microphone detected. Use demo audio or plug in a mic before starting.'
+            );
+          }
+        };
+
+        const updateMotionStatus = () => {
+          if (hasMotionSensors()) {
+            setReadinessState('motion', 'ready', 'Motion/tilt supported — toys will adapt if permission is granted.');
+          } else {
+            setReadinessState(
+              'motion',
+              'warn',
+              'Motion controls unavailable or locked down. Try on mobile or enable motion access.'
+            );
+          }
+        };
+
+        const updateReducedMotionStatus = () => {
+          const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+          const applyPreference = (query) => {
+            if (query.matches) {
+              setReadinessState('reduced', 'ready', 'Animations will soften because you prefer reduced motion.');
+            } else {
+              setReadinessState('reduced', 'ready', 'Full motion is enabled. Toggle reduced motion in your OS to soften effects.');
+            }
+          };
+
+          applyPreference(mediaQuery);
+          mediaQuery.addEventListener('change', applyPreference);
+        };
+
+        updateMicStatus();
+        updateMotionStatus();
+        updateReducedMotionStatus();
       });
     </script>
     <script type="module" src="assets/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add an interaction readiness panel to the landing hero that previews microphone, motion, and reduced-motion support without prompting users
- style the new panel with gradient glass cards and animated status dots to highlight capability states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db7b7ba38833285c92c791685b000)