### PR TITLE
Skip agent integration tests when Playwright Chromium is missing

### DIFF
--- a/tests/agent-integration.test.ts
+++ b/tests/agent-integration.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from 'bun:test';
+import fs from 'node:fs';
+import { chromium } from 'playwright';
 import { playToy } from '../scripts/play-toy.ts';
 
-test(
+const chromiumPath = chromium.executablePath();
+const hasChromium = fs.existsSync(chromiumPath);
+const integrationTest = hasChromium ? test : test.skip;
+
+integrationTest(
   'agents can launch and capture holy toy',
   async () => {
     // Increase timeout for browser launch
@@ -20,7 +26,7 @@ test(
   { timeout: 30000 },
 );
 
-test(
+integrationTest(
   'agents can detect failing toy',
   async () => {
     const result = await playToy({


### PR DESCRIPTION
### Motivation
- Prevent CI/local failures when Playwright's Chromium binary is not installed by skipping browser-dependent integration tests.

### Description
- Update `tests/agent-integration.test.ts` to detect the Playwright Chromium executable and choose `test` or `test.skip` dynamically.
- Add `fs` and `chromium` imports and compute `chromium.executablePath()` to set `hasChromium` and `integrationTest` alias.
- Replace direct `test(...)` calls with `integrationTest(...)` to avoid TypeScript issues with a non-existent `skip` option and to keep imports organized.
- No docs were modified.

### Testing
- Ran `bun run check` (Biome lint/format, `tsc --noEmit`, and `bun test`); the command completed successfully with browser tests skipped.
- Test summary: 74 tests executed, 72 passed, 2 skipped, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eafa26f448332b876dd71b4f695de)