### PR TITLE
Add Bun fallback for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check": "bun run lint && bun run typecheck && bun run test",
     "check:quick": "bun run lint && bun run typecheck",
     "check:toys": "bun run scripts/check-toys.ts",
-    "build": "node scripts/build.mjs",
+    "build": "node scripts/build.mjs || bun scripts/build.mjs",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",
     "pages:dev": "bun run build && bunx wrangler pages dev dist",


### PR DESCRIPTION
### Motivation
- Ensure builds succeed in Bun-first environments (for example Cloudflare Pages preview builders) when a Node binary is not available.
- Align the `build` script with the repo's Bun-first tooling and existing `postinstall` logic.

### Description
- Update `package.json` `build` script to `node scripts/build.mjs || bun scripts/build.mjs` so Bun is used if `node` is not present.
- Change is limited to `package.json` and does not alter runtime behavior beyond the command used to run the existing build script.

### Testing
- Ran the pre-commit hooks which executed `eslint .` and the auto-formatter `prettier --write .` and both completed successfully.
- No additional automated tests were required and no docs were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696083aeb2808332be3f04b49a3642fb)