### PR TITLE
Refine hero CTA hierarchy and hide search-clear from tab order

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -12,8 +12,6 @@ body {
   /* Mobile-specific improvements */
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  user-select: none;
 }
 canvas {
   display: block;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -911,9 +911,21 @@ header.hero {
   box-shadow: var(--shadow-soft);
 }
 
+.hero-cta-row .cta-button.primary {
+  padding: 0.85rem 1.6rem;
+  font-size: 1.05rem;
+  box-shadow: var(--shadow-strong);
+}
+
 .cta-button.ghost {
   background: transparent;
   border-color: transparent;
+}
+
+.hero-cta-row .cta-button.ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--surface-border);
+  color: var(--text-muted);
 }
 
 .cta-button:hover {

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
             Tap a stim and go. Light, fast, and built for instant immersion.
           </p>
         </div>
-        <div class="cta-row">
+        <div class="cta-row hero-cta-row">
           <a
             href="toy.html?toy=holy"
             class="cta-button primary"
@@ -208,6 +208,8 @@
                 type="button"
                 class="search-clear"
                 data-search-clear
+                aria-hidden="true"
+                tabindex="-1"
                 aria-label="Clear search"
               >
                 Clear
@@ -475,6 +477,12 @@
           if (clearSearchButton instanceof HTMLElement) {
             const hasQuery = cachedQuery.trim().length > 0;
             clearSearchButton.classList.toggle('is-visible', hasQuery);
+            clearSearchButton.setAttribute('aria-hidden', String(!hasQuery));
+            if (hasQuery) {
+              clearSearchButton.removeAttribute('tabindex');
+            } else {
+              clearSearchButton.setAttribute('tabindex', '-1');
+            }
           }
           if (resetFiltersButton instanceof HTMLElement) {
             const hasFilters = activeFilters.size > 0;


### PR DESCRIPTION
### Motivation
- Improve hero call-to-action prominence and visual hierarchy while softening secondary CTAs for clarity.
- Avoid invisible focus stops from the search clear control and restore normal text selection outside the canvas for better usability.

### Description
- Add `hero-cta-row` to the hero CTA container and update `assets/css/index.css` to increase the primary CTA padding and font size and apply a stronger shadow, and to tone down hero ghost buttons.
- Remove global `user-select: none` from `html, body` in `assets/css/base.css` and keep `user-select: none` on the `canvas` element to preserve selection behavior where appropriate.
- Make the search clear button initially `aria-hidden` and `tabindex="-1"` in `index.html` and update the `updateControlVisibility` function to toggle `aria-hidden` and `tabindex` so the button is excluded from the tab order when hidden and restored when visible.

### Testing
- Ran `bun run check` which ran linters, typecheck, and tests and showed linters/formatters passed but the test run failed overall.
- Test summary from the run: `71 passed, 3 failed` across the suite, with failures due to missing Playwright browser binaries causing agent tests to fail and one failing `app-shell` test that expected `mockLoadToy` to be called.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d6d7fc94c8332824a0180b26b4d9d)