### PR TITLE
Persist word cloud input state and improve control accessibility

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -183,6 +183,8 @@ body {
   top: 12px;
   left: 12px;
   padding: 10px 14px;
+  min-height: 44px;
+  min-width: 44px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -208,6 +210,7 @@ body {
     background 200ms ease;
   z-index: 1000;
   font-weight: 700;
+  touch-action: manipulation;
 }
 
 .home-link::before {

--- a/toys/words.html
+++ b/toys/words.html
@@ -140,6 +140,12 @@
         box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
       }
 
+      .pill-button:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.95);
+        outline-offset: 3px;
+        box-shadow: 0 0 0 4px rgba(64, 255, 255, 0.4);
+      }
+
       .pill-button.secondary {
         border-color: rgba(255, 255, 255, 0.2);
         background: rgba(255, 255, 255, 0.12);
@@ -179,6 +185,12 @@
 
       .control-button:active {
         transform: scale(0.9);
+      }
+
+      .control-button:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.95);
+        outline-offset: 4px;
+        box-shadow: 0 0 0 4px rgba(64, 255, 255, 0.45);
       }
 
       .control-icon {
@@ -328,6 +340,7 @@
         window.SpeechRecognition || window.webkitSpeechRecognition;
       const speechSupported = Boolean(SpeechRecognition);
       let recognition = null;
+      const STORAGE_KEY = 'stim-words-state';
 
       const seedWords = [
         'pulse',
@@ -365,6 +378,7 @@
         }
 
         updateWordCloud(wordsArray);
+        saveStoredState();
       }
 
       function normalizeInputWords(text) {
@@ -432,6 +446,44 @@
 
       const speechUnavailableMessage =
         'Speech recognition is unavailable. Use the manual input below or add sample words to keep the cloud active.';
+
+      function loadStoredState() {
+        if (!('sessionStorage' in window)) return null;
+
+        try {
+          const stored = window.sessionStorage.getItem(STORAGE_KEY);
+          if (!stored) return null;
+          const parsed = JSON.parse(stored);
+          if (!parsed || typeof parsed !== 'object') return null;
+          if (Array.isArray(parsed.words) && parsed.words.length) {
+            return {
+              words: parsed.words.filter((word) => typeof word === 'string'),
+              manualText:
+                typeof parsed.manualText === 'string' ? parsed.manualText : '',
+            };
+          }
+        } catch (error) {
+          console.warn('Unable to load stored word cloud state:', error);
+        }
+
+        return null;
+      }
+
+      function saveStoredState() {
+        if (!('sessionStorage' in window)) return;
+
+        try {
+          window.sessionStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({
+              words: wordsArray,
+              manualText: manualInput?.value ?? '',
+            })
+          );
+        } catch (error) {
+          console.warn('Unable to save word cloud state:', error);
+        }
+      }
 
       function focusManualInput() {
         if (!manualInput || !manualPanel) return;
@@ -524,6 +576,8 @@
         if (manualInput) {
           manualInput.value = '';
         }
+
+        saveStoredState();
       }
 
       function addDemoWords() {
@@ -552,6 +606,10 @@
 
       addWordsButton?.addEventListener('click', handleManualWordSubmit);
       demoWordsButton?.addEventListener('click', addDemoWords);
+
+      manualInput?.addEventListener('input', () => {
+        saveStoredState();
+      });
 
       manualInput?.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {
@@ -689,6 +747,15 @@
 
       initSpeechRecognition();
 
+      const storedState = loadStoredState();
+      if (storedState?.words?.length) {
+        wordsArray = storedState.words;
+      }
+
+      if (manualInput && storedState?.manualText) {
+        manualInput.value = storedState.manualText;
+      }
+
       if (speechSupported) {
         setStatus(
           'Unmute to sync with your mic. Enable speech to sprinkle your words into the cloud.'
@@ -747,6 +814,7 @@
       updateUnmuteIcon();
       updateSpeechIcon();
       updateWordCloud(wordsArray);
+      saveStoredState();
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Improve user experience by preserving manual word input and the in-memory word list across navigation/refresh so users don't lose their data when interacting with the Word Cloud toy. 
- Raise keyboard accessibility and mobile touch affordances to meet focus contrast and touch-target guidance for controls and the back-to-library link.

### Description
- Persist session-scoped state for the Word Cloud by adding `STORAGE_KEY`, `loadStoredState()` and `saveStoredState()` to `toys/words.html`, restoring `wordsArray` and manual input on load and saving on updates and input events.  
- Wire state persistence calls into `addWordsToCloud()`, `handleManualWordSubmit()`, `manualInput` `input` handler, and initial render so manual entries survive page reloads.  
- Improve keyboard focus styling by adding `:focus-visible` rules for `.pill-button` and `.control-button` in `toys/words.html` to meet focus contrast requirements.  
- Improve mobile/touch behavior and minimum touch target for the back link by adding `min-height`, `min-width`, and `touch-action: manipulation` to `.home-link` in `assets/css/base.css`.

### Testing
- Ran the repo quality/check gate with `bun run check` which executed Biome formatting/lint and TypeScript checks and then ran the test suite.  
- Biome format/lint and `tsc` passed with no fixes; automated tests ran and reported 64 passing tests and 10 failing tests.  
- Failures are concentrated in loader/app-shell tests (related to `createLoader` import behavior) and agent Playwright tests which also failed due to Playwright browsers missing in the CI environment; these failures are not caused by the word-cloud changes.  
- No documentation files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b43f7ec28833299728d17dd88903e)