### PR TITLE
Prefer Bun for script runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
     "typecheck:watch": "tsc --noEmit --watch",
     "dev": "vite",
     "dev:host": "vite --host",
-    "dev:check": "node scripts/dev-check.mjs",
+    "dev:check": "bun scripts/dev-check.mjs || node scripts/dev-check.mjs",
     "check": "bun run lint && bun run typecheck && bun run test",
     "check:quick": "bun run lint && bun run typecheck",
     "check:toys": "bun run scripts/check-toys.ts",
-    "build": "node scripts/build.mjs || bun scripts/build.mjs",
+    "build": "bun scripts/build.mjs || node scripts/build.mjs",
     "serve:dist": "bun run scripts/serve-dist.ts",
     "preview": "vite preview --host",
     "pages:dev": "bun run build && bunx wrangler pages dev dist",
     "pages:deploy": "bun run build && bunx wrangler pages deploy dist",
     "mcp": "bun run scripts/mcp-server.ts",
     "prepare": "husky install",
-    "postinstall": "node scripts/postinstall.mjs || bun scripts/postinstall.mjs"
+    "postinstall": "bun scripts/postinstall.mjs || node scripts/postinstall.mjs"
   },
   "devDependencies": {
     "@types/three": "^0.181.0",


### PR DESCRIPTION
### Motivation

- Modernize local developer workflow to prefer the Bun toolchain for faster installs and script execution.
- Keep Node as a reliable fallback to avoid breaking environments that don't use Bun.
- Align scripts with repository guidance that Bun is the preferred runtime (`packageManager` and docs reference Bun).

### Description

- Update `package.json` to prefer Bun-first invocation for `dev:check` by changing it to `"dev:check": "bun scripts/dev-check.mjs || node scripts/dev-check.mjs"`.
- Change the `build` script to `"build": "bun scripts/build.mjs || node scripts/build.mjs"` to run the Bun build path first.
- Change the `postinstall` script to `"postinstall": "bun scripts/postinstall.mjs || node scripts/postinstall.mjs"` so Husky/install steps favor Bun when available.
- Retain Node fallbacks for all modified scripts so environments without Bun remain functional.

### Testing

- Ran `bun run lint` which executed successfully.
- Ran `bun run typecheck` which failed due to pre-existing TypeScript errors in the repository (no new type errors introduced by this PR).
- Ran `bun run test` which completed with all tests passing (72 passed, 0 failed).
- No documentation files were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608459afc88332b595df046f9314bf)