### PR TITLE
Add semantic search/datalist, accessible card links & popover badges; convert preflight to dialog

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1214,6 +1214,15 @@ body {
   gap: 8px;
 }
 
+.preflight-dialog {
+  margin: 0;
+}
+
+.preflight-dialog::backdrop {
+  background: rgba(6, 8, 16, 0.7);
+  backdrop-filter: blur(2px);
+}
+
 .preflight-panel__statuses {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1342,7 +1342,7 @@ h1 {
     border-color 0.3s ease,
     background 0.3s ease;
   text-align: left;
-  cursor: pointer;
+  cursor: default;
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(8px);
   border: 1px solid var(--surface-border);
@@ -1357,6 +1357,26 @@ h1 {
   position: relative;
   overflow: hidden;
   touch-action: manipulation;
+}
+
+.webtoy-card__link {
+  color: inherit;
+  text-decoration: none;
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  z-index: 1;
+}
+
+.webtoy-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+  position: relative;
+  z-index: 0;
+  pointer-events: none;
 }
 
 /* Gradient shimmer overlay */
@@ -1451,10 +1471,14 @@ h1 {
   justify-content: center;
   gap: 0.5rem;
   margin-top: 0.9rem;
+  position: relative;
+  z-index: 2;
 }
 
 .capability-badge {
   padding: 0.4rem 0.75rem;
+  min-height: 44px;
+  min-width: 44px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--hover-bg);
   background: var(--accent-soft);
@@ -1462,6 +1486,12 @@ h1 {
   font-size: 0.85rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  touch-action: manipulation;
 }
 
 .capability-badge--warning {
@@ -1470,18 +1500,29 @@ h1 {
   color: #ffbf47;
 }
 
+.capability-badge:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.capability-popover {
+  max-width: 220px;
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 14, 26, 0.92);
+  color: var(--text-color);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+}
+
+.capability-popover:popover-open {
+  animation: fadeSlide 0.2s ease;
+}
+
 .capability-note {
   font-size: 0.8rem;
   color: var(--text-muted);
-}
-
-.webtoy-card a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.webtoy-card a:hover {
-  text-decoration: underline;
 }
 
 footer {

--- a/index.html
+++ b/index.html
@@ -108,9 +108,9 @@
           <p class="section-description">
             Tap a card to launch. Everything is accessible and ready to play.
           </p>
-          <div class="library-search">
+          <search class="library-search">
             <label class="sr-only" for="toy-search">Search the library</label>
-            <div class="search-field">
+            <form class="search-field" role="search" data-search-form>
               <input
                 id="toy-search"
                 type="search"
@@ -119,6 +119,7 @@
                 autocomplete="off"
                 aria-describedby="toy-search-hint"
                 inputmode="search"
+                list="toy-search-suggestions"
               />
               <button
                 type="button"
@@ -135,7 +136,8 @@
               >
                 Enter a name, tag, or capability
               </span>
-            </div>
+              <datalist id="toy-search-suggestions"></datalist>
+            </form>
             <div class="filter-row" role="group" aria-label="Curated filters">
               <div class="chip-row" data-chip-row>
                 <button
@@ -216,7 +218,7 @@
                 Loading library…
               </p>
             </div>
-          </div>
+          </search>
         </div>
         <main id="toy-list" class="webtoy-container"></main>
       </section>
@@ -263,6 +265,10 @@
         if (!list || list.childElementCount > 0) return;
 
         const search = document.getElementById('toy-search');
+        const searchForm = document.querySelector('[data-search-form]');
+        const searchSuggestions = document.getElementById(
+          'toy-search-suggestions'
+        );
         const searchResults = document.querySelector('[data-search-results]');
         const clearSearchButton = document.querySelector('[data-search-clear]');
         const resetFiltersButton = document.querySelector('[data-filter-reset]');
@@ -421,18 +427,32 @@
                 ? toy.module
                 : `toy.html?toy=${encodeURIComponent(toy.slug)}`;
 
-            const card = document.createElement('a');
+            const card = document.createElement('article');
             card.className = 'webtoy-card';
-            card.href = href;
             card.setAttribute('data-toy-fallback', 'true');
+
+            const link = document.createElement('a');
+            link.className = 'webtoy-card__link';
+            link.href = href;
 
             const title = document.createElement('h3');
             title.textContent = toy.title;
+            const titleId = `toy-title-${toy.slug}`;
+            title.id = titleId;
 
             const desc = document.createElement('p');
             desc.textContent = toy.description;
+            const descId = `toy-desc-${toy.slug}`;
+            desc.id = descId;
 
-            card.append(title, desc);
+            link.setAttribute('aria-labelledby', titleId);
+            link.setAttribute('aria-describedby', descId);
+
+            const content = document.createElement('div');
+            content.className = 'webtoy-card__content';
+            content.append(title, desc);
+
+            card.append(link, content);
 
             const badgeRow = document.createElement('div');
             badgeRow.className = 'webtoy-card-meta';
@@ -469,11 +489,23 @@
 
             if (badges.length > 0) {
               badges.forEach((badgeData) => {
-                const badge = document.createElement('span');
+                const badge = document.createElement('button');
+                const popover = document.createElement('div');
+                const popoverId = `capability-${toy.slug}-${badgeData.label
+                  .toLowerCase()
+                  .replace(/\s+/g, '-')}`;
                 badge.className = 'capability-badge';
+                badge.type = 'button';
                 badge.textContent = badgeData.label;
-                badge.title = badgeData.title;
+                badge.setAttribute('popovertarget', popoverId);
+                badge.setAttribute('popovertargetaction', 'toggle');
+                badge.setAttribute('aria-describedby', popoverId);
+                popover.className = 'capability-popover';
+                popover.id = popoverId;
+                popover.setAttribute('popover', 'auto');
+                popover.textContent = badgeData.title;
                 badgeRow.appendChild(badge);
+                badgeRow.appendChild(popover);
               });
 
               card.appendChild(badgeRow);
@@ -603,12 +635,35 @@
           updateControlVisibility();
         };
 
+        const updateSearchSuggestions = (toys) => {
+          if (!(searchSuggestions instanceof HTMLDataListElement)) return;
+          const suggestions = new Set();
+          toys.forEach((toy) => {
+            (toy.tags ?? []).forEach((tag) => suggestions.add(tag));
+            (toy.moods ?? []).forEach((mood) => suggestions.add(mood));
+            Object.entries(toy.capabilities || {})
+              .filter(([, enabled]) => !!enabled)
+              .forEach(([key]) => suggestions.add(key));
+            if (toy.requiresWebGPU) suggestions.add('webgpu');
+          });
+          searchSuggestions.innerHTML = '';
+          [...suggestions]
+            .filter((value) => typeof value === 'string' && value.trim())
+            .sort((a, b) => a.localeCompare(b))
+            .forEach((value) => {
+              const option = document.createElement('option');
+              option.value = value;
+              searchSuggestions.appendChild(option);
+            });
+        };
+
         fetch('./toys.json')
           .then((response) => (response.ok ? response.json() : null))
           .then((toys) => {
             if (!toys || list.childElementCount > 0) return;
 
             allToys = toys;
+            updateSearchSuggestions(allToys);
             const urlState = getStateFromUrl();
             const hasUrlState =
               urlState.query ||
@@ -624,6 +679,18 @@
               }
             }
             renderCards(applyFilters());
+
+            if (searchForm instanceof HTMLFormElement) {
+              searchForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                if (!(search instanceof HTMLInputElement)) return;
+                cachedQuery = search.value.toLowerCase().trim();
+                lastCommittedQuery = cachedQuery.trim();
+                commitState({ replace: false });
+                renderCards(applyFilters(cachedQuery), cachedQuery);
+                updateControlVisibility();
+              });
+            }
 
             if (search instanceof HTMLInputElement) {
               search.addEventListener('input', () => {

--- a/toys/words.html
+++ b/toys/words.html
@@ -252,6 +252,8 @@
             alt="Mic Access Icon"
             width="35"
             height="35"
+            loading="lazy"
+            decoding="async"
           />
         </button>
 
@@ -268,6 +270,8 @@
             alt="Add Word Icon"
             width="35"
             height="35"
+            loading="lazy"
+            decoding="async"
           />
         </button>
       </div>


### PR DESCRIPTION
### Motivation
- Improve accessibility and semantics for the library UI and capability hints, provide inline search suggestions, and make the preflight overlay behave as a proper modal with URL-driven state and focus restoration. 
- Reduce confusing clickable semantics by moving interactive behavior onto explicit interactive elements and give capability badges proper touch targets and keyboard focus.

### Description
- Replace the library search wrapper with a semantic search form, add a `datalist` for suggestions, and wire a submit handler so `Enter` commits the query (`index.html` + inline script). 
- Render fallback library cards as `article` elements with a full-card anchor overlay (`.webtoy-card__link`) and separate non-interactive content container for improved semantics and keyboard behavior (`index.html`, `assets/css/index.css`). 
- Convert capability badges from decorative `span`s to `button`s and add small popover hint elements with focus-visible styles and a 44×44px minimum touch target (`index.html`, `assets/css/index.css`). 
- Convert the preflight control-panel into a native `dialog` with URL query param state (`?modal=capability-check`), push/replace history handling, popstate syncing, focus restoration to the previously active element, and safe open/close helpers (`assets/js/core/capability-preflight.ts` + `assets/css/base.css` backdrop styles). 
- Add `loading="lazy"` and `decoding="async"` to a couple of legacy toy icons to improve load behavior (`toys/words.html`).

### Testing
- Ran the project checks with `bun run check` (which runs formatting/linting, `tsc`, and the test suite). 
- Automated test run produced passing unit checks for many modules but left 5 failing tests (lighting-setup tests, an app-shell navigation test) and environment-bound Playwright failures due to missing browser executables, so overall the test command exited with failures. 
- Also exercised the running dev server and captured a visual screenshot of the library popover to validate the UI changes locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bce297e788332a06eb1238990ff94)