### PR TITLE
Tone down toy descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,20 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 
 | Toy                                                       | Description                                                                           |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [3D Toy](./toy.html?toy=3dtoy)                            | Dive into a twisting 3D tunnel that responds to sound.                                |
+| [3D Toy](./toy.html?toy=3dtoy)                            | A twisting 3D tunnel that responds to sound.                                          |
 | [Aurora Painter](./toy.html?toy=aurora-painter)           | Paint flowing aurora ribbons that react to your microphone in layered waves.          |
-| [Star Guitar Visualizer](./toy.html?toy=brand)            | A visual journey inspired by an iconic music video, synced to your music.             |
+| [Star Guitar Visualizer](./toy.html?toy=brand)            | Visuals inspired by an iconic music video, synced to your music.                      |
 | [Pottery Wheel Sculptor](./toy.html?toy=clay)             | Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.          |
 | [Defrag Visualizer](./toy.html?toy=defrag)                | A nostalgic, sound-reactive visualizer evoking old defragmentation screens.           |
 | [Evolutionary Weirdcore](./toy.html?toy=evol)             | Watch surreal landscapes evolve with fractals and glitches that react to music.       |
 | [Geometry Visualizer](./toy.html?toy=geom)                | Push shifting geometric forms directly from live mic input with responsive controls.   |
-| [Ultimate Satisfying Visualizer](./toy.html?toy=holy)     | Layered halos, particles, and morphing shapes that respond to your music.             |
+| [Halo Visualizer](./toy.html?toy=holy)                   | Layered halos, particles, and shapes that respond to your music.                      |
 | [Multi-Capability Visualizer](./toy.html?toy=multi)       | Shapes and lights move with both sound and device motion. (Requires WebGPU.)          |
-| [Trippy Synesthetic Visualizer](./toy.html?toy=seary)     | Blend audio and visuals in a rich synesthetic experience.                             |
+| [Synesthetic Visualizer](./toy.html?toy=seary)           | Blend audio and visuals into linked patterns.                                         |
 | [Pattern Recognition Visualizer](./toy.html?toy=sgpat)    | See patterns form dynamically in response to sound.                                   |
 | [Terminal Word Grid](./toy.html?toy=legible)              | A retro green text grid that pulses to audio and surfaces fresh words as you play.    |
 | [SVG + Three.js Visualizer](./toy.html?toy=svgtest)       | A hybrid visualizer blending 2D and 3D elements, reacting in real time.               |
-| [Dreamy Spectrograph](./toy.html?toy=symph)               | A relaxing spectrograph that moves gently with your audio.                            |
+| [Spectrograph](./toy.html?toy=symph)                     | A spectrograph that moves gently with your audio.                                     |
 | [Interactive Word Cloud](./toy.html?toy=words)            | Speak and watch the word cloud react and shift with your voice.                       |
 | [Grid Visualizer](./toy.html?toy=cube-wave)               | Swap between cube waves and bouncing spheres without stopping the music.              |
 | [Bubble Harmonics](./toy.html?toy=bubble-harmonics)       | Translucent, audio-inflated bubbles that split into harmonics on high frequencies.    |

--- a/assets/data/toys.json
+++ b/assets/data/toys.json
@@ -2,13 +2,13 @@
   {
     "slug": "3dtoy",
     "title": "3D Toy",
-    "description": "Dive into a twisting 3D tunnel that responds to sound.",
+    "description": "A twisting 3D tunnel that responds to sound.",
     "module": "./assets/js/toys/three-d-toy.ts"
   },
   {
     "slug": "brand",
     "title": "Star Guitar Visualizer",
-    "description": "A visual journey inspired by an iconic music video, synced to your music.",
+    "description": "Visuals inspired by an iconic music video, synced to your music.",
     "module": "./toy.html?toy=brand"
   },
   {
@@ -31,8 +31,8 @@
   },
   {
     "slug": "seary",
-    "title": "Trippy Synesthetic Visualizer",
-    "description": "Blend audio and visuals in a rich synesthetic experience.",
+    "title": "Synesthetic Visualizer",
+    "description": "Blend audio and visuals into linked patterns.",
     "module": "./toy.html?toy=seary"
   },
   {
@@ -49,8 +49,8 @@
   },
   {
     "slug": "symph",
-    "title": "Dreamy Spectrograph",
-    "description": "A relaxing spectrograph that moves gently with your audio.",
+    "title": "Spectrograph",
+    "description": "A spectrograph that moves gently with your audio.",
     "module": "./toy.html?toy=symph"
   },
   {

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -2,7 +2,7 @@ export default [
   {
     slug: '3dtoy',
     title: '3D Toy',
-    description: 'Dive into a twisting 3D tunnel that responds to sound.',
+    description: 'A twisting 3D tunnel that responds to sound.',
     module: 'assets/js/toys/three-d-toy.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -20,7 +20,7 @@ export default [
     slug: 'brand',
     title: 'Star Guitar Visualizer',
     description:
-      'A visual journey inspired by an iconic music video, synced to your music.',
+      'Visuals inspired by an iconic music video, synced to your music.',
     module: 'assets/js/toys/brand.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -63,9 +63,9 @@ export default [
   },
   {
     slug: 'holy',
-    title: 'Ultimate Satisfying Visualizer',
+    title: 'Halo Visualizer',
     description:
-      'Layered halos, particles, and morphing shapes that respond to your music.',
+      'Layered halos, particles, and shapes that respond to your music.',
     module: 'assets/js/toys/holy.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -81,8 +81,8 @@ export default [
   },
   {
     slug: 'seary',
-    title: 'Trippy Synesthetic Visualizer',
-    description: 'Blend audio and visuals in a rich synesthetic experience.',
+    title: 'Synesthetic Visualizer',
+    description: 'Blend audio and visuals into linked patterns.',
     module: 'assets/js/toys/seary.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -115,8 +115,8 @@ export default [
   },
   {
     slug: 'symph',
-    title: 'Dreamy Spectrograph',
-    description: 'A relaxing spectrograph that moves gently with your audio.',
+    title: 'Spectrograph',
+    description: 'A spectrograph that moves gently with your audio.',
     module: 'assets/js/toys/symph.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -224,7 +224,7 @@ export default [
     slug: 'neon-wave',
     title: 'Neon Wave',
     description:
-      'Premium retro-wave visualizer with bloom effects, custom shaders, and four stunning color themes.',
+      'Retro-wave visualizer with bloom effects, custom shaders, and four color themes.',
     module: 'assets/js/toys/neon-wave.ts',
     type: 'module',
     requiresWebGPU: false,
@@ -240,7 +240,7 @@ export default [
     slug: 'milkdrop',
     title: 'MilkDrop Proto',
     description:
-      'A hardware-accelerated feedback engine inspired by the legendary MilkDrop visualizer system.',
+      'A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system.',
     module: 'assets/js/toys/milkdrop-toy.ts',
     type: 'module',
     requiresWebGPU: false,

--- a/assets/js/toys/neon-wave.ts
+++ b/assets/js/toys/neon-wave.ts
@@ -486,8 +486,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   function setupSettingsPanel() {
     settingsPanel.configure({
       title: 'Neon Wave',
-      description:
-        'Premium retro-wave visualizer with bloom effects. Pick a theme!',
+      description: 'Retro-wave visualizer with bloom effects. Pick a theme!',
     });
     settingsPanel.setQualityPresets({
       presets: DEFAULT_QUALITY_PRESETS,


### PR DESCRIPTION
### Motivation
- Reduce overtly promotional language in the toy registry and landing list to keep copy calmer and more descriptive. 
- Make labels and descriptions more neutral and consistent across programmatic data and the public README. 

### Description
- Updated toy names and descriptions in `assets/js/toys-data.js` to use more neutral phrasing. 
- Mirrored the same wording changes in the static catalog `assets/data/toys.json`. 
- Adjusted the toys list in `README.md` to match the toned-down titles and descriptions. 
- Shortened the Neon Wave settings copy in `assets/js/toys/neon-wave.ts` to remove promotional adjectives. 

### Testing
- Ran `bun run check`, which failed due to missing `playwright` types referenced from `scripts/play-toy.ts`. 
- Ran `biome lint` which completed successfully. 
- Ran `biome format --write` which completed successfully and kept formatting stable. 
- Updated files and verified the changed entries in `README.md`, `assets/js/toys-data.js`, `assets/data/toys.json`, and `assets/js/toys/neon-wave.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696472822f508332bbec0b0c9ad3bb8c)