### PR TITLE
Add renderer telemetry and WebGL fallback tuning

### DIFF
--- a/multi.html
+++ b/multi.html
@@ -57,11 +57,17 @@
 
       const canvas = document.getElementById('webglCanvas');
       const capabilityBanner = document.getElementById('capability-banner');
+      const allowWebGLFallback = true;
       const hasWebGPU = Boolean(navigator.gpu);
+      const useWebGLFallback = allowWebGLFallback && !hasWebGPU;
 
-      if (!hasWebGPU && capabilityBanner) {
+      if (useWebGLFallback && capabilityBanner) {
         capabilityBanner.textContent =
-          'Running in WebGL fallback mode. WebGPU adds extra bloom and lighting polish when supported.';
+          'WebGPU is unavailable, so you are seeing the lighter WebGL preset with fewer particles and simpler lighting.';
+        capabilityBanner.style.display = 'block';
+      } else if (!hasWebGPU && capabilityBanner) {
+        capabilityBanner.textContent =
+          'WebGPU is unavailable in this browser. Try a WebGPU-enabled browser for the full visual fidelity.';
         capabilityBanner.style.display = 'block';
       }
 
@@ -80,7 +86,7 @@
           fov: 75,
           position: { x: 0, y: 0, z: 50 },
         },
-        rendererOptions: hasWebGPU
+        rendererOptions: !useWebGLFallback
           ? {
               antialias: true,
               exposure: 1,
@@ -88,28 +94,43 @@
             }
           : {
               antialias: false,
-              exposure: 0.9,
-              maxPixelRatio: 1.25,
+              exposure: 0.85,
+              maxPixelRatio: 1.1,
             },
-        ambientLightOptions: { color: 0xffffff, intensity: 1 },
+        ambientLightOptions: {
+          color: 0xffffff,
+          intensity: useWebGLFallback ? 0.7 : 1,
+        },
       });
+
+      const baseMaterial = useWebGLFallback
+        ? THREE.MeshLambertMaterial
+        : THREE.MeshStandardMaterial;
 
       const torusKnot = new THREE.Mesh(
         new THREE.TorusKnotGeometry(10, 3, 100, 16),
-        new THREE.MeshStandardMaterial({
+        new baseMaterial({
           color: 0x00ff00,
-          metalness: 0.5,
-          roughness: 0.2,
+          ...(useWebGLFallback
+            ? {}
+            : {
+                metalness: 0.5,
+                roughness: 0.2,
+              }),
         })
       );
       toy.scene.add(torusKnot);
 
-      const pointLight = new THREE.PointLight(0xff0000, 2, 100);
+      const pointLight = new THREE.PointLight(
+        0xff0000,
+        useWebGLFallback ? 1.25 : 2,
+        useWebGLFallback ? 80 : 100
+      );
       pointLight.position.set(10, 20, 20);
       toy.scene.add(pointLight);
 
       const particlesGeometry = new THREE.BufferGeometry();
-      const particlesCount = hasWebGPU ? 1200 : 450;
+      const particlesCount = useWebGLFallback ? 320 : 1200;
       const particlesPosition = new Float32Array(particlesCount * 3);
       for (let i = 0; i < particlesCount * 3; i++) {
         particlesPosition[i] = (Math.random() - 0.5) * 500;
@@ -120,7 +141,7 @@
       );
       const particlesMaterial = new THREE.PointsMaterial({
         color: 0x00ff00,
-        size: 0.5,
+        size: useWebGLFallback ? 0.6 : 0.5,
       });
       const particles = new THREE.Points(particlesGeometry, particlesMaterial);
       toy.scene.add(particles);
@@ -129,11 +150,15 @@
       function createRandomShape() {
         const shapeType = Math.floor(Math.random() * 3);
         let shape;
-        const shapeMaterial = new THREE.MeshStandardMaterial({
+        const shapeMaterial = new baseMaterial({
           color: Math.random() * 0xffffff,
-          emissive: Math.random() * 0x222222,
-          metalness: 0.7,
-          roughness: 0.4,
+          ...(useWebGLFallback
+            ? {}
+            : {
+                emissive: Math.random() * 0x222222,
+                metalness: 0.7,
+                roughness: 0.4,
+              }),
         });
 
         switch (shapeType) {
@@ -158,7 +183,7 @@
         shapes.push(mesh);
       }
 
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < (useWebGLFallback ? 3 : 5); i++) {
         createRandomShape();
       }
 
@@ -368,8 +393,9 @@
         torusKnot.scale.setScalar(burstScale);
 
         pointLight.intensity =
-          Math.max(0.6, avgFrequency / 140) *
-          (spin * 500 + 0.5 + burstValue * 2);
+          Math.max(useWebGLFallback ? 0.4 : 0.6, avgFrequency / 140) *
+          (spin * 500 + 0.5 + burstValue * 2) *
+          (useWebGLFallback ? 0.6 : 1);
 
         particles.rotation.y += 0.001 + spin / 10;
 


### PR DESCRIPTION
### Motivation
- Ensure WebGPU gating remains enforceable for toys that `requiresWebGPU` while providing a friendly experience when WebGPU is unavailable.  
- Provide a lighter, tuned WebGL fallback preset for the multi visualizer to reduce particles and simplify lighting when `allowWebGLFallback` is enabled.  
- Add a lightweight telemetry hook so WebGPU support rates can be measured centrally before stricter gating is applied.  

### Description
- Added a telemetry API and event emission to `assets/js/core/renderer-capabilities.ts` including `RendererTelemetryEvent`, `RendererTelemetryHandler`, `setRendererTelemetryHandler`, `reportRendererTelemetry`, and deduplication by environment key.  
- `reportRendererTelemetry` dispatches a `CustomEvent('stims:renderer-capabilities', { detail })` and calls any registered handler so other modules can reuse the telemetry hook.  
- Updated `multi.html` to introduce `allowWebGLFallback` / `useWebGLFallback`, show a friendly capability banner when WebGPU is missing, and apply a lighter WebGL preset (reduced `particlesCount`, simplified materials/lighting, fewer shapes, and tuned exposure/PRI settings).  

### Testing
- Ran `bun run lint` which completed successfully.  
- Ran `bun run typecheck` which failed due to existing repository type issues (e.g., missing or mismatched `three`/environment typings) unrelated to this change.  
- Ran `bun run test` which passed (`72` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962023358e08332989912b52a83d5d8)