### PR TITLE
Add Bun and Node type dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.5",
+        "@types/node": "^25.0.6",
         "@types/three": "^0.181.0",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
@@ -212,9 +214,11 @@
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
+    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
-    "@types/node": ["@types/node@24.0.3", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg=="],
+    "@types/node": ["@types/node@25.0.6", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q=="],
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
@@ -273,6 +277,8 @@
     "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -658,7 +664,7 @@
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
-    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "postinstall": "bun scripts/postinstall.mjs || node scripts/postinstall.mjs"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "@types/node": "^25.0.6",
     "@types/three": "^0.181.0",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["bun", "node"]
   },
   "include": ["assets/**/*", "tests/**/*", "scripts/**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
### Motivation
- Ensure TypeScript can resolve Bun and Node globals used by scripts and tests so `bun:test`, `node:*`, and Bun runtime symbols type-check.
- Address import/typing issues seen in scripts like `scripts/mcp-worker.ts` by providing the appropriate runtime type packages.
- Use Bun tooling to install and lock the new dev dependencies so local `bun` workflows see consistent types.
- Note that if the MCP worker import still fails, `moduleResolution` may need to be switched to `node16`/`nodenext`/`bundler` as a follow-up.

### Description
- Added `@types/bun` and `@types/node` to `devDependencies` in `package.json` and updated `bun.lock` accordingly.
- Updated `tsconfig.json` to include the `types` entry `["bun","node"]` so Bun/Node types are injected into the compilation context.
- Installed the packages with `bun add -d @types/node @types/bun`, producing lockfile updates.
- Did not change `moduleResolution` in this change; leaving that for a follow-up if needed.

### Testing
- Ran `bun add -d @types/node @types/bun` and the packages installed successfully and updated `bun.lock`.
- Pre-commit checks ran `eslint .` and `prettier --write .` and completed successfully during the commit.
- Ran `bun run typecheck` (i.e. `tsc --noEmit`) and it failed due to many pre-existing TypeScript errors in `assets`/`tests` that are unrelated to these typings.
- No documentation files were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963023ba92883328ff33b485a0fb86f)