### PR TITLE
Improve library responsiveness and audio feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,8 @@
           <p class="eyebrow">System check</p>
           <h2>Confirm your device is ready</h2>
           <p class="section-description">
-            Get clear feedback on graphics, microphone access, and performance
+            Live readiness updates automatically. Open the system check for a
+            deeper read on graphics, microphone access, and performance
             presets before launching a stim. If mic access is blocked, demo,
             tab, and YouTube audio are available in the toy controls.
           </p>
@@ -178,7 +179,7 @@
         </div>
         <div class="cta-row system-actions">
           <button type="button" class="cta-button primary" data-open-preflight>
-            Run system check
+            Open system check
           </button>
           <a href="#toy-list" class="cta-button ghost">Browse toys</a>
         </div>
@@ -746,7 +747,7 @@
             });
         };
 
-        const scheduleRender = (query = cachedQuery, delay = 150) => {
+        const scheduleRender = (query = cachedQuery, delay = 50) => {
           if (pendingRender) {
             window.clearTimeout(pendingRender);
           }

--- a/toy.html
+++ b/toy.html
@@ -124,9 +124,6 @@
             if (!starter) throw new Error('Audio starter unavailable.');
             return starter({ stream });
           },
-          onSuccess: () => {
-            if (controlsContainer) controlsContainer.hidden = true;
-          },
           ...buildAudioInitState(result),
         });
       };


### PR DESCRIPTION
### Motivation
- Improve perceived responsiveness when filtering the library by reducing the debounce on card renders.  
- Make system readiness messaging clearer and the system-check CTA more direct.  
- Prevent audio controls from being globally disabled during source selection so alternate audio paths remain available while showing source-specific success feedback.

### Description
- Update copy and CTA in `index.html` to clarify live readiness and change the button label to `Open system check`.  
- Reduce the library search render debounce by changing `scheduleRender` delay from `150` to `50` ms in `index.html`.  
- Refactor `assets/js/ui/audio-controls.ts` to only disable the active trigger during requests by setting `data-loading`, `aria-busy`, and the button `disabled` state per-button, and to surface per-source success messages for microphone, demo, tab, and YouTube flows.  
- Keep audio controls visible after startup by removing the auto-hide behavior in `toy.html` so controls remain available post-start.

### Testing
- Ran `bun run check` which runs lint/format/typecheck and tests, and it reported failures in several tests (10 failing), primarily due to Playwright browser binaries missing and loader-related expectations (`createLoader` not found).  
- Ran `bun run typecheck` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6dc63c048332b5e79990a5155b3d)