### PR TITLE
Add realtime tuning controls to Evol, Geom, Holy, and Multi visualizers

### DIFF
--- a/evol.html
+++ b/evol.html
@@ -27,6 +27,45 @@
           value="1.0"
         />
       </div>
+      <div class="control-panel__row">
+        <label class="control-panel__text" for="audioImpact">
+          <span class="control-panel__label">Audio Impact</span>
+        </label>
+        <input
+          type="range"
+          id="audioImpact"
+          min="2"
+          max="14"
+          step="0.5"
+          value="8"
+        />
+      </div>
+      <div class="control-panel__row">
+        <label class="control-panel__text" for="warpStrength">
+          <span class="control-panel__label">Warp Strength</span>
+        </label>
+        <input
+          type="range"
+          id="warpStrength"
+          min="0"
+          max="1.5"
+          step="0.05"
+          value="1.0"
+        />
+      </div>
+      <div class="control-panel__row">
+        <label class="control-panel__text" for="glitchStrength">
+          <span class="control-panel__label">Glitch Strength</span>
+        </label>
+        <input
+          type="range"
+          id="glitchStrength"
+          min="0"
+          max="1"
+          step="0.05"
+          value="0.8"
+        />
+      </div>
     </div>
     <script type="module">
       import {
@@ -75,6 +114,9 @@
             uniform vec2 u_resolution;
             uniform float u_audioData;
             uniform float u_fractalIntensity;
+            uniform float u_audioImpact;
+            uniform float u_warpStrength;
+            uniform float u_glitchStrength;
             varying vec2 v_uv;
 
             float random(vec2 p) {
@@ -116,19 +158,19 @@
                 vec2 pos = (gl_FragCoord.xy / u_resolution.xy) * 2.0 - 1.0;
                 pos.x *= u_resolution.x / u_resolution.y;
 
-                float audioEffect = u_audioData * 8.0;
+                float audioEffect = u_audioData * u_audioImpact;
                 
                 // Warped coordinates for surreal effect
                 vec2 warpedUV = uv + vec2(
-                    sin(uv.y * 10.0 + u_time + audioEffect) * 0.05,
-                    cos(uv.x * 10.0 + u_time * 1.3) * 0.05
+                    sin(uv.y * 10.0 + u_time + audioEffect) * (0.05 * u_warpStrength),
+                    cos(uv.x * 10.0 + u_time * 1.3) * (0.05 * u_warpStrength)
                 );
                 
                 float distortion = fbm(warpedUV * u_fractalIntensity * 3.0 + audioEffect) * 0.6;
                 float distortion2 = fbm(warpedUV * u_fractalIntensity * 1.5 - u_time * 0.5) * 0.4;
                 
                 // Enhanced glitch effects
-                float glitch = step(0.92, random(uv * u_time * 3.0)) * 0.8;
+                float glitch = step(0.92, random(uv * u_time * 3.0)) * u_glitchStrength;
                 float scanline = sin(gl_FragCoord.y * 0.5 + u_time * 10.0) * 0.03;
                 float vhsNoise = random(vec2(u_time * 0.1, gl_FragCoord.y * 0.01)) * 0.05;
                 
@@ -229,6 +271,18 @@
         program,
         'u_fractalIntensity'
       );
+      const audioImpactLocation = gl.getUniformLocation(
+        program,
+        'u_audioImpact'
+      );
+      const warpStrengthLocation = gl.getUniformLocation(
+        program,
+        'u_warpStrength'
+      );
+      const glitchStrengthLocation = gl.getUniformLocation(
+        program,
+        'u_glitchStrength'
+      );
 
       const disposeResize = setupCanvasResize(canvas, gl, {
         maxPixelRatio: 2,
@@ -287,11 +341,29 @@
       let time = 0.0;
       let audioData = 0.0;
       let fractalIntensity = 1.0;
+      let audioImpact = 8.0;
+      let warpStrength = 1.0;
+      let glitchStrength = 0.8;
 
       document
         .getElementById('fractalIntensity')
         .addEventListener('input', (event) => {
-          fractalIntensity = event.target.value;
+          fractalIntensity = Number(event.target.value);
+        });
+      document
+        .getElementById('audioImpact')
+        .addEventListener('input', (event) => {
+          audioImpact = Number(event.target.value);
+        });
+      document
+        .getElementById('warpStrength')
+        .addEventListener('input', (event) => {
+          warpStrength = Number(event.target.value);
+        });
+      document
+        .getElementById('glitchStrength')
+        .addEventListener('input', (event) => {
+          glitchStrength = Number(event.target.value);
         });
 
       function render(ctxAudio) {
@@ -309,6 +381,9 @@
         gl.uniform1f(timeUniformLocation, time);
         gl.uniform1f(audioDataUniformLocation, audioData);
         gl.uniform1f(fractalIntensityLocation, fractalIntensity);
+        gl.uniform1f(audioImpactLocation, audioImpact);
+        gl.uniform1f(warpStrengthLocation, warpStrength);
+        gl.uniform1f(glitchStrengthLocation, glitchStrength);
 
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);

--- a/geom.html
+++ b/geom.html
@@ -18,11 +18,27 @@
         left: 10px;
         color: #fff;
         z-index: 1;
+        background: rgba(0, 0, 0, 0.55);
+        padding: 12px 14px;
+        border-radius: 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        min-width: 220px;
       }
       #startButton {
         padding: 10px 20px;
         font-size: 16px;
         cursor: pointer;
+      }
+      .control-group label {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        margin-bottom: 6px;
+      }
+      .control-group input[type='range'] {
+        width: 100%;
       }
       #error-message {
         position: absolute;
@@ -40,6 +56,48 @@
     <a href="index.html" class="home-link">Back to Library</a>
     <div id="controls">
       <button id="startButton">Start Microphone Visualizer</button>
+      <div class="control-group">
+        <label for="densityControl">
+          <span>Particle Density</span>
+          <span id="densityValue">1.0x</span>
+        </label>
+        <input
+          type="range"
+          id="densityControl"
+          min="0.5"
+          max="2"
+          step="0.1"
+          value="1"
+        />
+      </div>
+      <div class="control-group">
+        <label for="speedControl">
+          <span>Motion Speed</span>
+          <span id="speedValue">1.0x</span>
+        </label>
+        <input
+          type="range"
+          id="speedControl"
+          min="0.5"
+          max="2.5"
+          step="0.1"
+          value="1"
+        />
+      </div>
+      <div class="control-group">
+        <label for="trailControl">
+          <span>Trail Blend</span>
+          <span id="trailValue">0.25</span>
+        </label>
+        <input
+          type="range"
+          id="trailControl"
+          min="0.05"
+          max="0.6"
+          step="0.05"
+          value="0.25"
+        />
+      </div>
     </div>
     <div id="error-message" style="display: none"></div>
     <canvas id="gameCanvas" class="toy-canvas"></canvas>
@@ -60,12 +118,21 @@
       const canvas = document.getElementById('gameCanvas');
       const ctx = canvas.getContext('2d');
       const startButton = document.getElementById('startButton');
+      const densityControl = document.getElementById('densityControl');
+      const densityValue = document.getElementById('densityValue');
+      const speedControl = document.getElementById('speedControl');
+      const speedValue = document.getElementById('speedValue');
+      const trailControl = document.getElementById('trailControl');
+      const trailValue = document.getElementById('trailValue');
 
       let viewWidth = window.innerWidth;
       let viewHeight = window.innerHeight;
       let resizeCleanup = null;
       let activeQuality = null;
       const baseDensity = 0.6;
+      let densityMultiplier = 1;
+      let speedMultiplier = 1;
+      let trailBlend = 0.25;
 
       function applyQualityPreset(preset) {
         activeQuality = preset;
@@ -85,7 +152,7 @@
         const densityScale = Math.max(baseDensity, preset.particleScale ?? 1);
         particleCount = Math.max(
           200,
-          Math.round(baseParticleCount * densityScale)
+          Math.round(baseParticleCount * densityScale * densityMultiplier)
         );
         rebuildParticles();
       }
@@ -185,11 +252,13 @@
         } else {
           ctx.fillStyle = '#000';
         }
+        ctx.globalAlpha = trailBlend;
         ctx.fillRect(0, 0, viewWidth, viewHeight);
+        ctx.globalAlpha = 1;
 
         particles.forEach((p, index) => {
-          p.x += p.velocityX;
-          p.y += p.velocityY;
+          p.x += p.velocityX * speedMultiplier;
+          p.y += p.velocityY * speedMultiplier;
           p.rotation += p.angularVelocity;
 
           if (p.x < -p.size) p.x = viewWidth + p.size;
@@ -297,6 +366,32 @@
           console.error('Error starting audio:', error);
         }
       });
+
+      function updateDensity() {
+        densityMultiplier = Number(densityControl.value);
+        densityValue.textContent = `${densityMultiplier.toFixed(1)}x`;
+        applyQualityPreset(
+          activeQuality ?? { maxPixelRatio: 2, renderScale: 1 }
+        );
+      }
+
+      function updateSpeed() {
+        speedMultiplier = Number(speedControl.value);
+        speedValue.textContent = `${speedMultiplier.toFixed(1)}x`;
+      }
+
+      function updateTrail() {
+        trailBlend = Number(trailControl.value);
+        trailValue.textContent = trailBlend.toFixed(2);
+      }
+
+      densityControl.addEventListener('input', updateDensity);
+      speedControl.addEventListener('input', updateSpeed);
+      trailControl.addEventListener('input', updateTrail);
+
+      updateDensity();
+      updateSpeed();
+      updateTrail();
 
       window.addEventListener('beforeunload', () => {
         toy.dispose?.();

--- a/holy.html
+++ b/holy.html
@@ -224,6 +224,32 @@
           value="0.8"
         />
       </div>
+      <div class="slider-container">
+        <label for="bloomStrength"
+          >Bloom Strength: <span id="bloomStrengthValue">1.5</span></label
+        >
+        <input
+          type="range"
+          id="bloomStrength"
+          min="0.2"
+          max="2.5"
+          step="0.1"
+          value="1.5"
+        />
+      </div>
+      <div class="slider-container">
+        <label for="particleScale"
+          >Particle Size: <span id="particleScaleValue">1.0</span></label
+        >
+        <input
+          type="range"
+          id="particleScale"
+          min="0.5"
+          max="2"
+          step="0.1"
+          value="1"
+        />
+      </div>
     </div>
 
     <!-- Main Visualizer Script -->
@@ -255,6 +281,8 @@
       let particleCount = 600;
       let shapeDetail = 32;
       let shapeOpacity = 0.8;
+      let bloomStrength = 1.5;
+      let particleScale = 1;
       let instancedParticles;
       let particleMaterial;
       let particleGeometry;
@@ -273,6 +301,10 @@
       const shapeDetailValue = document.getElementById('shapeDetailValue');
       const opacitySlider = document.getElementById('opacity');
       const opacityValue = document.getElementById('opacityValue');
+      const bloomStrengthSlider = document.getElementById('bloomStrength');
+      const bloomStrengthValue = document.getElementById('bloomStrengthValue');
+      const particleScaleSlider = document.getElementById('particleScale');
+      const particleScaleValue = document.getElementById('particleScaleValue');
       const errorEl = document.getElementById('error-message');
 
       function showError(message) {
@@ -315,12 +347,12 @@
         // Bloom Pass for Glow Effect
         bloomPass = new UnrealBloomPass(
           new THREE.Vector2(window.innerWidth, window.innerHeight),
-          1.5, // strength
+          bloomStrength, // strength
           0.4, // radius
           0.85 // threshold
         );
         bloomPass.threshold = 0.21;
-        bloomPass.strength = 1.5;
+        bloomPass.strength = bloomStrength;
         bloomPass.radius = 0.55;
         composer.addPass(bloomPass);
 
@@ -452,6 +484,7 @@
             (Math.random() - 0.5) * 20,
             (Math.random() - 0.5) * 20
           );
+          dummy.scale.setScalar(particleScale);
           dummy.updateMatrix();
           instancedParticles.setMatrixAt(i, dummy.matrix);
           // Initialize colors
@@ -554,6 +587,7 @@
           dummy.position.y += (audioValue - 0.5) * 0.1;
           dummy.rotation.x += 0.01 * audioValue;
           dummy.rotation.y += 0.01 * audioValue;
+          dummy.scale.setScalar(particleScale);
           dummy.updateMatrix();
           instancedParticles.setMatrixAt(i, dummy.matrix);
 
@@ -697,6 +731,19 @@
         }
       }
 
+      function updateBloomStrength() {
+        bloomStrength = parseFloat(bloomStrengthSlider.value);
+        bloomStrengthValue.textContent = bloomStrength.toFixed(1);
+        if (bloomPass) {
+          bloomPass.strength = bloomStrength;
+        }
+      }
+
+      function updateParticleScale() {
+        particleScale = parseFloat(particleScaleSlider.value);
+        particleScaleValue.textContent = particleScale.toFixed(1);
+      }
+
       // Start Button Click Handler
       startButton.addEventListener('click', async () => {
         startButton.style.display = 'none';
@@ -737,6 +784,14 @@
       particleCountValue.textContent = particleCount;
       shapeDetailValue.textContent = shapeDetail;
       opacityValue.textContent = shapeOpacity.toFixed(1);
+      bloomStrengthValue.textContent = bloomStrength.toFixed(1);
+      particleScaleValue.textContent = particleScale.toFixed(1);
+
+      particleCountSlider.addEventListener('input', updateParticleCount);
+      shapeDetailSlider.addEventListener('input', updateShapeDetail);
+      opacitySlider.addEventListener('input', updateShapeOpacity);
+      bloomStrengthSlider.addEventListener('input', updateBloomStrength);
+      particleScaleSlider.addEventListener('input', updateParticleScale);
 
       // Prevent Context Menu on Long Press
       window.oncontextmenu = function (e) {

--- a/multi.html
+++ b/multi.html
@@ -146,6 +146,10 @@
       const particles = new THREE.Points(particlesGeometry, particlesMaterial);
       toy.scene.add(particles);
 
+      const hazeColor = 0x050505;
+      let hazeDensity = useWebGLFallback ? 0.0025 : 0.0018;
+      toy.scene.fog = new THREE.FogExp2(hazeColor, hazeDensity);
+
       const shapes = [];
       function createRandomShape() {
         const shapeType = Math.floor(Math.random() * 3);
@@ -215,6 +219,16 @@
         <label>
           Peak sensitivity
           <input class="fun-slider fun-sensitivity" type="range" min="0.1" max="1" step="0.05" value="0.35" aria-label="Peak sensitivity" />
+        </label>
+        <label>
+          Particle size <span class="fun-particle-size-value">0.6</span>
+          <input class="fun-slider fun-particle-size" type="range" min="0.3" max="1.2" step="0.05" value="${
+            useWebGLFallback ? 0.6 : 0.5
+          }" aria-label="Particle size" />
+        </label>
+        <label>
+          Haze density <span class="fun-haze-value">0.002</span>
+          <input class="fun-slider fun-haze" type="range" min="0" max="0.01" step="0.0005" value="${hazeDensity}" aria-label="Haze density" />
         </label>
       `;
 
@@ -370,6 +384,47 @@
         }
         burstsEnabled = target.checked;
       });
+
+      const particleSizeSlider =
+        funControls.container.querySelector('.fun-particle-size');
+      const particleSizeValue = funControls.container.querySelector(
+        '.fun-particle-size-value'
+      );
+      particleSizeSlider?.addEventListener('input', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+          return;
+        }
+        const nextValue = Number(target.value);
+        particlesMaterial.size = nextValue;
+        if (particleSizeValue) {
+          particleSizeValue.textContent = nextValue.toFixed(2);
+        }
+      });
+      if (particleSizeValue) {
+        particleSizeValue.textContent = particlesMaterial.size.toFixed(2);
+      }
+
+      const hazeSlider = funControls.container.querySelector('.fun-haze');
+      const hazeValue = funControls.container.querySelector('.fun-haze-value');
+      hazeSlider?.addEventListener('input', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+          return;
+        }
+        hazeDensity = Number(target.value);
+        if (toy.scene.fog instanceof THREE.FogExp2) {
+          toy.scene.fog.density = hazeDensity;
+        } else {
+          toy.scene.fog = new THREE.FogExp2(hazeColor, hazeDensity);
+        }
+        if (hazeValue) {
+          hazeValue.textContent = hazeDensity.toFixed(4);
+        }
+      });
+      if (hazeValue) {
+        hazeValue.textContent = hazeDensity.toFixed(4);
+      }
 
       function animate(ctx) {
         const delta = clock.getDelta();


### PR DESCRIPTION
### Motivation
- Provide more realtime tuning for the visualizers so users can adjust audio reactivity and visual fidelity without editing code. 
- Expose controls to balance GPU/visual quality (particle density, render scaling, bloom) and to fine-tune audio-driven effects. 
- Make shader/scene parameters controllable from the UI so artists and testers can experiment quickly. 

### Description
- Added new range controls to `evol.html` (`audioImpact`, `warpStrength`, `glitchStrength`) and wired them to new shader uniforms (`u_audioImpact`, `u_warpStrength`, `u_glitchStrength`) to scale audio and distortion effects. 
- Extended `geom.html` with an in-UI control panel (particle density, motion speed, trail blend) and connected those controls to `particleCount`, particle velocities, and canvas blending for trail effects. 
- Added `bloomStrength` and `particleScale` sliders to `holy.html` and hooked them into the `UnrealBloomPass` strength and instanced particle scaling so bloom and particle sizing are adjustable at runtime. 
- Updated `multi.html` to add scene haze/fog plus particle-size and haze density sliders integrated into the existing fun-controls UI for immediate scene atmosphere adjustments. 

### Testing
- Ran formatting with `bun run format` which completed successfully. 
- Ran linting with `bun run lint` which completed successfully. 
- Ran the test suite with `bun run test` which passed all tests (72 passed). 
- Ran type checking with `bun run typecheck` which reported failures related to `Uint8Array<ArrayBufferLike>` type mismatches in `assets/js/utils/audio-handler.ts` and `scripts/serve-dist.ts` that need follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963316c9ba48332876648f5f01c4097)