### PR TITLE
Guard app initializers with safe wrappers

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,12 +7,22 @@ import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
 import { initPreviewReels } from './utils/init-preview-reels.ts';
 
 const startApp = async () => {
-  initReadinessProbe();
-  await initLibraryView({ loadToy, initNavigation, loadFromQuery });
-  initQuickstartCta({ loadToy });
-  initNavScrollEffects();
-  initPreviewReels();
-  void initRepoStatusWidget();
+  const safeInit = async (name, fn) => {
+    try {
+      await fn();
+    } catch (error) {
+      console.error(`[main] ${name} failed`, error);
+    }
+  };
+
+  await safeInit('initReadinessProbe', () => initReadinessProbe());
+  await safeInit('initLibraryView', () =>
+    initLibraryView({ loadToy, initNavigation, loadFromQuery })
+  );
+  await safeInit('initQuickstartCta', () => initQuickstartCta({ loadToy }));
+  await safeInit('initNavScrollEffects', () => initNavScrollEffects());
+  await safeInit('initPreviewReels', () => initPreviewReels());
+  void safeInit('initRepoStatusWidget', () => initRepoStatusWidget());
 };
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
### Motivation
- Prevent a single initializer error from halting app startup so remaining UI glue can still run.
- Keep `initLibraryView` awaited because it controls the library loading state while allowing other initializers to be isolated.
- Provide a small, consistent error-logging pattern for startup initializers to reduce repetition.

### Description
- Add a lightweight `safeInit(name, fn)` helper inside `assets/js/main.js` that `try/catch`es and logs failures.
- Wrap existing initializers (`initReadinessProbe`, `initLibraryView`, `initQuickstartCta`, `initNavScrollEffects`, `initPreviewReels`) with `safeInit` and keep `initLibraryView` awaited via the helper.
- Run `initRepoStatusWidget` via `void safeInit(...)` so it runs but is not awaited.
- Preserve the existing `DOMContentLoaded` vs immediate `startApp()` call flow and only change the initializer invocation details.

### Testing
- Ran `bun run lint` which completed successfully.
- Ran `bun run typecheck` which failed due to pre-existing TypeScript errors in the repository.
- Ran `bun run test` and the test suite passed (72 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f2ca567083328910973ec59c6e15)