### PR TITLE
Add Cloudflare Pages caching headers

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,6 +48,7 @@ Any static host should point its document root to the `dist/` directory and pres
 - `dist/.vite/manifest.json` for asset lookups.
 
 If your platform supports immutable caching, enable it for `dist/assets/**`; keep HTML un-cached or lightly cached so updates propagate.
+Cloudflare Pages can read caching rules from `public/_headers`, which Vite copies into `dist/_headers` at build time. The repo ships defaults that set long-term caching for `assets/*` and force revalidation for HTML and `.vite` metadata; adjust those if your host requires a different policy.
 
 ## Cloudflare Pages Configuration
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/.vite/*
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
### Motivation

- Ensure Cloudflare Pages receives sensible `Cache-Control` defaults for HTML, hashed assets, and Vite manifest metadata so updates propagate reliably.
- Provide a repository-controlled `_headers` file that Vite will copy into `dist/_headers` at build time to make Pages deployments predictable.
- Clarify deployment guidance so contributors know where to set and adjust caching rules for static hosting.

### Description

- Add `public/_headers` with caching rules for `/`, `/*.html`, `/assets/*`, and `/.vite/*` to set `Cache-Control` policies.
- Update `docs/DEPLOYMENT.md` to document that Vite copies `public/_headers` to `dist/_headers` and to describe the recommended caching defaults for Cloudflare Pages.
- No runtime code paths or types were changed; this PR is limited to static hosting config and documentation.

### Testing

- Ran formatting with `bun run format` (`prettier --write .`) which completed successfully.
- Ran linting via `eslint .` which completed successfully.
- No unit tests or typechecks were required for this documentation/config change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d81610fc833291de5199bd5f4542)