### PR TITLE
Improve touch targets and Spiral Burst mode controls

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -836,6 +836,48 @@ body {
   align-items: stretch;
 }
 
+.control-panel__mode-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.control-panel__mode {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 8px 12px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-family: inherit;
+  letter-spacing: 0.01em;
+  touch-action: manipulation;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.control-panel__mode:hover {
+  transform: translateY(-1px);
+  opacity: 0.92;
+}
+
+.control-panel__mode:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
+.control-panel__mode.is-active {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #e9fbff;
+}
+
 .control-panel__row:first-of-type {
   border-top: none;
 }

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -675,21 +675,34 @@ header.hero {
 }
 
 .preview-dot {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  appearance: none;
+  touch-action: manipulation;
+}
+
+.preview-dot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
   width: 12px;
   height: 12px;
+  margin: auto;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  opacity: 0.75;
+  transform: scaleX(1);
   transition:
     transform 0.3s ease,
-    background 0.3s ease,
-    box-shadow 0.3s ease;
-  cursor: pointer;
-  padding: 0;
-  appearance: none;
-  transform: scaleX(1);
-  touch-action: manipulation;
+    opacity 0.3s ease;
 }
 
 .preview-dot:focus-visible {
@@ -697,8 +710,9 @@ header.hero {
   outline-offset: 2px;
 }
 
-.preview-dot.is-active {
+.preview-dot.is-active::before {
   transform: scaleX(2.2);
+  opacity: 1;
   background: linear-gradient(
     135deg,
     var(--accent-color),

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -50,6 +50,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   let activeQuality: QualityPreset = getActiveQualityPreset();
   let performanceSettings: PerformanceSettings = getActivePerformanceSettings();
   let currentMode: SpiralMode = 'burst';
+  let modeRow: HTMLDivElement | null = null;
 
   const toy = new WebToy({
     cameraOptions: { position: { x: 0, y: 0, z: 120 } },
@@ -283,7 +284,9 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     const buttons = container?.querySelectorAll('[data-spiral-mode]');
     buttons?.forEach((btn) => {
       const mode = btn.getAttribute('data-spiral-mode');
-      btn.classList.toggle('active', mode === currentMode);
+      const isActive = mode === currentMode;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
     });
   }
 
@@ -300,33 +303,26 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     });
 
     // Add mode buttons
-    const modeRow = document.createElement('div');
-    modeRow.className = 'control-panel__row';
-    modeRow.style.cssText =
-      'display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px;';
+    modeRow?.remove();
+    const row = document.createElement('div');
+    row.className = 'control-panel__row control-panel__mode-row';
+    modeRow = row;
 
     const modes: SpiralMode[] = ['burst', 'bloom', 'vortex', 'heartbeat'];
     modes.forEach((mode) => {
       const btn = document.createElement('button');
+      btn.type = 'button';
       btn.textContent = mode.charAt(0).toUpperCase() + mode.slice(1);
       btn.setAttribute('data-spiral-mode', mode);
-      btn.className = mode === currentMode ? 'active' : '';
-      btn.style.cssText = `
-        padding: 6px 12px;
-        border: 1px solid currentColor;
-        background: transparent;
-        color: inherit;
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 12px;
-        transition: all 0.2s;
-      `;
+      btn.className = 'control-panel__mode';
+      btn.classList.toggle('is-active', mode === currentMode);
+      btn.setAttribute('aria-pressed', String(mode === currentMode));
       btn.addEventListener('click', () => setMode(mode));
-      modeRow.appendChild(btn);
+      row.appendChild(btn);
     });
 
     const panel = container?.querySelector('.control-panel');
-    panel?.appendChild(modeRow);
+    panel?.appendChild(row);
   }
 
   function setupPerformancePanel() {
@@ -555,6 +551,8 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
         (bloomMesh.geometry as THREE.BufferGeometry).dispose();
         (bloomMesh.material as THREE.Material).dispose();
       }
+      modeRow?.remove();
+      modeRow = null;
       perfUnsub();
       unregisterGlobals();
     },

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -122,6 +122,7 @@ Manual scenarios to verify:
 - Test on touch devices or emulators. Avoid interactions that depend solely on hover.
 - For device motion input, gate logic behind feature detection (`window.DeviceMotionEvent`).
 - Ensure important controls are keyboard-focusable and include visible focus states.
+- For custom control-panel buttons, use `.control-panel__mode` (or the shared control-panel button styles) to guarantee 44x44 touch targets and visible focus treatment.
 - Normalize pointer handling with `assets/js/utils/pointer-input.ts` so toys share the same multi-touch pan/zoom/rotate gestures and hit detection. Prefer passing a canvas or container element so pointer math uses its exact bounds.
 - Apply the `.toy-canvas` class to fullscreen canvases and include `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">` in HTML heads to keep sizing consistent on mobile safe areas.
 - Sanity-check layout at common breakpoints (e.g., 320x568, 375x812, 768x1024) to confirm controls remain tappable and canvases stay clipped to the viewport.


### PR DESCRIPTION
### Motivation

- Ensure interactive preview dots meet the 44x44px touch-target requirement while preserving the original small visual dot and its transform/opacity-based active state.
- Standardize control-panel mode buttons so toy modules (example: Spiral Burst) expose keyboard-friendly, focus-visible, and touch-friendly controls that clean up on disposal.
- Keep the toy development guidance in sync with the new control pattern so contributors follow the same accessibility and mobile-target rules.

### Description

- Expand the clickable area for library preview dots to a 44x44 hitbox and move the 12px visual indicator into a `::before` pseudo-element so the active styling remains a transform/opacity change (`assets/css/index.css`).
- Add shared control-panel mode button styles (`.control-panel__mode` and `.control-panel__mode-row`) that provide 44x44 minimum targets, focus-visible outlines, and hover states (`assets/css/base.css`).
- Update `assets/js/toys/spiral-burst.ts` to create mode buttons using the new shared class, set `type="button"`, maintain `aria-pressed` state on toggle, and remove the mode row on `dispose` to avoid leaking DOM nodes and listeners.
- Document the recommended usage of `.control-panel__mode` in `docs/TOY_DEVELOPMENT.md` so future toys follow the same affordances.

### Testing

- Ran `bun run check` (Biome lint + format, TypeScript `tsc --noEmit`, and the test runner); Biome lint/format passed and TypeScript passed, but the unit test suite reported failing specs.
- Ran the test suite (`bun test`) where many tests passed (including `check-toys`, router utilities, sample-toy harness, performance/control-panel related specs), and several tests failed (notably `tests/app-shell.test.js`, `tests/lighting-setup.test.js`, and multiple loader-related specs).
- Type checking was run separately with `bun run typecheck` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c412c47c88332bacbd60cbb6aab17)