### PR TITLE
Improve responsive layout and add view transitions for library/toy views

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -34,6 +34,32 @@ body {
   display: none !important;
 }
 
+@supports (view-transition-name: none) {
+  .content {
+    view-transition-name: library-view;
+  }
+
+  .active-toy-container {
+    view-transition-name: toy-view;
+  }
+
+  ::view-transition-old(library-view),
+  ::view-transition-new(library-view),
+  ::view-transition-old(toy-view),
+  ::view-transition-new(toy-view) {
+    animation: fadeSlide 0.35s ease;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(library-view),
+  ::view-transition-new(library-view),
+  ::view-transition-old(toy-view),
+  ::view-transition-new(toy-view) {
+    animation-duration: 1ms;
+  }
+}
+
 .active-toy-container {
   position: fixed;
   inset: 0;
@@ -423,6 +449,21 @@ body {
   .toy-nav__back {
     width: 100%;
     justify-content: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .active-toy-nav__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .renderer-status {
+    width: 100%;
+  }
+
+  .renderer-pill__detail {
+    max-width: 100%;
   }
 }
 
@@ -896,6 +937,17 @@ body {
   }
   to {
     filter: hue-rotate(360deg);
+  }
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -540,7 +540,10 @@ header.hero {
   font-weight: 700;
   letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .preview-control:hover,
@@ -1590,6 +1593,120 @@ footer {
 .theme-toggle__label {
   font-weight: 700;
   letter-spacing: 0.01em;
+}
+
+@media (max-width: 1024px) {
+  .content {
+    padding: clamp(1.25rem, 2.5vw, 2.4rem);
+  }
+
+  .hero-grid {
+    align-items: start;
+  }
+
+  .preview-track {
+    min-height: 320px;
+  }
+
+  .feature-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .top-nav {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .nav-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .hero-visual {
+    width: 100%;
+  }
+
+  .preview-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .preview-launch {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hero-callouts {
+    width: 100%;
+  }
+}
+
+@media (max-width: 680px) {
+  .search-field {
+    flex-wrap: wrap;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .search-field__hint {
+    width: 100%;
+    white-space: normal;
+  }
+
+  .filter-row {
+    align-items: flex-start;
+  }
+
+  .sort-control {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .preview-controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .preview-control-buttons {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .preview-dots {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .brand {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .nav-actions {
+    width: 100%;
+  }
+
+  .theme-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .cta-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cta-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .signal-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 768px) {

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1255,6 +1255,25 @@ function setupDarkModeToggle(themeToggleId = 'theme-toggle') {
 
   const label = btn.querySelector('[data-theme-label]');
   const icon = btn.querySelector('.theme-toggle__icon');
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const runViewTransition = (action) => {
+    const doc = btn.ownerDocument;
+    if (
+      !doc ||
+      typeof doc.startViewTransition !== 'function' ||
+      prefersReducedMotion?.matches
+    ) {
+      action();
+      return;
+    }
+    doc.startViewTransition(() => {
+      action();
+    });
+  };
 
   const updateButtonState = () => {
     const isDark = theme === 'dark';
@@ -1278,9 +1297,11 @@ function setupDarkModeToggle(themeToggleId = 'theme-toggle') {
   updateButtonState();
 
   btn.addEventListener('click', () => {
-    theme = theme === 'dark' ? 'light' : 'dark';
-    applyTheme(theme, true);
-    updateButtonState();
+    runViewTransition(() => {
+      theme = theme === 'dark' ? 'light' : 'dark';
+      applyTheme(theme, true);
+      updateButtonState();
+    });
   });
 }
 

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -294,6 +294,27 @@ export function createToyView({
   };
 
   const getDocument = () => documentRef();
+  const prefersReducedMotion = () =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const runViewTransition = <T>(action: () => T) => {
+    const doc = getDocument();
+    if (
+      !doc ||
+      typeof doc.startViewTransition !== 'function' ||
+      prefersReducedMotion()
+    ) {
+      return action();
+    }
+
+    let result: T;
+    doc.startViewTransition(() => {
+      result = action();
+    });
+    return result!;
+  };
 
   const getToyList = () => getDocument()?.getElementById(listId) ?? null;
 
@@ -360,14 +381,14 @@ export function createToyView({
     state.rendererStatus = null;
     state.activeToyMeta = undefined;
     state.status = null;
-    render({ clearContainer: true });
+    runViewTransition(() => render({ clearContainer: true }));
   };
 
   const showActiveToyView = (onBack?: () => void, toy?: Toy) => {
     state.mode = 'toy';
     state.backHandler = onBack ?? state.backHandler;
     state.activeToyMeta = toy ?? state.activeToyMeta;
-    const { container } = render();
+    const { container } = runViewTransition(() => render());
     return container;
   };
 
@@ -380,7 +401,7 @@ export function createToyView({
       message: toyTitle ? `${toyTitle} is loading.` : 'Loading toy...',
     };
 
-    const { status } = render();
+    const { status } = runViewTransition(() => render());
     return status;
   };
 
@@ -410,7 +431,9 @@ export function createToyView({
       ],
     };
 
-    const { status } = render({ clearContainer: true });
+    const { status } = runViewTransition(() =>
+      render({ clearContainer: true })
+    );
     return status;
   };
 
@@ -434,7 +457,9 @@ export function createToyView({
       ],
     };
 
-    const { status } = render({ clearContainer: true });
+    const { status } = runViewTransition(() =>
+      render({ clearContainer: true })
+    );
     return status;
   };
 
@@ -477,7 +502,9 @@ export function createToyView({
       ],
     };
 
-    const { status } = render({ clearContainer: true });
+    const { status } = runViewTransition(() =>
+      render({ clearContainer: true })
+    );
     return status;
   };
 


### PR DESCRIPTION
### Motivation
- Improve the landing/library experience across a range of screen sizes and modernize transitions to meet current UX expectations.
- Add lightweight view transitions so theme toggles and navigation between the library and an active toy feel smoother.
- Respect users' reduced-motion preference so transitions are not forced on accessibility-sensitive devices.
- Keep small-screen in-toy navigation and preview controls usable and readable on phones and tablets.

### Description
- Add a `runViewTransition` wrapper and reduced-motion guard to `assets/js/toy-view.ts` and wire transitions into `showLibraryView`, `showActiveToyView`, loading and error states. 
- Update the theme toggle in `assets/js/library-view.js` to use `startViewTransition` when available and safe to animate. 
- Add view-transition CSS (`view-transition-name` and `::view-transition-*`) and a `fadeSlide` keyframe in `assets/css/base.css`, plus media-query safe-fallback for `prefers-reduced-motion`. 
- Add responsive breakpoints and layout tweaks in `assets/css/index.css` and small-screen adjustments to toy nav in `assets/css/base.css` to improve nav, hero, preview, and library control layouts.

### Testing
- Ran formatting with `bun run format` which completed successfully. 
- Ran linting with `bun run lint` which completed successfully. 
- Ran type checking with `bun run typecheck` which failed due to existing TypeScript errors in the repo (errors are pre-existing and not introduced by these changes). 
- Ran the test suite with `bun run test` which passed (72 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961dbf35b188332993bcf07e2128c0a)