### PR TITLE
Refactor toy loader helpers

### DIFF
--- a/assets/js/core/toy-capabilities.ts
+++ b/assets/js/core/toy-capabilities.ts
@@ -1,0 +1,48 @@
+import type { RendererCapabilities } from './renderer-capabilities.ts';
+import type { ensureWebGL } from '../utils/webgl-check.ts';
+
+type ToyCapabilityOptions = {
+  title?: string;
+  requiresWebGPU?: boolean;
+  allowWebGLFallback?: boolean;
+};
+
+type RenderCapabilityCheckInput = {
+  toy: ToyCapabilityOptions;
+  rendererCapabilities: () => Promise<RendererCapabilities>;
+  ensureWebGLCheck: typeof ensureWebGL;
+  initialCapabilities?: RendererCapabilities;
+};
+
+export type ToyCapabilityDecision = {
+  capabilities: RendererCapabilities;
+  supportsRendering: boolean;
+  shouldShowCapabilityError: boolean;
+  allowWebGLFallback: boolean;
+};
+
+export async function assessToyCapabilities({
+  toy,
+  rendererCapabilities,
+  ensureWebGLCheck,
+  initialCapabilities,
+}: RenderCapabilityCheckInput): Promise<ToyCapabilityDecision> {
+  const capabilities = initialCapabilities ?? (await rendererCapabilities());
+  const supportsRendering = ensureWebGLCheck({
+    title: toy.title
+      ? `${toy.title} needs graphics acceleration`
+      : 'Graphics support required',
+    description:
+      'We could not detect WebGL or WebGPU support on this device. Try a modern browser with hardware acceleration enabled.',
+  });
+
+  const shouldShowCapabilityError =
+    Boolean(toy.requiresWebGPU) && capabilities.preferredBackend !== 'webgpu';
+
+  return {
+    capabilities,
+    supportsRendering,
+    shouldShowCapabilityError,
+    allowWebGLFallback: Boolean(toy.allowWebGLFallback),
+  };
+}

--- a/assets/js/utils/toy-module-loader.ts
+++ b/assets/js/utils/toy-module-loader.ts
@@ -1,0 +1,83 @@
+import type { createManifestClient } from './manifest-client.ts';
+
+export type ToyModuleStarter = (args: {
+  container: HTMLElement;
+  slug: string;
+}) => Promise<unknown> | unknown;
+
+export type ToyModuleLoadFailureType = 'resolve' | 'import' | 'missing_start';
+
+export type ToyModuleLoadFailure = {
+  ok: false;
+  errorType: ToyModuleLoadFailureType;
+  error: Error;
+  moduleUrl?: string;
+};
+
+export type ToyModuleLoadSuccess = {
+  ok: true;
+  moduleUrl: string;
+  starter: ToyModuleStarter;
+};
+
+export type ToyModuleLoadResult = ToyModuleLoadSuccess | ToyModuleLoadFailure;
+
+function resolveModuleImportUrl(moduleUrl: string) {
+  if (moduleUrl.startsWith('./') || moduleUrl.startsWith('../')) {
+    return new URL(moduleUrl, new URL('../', import.meta.url)).toString();
+  }
+
+  return moduleUrl;
+}
+
+export async function loadToyModuleStarter({
+  moduleId,
+  manifestClient,
+}: {
+  moduleId: string;
+  manifestClient: ReturnType<typeof createManifestClient>;
+}): Promise<ToyModuleLoadResult> {
+  let moduleUrl: string;
+  try {
+    moduleUrl = await manifestClient.resolveModulePath(moduleId);
+  } catch (error) {
+    return {
+      ok: false,
+      errorType: 'resolve',
+      error: error as Error,
+    };
+  }
+
+  let moduleExports: unknown;
+  try {
+    const resolvedUrl = resolveModuleImportUrl(moduleUrl);
+    moduleExports = await import(resolvedUrl);
+  } catch (error) {
+    return {
+      ok: false,
+      errorType: 'import',
+      moduleUrl,
+      error: error as Error,
+    };
+  }
+
+  const startCandidate =
+    (moduleExports as { start?: unknown })?.start ??
+    (moduleExports as { default?: { start?: unknown } })?.default?.start;
+  const starter = typeof startCandidate === 'function' ? startCandidate : null;
+
+  if (!starter) {
+    return {
+      ok: false,
+      errorType: 'missing_start',
+      moduleUrl,
+      error: new Error('Toy module did not export a start function.'),
+    };
+  }
+
+  return {
+    ok: true,
+    moduleUrl,
+    starter,
+  };
+}


### PR DESCRIPTION
### Motivation

- Reduce `createLoader` complexity by extracting module resolution/import and renderer capability gating to make control flow easier to read and unit test.
- Centralize error handling for module loading so import/resolve failures produce typed results the loader can act on.
- Consolidate WebGL/WebGPU gating logic to a single decision point used by the loader when starting module toys.

### Description

- Add `assets/js/utils/toy-module-loader.ts` which resolves a module URL, performs the dynamic `import`, and returns a typed `ToyModuleLoadResult` containing either a `starter` function or a detailed error result.
- Add `assets/js/core/toy-capabilities.ts` which assesses rendering capabilities and returns a `ToyCapabilityDecision` used to gate rendering and fallback behavior.
- Update `assets/js/loader.ts` to keep `createLoader` as the orchestrator but delegate capability checks and module loading to the new helpers, simplify control flow, and surface import/resolution errors through the view.
- Improve relative module import resolution handling in the module loader so tests and local mocks resolve correctly.

### Testing

- Ran `bun run format` to apply formatting, which completed successfully.
- Ran `bun run lint` which passed without errors.
- Ran `bun run typecheck` which fails due to existing repository type issues (external `three`/`bun` typings), not caused by this change.
- Ran `bun run test` and all tests passed (72 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e5b853d48332a68788139ede4f4e)