### PR TITLE
Reduce promotional sections on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,54 +211,6 @@
               No installs or accounts. Enable your mic when prompted to see the
               visuals react. Code and contribution notes live on GitHub.
             </p>
-            <div class="repo-status" data-repo-status aria-live="polite">
-              <div class="repo-status__header">
-                <p class="eyebrow">Project health</p>
-                <p class="repo-status__title">GitHub status</p>
-                <p class="repo-status__description">
-                  Latest stats for
-                  <span class="repo-status__repo-name">zz-plant/stims</span>
-                  with live stars and recent activity.
-                </p>
-              </div>
-              <dl class="repo-status__metrics">
-                <div class="repo-status__metric">
-                  <dt>Stars</dt>
-                  <dd data-star-count aria-label="Stargazers">—</dd>
-                </div>
-                <div class="repo-status__metric">
-                  <dt>Last push</dt>
-                  <dd data-last-commit aria-label="Last commit date">—</dd>
-                </div>
-              </dl>
-              <p
-                class="repo-status__message"
-                data-status-fallback
-                hidden
-                role="status"
-                aria-live="polite"
-              >
-                Loading GitHub stats…
-              </p>
-            </div>
-            <div class="hero-highlights">
-              <div class="highlight-chip">
-                <span aria-hidden="true">🪩</span> Audio-reactive scenes and
-                tactile controls.
-              </div>
-              <div class="highlight-chip">
-                <span aria-hidden="true">⚡</span> Zero-install links that open
-                instantly.
-              </div>
-              <div class="highlight-chip">
-                <span aria-hidden="true">🌗</span> Light/dark mode remembers
-                your choice.
-              </div>
-              <div class="highlight-chip">
-                <span aria-hidden="true">🧭</span> Curated paths help you find a
-                vibe fast.
-              </div>
-            </div>
           </div>
           <div class="hero-visual" aria-hidden="true">
             <div class="preview-reel" data-preview-reel>
@@ -449,62 +401,6 @@
           </div>
         </div>
       </header>
-
-      <section class="feature-bands">
-        <div class="section-heading">
-          <p class="eyebrow">Design refresh</p>
-          <h2>Curated paths make discovery calmer</h2>
-          <p class="section-description">
-            We rebuilt the landing layout with layered glass, new gradients, and
-            cushioned cards. Spotlights and sound-first tips now sit above the
-            full library so you can either follow a vibe or dive straight into
-            every toy.
-          </p>
-        </div>
-        <div class="feature-grid">
-          <article class="feature-card">
-            <div class="feature-icon" aria-hidden="true">🌈</div>
-            <div class="feature-body">
-              <h3>Color-first spotlights</h3>
-              <p>
-                New highlight cards pair atmospheric gradients with clear
-                descriptions so you can pick a palette that matches your mood.
-              </p>
-              <p class="feature-meta">
-                Glassy borders, subtle glow, and rounded corners that feel
-                tactile.
-              </p>
-            </div>
-          </article>
-          <article class="feature-card">
-            <div class="feature-icon" aria-hidden="true">🎧</div>
-            <div class="feature-body">
-              <h3>Audio-aware guidance</h3>
-              <p>
-                Callouts explain how to start with microphone input, demos, or
-                device motion without ever feeling technical.
-              </p>
-              <p class="feature-meta">
-                Lightweight help text with improved readability on both themes.
-              </p>
-            </div>
-          </article>
-          <article class="feature-card">
-            <div class="feature-icon" aria-hidden="true">🧭</div>
-            <div class="feature-body">
-              <h3>Wayfinding that hugs the grid</h3>
-              <p>
-                New section spacing, pill-shaped highlights, and soft dividers
-                keep the experience airy even with dozens of entries.
-              </p>
-              <p class="feature-meta">
-                Library search and cards inherit the refreshed styling
-                automatically.
-              </p>
-            </div>
-          </article>
-        </div>
-      </section>
 
       <section class="library">
         <div class="section-heading">


### PR DESCRIPTION
### Motivation
- Reduce the amount of promotional copy on the landing page so the hero focuses on core CTAs and readiness information.
- Make the library section more prominent by removing decorative blocks that interrupt discovery flow.
- Improve scanning and reduce visual noise for first-time visitors.

### Description
- Removed the GitHub status block (`.repo-status`) from the hero area in `index.html`.
- Removed the hero highlight chips (`.hero-highlights`) in `index.html`.
- Removed the standalone promotional feature band section (`section.feature-bands`) so the library follows the hero directly.
- Changes are limited to `index.html` (104 lines removed).

### Testing
- Ran `eslint .` which passed.
- Ran `prettier --write .` which formatted files and completed successfully.
- Pre-commit hooks executed the above checks during commit and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69632363a2b48332842aceae64cea207)