### PR TITLE
Inject lighting constructors for tests

### DIFF
--- a/assets/js/lighting/lighting-setup.ts
+++ b/assets/js/lighting/lighting-setup.ts
@@ -27,6 +27,13 @@ type LightingInstance =
   | HemisphereLight
   | PointLight;
 
+type LightingConstructors = {
+  DirectionalLight: typeof DirectionalLight;
+  SpotLight: typeof SpotLight;
+  HemisphereLight: typeof HemisphereLight;
+  PointLight: typeof PointLight;
+};
+
 export function initLighting(
   scene: SceneLike,
   config: LightConfig = {
@@ -35,6 +42,12 @@ export function initLighting(
     intensity: 1,
     position: { x: 10, y: 10, z: 10 },
     castShadow: false,
+  },
+  constructors: LightingConstructors = {
+    DirectionalLight,
+    SpotLight,
+    HemisphereLight,
+    PointLight,
   },
 ): void {
   const {
@@ -46,28 +59,34 @@ export function initLighting(
   } = config ?? {};
 
   const { x, y, z } = { x: 10, y: 10, z: 10, ...(position ?? {}) };
+  const {
+    DirectionalLight: DirectionalLightConstructor,
+    SpotLight: SpotLightConstructor,
+    HemisphereLight: HemisphereLightConstructor,
+    PointLight: PointLightConstructor,
+  } = constructors;
   let light: LightingInstance;
 
   switch (type) {
     case 'DirectionalLight':
-      light = new DirectionalLight(color, intensity);
+      light = new DirectionalLightConstructor(color, intensity);
       light.position.set(x, y, z);
       if (castShadow) {
         light.castShadow = true;
       }
       break;
     case 'SpotLight':
-      light = new SpotLight(color, intensity);
+      light = new SpotLightConstructor(color, intensity);
       light.position.set(x, y, z);
       if (castShadow) {
         light.castShadow = true;
       }
       break;
     case 'HemisphereLight':
-      light = new HemisphereLight(color, 0x444444, intensity);
+      light = new HemisphereLightConstructor(color, 0x444444, intensity);
       break;
     default:
-      light = new PointLight(color, intensity);
+      light = new PointLightConstructor(color, intensity);
       light.position.set(x, y, z);
       if (castShadow) {
         light.castShadow = true;

--- a/tests/lighting-setup.test.js
+++ b/tests/lighting-setup.test.js
@@ -13,7 +13,16 @@ describe('initLighting', () => {
   test('uses default position values when position is omitted', () => {
     const scene = new Scene();
 
-    initLighting(scene, { type: 'DirectionalLight' }, stubLighting);
+    initLighting(
+      scene,
+      { type: 'DirectionalLight' },
+      {
+        DirectionalLight: stubLighting.DirectionalLight,
+        SpotLight: stubLighting.SpotLight,
+        HemisphereLight: stubLighting.HemisphereLight,
+        PointLight: stubLighting.PointLight,
+      },
+    );
 
     expect(scene.children).toHaveLength(1);
     const light = scene.children[0];
@@ -29,7 +38,12 @@ describe('initLighting', () => {
     initLighting(
       scene,
       { type: 'DirectionalLight', position: { y: 5 } },
-      stubLighting,
+      {
+        DirectionalLight: stubLighting.DirectionalLight,
+        SpotLight: stubLighting.SpotLight,
+        HemisphereLight: stubLighting.HemisphereLight,
+        PointLight: stubLighting.PointLight,
+      },
     );
 
     const light = scene.children[0];
@@ -42,7 +56,16 @@ describe('initLighting', () => {
     const scene = new Scene();
 
     expect(() =>
-      initLighting(scene, { type: 'HemisphereLight' }, stubLighting),
+      initLighting(
+        scene,
+        { type: 'HemisphereLight' },
+        {
+          DirectionalLight: stubLighting.DirectionalLight,
+          SpotLight: stubLighting.SpotLight,
+          HemisphereLight: stubLighting.HemisphereLight,
+          PointLight: stubLighting.PointLight,
+        },
+      ),
     ).not.toThrow();
     expect(scene.children[0]).toBeInstanceOf(stubLighting.HemisphereLight);
   });


### PR DESCRIPTION
### Motivation
- Allow unit tests to use lightweight `three` stubs so `instanceof` assertions work without constructing real Three.js classes.

### Description
- Add a `LightingConstructors` type and an optional `constructors` parameter to `initLighting` that defaults to the real `DirectionalLight`, `SpotLight`, `HemisphereLight`, and `PointLight` constructors.
- Use the injected constructors when creating lights inside `initLighting`.
- Update `tests/lighting-setup.test.js` to pass stub constructors from `tests/three-stub.ts` so the tests assert against the stub classes.

### Testing
- Ran `bun run check` (runs `biome check`, `bun run typecheck`, and `bun test`) which produced 72 passed and 2 failing tests; the failures are in Playwright-based integration tests due to missing browser binaries and not related to the lighting changes (error: install browsers with `npx playwright install`).
- The `lighting-setup` unit tests now pass after injecting constructors.
- Docs: none changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eafa26f448332b876dd71b4f695de)