### PR TITLE
Soften home page messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,33 +75,30 @@
             <p class="eyebrow">
               Open-source stims • Quick to try • No accounts
             </p>
-            <h1>Feel-first visuals that breathe with your audio.</h1>
+            <h1>Audio-reactive visuals for calm focus.</h1>
             <p class="tagline">
-              Visuals that respond to your world. Every stim is light, fast, and 
-              designed for instant immersion.
+              Tap a stim and go. Light, fast, and built for instant immersion.
             </p>
             <div class="signal-grid" role="list">
               <div class="signal-card" role="listitem">
                 <p class="signal-label">Cinematic by default</p>
                 <p class="signal-value">
-                  Layered gradients, softened edges, and light/dark palettes
-                  that respect your theme.
+                  Layered gradients and soft edges with light/dark palettes.
                 </p>
               </div>
               <div class="signal-card" role="listitem">
                 <p class="signal-label">Responsive everywhere</p>
                 <p class="signal-value">
-                  Keyboard, touch, and reduced-motion aware so focus stays on
-                  the sensation, not the setup.
+                  Works with keyboard, touch, and reduced-motion settings.
                 </p>
               </div>
             </div>
             <div class="readiness-panel" role="status" aria-live="polite">
               <div class="readiness-header">
-                <p class="eyebrow">Interaction readiness</p>
-                <p class="readiness-title">Quick pulse before you launch</p>
+                <p class="eyebrow">Ready check</p>
+                <p class="readiness-title">Quick check before you launch</p>
                 <p class="readiness-subtitle">
-                  Checking capabilities for the best experience.
+                  Verifying your device setup.
                 </p>
               </div>
               <ul class="readiness-list">
@@ -115,7 +112,7 @@
                     <span class="readiness-name">Microphone input</span>
                   </div>
                   <p class="readiness-note" data-status-note="mic">
-                    Detecting audio support…
+                    Checking audio support…
                   </p>
                 </li>
                 <li class="readiness-item">
@@ -128,7 +125,7 @@
                     <span class="readiness-name">Motion controls</span>
                   </div>
                   <p class="readiness-note" data-status-note="motion">
-                    Checking for device motion…
+                    Checking device motion…
                   </p>
                 </li>
                 <li class="readiness-item">
@@ -143,7 +140,7 @@
                     >
                   </div>
                   <p class="readiness-note" data-status-note="reduced">
-                    Reading your animation comfort settings…
+                    Reading motion preference…
                   </p>
                 </li>
               </ul>
@@ -166,7 +163,7 @@
               >
             </div>
             <p class="cta-helper">
-              No accounts required. Audio reactivity requires microphone access.
+              No accounts. Audio reactivity needs microphone access.
             </p>
             <div class="repo-status" data-repo-status aria-live="polite">
               <div class="repo-status__header">
@@ -174,8 +171,7 @@
                 <p class="repo-status__title">GitHub status</p>
                 <p class="repo-status__description">
                   Latest stats for
-                  <span class="repo-status__repo-name">zz-plant/stims</span>
-                  with live stars and recent activity.
+                  <span class="repo-status__repo-name">zz-plant/stims</span>.
                 </p>
               </div>
               <dl class="repo-status__metrics">
@@ -391,16 +387,15 @@
             </div>
             <div class="hero-callouts">
               <div class="callout-card">
-                <p class="callout-title">Built for instant focus</p>
+                <p class="callout-title">Quick start</p>
                 <p class="callout-copy">
-                  Clean typography, generous spacing, and animated gradients
-                  keep the landing experience calm while you choose a stim.
+                  Pick a stim, choose audio, and begin.
                 </p>
               </div>
               <div class="callout-row">
-                <span class="pill pill--accent">Live audio reactive</span>
-                <span class="pill pill--soft">Touch + keyboard friendly</span>
-                <span class="pill pill--contrast">WebGPU ready toys</span>
+                <span class="pill pill--accent">Audio reactive</span>
+                <span class="pill pill--soft">Touch + keyboard</span>
+                <span class="pill pill--contrast">WebGPU toys</span>
               </div>
             </div>
           </div>
@@ -409,52 +404,46 @@
 
       <section class="feature-bands">
         <div class="section-heading">
-          <p class="eyebrow">Design refresh</p>
-          <h2>Curated paths make discovery calmer</h2>
+          <p class="eyebrow">Getting started</p>
+          <h2>How to begin</h2>
           <p class="section-description">
-            A cleaner interface designed for focus. Follow a curated vibe or 
-            explore the full library.
+            Pick a stim, choose audio, and adjust controls.
           </p>
         </div>
         <div class="feature-grid">
           <article class="feature-card">
             <div class="feature-icon" aria-hidden="true">🌈</div>
             <div class="feature-body">
-              <h3>Color-first spotlights</h3>
+              <h3>Pick a stim</h3>
               <p>
-                New highlight cards pair atmospheric gradients with clear
-                descriptions so you can pick a palette that matches your mood.
+                Use the filters or the library list to find something you like.
               </p>
               <p class="feature-meta">
-                Glassy borders, subtle glow, and rounded corners that feel
-                tactile.
+                Try calm, energetic, or a color palette.
               </p>
             </div>
           </article>
           <article class="feature-card">
             <div class="feature-icon" aria-hidden="true">🎧</div>
             <div class="feature-body">
-              <h3>Audio-aware guidance</h3>
+              <h3>Choose audio</h3>
               <p>
-                Callouts explain how to start with microphone input, demos, or
-                device motion without ever feeling technical.
+                Use your microphone or demo audio.
               </p>
               <p class="feature-meta">
-                Instant visual feedback.
+                You can switch later.
               </p>
             </div>
           </article>
           <article class="feature-card">
             <div class="feature-icon" aria-hidden="true">🧭</div>
             <div class="feature-body">
-              <h3>Wayfinding that hugs the grid</h3>
+              <h3>Adjust controls</h3>
               <p>
-                New section spacing, pill-shaped highlights, and soft dividers
-                keep the experience airy even with dozens of entries.
+                Tweak the controls and switch toys when you want.
               </p>
               <p class="feature-meta">
-                Library search and cards inherit the refreshed styling
-                automatically.
+                Keyboard and touch controls are available.
               </p>
             </div>
           </article>


### PR DESCRIPTION
### Motivation
- Reduce the site’s promotional tone and make on-page instructions more direct and scannable.
- Streamline the hero and feature copy so newcomers can get started quickly without extra marketing language.
- Make readiness and audio/demo guidance clearer and less verbose.
- Apply a consistent, simpler voice across the landing content.

### Description
- Updated copy in `index.html` including the hero headline and tagline, signal cards, readiness panel labels and notes, CTA helper, callout card, pill labels, and feature band headings and cards.
- Replaced verbose marketing phrasing with concise instructions like `Quick start`, `Pick a stim`, `Choose audio`, and `Adjust controls` to emphasize action over description. 
- Kept the existing UI and JavaScript behavior unchanged; this is a content-only change to `index.html`.
- Commit message: `Soften home page messaging`.

### Testing
- Ran `biome lint assets scripts tests` and it completed with no issues.
- Ran `biome format --write assets scripts tests` and it completed with no changes applied.
- Launched the dev server with `bun run dev -- --host 0.0.0.0 --port 5173` and the server started successfully.
- Captured a Playwright screenshot of the updated home page (`artifacts/index-hero.png`) to verify visual copy updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696470b366208332aca9507b114cecfa)