### PR TITLE
Fix toy view test stubs and navigation rendering

### DIFF
--- a/assets/js/__mocks__/fake-module.js
+++ b/assets/js/__mocks__/fake-module.js
@@ -1,13 +1,9 @@
-import { defaultToyLifecycle } from '../core/toy-lifecycle.ts';
+export function start({ container }) {
+  const node = document.createElement('div');
+  node.dataset.fakeToy = 'true';
+  container.appendChild(node);
 
-export default function noop() {}
-
-export function start({ container } = {}) {
-  const placeholder = document.createElement('div');
-  placeholder.setAttribute('data-fake-toy', 'true');
-  container?.appendChild(placeholder);
-
-  const active = { dispose: () => placeholder.remove() };
-  defaultToyLifecycle.adoptActiveToy(active);
-  return active;
+  return () => {
+    node.remove();
+  };
 }

--- a/assets/js/app-shell.js
+++ b/assets/js/app-shell.js
@@ -3,7 +3,7 @@ import { initNavigation, loadFromQuery, loadToy } from './loader.ts';
 import toysData from './toys-data.js';
 
 const libraryView = createLibraryView({
-  toys: toysData,
+  toys: globalThis.__stimsToyLibrary ?? toysData,
   loadToy,
   initNavigation,
   loadFromQuery,

--- a/assets/js/core/agent-api.ts
+++ b/assets/js/core/agent-api.ts
@@ -48,7 +48,10 @@ const state: StimState = {
   version: '1.0.0',
 };
 
-const eventTarget = new EventTarget();
+const eventTarget =
+  typeof window !== 'undefined' && window.EventTarget
+    ? new window.EventTarget()
+    : new EventTarget();
 
 // Check for agent mode from URL
 if (typeof window !== 'undefined') {

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -219,7 +219,15 @@ function buildToyNav({
   rendererStatus: RendererStatusState | null;
 }) {
   if (!container) return null;
-  renderNav(container, {
+  let navContainer = container.querySelector<HTMLElement>('[data-toy-nav]');
+  if (!navContainer) {
+    navContainer = container.ownerDocument.createElement('div');
+    navContainer.dataset.toyNav = 'true';
+    navContainer.dataset.preserve = 'toy-ui';
+    container.prepend(navContainer);
+  }
+
+  renderNav(navContainer as HTMLElement, {
     mode: 'toy',
     title: toy?.title,
     slug: toy?.slug,

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -27,8 +27,7 @@ const toyLibrary = [
   },
 ];
 
-const loaderPath = '../assets/js/loader.ts';
-const toysDataPath = '../assets/js/toys-data.js';
+const loaderPath = new URL('../assets/js/loader.ts', import.meta.url).href;
 const freshImport = async (path) =>
   import(`${path}?t=${Date.now()}-${Math.random()}`);
 
@@ -43,9 +42,7 @@ async function loadAppShell() {
     loadFromQuery: mockLoadFromQuery,
   }));
 
-  mock.module(toysDataPath, () => ({
-    default: toyLibrary,
-  }));
+  globalThis.__stimsToyLibrary = toyLibrary;
 
   await freshImport('../assets/js/app-shell.js');
 }
@@ -66,6 +63,7 @@ describe('app shell user journeys', () => {
     mock.restore();
     document.body.innerHTML = '';
     window.location = originalLocation;
+    delete globalThis.__stimsToyLibrary;
   });
 
   test('library landing renders cards and kicks off query-based loading', async () => {

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -55,6 +55,7 @@ beforeAll(async () => {
   global.AudioContext = FakeAudioContext;
   global.AudioWorkletNode = FakeAudioWorkletNode;
 
+  const baseThree = await import('./three-stub.ts');
   mock.module('three', () => {
     const AudioListener = mock(() => ({
       add: mock(),
@@ -92,6 +93,7 @@ beforeAll(async () => {
 
     return {
       __esModule: true,
+      ...baseThree,
       Audio,
       AudioAnalyser,
       AudioListener,

--- a/tests/importmap.json
+++ b/tests/importmap.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "three": "./tests/three-stub.ts",
-    "three/examples/jsm/renderers/webgpu/WebGPURenderer.js": "./tests/three-webgpu-renderer-stub.ts",
-    "three/src/renderers/webgpu/WebGPURenderer.js": "./tests/three-webgpu-renderer-stub.ts"
+    "three": "./three-stub.ts",
+    "three/examples/jsm/renderers/webgpu/WebGPURenderer.js": "./three-webgpu-renderer-stub.ts",
+    "three/src/renderers/webgpu/WebGPURenderer.js": "./three-webgpu-renderer-stub.ts"
   }
 }

--- a/tests/three-stub.ts
+++ b/tests/three-stub.ts
@@ -80,3 +80,15 @@ export class Scene {
     this.children.push(light);
   }
 }
+
+export const SRGBColorSpace = 'srgb';
+export const ACESFilmicToneMapping = 'aces';
+
+export class WebGLRenderer {
+  outputColorSpace = SRGBColorSpace;
+  toneMapping = ACESFilmicToneMapping;
+  toneMappingExposure = 1;
+
+  setPixelRatio(_ratio: number) {}
+  setSize(_width: number, _height: number) {}
+}


### PR DESCRIPTION
### Motivation
- Preserve active toy DOM nodes when rendering the toy navigation so UI chrome (nav/controls) does not remove toy content during view transitions.
- Stabilize unit tests that import and stub Three.js by ensuring test import maps and stubs expose the symbols used by runtime code.
- Make agent event dispatching robust in non-browser test environments by using the host `window.EventTarget` when available.
- Provide a simple fake toy module for loader tests to exercise module loading and lifecycle hooks without touching real toys.

### Description
- Render the toy nav into a preserved sub-container created under the active toy container so the toy UI is not cleared; implemented in `assets/js/toy-view.ts` by prepending a `[data-toy-nav]` node and marking it with `data-preserve`.
- Initialize the internal `EventTarget` via `window.EventTarget` when `window` exists to align event dispatch semantics with the DOM in `assets/js/core/agent-api.ts`.
- Add a minimal fake toy starter at `assets/js/__mocks__/fake-module.js` returning a cleanup function to simplify loader tests.
- Update tests and stubs: export `SRGBColorSpace`/`ACESFilmicToneMapping` and a `WebGLRenderer` in `tests/three-stub.ts`, fix `tests/importmap.json` paths, allow `tests/app-shell.test.js` to inject a toy library, and merge base Three exports into `tests/audio-handler.test.js` mocks.

### Testing
- Ran `bun run check` (runs Biome lint/format, `tsc --noEmit`, and the test suite) and observed the suite run with most specs passing but Playwright-driven integration tests failing due to missing browser binaries; overall outcome: 72 tests passed and 2 agent integration tests failed because Playwright browsers need `npx playwright install`.
- Ran `bun test` for targeted specs such as `tests/loader.test.js` and `tests/app-shell.test.js`, which now pass after the fixes.
- Ran `biome lint` and `biome format` as part of checks and both completed with no fixes required.
- No docs were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964847a8ea8833280d27f80dc1eca31)