### PR TITLE
Add agent-friendly QA shortcut to QA_PLAN.md

### DIFF
--- a/docs/QA_PLAN.md
+++ b/docs/QA_PLAN.md
@@ -19,19 +19,27 @@ This guide captures the highest-impact flows to validate and how we keep them co
 
 Use Bun to match the repository tooling:
 
+- For a single command that mirrors CI (lint + typecheck + tests):
+  ```bash
+  bun run check
+  ```
+
 - Run the happy-dom suites for the app shell, settings panel, and microphone flows:
   ```bash
   bun run test tests/app-shell.test.js tests/settings-panel.test.ts tests/microphone-flow.test.ts
   ```
 
 - For a quick server wiring check before pushing UI changes:
-
   ```bash
   bun run dev:check
   ```
 
-- Full project sweep (lint, types, build, tests) as enforced in CI:
+## Agent-friendly QA shortcut
 
-  ```bash
-  bun run check
-  ```
+When you want a fast, reproducible QA pass without browsing the docs, run the full
+quality gate and then the focused QA suite:
+
+```bash
+bun run check
+bun run test tests/app-shell.test.js tests/settings-panel.test.ts tests/microphone-flow.test.ts
+```


### PR DESCRIPTION
### Motivation

- Make it easier and faster to run the repository QA checks by providing a compact, reproducible command sequence. 
- Surface the single-command CI mirror (`check`) so contributors and automation agents can run a quick quality gate. 
- Reduce friction for agents by combining the full quality gate and the focused UI test suite into one visible shortcut. 

### Description

- Update `docs/QA_PLAN.md` to add a `For a single command that mirrors CI` snippet that shows `bun run check`.
- Add a new `Agent-friendly QA shortcut` section that runs `bun run check` followed by the focused UI tests `bun run test tests/app-shell.test.js tests/settings-panel.test.ts tests/microphone-flow.test.ts`.
- Keep the existing instructions for running the focused happy-dom suites and the quick server wiring check (`bun run dev:check`).
- Reorder and clarify the QA instructions for a clearer, faster workflow.

### Testing

- Ran `bun run format` and it completed successfully.
- Ran `biome lint assets scripts tests` and it completed successfully.
- Ran `biome format --write assets scripts tests` and it completed successfully.
- Confirmed the updated file `docs/QA_PLAN.md` was added to the commit and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696556dcc5108332a4723ae5b3be0b1e)