### PR TITLE
Standardize audio analyser types

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -1,6 +1,8 @@
-import type * as THREE from 'three';
 import { getFrequencyData } from '../utils/audio-handler';
-import type { AudioInitOptions } from '../utils/audio-handler';
+import type {
+  AudioInitOptions,
+  FrequencyAnalyser,
+} from '../utils/audio-handler';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type WebToyInstance = any;
@@ -10,7 +12,7 @@ type WebToyInstance = any;
  */
 export interface AnimationContext {
   toy: WebToyInstance;
-  analyser: THREE.AudioAnalyser | null;
+  analyser: FrequencyAnalyser | null;
 }
 
 /**

--- a/assets/js/core/services/audio-service.ts
+++ b/assets/js/core/services/audio-service.ts
@@ -3,10 +3,11 @@ import {
   getMicrophonePermissionState,
   initAudio,
   type AudioInitOptions,
+  type FrequencyAnalyser,
 } from '../../utils/audio-handler.ts';
 
 export type AudioHandle = {
-  analyser: THREE.AudioAnalyser;
+  analyser: FrequencyAnalyser;
   listener: THREE.AudioListener;
   audio: THREE.Audio | THREE.PositionalAudio;
   stream?: MediaStream;

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -13,6 +13,7 @@ import {
 import type { RendererInitConfig } from './renderer-setup.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
 import { defaultToyLifecycle } from './toy-lifecycle.ts';
+import type { FrequencyAnalyser } from '../utils/audio-handler.ts';
 
 export default class WebToy {
   canvas: HTMLCanvasElement;
@@ -23,7 +24,7 @@ export default class WebToy {
   rendererInfo: RendererHandle['info'] | null;
   rendererReady: Promise<RendererHandle | null>;
   rendererOptions: Parameters<typeof requestRenderer>[0]['options'];
-  analyser: THREE.AudioAnalyser | null;
+  analyser: FrequencyAnalyser | null;
   audioListener: THREE.AudioListener | null;
   audio: THREE.Audio | THREE.PositionalAudio | null;
   audioStream: MediaStream | null;

--- a/assets/js/toys/brand.ts
+++ b/assets/js/toys/brand.ts
@@ -5,6 +5,7 @@ import { getContextFrequencyData } from '../core/animation-loop';
 import { ensureWebGL } from '../utils/webgl-check';
 import { showError } from '../utils/error-display';
 import { startToyAudio } from '../utils/start-audio';
+import type { FrequencyAnalyser } from '../utils/audio-handler';
 import { initHints } from '../../ui/hints';
 import { initFunControls } from '../../ui/fun-controls';
 import { createBrandFunAdapter } from '../../brand/fun-adapter';
@@ -209,7 +210,7 @@ export async function startBrandToy({
   poleMesh.instanceMatrix.needsUpdate = true;
 
   const animate = (ctx: {
-    analyser: THREE.AudioAnalyser | null;
+    analyser: FrequencyAnalyser | null;
     toy: WebToy;
   }) => {
     const dataArray = getContextFrequencyData(ctx);

--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -1,14 +1,14 @@
 // patternRecognition.js: A pattern recognition and predictive listening script for audio-based visualizers
 
-import type { AudioAnalyser } from 'three';
+import type { FrequencyAnalyser } from './audio-handler';
 
 class PatternRecognizer {
-  analyser: AudioAnalyser;
+  analyser: FrequencyAnalyser;
   bufferSize: number;
   patternBuffer: Uint8Array[];
   writeIndex: number;
   filled: number;
-  constructor(analyser: AudioAnalyser, bufferSize = 30) {
+  constructor(analyser: FrequencyAnalyser, bufferSize = 30) {
     // Reduced buffer size for performance
     this.analyser = analyser;
     this.bufferSize = bufferSize;

--- a/assets/js/utils/peak-detector.ts
+++ b/assets/js/utils/peak-detector.ts
@@ -1,8 +1,8 @@
-import type { AudioAnalyser } from 'three';
 import { getAverageFrequency, getFrequencyData } from './audio-handler';
+import type { FrequencyAnalyser } from './audio-handler';
 
 export interface PeakDetectorOptions {
-  analyser?: AudioAnalyser;
+  analyser?: FrequencyAnalyser;
   /** Custom provider for FFT data; use when you already have a buffer handy. */
   getData?: () => Uint8Array;
   /** How much louder than the baseline the signal must be to trigger a peak. */


### PR DESCRIPTION
### Motivation
- Unify audio analyser typing across the codebase so helpers, toys, and services use the same analyser API instead of a mix of `THREE.AudioAnalyser` and local implementations.
- Make utilities like pattern recognition and peak detection accept the shared `FrequencyAnalyser` produced by the audio pipeline to avoid casting and duplicated adapter code.
- Reduce coupling to Three.js-specific analyser types and centralize frequency access through `getFrequencyData`/`FrequencyAnalyser`.

### Description
- Replace usages of `THREE.AudioAnalyser` with the shared `FrequencyAnalyser` type in `assets/js/core/animation-loop.ts`, `assets/js/core/services/audio-service.ts`, and `assets/js/core/web-toy.ts`.
- Update helper modules to reference `FrequencyAnalyser` by importing the type from `assets/js/utils/audio-handler.ts` in `assets/js/utils/patternRecognition.ts` and `assets/js/utils/peak-detector.ts`.
- Adjust `assets/js/toys/brand.ts` to import and use `FrequencyAnalyser` in the animate callback signature so toy code aligns with the unified analyser type.

### Testing
- Ran `bun run lint` (pre-commit hooks invoked `eslint`/`prettier`) and lint/format steps completed during commit.
- Ran `bun run typecheck` (`tsc --noEmit`) which failed due to existing repository-wide type issues unrelated to these changes, so typecheck did not fully pass in this environment.
- No changes to runtime logic or unit tests were introduced, so existing tests were not modified or re-run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ff0b57508332ad5c9cf7c25efbeb)