### PR TITLE
Sync library state to URL/sessionStorage and improve accessibility/touch targets

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -22,6 +22,15 @@ canvas {
   user-select: none;
 }
 
+a,
+button,
+input,
+select,
+textarea,
+[role="button"] {
+  touch-action: manipulation;
+}
+
 .toy-canvas {
   width: 100vw;
   height: 100vh;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -102,6 +102,11 @@ html.light .hero-background-canvas {
     background 0.2s ease,
     border-color 0.2s ease;
   z-index: 20;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .skip-link:focus-visible {
@@ -249,6 +254,11 @@ h6 {
   border-radius: 999px;
   transition: background 0.2s ease;
   touch-action: manipulation;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .nav-link:hover {
@@ -788,6 +798,22 @@ header.hero {
   line-height: 1.5;
 }
 
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 0.25rem;
+  margin: -0.25rem 0;
+  border-radius: 8px;
+  touch-action: manipulation;
+}
+
+.text-link:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
 .cta-button {
   padding: 0.7rem 1.25rem;
   border-radius: var(--radius-pill);
@@ -812,6 +838,9 @@ header.hero {
   background-size: auto;
   animation: none;
   touch-action: manipulation;
+  min-height: 44px;
+  min-width: 44px;
+  justify-content: center;
 }
 
 .cta-button.primary {
@@ -1080,6 +1109,13 @@ h1 {
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
 }
 
+.search-field:focus-within {
+  border-color: rgba(96, 165, 250, 0.85);
+  box-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.25),
+    0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
 .search-field input {
   flex: 1;
   background: transparent;
@@ -1087,7 +1123,8 @@ h1 {
   color: var(--text-color);
   font-size: 1rem;
   padding: 0.55rem 0.35rem;
-  outline: none;
+  min-height: 44px;
+  touch-action: manipulation;
 }
 
 .search-field input::placeholder {
@@ -1123,6 +1160,8 @@ h1 {
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.01em;
+  min-height: 44px;
+  min-width: 44px;
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease,
@@ -1143,6 +1182,12 @@ h1 {
   box-shadow: 0 12px 28px rgba(59, 130, 246, 0.2);
 }
 
+.filter-chip:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
 .sort-control {
   display: inline-flex;
   align-items: center;
@@ -1153,6 +1198,14 @@ h1 {
   background: rgba(255, 255, 255, 0.04);
   color: var(--text-color);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+  min-height: 44px;
+}
+
+.sort-control:focus-within {
+  border-color: rgba(96, 165, 250, 0.85);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.2),
+    0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
 .sort-control select {
@@ -1160,8 +1213,9 @@ h1 {
   border: none;
   color: inherit;
   font-weight: 700;
-  outline: none;
   touch-action: manipulation;
+  font-size: 1rem;
+  min-height: 44px;
 }
 
 .webtoy-container {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -33,11 +33,15 @@ header {
   background-color: #1f1f1f;
   color: #ffffff;
   transition: all 0.3s;
+  font-size: 1rem;
+  min-height: 44px;
 }
 
 #search-bar:focus {
   border-color: #1e90ff;
-  outline: none;
+  outline: 2px solid rgba(30, 144, 255, 0.9);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(30, 144, 255, 0.35);
 }
 
 /* Webtoy Cards */
@@ -114,6 +118,9 @@ button {
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.3s;
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
 }
 
 button:hover {
@@ -121,5 +128,7 @@ button:hover {
 }
 
 button:focus {
-  outline: none;
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
 }

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
               href="https://github.com/zz-plant/stims"
               target="_blank"
               rel="noopener noreferrer"
+              class="text-link"
             >
               Check out our open-source project.
             </a>
@@ -252,9 +253,15 @@
 
         const search = document.getElementById('toy-search');
         const searchResults = document.querySelector('[data-search-results]');
+        const STORAGE_KEY = 'stims-library-state';
+        const QUERY_PARAM = 'q';
+        const FILTER_PARAM = 'filters';
+        const SORT_PARAM = 'sort';
         let cachedQuery = '';
         let sortBy = 'featured';
         const activeFilters = new Set();
+        let lastCommittedQuery = '';
+        let pendingCommit;
 
         const shouldDeferToEnhanced = () =>
           document.body.dataset.libraryEnhanced === 'true';
@@ -346,6 +353,15 @@
               search.value = '';
               cachedQuery = '';
             }
+            activeFilters.clear();
+            sortBy = 'featured';
+            const chips = document.querySelectorAll('[data-filter-chip]');
+            chips.forEach((chip) => chip.classList.remove('is-active'));
+            const sortControl = document.querySelector('[data-sort-control]');
+            if (sortControl && sortControl.tagName === 'SELECT') {
+              sortControl.value = sortBy;
+            }
+            commitState({ replace: false });
             renderCards(allToys, '');
           });
 
@@ -443,18 +459,149 @@
           });
         };
 
+        const parseFilters = (value) => {
+          if (!value) return [];
+          return value
+            .split(',')
+            .map((token) => token.trim())
+            .filter(Boolean);
+        };
+
+        const getStateFromUrl = () => {
+          const params = new URLSearchParams(window.location.search);
+          return {
+            query: params.get(QUERY_PARAM) ?? '',
+            filters: parseFilters(params.get(FILTER_PARAM)),
+            sort: params.get(SORT_PARAM) ?? 'featured',
+          };
+        };
+
+        const saveStateToStorage = (state) => {
+          try {
+            window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+          } catch (error) {
+            console.warn('Unable to persist library state', error);
+          }
+        };
+
+        const readStateFromStorage = () => {
+          try {
+            const stored = window.sessionStorage.getItem(STORAGE_KEY);
+            if (!stored) return null;
+            const parsed = JSON.parse(stored);
+            if (parsed && typeof parsed === 'object') return parsed;
+          } catch (error) {
+            console.warn('Unable to restore library state', error);
+          }
+          return null;
+        };
+
+        const stateToParams = (state) => {
+          const params = new URLSearchParams(window.location.search);
+          if (state.query) {
+            params.set(QUERY_PARAM, state.query);
+          } else {
+            params.delete(QUERY_PARAM);
+          }
+          if (state.filters?.length) {
+            params.set(FILTER_PARAM, state.filters.join(','));
+          } else {
+            params.delete(FILTER_PARAM);
+          }
+          if (state.sort && state.sort !== 'featured') {
+            params.set(SORT_PARAM, state.sort);
+          } else {
+            params.delete(SORT_PARAM);
+          }
+          return params;
+        };
+
+        const commitState = ({ replace }) => {
+          const state = {
+            query: cachedQuery.trim(),
+            filters: Array.from(activeFilters),
+            sort: sortBy,
+          };
+          const params = stateToParams(state);
+          const nextUrl = `${window.location.pathname}${
+            params.toString() ? `?${params.toString()}` : ''
+          }`;
+          if (replace) {
+            window.history.replaceState(state, '', nextUrl);
+          } else {
+            window.history.pushState(state, '', nextUrl);
+          }
+          saveStateToStorage(state);
+        };
+
+        const applyState = (state) => {
+          cachedQuery = state.query ?? '';
+          sortBy = state.sort ?? 'featured';
+          activeFilters.clear();
+          (state.filters ?? []).forEach((token) => activeFilters.add(token));
+          lastCommittedQuery = cachedQuery.trim();
+
+          if (search instanceof HTMLInputElement) {
+            search.value = cachedQuery;
+          }
+
+          const chips = document.querySelectorAll('[data-filter-chip]');
+          chips.forEach((chip) => {
+            const type = chip.getAttribute('data-filter-type');
+            const value = chip.getAttribute('data-filter-value');
+            if (!type || !value) return;
+            const token = `${type}:${value.toLowerCase()}`;
+            chip.classList.toggle('is-active', activeFilters.has(token));
+          });
+
+          const sortControl = document.querySelector('[data-sort-control]');
+          if (sortControl && sortControl.tagName === 'SELECT') {
+            sortControl.value = sortBy;
+          }
+        };
+
         fetch('./toys.json')
           .then((response) => (response.ok ? response.json() : null))
           .then((toys) => {
             if (!toys || list.childElementCount > 0) return;
 
             allToys = toys;
+            const urlState = getStateFromUrl();
+            const hasUrlState =
+              urlState.query ||
+              urlState.filters.length ||
+              urlState.sort !== 'featured';
+            if (hasUrlState) {
+              applyState(urlState);
+            } else {
+              const storedState = readStateFromStorage();
+              if (storedState) {
+                applyState(storedState);
+                commitState({ replace: true });
+              }
+            }
             renderCards(applyFilters());
 
             if (search instanceof HTMLInputElement) {
               search.addEventListener('input', () => {
                 cachedQuery = search.value.toLowerCase().trim();
+                commitState({ replace: true });
+                if (pendingCommit) {
+                  window.clearTimeout(pendingCommit);
+                }
+                pendingCommit = window.setTimeout(() => {
+                  if (cachedQuery.trim() !== lastCommittedQuery) {
+                    lastCommittedQuery = cachedQuery.trim();
+                    commitState({ replace: false });
+                  }
+                }, 500);
                 renderCards(applyFilters(cachedQuery), cachedQuery);
+              });
+              search.addEventListener('blur', () => {
+                if (cachedQuery.trim() !== lastCommittedQuery) {
+                  lastCommittedQuery = cachedQuery.trim();
+                  commitState({ replace: false });
+                }
               });
             }
 
@@ -471,6 +618,7 @@
                 } else {
                   activeFilters.delete(token);
                 }
+                commitState({ replace: false });
                 renderCards(applyFilters(), cachedQuery);
               });
             });
@@ -479,9 +627,16 @@
             if (sortControl && sortControl.tagName === 'SELECT') {
               sortControl.addEventListener('change', () => {
                 sortBy = sortControl.value;
+                commitState({ replace: false });
                 renderCards(applyFilters(), cachedQuery);
               });
             }
+
+            window.addEventListener('popstate', () => {
+              const nextState = getStateFromUrl();
+              applyState(nextState);
+              renderCards(applyFilters(), cachedQuery);
+            });
           })
           .catch((error) => {
             console.error('Unable to render library fallback', error);


### PR DESCRIPTION
### Motivation
- Preserve library search, filters, and sort across navigation and sessions so users can use the Back button and return to the same view.
- Make controls reliable and usable on mobile/touch and keyboard-only environments by ensuring minimum touch targets and clear focus styles.

### Description
- Added URL and session storage state handling for the library (query param `q`, `filters`, `sort`) with `commitState`, `applyState`, `getStateFromUrl`, and helpers in `assets/js/library-view.js` and the fallback `index.html` script.
- Hydration and restore logic was added so URL state wins when present, otherwise sessionStorage is restored, and `popstate` events re-apply state to support back/forward navigation.
- Debounced URL updates from the search input and a commit-on-blur behavior were implemented to avoid noisy history entries while keeping the URL as source of truth.
- Improved UI accessibility and mobile friendliness by enforcing 44x44px minimum touch targets, adding `touch-action: manipulation` to interactive elements, and adding visible `:focus-visible` styles and `focus-within` affordances in `assets/css/index.css`, `assets/css/base.css`, and `assets/css/styles.css`.

### Testing
- Ran `biome lint` and `biome format` successfully across affected files.
- Ran `bun run check` which reported a TypeScript test setup failure (`tests/setup.ts` missing `GPUTextureUsage.TRANSIENT_ATTACHMENT`) unrelated to the library changes and therefore failing the full check.
- Started the dev server (`bun run dev`) and captured a visual smoke screenshot of the updated library UI via a headless browser, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b01c80bdc83328471bcd6458544d3)