### PR TITLE
Handle missing toys and add library empty state

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1294,6 +1294,23 @@ export function createLibraryView({
     meta.textContent = `${visibleCount} ${descriptor} • ${total} in library`;
   };
 
+  const resetFiltersAndSearch = () => {
+    searchQuery = '';
+    activeFilters.clear();
+
+    const chips = document.querySelectorAll('[data-filter-chip].is-active');
+    chips.forEach((chip) => chip.classList.remove('is-active'));
+
+    if (searchInputId) {
+      const search = document.getElementById(searchInputId);
+      if (search && 'value' in search) {
+        search.value = '';
+      }
+    }
+
+    renderToys(applyFilters());
+  };
+
   const getHaystack = (toy) => {
     const capabilityTerms = Object.entries(toy.capabilities || {})
       .filter(([, enabled]) => Boolean(enabled))
@@ -1486,6 +1503,31 @@ export function createLibraryView({
     if (!list) return;
     list.innerHTML = '';
     iconInstance = 0;
+
+    if (listToRender.length === 0) {
+      const emptyState = document.createElement('div');
+      emptyState.className = 'library-empty-state';
+      emptyState.setAttribute('role', 'status');
+      emptyState.setAttribute('aria-live', 'polite');
+
+      const message = document.createElement('p');
+      message.className = 'library-empty-state__message';
+      message.textContent =
+        'No stims match your search or filters. Try adjusting your query.';
+
+      const resetButton = document.createElement('button');
+      resetButton.type = 'button';
+      resetButton.className = 'cta-button';
+      resetButton.textContent = 'Clear filters';
+      resetButton.addEventListener('click', () => resetFiltersAndSearch());
+
+      emptyState.appendChild(message);
+      emptyState.appendChild(resetButton);
+      list.appendChild(emptyState);
+      updateResultsMeta(0);
+      return;
+    }
+
     listToRender.forEach((toy) => list.appendChild(createCard(toy)));
     updateResultsMeta(listToRender.length);
   };

--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -219,7 +219,7 @@ export function createLoader({
     const toy = toys.find((t) => t.slug === slug);
     if (!toy) {
       console.error(`Toy not found: ${slug}`);
-      backToLibrary();
+      view.showUnavailableToy?.(slug, { onBack: backToLibrary });
       return;
     }
 

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -99,6 +99,14 @@ function renderStatusElement(
         ? 'is-warning'
         : 'is-loading';
   statusElement.className = `active-toy-status ${statusVariant}`;
+  statusElement.setAttribute(
+    'role',
+    status.variant === 'error' ? 'alert' : 'status'
+  );
+  statusElement.setAttribute(
+    'aria-live',
+    status.variant === 'error' ? 'assertive' : 'polite'
+  );
 
   const glow = doc.createElement('div');
   glow.className = 'active-toy-status__glow';
@@ -406,6 +414,30 @@ export function createToyView({
     return status;
   };
 
+  const showUnavailableToy = (
+    slug: string,
+    { onBack }: { onBack?: () => void } = {}
+  ) => {
+    state.mode = 'toy';
+    state.backHandler = onBack ?? state.backHandler;
+    state.activeToyMeta = undefined;
+    state.status = {
+      variant: 'error',
+      title: 'Toy unavailable',
+      message: `We couldn't find the stim "${slug}". It may have been moved or removed.`,
+      actions: [
+        {
+          label: 'Back to library',
+          onClick: onBack,
+          primary: true,
+        },
+      ],
+    };
+
+    const { status } = render({ clearContainer: true });
+    return status;
+  };
+
   const showCapabilityError = (
     toy: Toy | undefined,
     options: CapabilityOptions = {}
@@ -465,5 +497,6 @@ export function createToyView({
       clearContainerContent(findActiveToyContainer()),
     ensureActiveToyContainer,
     setRendererStatus,
+    showUnavailableToy,
   };
 }


### PR DESCRIPTION
## Summary
- surface an accessible unavailable message when a requested toy slug is missing instead of silently redirecting
- add aria live-region roles to toy status overlays for better announcements
- render an empty-state block in the library grid with a clear-filters action that resets search and filter state

## Tests
- bun run lint
- bun run typecheck (fails: existing type errors in repository)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695749d352bc8332bdd6a8adc7017899)