### PR TITLE
Relax scaffoldToy options typing

### DIFF
--- a/scripts/scaffold-toy.ts
+++ b/scripts/scaffold-toy.ts
@@ -18,6 +18,15 @@ type ScaffoldOptions = {
   root?: string;
 };
 
+type ScaffoldToyOptions = {
+  slug: string;
+  title: string;
+  description: string;
+  type?: ToyType;
+  createTest?: boolean;
+  root?: string;
+};
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
@@ -88,7 +97,7 @@ export async function scaffoldToy({
   type = 'module',
   createTest = false,
   root = repoRoot,
-}: Required<Omit<ScaffoldOptions, 'root'>> & { root?: string }) {
+}: ScaffoldToyOptions) {
   await ensureToysDataValid(root);
 
   if (await fileExists(toyModulePath(slug, root))) {


### PR DESCRIPTION
### Motivation

- Avoid forcing callers to provide `createSpec` via the broad `Required<...>` typing when it is not needed. 
- Make the `scaffoldToy` API clearer by requiring only the fields that callers should provide. 
- Reduce friction for programmatic callers and CLI-invoked code paths by providing a focused options type.

### Description

- Add a new `ScaffoldToyOptions` type that requires `slug`, `title`, and `description` and optionally accepts `type`, `createTest`, and `root`.
- Change the `scaffoldToy` function signature to accept `ScaffoldToyOptions` instead of `Required<Omit<ScaffoldOptions, 'root'>> & { root?: string }`.
- This relaxes the type contract so callers are no longer forced to pass `createSpec` while preserving existing runtime behavior.
- No documentation files were modified.

### Testing

- Ran `bun run lint` which completed successfully. 
- Ran `bun run typecheck` which failed in this environment due to missing `bun`/`node` type definitions. 
- Ran `bun run test` and all tests passed (`72 pass`, `0 fail`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630ae3c188833299ba45020d0c6380)