### PR TITLE
Disable WebGPU on mobile devices

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -36,6 +36,12 @@ let cachedEnvironmentKey: unknown = null;
 let telemetryHandler: RendererTelemetryHandler | null = null;
 let telemetryReportedKey: unknown = null;
 
+const isMobileUserAgent =
+  typeof navigator !== 'undefined' &&
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent,
+  );
+
 const buildFallback = (
   fallbackReason: string,
   { triedWebGPU = false, shouldRetryWebGPU = false }: FallbackOptions = {},
@@ -92,6 +98,15 @@ async function probeRendererCapabilities(): Promise<RendererCapabilities> {
   if (isCompatibilityModeEnabled()) {
     return cacheResult(
       buildFallback('Compatibility mode is enabled. Using WebGL.', {
+        triedWebGPU: false,
+        shouldRetryWebGPU: false,
+      }),
+    );
+  }
+
+  if (isMobileUserAgent) {
+    return cacheResult(
+      buildFallback('WebGPU is disabled on mobile devices. Using WebGL.', {
         triedWebGPU: false,
         shouldRetryWebGPU: false,
       }),


### PR DESCRIPTION
### Motivation
- Mobile browsers show unstable WebGPU behavior and several toys fail on smartphones, so force a safer WebGL path for mobile user agents to improve reliability and performance.

### Description
- Add a mobile user-agent check and short-circuit WebGPU probing to return a WebGL fallback in `assets/js/core/renderer-capabilities.ts`.
- This makes the renderer prefer WebGL on Android/iOS and similar mobile UA strings to avoid attempting WebGPU on phones.

### Testing
- Ran `bun run check` (runs `biome check`, `tsc --noEmit`, and tests); `biome` and `tsc` passed but the test suite failed due to Playwright browsers missing (`chromium_headless_shell`), causing the overall check to fail.
- Ran `bun run typecheck` which succeeded (`tsc --noEmit`).

Docs
- none

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eabe6dc2c8332ad0975ab09a0669a)