### PR TITLE
Make main bootstrap resilient

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,23 +6,25 @@ import { initQuickstartCta } from './utils/init-quickstart.ts';
 import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
 import { initPreviewReels } from './utils/init-preview-reels.ts';
 
-const safeInit = async (label, init) => {
-  try {
-    await init();
-  } catch (error) {
-    console.error(`Failed to initialize ${label}`, error);
-  }
+const runInit = (label, init) => {
+  Promise.resolve()
+    .then(() => init())
+    .catch((error) => {
+      console.error(`Failed to initialize ${label}`, error);
+    });
 };
 
 const startApp = async () => {
   initReadinessProbe();
-  await safeInit('library view', () =>
-    initLibraryView({ loadToy, initNavigation, loadFromQuery })
+  await initLibraryView({ loadToy, initNavigation, loadFromQuery }).catch(
+    (error) => {
+      console.error('Failed to initialize library view', error);
+    }
   );
-  await safeInit('quickstart CTA', () => initQuickstartCta({ loadToy }));
-  await safeInit('nav scroll effects', initNavScrollEffects);
-  await safeInit('preview reels', initPreviewReels);
-  await safeInit('repo status widget', initRepoStatusWidget);
+  runInit('quickstart CTA', () => initQuickstartCta({ loadToy }));
+  runInit('nav scroll effects', initNavScrollEffects);
+  runInit('preview reels', initPreviewReels);
+  runInit('repo status widget', initRepoStatusWidget);
 };
 
 if (document.readyState === 'loading') {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,13 +6,23 @@ import { initQuickstartCta } from './utils/init-quickstart.ts';
 import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
 import { initPreviewReels } from './utils/init-preview-reels.ts';
 
+const safeInit = async (label, init) => {
+  try {
+    await init();
+  } catch (error) {
+    console.error(`Failed to initialize ${label}`, error);
+  }
+};
+
 const startApp = async () => {
   initReadinessProbe();
-  await initLibraryView({ loadToy, initNavigation, loadFromQuery });
-  initQuickstartCta({ loadToy });
-  initNavScrollEffects();
-  initPreviewReels();
-  void initRepoStatusWidget();
+  await safeInit('library view', () =>
+    initLibraryView({ loadToy, initNavigation, loadFromQuery })
+  );
+  await safeInit('quickstart CTA', () => initQuickstartCta({ loadToy }));
+  await safeInit('nav scroll effects', initNavScrollEffects);
+  await safeInit('preview reels', initPreviewReels);
+  await safeInit('repo status widget', initRepoStatusWidget);
 };
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
### Motivation
- Prevent a single landing-page initializer from aborting the entire app startup when it throws. 
- Improve robustness of the client bootstrap so optional UI pieces can fail independently. 
- Keep readiness probe running unguarded while feature initializers are isolated. 

### Description
- Add a `safeInit` helper that runs an initializer inside a `try/catch` and logs failures. 
- Replace direct initializer calls in `startApp` with `safeInit` for the library view, quickstart CTA, nav scroll effects, preview reels, and repo status widget. 
- Preserve the unguarded call to `initReadinessProbe` so readiness is still reported before feature inits. 

### Testing
- Ran `bun run format` which completed successfully. 
- Ran `bun run lint` which completed successfully. 
- Ran `bun run typecheck` which failed due to existing repository type errors unrelated to this change. 
- Ran `bun run test` which failed one test (`tests/sample-toy.test.ts`) causing the test suite to report 1 failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e402a0dc833286e0c922c7b594d5)