### PR TITLE
Refresh hero reel and library filters

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -106,8 +106,46 @@ html {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 0;
+  padding: 0.9rem 1.05rem;
   margin-bottom: 0.75rem;
+  position: sticky;
+  top: clamp(0.5rem, 1vw, 1rem);
+  z-index: 10;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    120deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.02)
+  );
+  border: 1px solid var(--surface-border);
+  backdrop-filter: blur(16px) saturate(140%);
+  box-shadow: var(--shadow-soft);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.top-nav::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    130deg,
+    rgba(109, 240, 255, 0.08),
+    rgba(155, 123, 255, 0.06)
+  );
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.top-nav--scrolled {
+  box-shadow:
+    0 18px 38px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(109, 240, 255, 0.14);
+  border-color: rgba(109, 240, 255, 0.28);
+  transform: translateY(-2px);
 }
 
 .brand {
@@ -441,69 +479,207 @@ header.hero {
   isolation: isolate;
 }
 
-.orbital {
-  width: min(480px, 80vw);
-  aspect-ratio: 1 / 1;
+.preview-reel {
+  width: min(520px, 90vw);
+  border-radius: 24px;
+  background: linear-gradient(
+    160deg,
+    rgba(109, 240, 255, 0.12),
+    rgba(155, 123, 255, 0.1)
+  );
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(12px) saturate(120%);
+  overflow: hidden;
+  position: relative;
+}
+
+.preview-track {
+  position: relative;
+  min-height: 360px;
+}
+
+.preview-card {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(12px) scale(0.99);
+  transition:
+    opacity 0.5s ease,
+    transform 0.6s ease;
+  padding: clamp(1.2rem, 1vw + 0.8rem, 1.6rem);
+  display: grid;
+  gap: 0.8rem;
+  align-content: space-between;
+  background: linear-gradient(
+    160deg,
+    rgba(12, 17, 45, 0.8),
+    rgba(20, 26, 56, 0.82)
+  );
+  border-radius: 20px;
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-surface);
+  pointer-events: none;
+}
+
+.preview-card.is-active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.preview-media {
+  position: relative;
+  padding: 1rem;
+  border-radius: 16px;
+  background:
+    var(--preview-image, none),
+    radial-gradient(
+      circle at 25% 20%,
+      rgba(109, 240, 255, 0.2),
+      transparent 35%
+    ),
+    radial-gradient(
+      circle at 80% 30%,
+      rgba(255, 111, 227, 0.16),
+      transparent 40%
+    ),
+    linear-gradient(140deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  border: 1px solid var(--surface-border);
+  overflow: hidden;
+  min-height: 180px;
+  background-size: cover, auto, auto, auto;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.preview-media--clay {
+  background: linear-gradient(140deg, rgba(255, 200, 150, 0.18), rgba(109, 240, 255, 0.08));
+}
+
+.preview-media--geom {
+  background: linear-gradient(140deg, rgba(109, 240, 255, 0.18), rgba(155, 123, 255, 0.14));
+}
+
+.preview-frame {
   position: relative;
   display: grid;
-  place-items: center;
-  filter: drop-shadow(0 20px 40px rgba(0, 0, 0, 0.35));
+  gap: 0.35rem;
+  z-index: 1;
 }
 
-.orbital__ring {
+.preview-glow {
   position: absolute;
-  inset: 10%;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.22);
-  backdrop-filter: blur(6px);
-  mix-blend-mode: screen;
-  animation: shimmerDrift 18s ease-in-out infinite;
-}
-
-.orbital__ring--outer {
-  inset: 4%;
-  border-color: rgba(109, 240, 255, 0.3);
-  box-shadow: 0 0 40px rgba(109, 240, 255, 0.22);
-  animation-duration: 26s;
-}
-
-.orbital__ring--inner {
-  inset: 22%;
-  border-color: rgba(255, 111, 227, 0.3);
-  box-shadow: 0 0 24px rgba(255, 111, 227, 0.22);
-  animation-direction: reverse;
-  animation-duration: 20s;
-}
-
-.orbital__pulse {
-  position: absolute;
-  width: 32%;
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at 45% 35%,
-    rgba(255, 255, 255, 0.75),
+  inset: 0;
+  filter: blur(18px);
+  opacity: 0.75;
+  background: conic-gradient(
+    from 120deg,
     rgba(109, 240, 255, 0.45),
-    transparent 70%
+    rgba(255, 111, 227, 0.35),
+    rgba(109, 240, 255, 0.2)
   );
-  filter: blur(10px);
-  animation: glowPulse 7s ease-in-out infinite;
+  mix-blend-mode: screen;
 }
 
-.orbital__core {
+.preview-glow--clay {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 200, 150, 0.4), transparent 45%),
+    radial-gradient(circle at 80% 60%, rgba(109, 240, 255, 0.35), transparent 40%);
+}
+
+.preview-glow--geom {
+  background: radial-gradient(circle at 30% 40%, rgba(109, 240, 255, 0.4), transparent 45%),
+    radial-gradient(circle at 70% 35%, rgba(155, 123, 255, 0.4), transparent 42%);
+}
+
+.preview-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.08);
+  width: fit-content;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.preview-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.preview-caption {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.preview-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.preview-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--surface-border);
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+}
+
+.preview-meta__copy {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.preview-meta__title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.preview-meta__description {
+  margin: 0;
+  max-width: 420px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.preview-launch {
+  white-space: nowrap;
+}
+
+.preview-dots {
   position: absolute;
-  width: 18%;
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  background: linear-gradient(
-    145deg,
-    var(--accent-color),
-    var(--accent-purple)
-  );
+  bottom: 0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.6rem;
+}
+
+.preview-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  transition: all 0.3s ease;
+}
+
+.preview-dot.is-active {
+  width: 26px;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-purple));
   box-shadow:
-    0 0 0 4px rgba(255, 255, 255, 0.08),
-    0 16px 32px rgba(0, 0, 0, 0.4),
-    0 0 28px var(--glow-color);
+    0 0 0 4px rgba(109, 240, 255, 0.24),
+    0 12px 24px rgba(0, 0, 0, 0.35);
 }
 
 .hero-callouts {
@@ -979,6 +1155,70 @@ h1 {
   white-space: nowrap;
 }
 
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  border: 1px solid var(--surface-border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  color: var(--text-color);
+  border-radius: var(--radius-pill);
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.filter-chip:hover {
+  transform: translateY(-2px);
+  border-color: rgba(109, 240, 255, 0.35);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+}
+
+.filter-chip.is-active {
+  background: linear-gradient(135deg, rgba(109, 240, 255, 0.18), rgba(155, 123, 255, 0.14));
+  border-color: rgba(109, 240, 255, 0.4);
+  box-shadow:
+    0 12px 28px rgba(109, 240, 255, 0.2),
+    0 0 0 4px rgba(109, 240, 255, 0.12);
+}
+
+.sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--surface-border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+  color: var(--text-color);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+}
+
+.sort-control select {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-weight: 700;
+  outline: none;
+}
+
 .webtoy-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -1195,11 +1435,14 @@ footer {
 }
 
 .theme-toggle {
-  padding: 0.55rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1rem;
   background: linear-gradient(
     135deg,
-    rgba(255, 255, 255, 0.05),
-    rgba(255, 255, 255, 0)
+    rgba(255, 255, 255, 0.08),
+    rgba(255, 255, 255, 0.02)
   );
   color: var(--text-color);
   border: 1px solid var(--surface-border);
@@ -1208,7 +1451,8 @@ footer {
   transition:
     background 0.2s ease,
     transform 0.2s ease,
-    box-shadow 0.2s ease;
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
 }
 
@@ -1216,6 +1460,7 @@ footer {
   background: var(--hover-bg);
   transform: translateY(-2px);
   box-shadow: 0 14px 32px rgba(0, 0, 0, 0.3);
+  border-color: rgba(109, 240, 255, 0.4);
 }
 
 .theme-toggle:focus-visible {
@@ -1223,6 +1468,25 @@ footer {
   outline-offset: 3px;
   background: var(--hover-bg);
   box-shadow: 0 0 20px var(--glow-color);
+}
+
+.theme-toggle__icon {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 12px;
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 255, 255, 0.9),
+    rgba(109, 240, 255, 0.35)
+  );
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.2);
+}
+
+.theme-toggle__label {
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 @media (max-width: 768px) {
@@ -1236,13 +1500,14 @@ footer {
 
   .top-nav {
     position: static;
+    border-radius: 14px;
   }
 
   .hero-grid {
     grid-template-columns: 1fr;
   }
 
-  .orbital {
-    margin: 0 auto;
+  .preview-reel {
+    width: 100%;
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,7 +4,7 @@ import { initRepoStatusWidget } from './repo-status.js';
 import toysData from './toys-data.js';
 
 const libraryView = createLibraryView({
-  toys: toysData,
+  toys: [],
   loadToy,
   initNavigation,
   loadFromQuery,
@@ -17,6 +17,19 @@ const libraryView = createLibraryView({
   enableDarkModeToggle: true,
   themeToggleId: 'theme-toggle',
 });
+
+const resolveToys = async () => {
+  try {
+    const response = await fetch('./toys.json', { cache: 'no-store' });
+    if (response.ok) {
+      const data = await response.json();
+      if (Array.isArray(data)) return data;
+    }
+  } catch (error) {
+    console.warn('Falling back to bundled toy data', error);
+  }
+  return toysData;
+};
 
 const bindQuickstartCta = () => {
   const quickstart = document.querySelector('[data-quickstart-slug]');
@@ -39,9 +52,123 @@ const bindQuickstartCta = () => {
   });
 };
 
-const startApp = () => {
+const initNavScrollEffects = () => {
+  const nav = document.querySelector('[data-top-nav]');
+  if (!nav) return;
+
+  let ticking = false;
+  const applyNavState = () => {
+    ticking = false;
+    const isScrolled = window.scrollY > 24;
+    nav.classList.toggle('top-nav--scrolled', isScrolled);
+  };
+
+  applyNavState();
+  window.addEventListener(
+    'scroll',
+    () => {
+      if (!ticking) {
+        window.requestAnimationFrame(applyNavState);
+        ticking = true;
+      }
+    },
+    { passive: true }
+  );
+};
+
+const initPreviewReels = () => {
+  const reels = document.querySelectorAll('[data-preview-reel]');
+  const Observer = globalThis.IntersectionObserver;
+  if (reels.length === 0 || typeof Observer === 'undefined') return;
+
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  reels.forEach((reel) => {
+    const cards = Array.from(reel.querySelectorAll('[data-preview-card]'));
+    const dots = Array.from(reel.querySelectorAll('[data-preview-dot]'));
+    if (cards.length === 0) return;
+
+    let timerId;
+    let activeIndex = Math.max(
+      0,
+      cards.findIndex((card) => card.classList.contains('is-active'))
+    );
+
+    const lazyLoadMedia = (card) => {
+      if (!card || card.dataset.loaded === 'true') return;
+      const media = card.querySelector('.preview-media');
+      const src = card.getAttribute('data-preview-src');
+      if (media && src) {
+        media.style.setProperty('--preview-image', `url(${src})`);
+      }
+      card.dataset.loaded = 'true';
+    };
+
+    const setActive = (index) => {
+      activeIndex = index;
+      cards.forEach((card, idx) => {
+        const isActive = idx === index;
+        card.classList.toggle('is-active', isActive);
+        if (dots[idx]) {
+          dots[idx].classList.toggle('is-active', isActive);
+        }
+        if (isActive) lazyLoadMedia(card);
+      });
+    };
+
+    const tick = () => {
+      const nextIndex = (activeIndex + 1) % cards.length;
+      setActive(nextIndex);
+    };
+
+    const startTimer = () => {
+      if (prefersReducedMotion.matches || cards.length < 2) return;
+      timerId = window.setInterval(tick, 5200);
+    };
+
+    const stopTimer = () => {
+      if (timerId) {
+        window.clearInterval(timerId);
+        timerId = undefined;
+      }
+    };
+
+    const observer = new Observer(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            lazyLoadMedia(cards[activeIndex]);
+            startTimer();
+          } else {
+            stopTimer();
+          }
+        });
+      },
+      { threshold: 0.4 }
+    );
+
+    observer.observe(reel);
+    setActive(activeIndex);
+
+    prefersReducedMotion.addEventListener('change', () => {
+      stopTimer();
+      if (!prefersReducedMotion.matches) {
+        startTimer();
+      }
+    });
+  });
+};
+
+const startApp = async () => {
+  const resolvedToys = await resolveToys();
+  libraryView.setToys(resolvedToys);
   libraryView.init();
   bindQuickstartCta();
+  initNavScrollEffects();
+  initPreviewReels();
+  document.body.dataset.libraryEnhanced = 'true';
   void initRepoStatusWidget();
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
   </head>
   <body>
     <div class="content">
-      <nav class="top-nav">
+      <nav class="top-nav" data-top-nav>
         <div class="brand">
           <span class="brand-mark"></span>
           <div class="brand-copy">
@@ -71,7 +71,7 @@
             href="https://github.com/zz-plant/stims"
             target="_blank"
             rel="noopener noreferrer"
-            >GitHub</a
+          >GitHub</a
           >
           <button
             id="theme-toggle"
@@ -79,7 +79,8 @@
             aria-pressed="false"
             aria-label="Switch to dark mode"
           >
-            Dark Mode
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+            <span class="theme-toggle__label" data-theme-label>Dark mode</span>
           </button>
         </div>
       </nav>
@@ -237,11 +238,124 @@
             </div>
           </div>
           <div class="hero-visual" aria-hidden="true">
-            <div class="orbital">
-              <span class="orbital__ring orbital__ring--outer"></span>
-              <span class="orbital__ring orbital__ring--inner"></span>
-              <span class="orbital__pulse"></span>
-              <span class="orbital__core"></span>
+            <div class="preview-reel" data-preview-reel>
+              <div class="preview-track">
+                <article
+                  class="preview-card is-active"
+                  data-preview-card
+                  data-preview-src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
+                >
+                  <div class="preview-media">
+                    <div class="preview-glow preview-glow--halo"></div>
+                    <div class="preview-frame">
+                      <span class="preview-tag">Halo Flow</span>
+                      <p class="preview-title">Halo Flow</p>
+                      <p class="preview-caption">
+                        Ribbons, halos, and soft bloom that ride your music.
+                      </p>
+                      <div class="preview-badges">
+                        <span class="pill pill--accent">Mic reactive</span>
+                        <span class="pill pill--contrast">Web-ready</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="preview-meta">
+                    <div class="preview-meta__copy">
+                      <p class="eyebrow">Featured</p>
+                      <p class="preview-meta__title">Start with Halo Flow</p>
+                      <p class="preview-meta__description">
+                        Our most popular stim. Crisp halos, layered gradients,
+                        and instant audio response.
+                      </p>
+                    </div>
+                    <a
+                      class="cta-button primary preview-launch"
+                      href="toy.html?toy=holy"
+                    >
+                      Launch
+                    </a>
+                  </div>
+                </article>
+                <article
+                  class="preview-card"
+                  data-preview-card
+                  data-preview-src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
+                >
+                  <div class="preview-media preview-media--clay">
+                    <div class="preview-glow preview-glow--clay"></div>
+                    <div class="preview-frame">
+                      <span class="preview-tag">Clay</span>
+                      <p class="preview-title">Pottery Wheel</p>
+                      <p class="preview-caption">
+                        Sculpt smooth vessels with tactile carving and soft
+                        lighting.
+                      </p>
+                      <div class="preview-badges">
+                        <span class="pill pill--soft">Touch friendly</span>
+                        <span class="pill pill--accent">Demo audio</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="preview-meta">
+                    <div class="preview-meta__copy">
+                      <p class="eyebrow">Haptic calm</p>
+                      <p class="preview-meta__title">Spin the clay wheel</p>
+                      <p class="preview-meta__description">
+                        A softer, calmer start when you want tactile focus with
+                        slow motion.
+                      </p>
+                    </div>
+                    <a
+                      class="cta-button primary preview-launch"
+                      href="toy.html?toy=clay"
+                    >
+                      Launch
+                    </a>
+                  </div>
+                </article>
+                <article
+                  class="preview-card"
+                  data-preview-card
+                  data-preview-src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
+                >
+                  <div class="preview-media preview-media--geom">
+                    <div class="preview-glow preview-glow--geom"></div>
+                    <div class="preview-frame">
+                      <span class="preview-tag">Geom</span>
+                      <p class="preview-title">Geometry Visualizer</p>
+                      <p class="preview-caption">
+                        Shifting prisms with crisp depth cues and kinetic
+                        lighting.
+                      </p>
+                      <div class="preview-badges">
+                        <span class="pill pill--contrast">WebGPU ready</span>
+                        <span class="pill">Motion aware</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="preview-meta">
+                    <div class="preview-meta__copy">
+                      <p class="eyebrow">High energy</p>
+                      <p class="preview-meta__title">Push geometry hard</p>
+                      <p class="preview-meta__description">
+                        Great when you want sharper motion, tilt input, and
+                        immediate depth.
+                      </p>
+                    </div>
+                    <a
+                      class="cta-button primary preview-launch"
+                      href="toy.html?toy=geom"
+                    >
+                      Launch
+                    </a>
+                  </div>
+                </article>
+              </div>
+              <div class="preview-dots" role="presentation">
+                <span class="preview-dot is-active" data-preview-dot></span>
+                <span class="preview-dot" data-preview-dot></span>
+                <span class="preview-dot" data-preview-dot></span>
+              </div>
             </div>
             <div class="hero-callouts">
               <div class="callout-card">
@@ -341,6 +455,73 @@
                 >Search name, tags, mood, mic/motion/demo audio</span
               >
             </div>
+            <div class="filter-row" role="group" aria-label="Curated filters">
+              <div class="chip-row" data-chip-row>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="mood"
+                  data-filter-value="calm"
+                >
+                  Calm
+                </button>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="mood"
+                  data-filter-value="energetic"
+                >
+                  Energetic
+                </button>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="capability"
+                  data-filter-value="microphone"
+                >
+                  Microphone
+                </button>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="capability"
+                  data-filter-value="motion"
+                >
+                  Motion
+                </button>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="capability"
+                  data-filter-value="demoAudio"
+                >
+                  Demo audio
+                </button>
+                <button
+                  type="button"
+                  class="filter-chip"
+                  data-filter-chip
+                  data-filter-type="feature"
+                  data-filter-value="webgpu"
+                >
+                  WebGPU
+                </button>
+              </div>
+              <label class="sort-control">
+                <span>Sort</span>
+                <select data-sort-control>
+                  <option value="featured">Featured</option>
+                  <option value="newest">Newest</option>
+                  <option value="immersive">Most immersive</option>
+                  <option value="az">A → Z</option>
+                </select>
+              </label>
+            </div>
             <div class="search-meta">
               <p
                 class="search-meta__results"
@@ -400,6 +581,72 @@
         const search = document.getElementById('toy-search');
         const searchResults = document.querySelector('[data-search-results]');
         let cachedQuery = '';
+        let sortBy = 'featured';
+        const activeFilters = new Set();
+
+        const shouldDeferToEnhanced = () =>
+          document.body.dataset.libraryEnhanced === 'true';
+
+        const getHaystack = (toy) => {
+          const capabilityTerms = Object.entries(toy.capabilities || {})
+            .filter(([, enabled]) => !!enabled)
+            .map(([key]) => key.toLowerCase());
+
+          return [
+            toy.title,
+            toy.slug,
+            toy.description,
+            ...(toy.tags ?? []),
+            ...(toy.moods ?? []),
+            ...capabilityTerms,
+            toy.requiresWebGPU ? 'webgpu' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase();
+        };
+
+        const matchesFilters = (toy) => {
+          if (activeFilters.size === 0) return true;
+          return Array.from(activeFilters).every((token) => {
+            const [type, value] = token.split(':');
+            if (!type || !value) return true;
+            if (type === 'mood') {
+              return (toy.moods ?? []).some(
+                (mood) => mood.toLowerCase() === value
+              );
+            }
+            if (type === 'capability') {
+              return Boolean(toy.capabilities?.[value]);
+            }
+            if (type === 'feature') {
+              return value === 'webgpu' ? Boolean(toy.requiresWebGPU) : true;
+            }
+            return true;
+          });
+        };
+
+        const capabilityScore = (toy) =>
+          (toy.requiresWebGPU ? 2 : 0) +
+          Number(toy.capabilities?.microphone) +
+          Number(toy.capabilities?.motion) +
+          Number(toy.capabilities?.demoAudio);
+
+        const sortList = (list) => {
+          const sorted = [...list];
+          switch (sortBy) {
+            case 'newest':
+              return sorted.reverse();
+            case 'az':
+              return sorted.sort((a, b) => a.title.localeCompare(b.title));
+            case 'immersive':
+              return sorted.sort(
+                (a, b) => capabilityScore(b) - capabilityScore(a)
+              );
+            default:
+              return sorted;
+          }
+        };
         let allToys = [];
 
         const updateResultsMeta = (count, total, query = '') => {
@@ -434,9 +681,25 @@
           list.appendChild(empty);
         };
 
-        const renderCards = (toys, query = '') => {
+        const applyFilters = (query = cachedQuery) => {
+          const normalized = (query || '').toLowerCase();
+          const filtered = allToys.filter((toy) => {
+            const matchesQuery = !normalized || getHaystack(toy).includes(normalized);
+            return matchesQuery && matchesFilters(toy);
+          });
+
+          return sortList(filtered);
+        };
+
+        const renderCards = (toys = applyFilters(), query = '') => {
+          if (shouldDeferToEnhanced()) return;
+
           list.innerHTML = '';
-          updateResultsMeta(toys.length, allToys.length, query || cachedQuery);
+          updateResultsMeta(
+            toys.length,
+            allToys.length,
+            query || cachedQuery
+          );
 
           if (toys.length === 0) {
             renderEmptyState();
@@ -517,40 +780,37 @@
             if (!toys || list.childElementCount > 0) return;
 
             allToys = toys;
-            renderCards(allToys);
+            renderCards(applyFilters());
 
             if (search instanceof HTMLInputElement) {
               search.addEventListener('input', () => {
-                const query = search.value.toLowerCase().trim();
-                cachedQuery = query;
+                cachedQuery = search.value.toLowerCase().trim();
+                renderCards(applyFilters(cachedQuery), cachedQuery);
+              });
+            }
 
-                if (!query) {
-                  renderCards(allToys);
-                  return;
+            const chips = document.querySelectorAll('[data-filter-chip]');
+            chips.forEach((chip) => {
+              chip.addEventListener('click', () => {
+                const type = chip.getAttribute('data-filter-type');
+                const value = chip.getAttribute('data-filter-value');
+                if (!type || !value) return;
+                const token = `${type}:${value.toLowerCase()}`;
+                const isActive = chip.classList.toggle('is-active');
+                if (isActive) {
+                  activeFilters.add(token);
+                } else {
+                  activeFilters.delete(token);
                 }
+                renderCards(applyFilters(), cachedQuery);
+              });
+            });
 
-                const filtered = allToys.filter((toy) => {
-                  const capabilityTerms = Object.entries(toy.capabilities || {})
-                    .filter(([, enabled]) => !!enabled)
-                    .map(([key]) => key.toLowerCase());
-
-                  const haystack = [
-                    toy.title,
-                    toy.slug,
-                    toy.description,
-                    ...(toy.tags ?? []),
-                    ...(toy.moods ?? []),
-                    ...capabilityTerms,
-                    toy.requiresWebGPU ? 'webgpu' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')
-                    .toLowerCase();
-
-                  return haystack.includes(query);
-                });
-
-                renderCards(filtered, query);
+            const sortControl = document.querySelector('[data-sort-control]');
+            if (sortControl && sortControl.tagName === 'SELECT') {
+              sortControl.addEventListener('change', () => {
+                sortBy = sortControl.value;
+                renderCards(applyFilters(), cachedQuery);
               });
             }
           })


### PR DESCRIPTION
## Summary
- replace the hero orbital graphic with a rotating premium preview reel and animated theme toggle in the sticky glass nav
- add curated chips, sorting controls, and richer filtering logic to the library (including fallback rendering)
- lazy-load preview media and fetch library data before initialization to keep the landing experience responsive

## Testing
- bun run lint
- bun run test
- bun run typecheck *(fails: existing project type errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e153792308332bb1da50e57265c7e)