### PR TITLE
Expand palette moods and gesture/keyboard controls for Aurora, Spiral, and Star toys

### DIFF
--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -15,6 +15,13 @@ export default [
     module: 'assets/js/toys/aurora-painter.ts',
     type: 'module',
     requiresWebGPU: false,
+    moods: ['dreamy', 'ethereal', 'luminous'],
+    tags: ['aurora', 'ribbons', 'gestural'],
+    controls: [
+      'Ribbon density',
+      'Pinch/rotate gestures',
+      'Arrow-key mood switching',
+    ],
   },
   {
     slug: 'clay',
@@ -129,6 +136,9 @@ export default [
     module: 'assets/js/toys/spiral-burst.ts',
     type: 'module',
     requiresWebGPU: false,
+    moods: ['energetic', 'pulsing', 'cosmic'],
+    tags: ['spirals', 'burst', 'gestural'],
+    controls: ['Mode buttons', 'Pinch/rotate gestures', 'Arrow-key mode swap'],
   },
   {
     slug: 'rainbow-tunnel',
@@ -145,6 +155,9 @@ export default [
     module: 'assets/js/toys/star-field.ts',
     type: 'module',
     requiresWebGPU: false,
+    moods: ['serene', 'drifting', 'celestial'],
+    tags: ['stars', 'nebula', 'gestural'],
+    controls: ['Pinch/rotate gestures', 'Arrow-key mood switching'],
   },
   {
     slug: 'fractal-kite-garden',
@@ -174,7 +187,15 @@ export default [
     module: 'assets/js/toys/bioluminescent-tidepools.ts',
     type: 'module',
     requiresWebGPU: false,
-    controls: ['Trail length', 'Glow strength', 'Current speed'],
+    moods: ['serene', 'ethereal', 'fiery', 'dreamy'],
+    tags: ['ocean', 'bioluminescent', 'caustics', 'gestural'],
+    controls: [
+      'Trail length',
+      'Glow strength',
+      'Current speed',
+      'Pinch/rotate gestures',
+      'Arrow-key mood switching',
+    ],
   },
   {
     slug: 'neon-wave',

--- a/assets/js/toys/aurora-painter.ts
+++ b/assets/js/toys/aurora-painter.ts
@@ -17,11 +17,70 @@ import {
   resolveToyAudioOptions,
   type ToyAudioRequest,
 } from '../utils/audio-start';
+import { createPointerInput } from '../utils/pointer-input';
 import { startToyAudio } from '../utils/start-audio';
+
+type AuroraPalette = {
+  name: string;
+  background: THREE.ColorRepresentation;
+  fog: THREE.ColorRepresentation;
+  light: THREE.ColorRepresentation;
+  emissive: THREE.ColorRepresentation;
+  hueShift: number;
+  saturation: number;
+};
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
   const settingsPanel = getSettingsPanel();
   let activeQuality: QualityPreset = getActiveQualityPreset();
+  let activePaletteIndex = 0;
+
+  const palettes: AuroraPalette[] = [
+    {
+      name: 'Polar',
+      background: '#03060c',
+      fog: '#03060c',
+      light: '#aadfff',
+      emissive: '#0b1327',
+      hueShift: 0.52,
+      saturation: 0.82,
+    },
+    {
+      name: 'Solarflare',
+      background: '#120509',
+      fog: '#120509',
+      light: '#ffd0b8',
+      emissive: '#3b0e14',
+      hueShift: 0.98,
+      saturation: 0.78,
+    },
+    {
+      name: 'Verdant',
+      background: '#021512',
+      fog: '#021512',
+      light: '#b6ffe8',
+      emissive: '#043326',
+      hueShift: 0.34,
+      saturation: 0.86,
+    },
+    {
+      name: 'Amethyst',
+      background: '#07051f',
+      fog: '#07051f',
+      light: '#e1c1ff',
+      emissive: '#200e48',
+      hueShift: 0.72,
+      saturation: 0.8,
+    },
+  ];
+
+  const controls = {
+    speed: 1,
+    glow: 1,
+  };
+  let targetSpeed = controls.speed;
+  let targetGlow = controls.glow;
+  let rotationLatch = 0;
 
   const toy = new WebToy({
     cameraOptions: { position: { x: 0, y: 0, z: 45 }, fov: 60 },
@@ -160,9 +219,13 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
     const swirl = time * 0.65 + ribbon.colorOffset * Math.PI * 2;
     const sway =
-      Math.sin(time * 1.3 + ribbon.colorOffset * 4) * (0.7 + bass / 260);
+      Math.sin(time * 1.3 + ribbon.colorOffset * 4) *
+      (0.7 + bass / 260) *
+      controls.speed;
     const lift =
-      Math.cos(time * 0.9 + ribbon.colorOffset * 2) * (0.6 + treble / 400);
+      Math.cos(time * 0.9 + ribbon.colorOffset * 2) *
+      (0.6 + treble / 400) *
+      controls.speed;
 
     ribbon.points[0].set(
       Math.cos(swirl) * (8 + avg / 45) + sway,
@@ -176,21 +239,26 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     ribbon.mesh.geometry = new THREE.TubeGeometry(
       ribbon.curve,
       ribbon.tubeSegments,
-      radius,
+      radius * (0.8 + controls.glow * 0.3),
       16,
       false,
     );
 
     const material = ribbon.mesh.material as THREE.MeshStandardMaterial;
-    const hue = (0.52 + ribbon.colorOffset + avg / 360 + time * 0.025) % 1;
-    material.color.setHSL(hue, 0.8, 0.52 + treble / 520);
-    material.opacity = 0.55 + Math.min(0.4, bass / 260);
-    material.emissiveIntensity = 0.25 + avg / 380;
+    const palette = palettes[activePaletteIndex];
+    const hue =
+      (palette.hueShift + ribbon.colorOffset + avg / 360 + time * 0.025) % 1;
+    material.color.setHSL(hue, palette.saturation, 0.52 + treble / 520);
+    material.opacity = 0.45 + Math.min(0.45, bass / 260) * controls.glow;
+    material.emissiveIntensity = 0.25 + (avg / 380) * controls.glow;
   }
 
   function animate(ctx: AnimationContext) {
     const data = getContextFrequencyData(ctx);
-    const time = performance.now() * 0.0015;
+    controls.speed = THREE.MathUtils.lerp(controls.speed, targetSpeed, 0.08);
+    controls.glow = THREE.MathUtils.lerp(controls.glow, targetGlow, 0.08);
+
+    const time = performance.now() * 0.0015 * controls.speed;
 
     ribbons.forEach((ribbon) => updateRibbon(ribbon, data, time));
 
@@ -230,7 +298,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     settingsPanel.configure({
       title: 'Aurora painter',
       description:
-        'Control render scale and ribbon density without restarting audio.',
+        'Control render scale and ribbon density without restarting audio. Pinch to swell the ribbons and rotate to switch moods.',
     });
     settingsPanel.setQualityPresets({
       presets: DEFAULT_QUALITY_PRESETS,
@@ -247,10 +315,82 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     );
   }
 
+  function applyPalette(index: number) {
+    const palette = palettes[index];
+    toy.scene.background = new THREE.Color(palette.background);
+    if (toy.scene.fog instanceof THREE.FogExp2) {
+      toy.scene.fog.color = new THREE.Color(palette.fog);
+    }
+    const light = toy.scene.children.find(
+      (child) => child instanceof THREE.DirectionalLight,
+    ) as THREE.DirectionalLight | undefined;
+    if (light) {
+      light.color = new THREE.Color(palette.light);
+    }
+    ribbons.forEach((ribbon) => {
+      const material = ribbon.mesh.material as THREE.MeshStandardMaterial;
+      material.emissive = new THREE.Color(palette.emissive);
+    });
+  }
+
+  const pointerInput = createPointerInput({
+    target: window,
+    boundsElement: toy.canvas,
+    onChange: (summary) => {
+      if (!summary.pointers.length) return;
+      const centroid = summary.normalizedCentroid;
+      targetGlow = THREE.MathUtils.clamp(1 + centroid.y * 0.35, 0.7, 1.6);
+      targetSpeed = THREE.MathUtils.clamp(1 + centroid.x * 0.35, 0.7, 1.6);
+    },
+    onGesture: (gesture) => {
+      if (gesture.pointerCount < 2) return;
+      targetGlow = THREE.MathUtils.clamp(
+        targetGlow + (gesture.scale - 1) * 0.4,
+        0.7,
+        1.7,
+      );
+      targetSpeed = THREE.MathUtils.clamp(
+        targetSpeed + gesture.translation.x * 0.5,
+        0.6,
+        1.8,
+      );
+      if (rotationLatch <= 0.45 && gesture.rotation > 0.45) {
+        activePaletteIndex = (activePaletteIndex + 1) % palettes.length;
+        applyPalette(activePaletteIndex);
+      } else if (rotationLatch >= -0.45 && gesture.rotation < -0.45) {
+        activePaletteIndex =
+          (activePaletteIndex - 1 + palettes.length) % palettes.length;
+        applyPalette(activePaletteIndex);
+      }
+      rotationLatch = gesture.rotation;
+    },
+    preventGestures: false,
+  });
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowRight') {
+      activePaletteIndex = (activePaletteIndex + 1) % palettes.length;
+      applyPalette(activePaletteIndex);
+    } else if (event.key === 'ArrowLeft') {
+      activePaletteIndex =
+        (activePaletteIndex - 1 + palettes.length) % palettes.length;
+      applyPalette(activePaletteIndex);
+    } else if (event.key === 'ArrowUp') {
+      targetSpeed = THREE.MathUtils.clamp(targetSpeed + 0.1, 0.6, 1.8);
+    } else if (event.key === 'ArrowDown') {
+      targetSpeed = THREE.MathUtils.clamp(targetSpeed - 0.1, 0.6, 1.8);
+    }
+  }
+
   setupSettingsPanel();
   if (!ribbons.length) {
     rebuildRibbons();
   }
+  applyPalette(activePaletteIndex);
+  if (toy.canvas instanceof HTMLElement) {
+    toy.canvas.style.touchAction = 'manipulation';
+  }
+  window.addEventListener('keydown', handleKeydown);
 
   // Register globals for toy.html buttons
   // Register globals for toy.html buttons
@@ -260,7 +400,8 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     dispose: () => {
       toy.dispose();
       disposeRibbons();
-      disposeRibbons();
+      pointerInput.dispose();
+      window.removeEventListener('keydown', handleKeydown);
       unregisterGlobals();
     },
   };

--- a/public/toys.json
+++ b/public/toys.json
@@ -17,8 +17,8 @@
     "module": "assets/js/toys/aurora-painter.ts",
     "type": "module",
     "requiresWebGPU": false,
-    "tags": ["aurora", "painting", "ribbons"],
-    "moods": ["calm", "flow"],
+    "tags": ["aurora", "ribbons", "gestural"],
+    "moods": ["dreamy", "ethereal", "luminous"],
     "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
@@ -161,8 +161,8 @@
     "module": "assets/js/toys/spiral-burst.ts",
     "type": "module",
     "requiresWebGPU": false,
-    "tags": ["spiral", "burst", "particles", "modes", "beat-detection", "3d"],
-    "moods": ["vivid", "excited", "immersive", "energetic"],
+    "tags": ["spiral", "burst", "gestural", "modes", "beat-detection", "3d"],
+    "moods": ["energetic", "pulsing", "cosmic"],
     "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
@@ -183,8 +183,8 @@
     "module": "assets/js/toys/star-field.ts",
     "type": "module",
     "requiresWebGPU": false,
-    "tags": ["stars", "space", "shimmer"],
-    "moods": ["calm", "dreamy"],
+    "tags": ["stars", "nebula", "gestural"],
+    "moods": ["serene", "drifting", "celestial"],
     "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   },
   {
@@ -216,8 +216,8 @@
     "module": "assets/js/toys/bioluminescent-tidepools.ts",
     "type": "module",
     "requiresWebGPU": false,
-    "tags": ["ocean", "bioluminescent", "currents"],
-    "moods": ["serene", "glowing"],
+    "tags": ["ocean", "bioluminescent", "caustics", "gestural"],
+    "moods": ["serene", "ethereal", "fiery", "dreamy"],
     "capabilities": { "microphone": true, "demoAudio": true, "motion": false }
   }
 ]


### PR DESCRIPTION
### Motivation
- Provide richer, mood-driven visuals and on-canvas controls so users can change palettes and shape behavior with touch gestures and keyboard shortcuts without opening settings. 
- Surface consistent gestural affordances (pinch/rotate) and keyboard fallbacks across multiple toys while keeping mobile touch latency improvements via `touch-action: manipulation`.
- Improve audio-reactive expressiveness by exposing shader/preset uniforms for glow/caustics/particle behavior and smoothing control changes for stable frame rates.

### Description
- Added palette types and arrays and wired palette-driven colors into rendering for `Aurora Painter`, `Spiral Burst`, and `Star Field`, and extended `Bioluminescent Tidepools` with a `TidePalette` and new shader uniforms; updates live in `assets/js/toys/aurora-painter.ts`, `assets/js/toys/spiral-burst.ts`, `assets/js/toys/star-field.ts`, and `assets/js/toys/bioluminescent-tidepools.ts`.
- Hooked up `createPointerInput` with `onChange` and `onGesture` handlers to modulate runtime control targets (speed/boosts/drift/glow/threshold/trail length), added smooth lerp interpolation to avoid abrupt changes, and enabled `preventGestures: false` to allow pinch/rotate gestures.
- Added keyboard handlers (arrow keys) to cycle palettes or change modes/controls and ensured proper cleanup by disposing `pointerInput` and removing `keydown` listeners in each toy `dispose`.
- Introduced a small nebula shader backdrop for `Star Field`, added per-toy shader uniforms for palette colors (including tidepool caustics/foam), and updated metadata rows in `assets/js/toys-data.js` and `public/toys.json` to reflect new `moods`, `tags`, and `controls`.

### Testing
- Ran `bun run check` (runs `biome check`, `tsc --noEmit`, and the test suite); formatting and typecheck passed but the full test run failed due to Playwright browser binaries missing in the agent environment causing 2 failing agent integration tests (Playwright launch errors).
- Ran `biome format` / `bun run format` and formatting completed successfully with fixes applied.
- Note: CI-local visual verification (dev server + screenshots) was exercised during development but is not part of the automated test results above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea547bb988332a8df346573eb4aed)