### PR TITLE
Refactor AGENTS.md into progressive-disclosure agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,17 @@
-# Agent Guidelines
+# Agent Guidelines (Essentials)
 
-These instructions apply to the entire repository.
+Stim Webtoys Library is a collection of interactive, audio-reactive web toys built with Three.js/WebGL for responsive visual play.
 
-## Core Conventions
+## Essentials
 
-- **Metadata conventions:**
-  - **Commit messages:** Use concise, descriptive titles in sentence case (no trailing period) that summarize the change, e.g., `Add docs on data flow`.
-  - **PR summaries:** Include a short summary plus explicit lists of tests run and any docs touched or added so reviewers can verify coverage.
-  - **Docs map:** Refer to `docs/README.md` for an overview of the documentation structure when adding or updating documentation.
-- Prefer **Bun** tooling to match `packageManager` (for installs use `bun install --frozen-lockfile` when dependencies change, and run scripts with `bun run ...`).
-- For JavaScript/TypeScript changes, run the relevant quality checks before committing: `bun run check` (which runs Biome and tests) and `bun run typecheck`.
-- **Tooling:** We use **Biome** for linting and formatting. Do not use ESLint or Prettier.
-- For documentation-only changes (Markdown/prose), you can skip `bun run typecheck` and `bun run test`, but still run `bun run format` on touched docs.
-- Keep the docs in `docs/` and the root `README.md` in sync with workflow or toy changes so contributors can find updated guidance.
+- **Package manager:** Bun (use `bun install --frozen-lockfile` when dependencies change; run scripts with `bun run ...`).
+- **Non-standard quality gates for JS/TS changes:** run `bun run check` (Biome + tests) and `bun run typecheck` before committing.
+- **Metadata:** commit messages use sentence case with no trailing period; PR summaries include a short summary plus explicit lists of tests run and docs touched/added.
 
-## Toy Development
+## More detailed guidance
 
-**Project Structure:**
-- Toy modules: `assets/js/toys/` (TypeScript modules exporting `start()`)
-- Toy registry: `assets/js/toys-data.js` (slugs, metadata, capabilities)
-- Legacy HTML toys: `toys/` directory (standalone pages)
-- Loader logic: `toy.html` + `assets/js/loader.ts`
-- Audio handling: `assets/js/core/audio-handler.ts`
-
-**Key Patterns:**
-- Every toy module exports `start({ container, canvas?, audioContext? })`
-- `start()` returns a cleanup function that removes all DOM nodes
-- Audio reactivity uses `registerToyGlobals` to expose `startAudio` and `startAudioFallback`
-- Toys support microphone input or demo audio fallback
-
-## Workflows for Agents
-
-Use these workflows (in `.agent/workflows/`) to interact with toys:
-
-| Workflow | Command | Purpose |
-|----------|---------|---------|
-| `/create-toy` | Create new toy module | Scaffold a new toy with the standard template |
-| `/play-toy` | Launch toy in browser | Start dev server and interact with toys |
-| `/test-toy` | Run toy tests | Execute automated tests for toys |
-
-### Quick Commands
-
-```bash
-# Create a new toy
-bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test
-
-# Check all toys are registered correctly
-bun run check:toys
-
-# Run all tests
-bun test
-
-# Start dev server for interactive testing
-bun run dev
-
-# Type check
-bun run typecheck
-
-# Full quality check (lint + tests)
-bun run check
-```
-
-### Testing a Specific Toy
-
-1. Start dev server: `bun run dev`
-2. Navigate to: `http://localhost:5173/toy.html?toy=<slug>`
-3. Click "Use demo audio" to bypass microphone permissions
-4. Verify visuals render and respond to audio
-
-### Common Toy Slugs
-
-- `holy` - Ultimate Satisfying Visualizer
-- `geom` - Geometry Visualizer  
-- `spiral-burst` - Spiral Burst
-- `neon-wave` - Neon Wave
-- `milkdrop` - MilkDrop Proto
-
-## Documentation
-
-- `docs/TOY_DEVELOPMENT.md` - Full toy development playbook
-- `docs/TOY_TESTING_SPEC.md` - Automated testing specification
-- `docs/ARCHITECTURE.md` - System architecture overview
+- [Tooling & quality checks](./docs/agents/tooling-and-quality.md)
+- [Metadata & documentation expectations](./docs/agents/metadata-and-docs.md)
+- [Toy development structure & patterns](./docs/agents/toy-development.md)
+- [Toy workflows & common commands](./docs/agents/toy-workflows.md)
+- [Reference documentation pointers](./docs/agents/reference-docs.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This folder contains resources for contributors who are building or maintaining 
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md): end-to-end app architecture, loader flow, and core runtime composition with diagrams.
 - [`DEPLOYMENT.md`](./DEPLOYMENT.md): build, preview, static hosting layout, and Cloudflare Worker deployment steps.
 - [`MCP_SERVER.md`](./MCP_SERVER.md): how to launch and use the MCP stdio server (`scripts/mcp-server.ts`) and its registered tools.
+- [`agents/README.md`](./agents/README.md): agent-specific guidance split into progressive disclosure files.
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,9 @@
+# Agent Guidance Index
+
+Start with the root [AGENTS.md](../../AGENTS.md) for the essentials, then use these deeper references as needed:
+
+- [Tooling & quality checks](./tooling-and-quality.md)
+- [Metadata & documentation expectations](./metadata-and-docs.md)
+- [Toy development structure & patterns](./toy-development.md)
+- [Toy workflows & common commands](./toy-workflows.md)
+- [Reference documentation pointers](./reference-docs.md)

--- a/docs/agents/metadata-and-docs.md
+++ b/docs/agents/metadata-and-docs.md
@@ -1,0 +1,11 @@
+# Metadata & Documentation Expectations
+
+## Metadata conventions
+
+- **Commit messages:** concise, descriptive titles in sentence case (no trailing period), e.g., `Add docs on data flow`.
+- **PR summaries:** include a short summary plus explicit lists of tests run and any docs touched or added so reviewers can verify coverage.
+
+## Documentation expectations
+
+- Refer to `docs/README.md` for the documentation map when adding or updating docs.
+- Keep the docs in `docs/` and the root `README.md` in sync with workflow or toy changes so contributors can find updated guidance.

--- a/docs/agents/reference-docs.md
+++ b/docs/agents/reference-docs.md
@@ -1,0 +1,5 @@
+# Reference Documentation
+
+- `docs/TOY_DEVELOPMENT.md` - Full toy development playbook.
+- `docs/TOY_TESTING_SPEC.md` - Automated testing specification.
+- `docs/ARCHITECTURE.md` - System architecture overview.

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -1,0 +1,22 @@
+# Tooling & Quality Checks
+
+## Package manager
+
+- Prefer **Bun** tooling to match the repo `packageManager`.
+- For dependency changes, install with `bun install --frozen-lockfile`.
+- Run scripts with `bun run ...`.
+
+## Linting & formatting
+
+- Use **Biome** for linting and formatting. Do not use ESLint or Prettier.
+
+## Required checks
+
+- For JavaScript/TypeScript changes, run the relevant quality checks before committing:
+  - `bun run check` (Biome + tests)
+  - `bun run typecheck`
+
+## Documentation-only changes
+
+- For Markdown/prose-only changes, you can skip `bun run typecheck` and `bun run test`.
+- Still run `bun run format` on touched docs.

--- a/docs/agents/toy-development.md
+++ b/docs/agents/toy-development.md
@@ -1,0 +1,16 @@
+# Toy Development
+
+## Project structure
+
+- Toy modules: `assets/js/toys/` (TypeScript modules exporting `start()`)
+- Toy registry: `assets/js/toys-data.js` (slugs, metadata, capabilities)
+- Legacy HTML toys: `toys/` directory (standalone pages)
+- Loader logic: `toy.html` + `assets/js/loader.ts`
+- Audio handling: `assets/js/core/audio-handler.ts`
+
+## Key patterns
+
+- Every toy module exports `start({ container, canvas?, audioContext? })`.
+- `start()` returns a cleanup function that removes all DOM nodes.
+- Audio reactivity uses `registerToyGlobals` to expose `startAudio` and `startAudioFallback`.
+- Toys support microphone input or demo audio fallback.

--- a/docs/agents/toy-workflows.md
+++ b/docs/agents/toy-workflows.md
@@ -1,0 +1,48 @@
+# Toy Workflows & Commands
+
+## Agent workflows
+
+Use these workflows (in `.agent/workflows/`) to interact with toys:
+
+| Workflow | Command | Purpose |
+| --- | --- | --- |
+| `/create-toy` | Create new toy module | Scaffold a new toy with the standard template |
+| `/play-toy` | Launch toy in browser | Start dev server and interact with toys |
+| `/test-toy` | Run toy tests | Execute automated tests for toys |
+
+## Quick commands
+
+```bash
+# Create a new toy
+bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test
+
+# Check all toys are registered correctly
+bun run check:toys
+
+# Run all tests
+bun test
+
+# Start dev server for interactive testing
+bun run dev
+
+# Type check
+bun run typecheck
+
+# Full quality check (lint + tests)
+bun run check
+```
+
+## Testing a specific toy
+
+1. Start dev server: `bun run dev`
+2. Navigate to: `http://localhost:5173/toy.html?toy=<slug>`
+3. Click "Use demo audio" to bypass microphone permissions
+4. Verify visuals render and respond to audio
+
+## Common toy slugs
+
+- `holy` - Ultimate Satisfying Visualizer
+- `geom` - Geometry Visualizer
+- `spiral-burst` - Spiral Burst
+- `neon-wave` - Neon Wave
+- `milkdrop` - MilkDrop Proto


### PR DESCRIPTION
### Motivation
- Reduce cognitive load by surfacing only essentials in the root `AGENTS.md` and moving detailed guidance into focused, discoverable files. 
- Ensure every agent sees the one-line project description, package manager, non-standard commands, and metadata expectations up front. 
- Improve discoverability by linking a scoped `docs/agents/` index from the central docs map. 

### Description
- Replace `AGENTS.md` with a minimal essentials-only file containing the project one-liner, `Bun` package manager guidance, required JS/TS quality gates, and metadata conventions. 
- Add `docs/agents/` files: `README.md`, `tooling-and-quality.md`, `metadata-and-docs.md`, `toy-development.md`, `toy-workflows.md`, and `reference-docs.md` to hold the detailed guidance. 
- Update `docs/README.md` to link the new `docs/agents/README.md`. 
- Apply Biome formatting and commit the reorganized docs. 

### Testing
- Ran `bun run format`, which completed successfully. 
- Ran `biome lint assets scripts tests`, which reported no errors. 
- Ran `biome format --write assets scripts tests`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d247479b083329d59d3308c1af746)