### PR TITLE
Add system render/motion prefs, share-link UI, and tab-audio capture

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -312,6 +312,55 @@ body {
   justify-content: flex-end;
 }
 
+.toy-nav__share-wrapper {
+  display: grid;
+  gap: 4px;
+  justify-items: flex-end;
+}
+
+.toy-nav__share {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(111, 247, 255, 0.6);
+  background: rgba(17, 216, 255, 0.12);
+  color: #e9fbff;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 200ms ease,
+    border-color 200ms ease;
+  touch-action: manipulation;
+}
+
+.toy-nav__share:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 0, 153, 0.8);
+  box-shadow:
+    0 12px 24px rgba(0, 0, 0, 0.35),
+    0 0 16px rgba(255, 0, 153, 0.35);
+}
+
+.toy-nav__share:focus-visible {
+  outline: 2px solid rgba(111, 247, 255, 0.9);
+  outline-offset: 3px;
+  box-shadow:
+    0 0 0 3px rgba(0, 0, 0, 0.35),
+    0 0 18px rgba(17, 216, 255, 0.65);
+}
+
+.toy-nav__share-status {
+  min-height: 16px;
+  font-size: 0.75rem;
+  color: rgba(233, 251, 255, 0.75);
+}
+
 .renderer-status {
   display: grid;
   gap: 6px;
@@ -458,6 +507,15 @@ body {
     width: 100%;
   }
 
+  .toy-nav__share-wrapper {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .toy-nav__share {
+    width: 100%;
+  }
+
   .toy-nav__back {
     width: 100%;
     justify-content: center;
@@ -516,6 +574,7 @@ body {
     0 0 24px rgba(17, 216, 255, 0.35);
   backdrop-filter: blur(18px) saturate(130%);
   color: #e9fbff;
+  overscroll-behavior: contain;
 }
 
 .rendering-overlay__panel h1 {
@@ -550,6 +609,46 @@ body {
   gap: 12px;
   flex-wrap: wrap;
   margin-bottom: 14px;
+}
+
+.rendering-overlay__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.rendering-overlay__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(111, 247, 255, 0.6);
+  background: rgba(17, 216, 255, 0.12);
+  color: #e9fbff;
+  text-decoration: none;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    box-shadow 200ms ease,
+    border-color 200ms ease;
+  touch-action: manipulation;
+}
+
+.rendering-overlay__button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 0, 153, 0.8);
+  box-shadow:
+    0 10px 20px rgba(0, 0, 0, 0.25),
+    0 0 12px rgba(17, 216, 255, 0.35);
+}
+
+.rendering-overlay__button:focus-visible {
+  outline: 2px solid rgba(111, 247, 255, 0.9);
+  outline-offset: 3px;
 }
 
 .rendering-overlay__links a {
@@ -638,6 +737,7 @@ body {
   backdrop-filter: blur(12px) saturate(130%);
   z-index: 1100;
   overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 .control-panel--floating {
@@ -772,6 +872,19 @@ body {
   font-size: 0.95rem;
 }
 
+.control-panel__note {
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: rgba(233, 251, 255, 0.75);
+}
+
+.control-panel__value {
+  min-width: 52px;
+  text-align: right;
+  font-weight: 700;
+  color: rgba(233, 251, 255, 0.85);
+}
+
 .control-panel__label.small {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -787,6 +900,7 @@ body {
   border: 1px solid rgba(111, 247, 255, 0.6);
   background: rgba(8, 12, 20, 0.85);
   color: #e9fbff;
+  font-size: 1rem;
 }
 
 .control-panel__recent {
@@ -857,6 +971,7 @@ body {
   box-shadow:
     0 0 14px rgba(17, 216, 255, 0.25),
     inset 0 0 12px rgba(255, 0, 153, 0.18);
+  font-size: 1rem;
 }
 
 .control-panel select:focus,
@@ -977,6 +1092,23 @@ body {
   box-shadow:
     0 0 18px rgba(255, 0, 153, 0.4),
     0 0 10px rgba(111, 247, 255, 0.35);
+}
+
+.cta-button[data-loading="true"] {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+.cta-button[data-loading="true"]::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: rgba(255, 255, 255, 0.9);
+  margin-right: 6px;
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes grid-glide {

--- a/assets/js/core/motion-preferences.ts
+++ b/assets/js/core/motion-preferences.ts
@@ -1,0 +1,74 @@
+export type MotionPreference = {
+  enabled: boolean;
+};
+
+type MotionPreferenceSubscriber = (preference: MotionPreference) => void;
+
+type MotionPreferenceInput = Partial<MotionPreference>;
+
+const MOTION_PREFERENCE_KEY = 'stims:motion-enabled';
+
+const subscribers = new Set<MotionPreferenceSubscriber>();
+let activePreference: MotionPreference | null = null;
+
+function getStorage(): Storage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch (error) {
+    console.debug('localStorage unavailable', error);
+    return null;
+  }
+}
+
+function readFromStorage(): MotionPreference {
+  const storage = getStorage();
+  const raw = storage?.getItem(MOTION_PREFERENCE_KEY);
+  if (raw === null) {
+    return { enabled: true };
+  }
+  return { enabled: raw !== 'false' };
+}
+
+function persistToStorage(preference: MotionPreference) {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(MOTION_PREFERENCE_KEY, preference.enabled ? 'true' : 'false');
+}
+
+export function getActiveMotionPreference() {
+  if (!activePreference) {
+    activePreference = readFromStorage();
+  }
+  return activePreference;
+}
+
+export function setMotionPreference(update: MotionPreferenceInput) {
+  const current = getActiveMotionPreference();
+  const next = {
+    ...current,
+    ...update,
+    enabled:
+      typeof update.enabled === 'boolean' ? update.enabled : current.enabled,
+  };
+  activePreference = next;
+  persistToStorage(next);
+  subscribers.forEach((subscriber) => subscriber(next));
+  return next;
+}
+
+export function subscribeToMotionPreference(
+  subscriber: MotionPreferenceSubscriber,
+) {
+  subscribers.add(subscriber);
+  if (activePreference) {
+    subscriber(activePreference);
+  }
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+export function resetMotionPreferenceState() {
+  activePreference = null;
+  subscribers.clear();
+}

--- a/assets/js/core/render-preferences.ts
+++ b/assets/js/core/render-preferences.ts
@@ -1,0 +1,159 @@
+export type RenderPreferences = {
+  compatibilityMode: boolean;
+  maxPixelRatio: number | null;
+  renderScale: number | null;
+};
+
+type RenderPreferenceSubscriber = (preferences: RenderPreferences) => void;
+
+type RenderPreferenceInput = Partial<RenderPreferences>;
+
+type RenderPreferenceStorage = {
+  compatibilityMode?: string | null;
+  maxPixelRatio?: string | null;
+  renderScale?: string | null;
+};
+
+export const COMPATIBILITY_MODE_KEY = 'stims:compatibility-mode';
+export const MAX_PIXEL_RATIO_KEY = 'stims:max-pixel-ratio';
+export const RENDER_SCALE_KEY = 'stims:render-scale';
+
+const subscribers = new Set<RenderPreferenceSubscriber>();
+let activePreferences: RenderPreferences | null = null;
+
+function getStorage(): Storage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch (error) {
+    console.debug('localStorage unavailable', error);
+    return null;
+  }
+}
+
+function readNumber(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function readFromStorage(): RenderPreferences {
+  const storage = getStorage();
+  const compatibilityMode = storage?.getItem(COMPATIBILITY_MODE_KEY) === 'true';
+  const maxPixelRatio = readNumber(storage?.getItem(MAX_PIXEL_RATIO_KEY));
+  const renderScale = readNumber(storage?.getItem(RENDER_SCALE_KEY));
+
+  return {
+    compatibilityMode,
+    maxPixelRatio,
+    renderScale,
+  };
+}
+
+function persistToStorage(preferences: RenderPreferences) {
+  const storage = getStorage();
+  if (!storage) return;
+
+  const entries: RenderPreferenceStorage = {
+    compatibilityMode: preferences.compatibilityMode ? 'true' : 'false',
+    maxPixelRatio:
+      typeof preferences.maxPixelRatio === 'number'
+        ? String(preferences.maxPixelRatio)
+        : null,
+    renderScale:
+      typeof preferences.renderScale === 'number'
+        ? String(preferences.renderScale)
+        : null,
+  };
+
+  storage.setItem(COMPATIBILITY_MODE_KEY, entries.compatibilityMode ?? 'false');
+
+  const maxPixelRatioValue = entries.maxPixelRatio ?? null;
+  if (maxPixelRatioValue === null) {
+    storage.removeItem(MAX_PIXEL_RATIO_KEY);
+  } else {
+    storage.setItem(MAX_PIXEL_RATIO_KEY, maxPixelRatioValue);
+  }
+
+  const renderScaleValue = entries.renderScale ?? null;
+  if (renderScaleValue === null) {
+    storage.removeItem(RENDER_SCALE_KEY);
+  } else {
+    storage.setItem(RENDER_SCALE_KEY, renderScaleValue);
+  }
+}
+
+function normalizePreferences(
+  input: RenderPreferences,
+  options: { clampValues?: boolean } = {},
+): RenderPreferences {
+  const { clampValues = true } = options;
+  const maxPixelRatio =
+    typeof input.maxPixelRatio === 'number'
+      ? clampValues
+        ? clamp(input.maxPixelRatio, 0.75, 3)
+        : input.maxPixelRatio
+      : null;
+  const renderScale =
+    typeof input.renderScale === 'number'
+      ? clampValues
+        ? clamp(input.renderScale, 0.6, 1.4)
+        : input.renderScale
+      : null;
+
+  return {
+    compatibilityMode: Boolean(input.compatibilityMode),
+    maxPixelRatio,
+    renderScale,
+  };
+}
+
+export function getActiveRenderPreferences() {
+  if (!activePreferences) {
+    activePreferences = normalizePreferences(readFromStorage(), {
+      clampValues: true,
+    });
+  }
+  return activePreferences;
+}
+
+export function setRenderPreferences(update: RenderPreferenceInput) {
+  const current = getActiveRenderPreferences();
+  const next = normalizePreferences({ ...current, ...update });
+  activePreferences = next;
+  persistToStorage(next);
+  subscribers.forEach((subscriber) => subscriber(next));
+  return next;
+}
+
+export function clearRenderOverrides() {
+  return setRenderPreferences({ maxPixelRatio: null, renderScale: null });
+}
+
+export function setCompatibilityMode(enabled: boolean) {
+  return setRenderPreferences({ compatibilityMode: enabled });
+}
+
+export function isCompatibilityModeEnabled() {
+  return getActiveRenderPreferences().compatibilityMode;
+}
+
+export function subscribeToRenderPreferences(
+  subscriber: RenderPreferenceSubscriber,
+) {
+  subscribers.add(subscriber);
+  if (activePreferences) {
+    subscriber(activePreferences);
+  }
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+export function resetRenderPreferencesState() {
+  activePreferences = null;
+  subscribers.clear();
+}

--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -1,5 +1,7 @@
 /* global GPUAdapter, GPUDevice, GPU */
 
+import { isCompatibilityModeEnabled } from './render-preferences.ts';
+
 export type RendererBackend = 'webgl' | 'webgpu';
 
 export type RendererCapabilities = {
@@ -85,6 +87,15 @@ function resetCache() {
 async function probeRendererCapabilities(): Promise<RendererCapabilities> {
   if (typeof navigator === 'undefined') {
     return cacheResult(buildFallback('Renderer capabilities are unavailable.'));
+  }
+
+  if (isCompatibilityModeEnabled()) {
+    return cacheResult(
+      buildFallback('Compatibility mode is enabled. Using WebGL.', {
+        triedWebGPU: false,
+        shouldRetryWebGPU: false,
+      }),
+    );
   }
 
   const { gpu } = navigator as Navigator & { gpu?: GPU };

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -1,0 +1,166 @@
+import {
+  getActiveMotionPreference,
+  setMotionPreference,
+} from '../core/motion-preferences.ts';
+import {
+  clearRenderOverrides,
+  getActiveRenderPreferences,
+  setCompatibilityMode,
+  setRenderPreferences,
+} from '../core/render-preferences.ts';
+import {
+  DEFAULT_QUALITY_PRESETS,
+  getActiveQualityPreset,
+  PersistentSettingsPanel,
+  type QualityPreset,
+  subscribeToQualityPreset,
+} from '../core/settings-panel.ts';
+
+type SystemControlOptions = {
+  title?: string;
+  description?: string;
+  qualityPresets?: QualityPreset[];
+  defaultPresetId?: string;
+};
+
+function createValueLabel(label: string) {
+  const value = document.createElement('span');
+  value.className = 'control-panel__value';
+  value.textContent = label;
+  return value;
+}
+
+export function initSystemControls(
+  host: HTMLElement,
+  options: SystemControlOptions = {},
+) {
+  const {
+    title = 'Performance & compatibility',
+    description = 'Adjust visual fidelity, GPU mode, and motion preferences. Changes persist for this device.',
+    qualityPresets = DEFAULT_QUALITY_PRESETS,
+    defaultPresetId = 'balanced',
+  } = options;
+
+  const panel = new PersistentSettingsPanel(host);
+  panel.configure({ title, description });
+
+  panel.setQualityPresets({
+    presets: qualityPresets,
+    defaultPresetId,
+  });
+
+  const renderPreferences = getActiveRenderPreferences();
+  const activeQuality = getActiveQualityPreset({
+    presets: qualityPresets,
+    defaultPresetId,
+  });
+
+  panel.addToggle({
+    label: 'Compatibility mode (force WebGL)',
+    description:
+      'Disable WebGPU and favor the most compatible renderer for older hardware.',
+    defaultValue: renderPreferences.compatibilityMode,
+    onChange: (value) => {
+      setCompatibilityMode(value);
+    },
+  });
+
+  panel.addToggle({
+    label: 'Allow motion input',
+    description: 'Enable device tilt controls for toys that support motion.',
+    defaultValue: getActiveMotionPreference().enabled,
+    onChange: (value) => {
+      setMotionPreference({ enabled: value });
+    },
+  });
+
+  const resolutionRow = panel.addSection(
+    'Resolution scale',
+    'Lower values reduce GPU load; higher values sharpen details.',
+  );
+  const resolutionValue = createValueLabel('');
+  const resolutionSlider = document.createElement('input');
+  resolutionSlider.type = 'range';
+  resolutionSlider.min = '0.6';
+  resolutionSlider.max = '1';
+  resolutionSlider.step = '0.05';
+  resolutionSlider.value = String(
+    renderPreferences.renderScale ?? activeQuality.renderScale ?? 1,
+  );
+  resolutionSlider.setAttribute('aria-label', 'Resolution scale');
+  resolutionSlider.className = 'control-panel__slider';
+  const updateResolutionValue = (value: number) => {
+    resolutionValue.textContent = `${Math.round(value * 100)}%`;
+  };
+  updateResolutionValue(Number(resolutionSlider.value));
+  resolutionSlider.addEventListener('input', (event) => {
+    const value = Number((event.target as HTMLInputElement).value);
+    updateResolutionValue(value);
+    setRenderPreferences({ renderScale: value });
+  });
+  resolutionRow.append(resolutionSlider, resolutionValue);
+
+  const pixelRatioRow = panel.addSection(
+    'Max pixel ratio',
+    'Caps the effective DPI to balance clarity and thermal load.',
+  );
+  const pixelRatioValue = createValueLabel('');
+  const pixelRatioSlider = document.createElement('input');
+  pixelRatioSlider.type = 'range';
+  pixelRatioSlider.min = '0.75';
+  pixelRatioSlider.max = '3';
+  pixelRatioSlider.step = '0.05';
+  pixelRatioSlider.value = String(
+    renderPreferences.maxPixelRatio ?? activeQuality.maxPixelRatio,
+  );
+  pixelRatioSlider.setAttribute('aria-label', 'Maximum pixel ratio');
+  pixelRatioSlider.className = 'control-panel__slider';
+  const updatePixelRatioValue = (value: number) => {
+    pixelRatioValue.textContent = value.toFixed(2);
+  };
+  updatePixelRatioValue(Number(pixelRatioSlider.value));
+  pixelRatioSlider.addEventListener('input', (event) => {
+    const value = Number((event.target as HTMLInputElement).value);
+    updatePixelRatioValue(value);
+    setRenderPreferences({ maxPixelRatio: value });
+  });
+  pixelRatioRow.append(pixelRatioSlider, pixelRatioValue);
+
+  const resetRow = panel.addSection('Custom overrides', undefined);
+  const resetButton = document.createElement('button');
+  resetButton.type = 'button';
+  resetButton.className = 'cta-button ghost';
+  resetButton.textContent = 'Reset overrides to preset';
+  resetButton.addEventListener('click', () => {
+    clearRenderOverrides();
+    const preset = getActiveQualityPreset({
+      presets: qualityPresets,
+      defaultPresetId,
+    });
+    resolutionSlider.value = String(preset.renderScale ?? 1);
+    pixelRatioSlider.value = String(preset.maxPixelRatio);
+    updateResolutionValue(Number(resolutionSlider.value));
+    updatePixelRatioValue(Number(pixelRatioSlider.value));
+  });
+  resetRow.appendChild(resetButton);
+
+  subscribeToQualityPreset((preset) => {
+    const preferences = getActiveRenderPreferences();
+    if (
+      preferences.renderScale === null ||
+      preferences.renderScale === undefined
+    ) {
+      resolutionSlider.value = String(preset.renderScale ?? 1);
+      updateResolutionValue(Number(resolutionSlider.value));
+    }
+    if (
+      preferences.maxPixelRatio === null ||
+      preferences.maxPixelRatio === undefined
+    ) {
+      pixelRatioSlider.value = String(preset.maxPixelRatio);
+      updatePixelRatioValue(Number(pixelRatioSlider.value));
+    }
+  });
+
+  return panel.getElement();
+}

--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -56,6 +56,15 @@ function buildOverlay(content: OverlayContent) {
   body.textContent = content.description;
   panel.appendChild(body);
 
+  const actions = document.createElement('div');
+  actions.className = 'rendering-overlay__actions';
+  const backLink = document.createElement('a');
+  backLink.className = 'rendering-overlay__button';
+  backLink.href = 'index.html';
+  backLink.textContent = 'Back to library';
+  actions.appendChild(backLink);
+  panel.appendChild(actions);
+
   const stepsList = document.createElement('ul');
   stepsList.className = 'rendering-overlay__steps';
   content.steps.forEach((step) => {
@@ -115,7 +124,7 @@ export function ensureWebGL(options: EnsureOptions = {}) {
   const defaultContent: OverlayContent = {
     title: 'WebGL or WebGPU is required',
     description:
-      'This visual needs GPU acceleration to draw its 3D graphics. Update your browser or enable hardware acceleration to continue.',
+      'This visual needs GPU acceleration to draw its 3D graphics. Update your browser, enable hardware acceleration, or return to the library to switch to compatibility mode.',
     steps: [
       'Use a modern browser like Chrome, Edge, or Firefox.',
       'Check that hardware acceleration is turned on in browser settings.',

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
+  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,

--- a/toy.html
+++ b/toy.html
@@ -10,15 +10,18 @@
   <body>
     <div id="nav-container"></div>
     <div id="controls-container"></div>
+    <div id="settings-container"></div>
     <script type="module" src="assets/js/toyMain.ts"></script>
     <script type="module">
       import { attachCapabilityPreflight } from './assets/js/core/capability-preflight.ts';
       import { startToyPage } from './assets/js/toyMain.ts';
       import { initNavigation } from './assets/js/ui/nav.ts';
       import { initAudioControls } from './assets/js/ui/audio-controls.ts';
+      import { initSystemControls } from './assets/js/ui/system-controls.ts';
 
       const navContainer = document.getElementById('nav-container');
       const controlsContainer = document.getElementById('controls-container');
+      const settingsContainer = document.getElementById('settings-container');
       
       let loaderStarted = false;
       const startLoaderIfNeeded = () => {
@@ -86,10 +89,21 @@
             if (!starter) throw new Error('Audio starter unavailable.');
             return starter({ stream });
           },
+          onRequestTabAudio: async (stream) => {
+            startLoaderIfNeeded();
+            const starter = getStarter();
+            if (!starter) throw new Error('Audio starter unavailable.');
+            return starter({ stream });
+          },
           onSuccess: () => {
             if (controlsContainer) controlsContainer.hidden = true;
           }
         });
+      };
+
+      const setupSystemControls = () => {
+        if (!settingsContainer || settingsContainer.childElementCount > 0) return;
+        initSystemControls(settingsContainer);
       };
 
       attachCapabilityPreflight({
@@ -98,12 +112,14 @@
           if (result.canProceed) {
             startLoaderIfNeeded();
             setupAudio();
+            setupSystemControls();
           }
         },
         onRetry: (result) => {
           if (result.canProceed) {
             startLoaderIfNeeded();
             setupAudio();
+            setupSystemControls();
           }
         },
         host: document.body,


### PR DESCRIPTION
### Motivation
- Provide persistent device-level render preferences (compatibility mode, pixel-ratio, render-scale) and a central system control panel so users can tune fidelity and fallback behavior without changing code paths.
- Improve audio UX by adding explicit tab capture and button loading states to prevent double submissions and surface progress.
- Surface a copyable share link in the toy navigation and make WebGL/WebGPU capability failures actionable with a library-back action.
- Respect a global motion preference in motion-enabled toys so device-tilt controls can be toggled centrally.

### Description
- Added persistent preference modules `core/render-preferences.ts` and `core/motion-preferences.ts` and a UI panel `ui/system-controls.ts` that exposes compatibility mode, resolution scale, max pixel ratio, and motion toggles.
- Wired compatibility mode into renderer probing so `renderer-capabilities` will force a WebGL fallback when enabled, and plumbed render overrides into the render service so `buildSettings` prefers stored overrides when present.
- Expanded audio controls in `ui/audio-controls.ts` to support tab capture (`getDisplayMedia`), added loading/aria-busy states and exclusive button disabling to prevent double-submission, and threaded a small helper through YouTube capture logic for consistent button state handling.
- Added a share action to the toy nav (`ui/nav.ts`) with copy-to-clipboard feedback, and enhanced the WebGL overlay (`utils/webgl-check.ts`) with a back-to-library action and more informative messaging.
- Updated the tactile sand toy (`toys/tactile-sand-table.ts`) to consult the global motion preference and subscribe to changes, and added CSS updates in `assets/css/base.css` for the new controls, share UI and loading spinner states; minor test harness tweak in `tests/setup.ts` to include `TRANSIENT_ATTACHMENT` for WebGPU stubs.

### Testing
- Ran the full project check: `bun run check` which runs linter/formatters, TypeScript typecheck and the test suite; the run produced 69 passing tests, 5 failing tests, and 1 error in this environment.
- Notable failures were agent/playwright integration tests and a few app-shell/lighting tests that are environment-dependent (Playwright browsers not installed in this execution environment), so CI should re-run in the normal pipeline where browser binaries are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b22d830f883328474ecdade7eb69f)