### PR TITLE
Skip redundant Cloudflare Pages builds

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -51,7 +51,7 @@ If your platform supports immutable caching, enable it for `dist/assets/**`; kee
 
 ## Cloudflare Pages Configuration
 
-Cloudflare Pages reads the build command from the project settings in the dashboard, so keep `wrangler.toml` limited to the shared metadata (`name`, `compatibility_date`, and `pages_build_output_dir`). Do **not** add a `[build]` table—Pages rejects it and will surface a configuration validation error. Configure the build command (for example, `bun run build`) directly in Pages, or rely on `CF_PAGES=1` with the existing install script to generate `dist/` during install.
+Cloudflare Pages reads the build command from the project settings in the dashboard, so keep `wrangler.toml` limited to the shared metadata (`name`, `compatibility_date`, and `pages_build_output_dir`). Do **not** add a `[build]` table—Pages rejects it and will surface a configuration validation error. Configure the build command (for example, `bun run build`) directly in Pages, or rely on `CF_PAGES=1` with the existing install script to generate `dist/` during install. If the install step already populated `dist/` (the repo’s build script checks for this), the subsequent build command will no-op on Pages to avoid a second Vite build.
 
 > **Install step:** Make sure devDependencies are present so `vite` exists at build time. In Cloudflare Pages, set the install command to `bun install` (or `npm install`) and keep `NPM_CONFIG_PRODUCTION=false` (the repo ships `.npmrc` with `production=false` for this). If you prefer Bun, set `BUN_INSTALL_DEV=true` to mirror local installs.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:host": "vite --host",
     "dev:check": "node scripts/dev-check.mjs",
     "check:toys": "bun run scripts/check-toys.ts",
-    "build": "vite build",
+    "build": "node scripts/build.mjs",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",
     "pages:dev": "bun run build && bunx wrangler pages dev dist",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* global process, console */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const normalizeBoolean = (value) => value?.toLowerCase?.() ?? '';
+const isCloudflarePages = ['1', 'true'].includes(normalizeBoolean(process.env.CF_PAGES));
+const distDir = join(process.cwd(), 'dist');
+const distIndex = join(distDir, 'index.html');
+const manifest = join(distDir, '.vite', 'manifest.json');
+const hasReusableArtifacts = existsSync(distIndex) && existsSync(manifest);
+
+if (isCloudflarePages && hasReusableArtifacts) {
+  console.log('[build] CF_PAGES detected and dist/ already populated; skipping Vite rebuild.');
+  process.exit(0);
+}
+
+console.log('[build] Running Vite build...');
+execSync('vite build', { stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- add a build wrapper that reuses Cloudflare Pages postinstall artifacts when dist already exists
- point the build script at the wrapper and document the Pages no-op behavior

## Testing
- bun run lint
- bun run typecheck *(fails: existing repository type errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd6e03170833292416f14aaa58513)