### PR TITLE
Library: add clear-search and reset-filters controls

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1137,6 +1137,44 @@ h1 {
   white-space: nowrap;
 }
 
+.search-clear {
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-color);
+  border-radius: var(--radius-pill);
+  padding: 0.45rem 0.85rem;
+  font-weight: 600;
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.search-clear.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.search-clear:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+}
+
+.search-clear:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
 .filter-row {
   display: flex;
   flex-wrap: wrap;
@@ -1183,6 +1221,44 @@ h1 {
 }
 
 .filter-chip:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
+.filter-reset {
+  border: 1px solid var(--surface-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-color);
+  border-radius: var(--radius-pill);
+  padding: 0.45rem 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  min-height: 44px;
+  min-width: 44px;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.filter-reset:hover {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+}
+
+.filter-reset.is-active {
+  border-color: rgba(244, 63, 94, 0.45);
+  background: rgba(244, 63, 94, 0.12);
+  box-shadow: 0 10px 22px rgba(244, 63, 94, 0.18);
+}
+
+.filter-reset:focus-visible {
   outline: 2px solid rgba(96, 165, 250, 0.95);
   outline-offset: 2px;
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);

--- a/index.html
+++ b/index.html
@@ -120,6 +120,14 @@
                 aria-describedby="toy-search-hint"
                 inputmode="search"
               />
+              <button
+                type="button"
+                class="search-clear"
+                data-search-clear
+                aria-label="Clear search"
+              >
+                Clear
+              </button>
               <span
                 id="toy-search-hint"
                 aria-hidden="true"
@@ -185,6 +193,9 @@
                   WebGPU
                 </button>
               </div>
+              <button type="button" class="filter-reset" data-filter-reset>
+                Clear filters
+              </button>
               <label class="sort-control">
                 <span>Sort</span>
                 <select data-sort-control>
@@ -253,6 +264,8 @@
 
         const search = document.getElementById('toy-search');
         const searchResults = document.querySelector('[data-search-results]');
+        const clearSearchButton = document.querySelector('[data-search-clear]');
+        const resetFiltersButton = document.querySelector('[data-filter-reset]');
         const STORAGE_KEY = 'stims-library-state';
         const QUERY_PARAM = 'q';
         const FILTER_PARAM = 'filters';
@@ -367,6 +380,17 @@
 
           empty.append(message, reset);
           list.appendChild(empty);
+        };
+
+        const updateControlVisibility = () => {
+          if (clearSearchButton instanceof HTMLElement) {
+            const hasQuery = cachedQuery.trim().length > 0;
+            clearSearchButton.classList.toggle('is-visible', hasQuery);
+          }
+          if (resetFiltersButton instanceof HTMLElement) {
+            const hasFilters = activeFilters.size > 0;
+            resetFiltersButton.classList.toggle('is-active', hasFilters);
+          }
         };
 
         const applyFilters = (query = cachedQuery) => {
@@ -551,13 +575,16 @@
             const value = chip.getAttribute('data-filter-value');
             if (!type || !value) return;
             const token = `${type}:${value.toLowerCase()}`;
-            chip.classList.toggle('is-active', activeFilters.has(token));
+            const isActive = activeFilters.has(token);
+            chip.classList.toggle('is-active', isActive);
+            chip.setAttribute('aria-pressed', String(isActive));
           });
 
           const sortControl = document.querySelector('[data-sort-control]');
           if (sortControl && sortControl.tagName === 'SELECT') {
             sortControl.value = sortBy;
           }
+          updateControlVisibility();
         };
 
         fetch('./toys.json')
@@ -596,6 +623,7 @@
                   }
                 }, 500);
                 renderCards(applyFilters(cachedQuery), cachedQuery);
+                updateControlVisibility();
               });
               search.addEventListener('blur', () => {
                 if (cachedQuery.trim() !== lastCommittedQuery) {
@@ -607,6 +635,10 @@
 
             const chips = document.querySelectorAll('[data-filter-chip]');
             chips.forEach((chip) => {
+              chip.setAttribute(
+                'aria-pressed',
+                String(chip.classList.contains('is-active'))
+              );
               chip.addEventListener('click', () => {
                 const type = chip.getAttribute('data-filter-type');
                 const value = chip.getAttribute('data-filter-value');
@@ -618,8 +650,10 @@
                 } else {
                   activeFilters.delete(token);
                 }
+                chip.setAttribute('aria-pressed', String(isActive));
                 commitState({ replace: false });
                 renderCards(applyFilters(), cachedQuery);
+                updateControlVisibility();
               });
             });
 
@@ -629,6 +663,35 @@
                 sortBy = sortControl.value;
                 commitState({ replace: false });
                 renderCards(applyFilters(), cachedQuery);
+              });
+            }
+
+            if (
+              clearSearchButton instanceof HTMLButtonElement &&
+              search instanceof HTMLInputElement
+            ) {
+              clearSearchButton.addEventListener('click', () => {
+                search.value = '';
+                cachedQuery = '';
+                lastCommittedQuery = '';
+                commitState({ replace: false });
+                renderCards(applyFilters(''), '');
+                updateControlVisibility();
+                search.focus();
+              });
+            }
+
+            if (resetFiltersButton instanceof HTMLButtonElement) {
+              resetFiltersButton.addEventListener('click', () => {
+                activeFilters.clear();
+                const chips = document.querySelectorAll('[data-filter-chip]');
+                chips.forEach((chip) => {
+                  chip.classList.remove('is-active');
+                  chip.setAttribute('aria-pressed', 'false');
+                });
+                commitState({ replace: false });
+                renderCards(applyFilters(), cachedQuery);
+                updateControlVisibility();
               });
             }
 


### PR DESCRIPTION
### Motivation
- Improve library UX by making search and filter controls easier to clear and more discoverable while preserving URL/state history. 
- Increase accessibility and keyboard friendliness by exposing filter state via `aria-pressed` and providing explicit clear/reset controls that meet the 44×44 touch target and focus-visible patterns. 

### Description
- Added a `Clear` button next to the search input and a `Clear filters` button next to the filter chips and wired them with `data-search-clear` and `data-filter-reset` attributes. 
- Implemented `updateControlVisibility()` and handlers to update URL/session state (`commitState`), render results, and keep controls in sync with `cachedQuery` and `activeFilters`. 
- Set `aria-pressed` on filter chips and updated chip logic so keyboard users receive proper pressed-state feedback and focus behavior. 
- Added CSS for `.search-clear` and `.filter-reset` to match existing visual system, preserve 44px minimum touch targets, and provide consistent `:focus-visible` styles. 

### Testing
- Ran `bun run check` (which runs Biome + typecheck + tests) and it failed with a TypeScript error in tests: `tests/setup.ts(44,1) TS2741: Property 'TRANSIENT_ATTACHMENT' is missing ...` so the full check did not pass. 
- Ran `biome lint assets scripts tests` which completed with no issues. 
- Ran `biome format --write assets scripts tests` which completed with no changes needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b08201698833289827f72726144ba)