### PR TITLE
Improve mobile touch targets and accessibility in control panel

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -816,6 +816,12 @@ body {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.control-panel__row--toggle {
+  cursor: pointer;
+  min-height: 44px;
+  touch-action: manipulation;
+}
+
 .control-panel__row--stacked {
   flex-direction: column;
   align-items: stretch;
@@ -877,6 +883,9 @@ body {
 }
 
 .control-panel__label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   font-weight: 600;
   font-size: 0.95rem;
 }
@@ -904,6 +913,7 @@ body {
 .control-panel__input {
   flex: 1 1 180px;
   width: 100%;
+  min-height: 44px;
   padding: 10px 12px;
   border-radius: 4px;
   border: 1px solid rgba(111, 247, 255, 0.6);
@@ -926,7 +936,12 @@ body {
 }
 
 .control-panel__chip {
-  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 6px 12px;
   border-radius: 6px;
   background: rgba(111, 247, 255, 0.1);
   border: 1px solid rgba(111, 247, 255, 0.3);
@@ -935,6 +950,7 @@ body {
   font-family: inherit;
   cursor: pointer;
   transition: all 0.2s ease;
+  touch-action: manipulation;
 }
 
 .control-panel__chip:hover {
@@ -956,8 +972,8 @@ body {
 }
 
 .control-panel input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   accent-color: #70f0ff;
   filter: drop-shadow(0 0 6px rgba(111, 247, 255, 0.5));
   cursor: pointer;
@@ -975,6 +991,7 @@ body {
   border-radius: 2px;
   padding: 10px 12px;
   min-width: 150px;
+  min-height: 44px;
   font-weight: 700;
   letter-spacing: 0.01em;
   box-shadow:
@@ -996,7 +1013,7 @@ body {
 .control-panel__slider {
   appearance: none;
   width: 100%;
-  height: 12px;
+  height: 44px;
   border-radius: 999px;
   background: linear-gradient(
     90deg,

--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -190,9 +190,11 @@ export class PersistentSettingsPanel {
       const text = document.createElement('div');
       text.className = 'control-panel__text';
 
-      const label = document.createElement('span');
+      const selectId = 'quality-preset-select';
+      const label = document.createElement('label');
       label.className = 'control-panel__label';
       label.textContent = 'Quality preset';
+      label.htmlFor = selectId;
 
       const hint = document.createElement('small');
       hint.textContent = 'Adjust resolution and particle density.';
@@ -200,6 +202,7 @@ export class PersistentSettingsPanel {
       text.append(label, hint);
 
       const select = document.createElement('select');
+      select.id = selectId;
       select.addEventListener('change', () =>
         this.handleQualityChange(select.value),
       );
@@ -228,16 +231,23 @@ export class PersistentSettingsPanel {
     }
   }
 
-  addSection(title: string, description?: string): HTMLDivElement {
+  addSection(
+    title: string,
+    description?: string,
+    labelFor?: string,
+  ): HTMLDivElement {
     const row = document.createElement('div');
     row.className = 'control-panel__row';
 
     const text = document.createElement('div');
     text.className = 'control-panel__text';
 
-    const label = document.createElement('span');
+    const label = document.createElement(labelFor ? 'label' : 'span');
     label.className = 'control-panel__label';
     label.textContent = title;
+    if (labelFor && label instanceof HTMLLabelElement) {
+      label.htmlFor = labelFor;
+    }
     text.appendChild(label);
 
     if (description) {
@@ -256,8 +266,8 @@ export class PersistentSettingsPanel {
 
   addToggle(options: ToggleOptions) {
     const { label, description, defaultValue = false, onChange } = options;
-    const actions = this.addSection(label, description);
-    actions.classList.add('control-panel__actions--inline');
+    const row = document.createElement('label');
+    row.className = 'control-panel__row control-panel__row--toggle';
 
     const input = document.createElement('input');
     input.type = 'checkbox';
@@ -267,9 +277,28 @@ export class PersistentSettingsPanel {
     input.id = toggleId;
     input.setAttribute('aria-label', label);
 
+    const text = document.createElement('div');
+    text.className = 'control-panel__text';
+
+    const labelText = document.createElement('span');
+    labelText.className = 'control-panel__label';
+    labelText.textContent = label;
+    text.appendChild(labelText);
+
+    if (description) {
+      const hint = document.createElement('small');
+      hint.textContent = description;
+      text.appendChild(hint);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'control-panel__actions control-panel__actions--inline';
+
     input.addEventListener('change', () => onChange?.(input.checked));
 
     actions.appendChild(input);
+    row.append(text, actions);
+    this.sectionHost.appendChild(row);
     return input;
   }
 


### PR DESCRIPTION
### Motivation
- Make the settings/control panel easier and more reliable to use on handheld devices by increasing hit areas and ensuring form controls have explicit labels for accessibility and mobile behaviors.

### Description
- Add explicit `label` linkage for the quality preset `select` and allow `addSection` to accept `labelFor` so controls can be programmatically associated with their labels (`assets/js/core/settings-panel.ts`).
- Replace toggle rows with labeled row markup so toggles are keyboard-focusable and have a larger tap target, and expose clear label text and helper `small` hints (`assets/js/core/settings-panel.ts`).
- Expand touch targets and mobile sizing across control-panel UI by adding `.control-panel__row--toggle`, increasing `min-height` for inputs/selects/chips/sliders, enlarging checkboxes, and adding `touch-action: manipulation` where appropriate (`assets/css/base.css`).
- Keep behavior unchanged for quality preset persistence and event callbacks; only markup and styles were updated to improve accessibility and mobile friendliness.

### Testing
- Ran the full quality check with `bun run check`, which executed linting, typecheck and tests; lint/format steps passed but the run failed with test errors and missing Playwright browser binaries in this environment (`bun test` produced multiple failing tests and Playwright install warnings).
- Ran `biome lint` and `biome format` as part of pre-commit checks which completed successfully. 
- Performed a visual smoke test by launching the dev server and capturing a Playwright screenshot of the control panel, which succeeded and produced `artifacts/mobile-control-panel.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b464e887c833284fc9a03c1366694)