### PR TITLE
Improve theme bootstrap and toggle sync

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1216,40 +1216,70 @@ const iconRenderers = {
   },
 };
 
+const getThemeController = () => {
+  if (window.__stimsTheme) {
+    return window.__stimsTheme;
+  }
+
+  const resolveThemePreference = () => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  };
+
+  const applyTheme = (theme, persist = false) => {
+    const root = document.documentElement;
+    if (theme === 'light') {
+      root.classList.add('light');
+    } else {
+      root.classList.remove('light');
+    }
+    if (persist) {
+      localStorage.setItem('theme', theme);
+    }
+  };
+
+  return { resolveThemePreference, applyTheme };
+};
+
 function setupDarkModeToggle(themeToggleId = 'theme-toggle') {
   const btn = document.getElementById(themeToggleId);
   if (!btn) return;
+
+  const { resolveThemePreference, applyTheme } = getThemeController();
+  let theme = resolveThemePreference();
+
   const label = btn.querySelector('[data-theme-label]');
   const icon = btn.querySelector('.theme-toggle__icon');
-  let dark = localStorage.getItem('theme') !== 'light';
+
   const updateButtonState = () => {
-    const labelText = dark ? 'Light mode' : 'Dark mode';
+    const isDark = theme === 'dark';
+    const labelText = isDark ? 'Light mode' : 'Dark mode';
     if (label) {
       label.textContent = labelText;
     } else {
       btn.textContent = labelText;
     }
     if (icon) {
-      icon.textContent = dark ? '☀️' : '🌙';
+      icon.textContent = isDark ? '☀️' : '🌙';
     }
-    btn.setAttribute('aria-pressed', String(dark));
+    btn.setAttribute('aria-pressed', String(isDark));
     btn.setAttribute(
       'aria-label',
-      dark ? 'Switch to light mode' : 'Switch to dark mode'
+      isDark ? 'Switch to light mode' : 'Switch to dark mode'
     );
   };
 
+  applyTheme(theme);
   updateButtonState();
+
   btn.addEventListener('click', () => {
-    dark = !dark;
-    const root = document.documentElement;
-    if (dark) {
-      root.classList.remove('light');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      root.classList.add('light');
-      localStorage.setItem('theme', 'light');
-    }
+    theme = theme === 'dark' ? 'light' : 'dark';
+    applyTheme(theme, true);
     updateButtonState();
   });
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,35 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stim Webtoys Library</title>
+    <script>
+      (function () {
+        const resolveThemePreference = () => {
+          const stored = localStorage.getItem('theme');
+          if (stored === 'light' || stored === 'dark') {
+            return stored;
+          }
+          return window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        };
+
+        const applyTheme = (theme, persist = false) => {
+          const root = document.documentElement;
+          if (theme === 'light') {
+            root.classList.add('light');
+          } else {
+            root.classList.remove('light');
+          }
+          if (persist) {
+            localStorage.setItem('theme', theme);
+          }
+        };
+
+        window.__stimsTheme = { resolveThemePreference, applyTheme };
+
+        applyTheme(resolveThemePreference());
+      })();
+    </script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
@@ -45,12 +74,6 @@
             "inLanguage": "en"
           }
         ]
-      }
-    </script>
-    <script>
-      const savedTheme = localStorage.getItem('theme');
-      if (savedTheme === 'light') {
-        document.documentElement.classList.add('light');
       }
     </script>
   </head>


### PR DESCRIPTION
## Summary
- add a shared theme resolver used by the initial bootstrap and the library toggle
- default theme to the system preference when no stored choice exists and keep toggle UI state in sync

## Tests
- bun run lint
- bun run typecheck (fails: existing TypeScript errors in three-related files and utilities)
- bun run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695749e2e9c4833287613b28fc0abbf3)