### PR TITLE
Add synthetic audio fallback motion

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -2,7 +2,7 @@ import type {
   AudioInitOptions,
   FrequencyAnalyser,
 } from '../utils/audio-handler';
-import { getFrequencyData } from '../utils/audio-handler';
+import { getAverageFrequency, getFrequencyData } from '../utils/audio-handler';
 
 // biome-ignore lint/suspicious/noExplicitAny: generic toy instance
 type WebToyInstance = any;
@@ -14,6 +14,40 @@ export interface AnimationContext {
   toy: WebToyInstance;
   analyser: FrequencyAnalyser | null;
   time: number;
+}
+
+const fallbackBuffers = new Map<number, Uint8Array>();
+const FALLBACK_BIN_COUNT = 64;
+const SILENCE_THRESHOLD = 6;
+
+function getFallbackBuffer(length: number): Uint8Array {
+  if (!fallbackBuffers.has(length)) {
+    fallbackBuffers.set(length, new Uint8Array(length));
+  }
+  return fallbackBuffers.get(length) as Uint8Array;
+}
+
+function fillSyntheticFrequencyData(
+  buffer: Uint8Array,
+  time: number,
+): Uint8Array {
+  const len = buffer.length;
+  const pulse = (Math.sin(time * 0.8) + 1) / 2;
+  const ripple = (Math.sin(time * 0.35) + 1) / 2;
+  const base = 18 + pulse * 12;
+  const amplitude = 24 + ripple * 28;
+
+  for (let i = 0; i < len; i += 1) {
+    const ratio = i / len;
+    const wave =
+      Math.sin(time * 1.5 + ratio * Math.PI * 4) * 0.6 +
+      Math.sin(time * 0.7 + ratio * Math.PI * 2) * 0.4;
+    const normalized = wave * 0.5 + 0.5;
+    const value = base + normalized * amplitude;
+    buffer[i] = Math.min(255, Math.max(0, Math.round(value)));
+  }
+
+  return buffer;
 }
 
 /**
@@ -48,8 +82,35 @@ export async function startAudioLoop(
 }
 
 /**
- * Get frequency data from the animation context, with fallback to empty array.
+ * Get frequency data from the animation context, with fallback to synthetic motion.
  */
 export function getContextFrequencyData(ctx: AnimationContext): Uint8Array {
-  return ctx.analyser ? getFrequencyData(ctx.analyser) : new Uint8Array(0);
+  const time = ctx.time ?? 0;
+
+  if (!ctx.analyser) {
+    const buffer = getFallbackBuffer(FALLBACK_BIN_COUNT);
+    return fillSyntheticFrequencyData(buffer, time);
+  }
+
+  const data = getFrequencyData(ctx.analyser);
+  if (data.length === 0) {
+    const buffer = getFallbackBuffer(FALLBACK_BIN_COUNT);
+    return fillSyntheticFrequencyData(buffer, time);
+  }
+
+  const average = getAverageFrequency(data);
+  if (average >= SILENCE_THRESHOLD) {
+    return data;
+  }
+
+  const buffer = getFallbackBuffer(data.length);
+  fillSyntheticFrequencyData(buffer, time);
+  const audioWeight = Math.max(0, average / SILENCE_THRESHOLD);
+  const fallbackWeight = 1 - audioWeight;
+
+  for (let i = 0; i < data.length; i += 1) {
+    buffer[i] = Math.round(buffer[i] * fallbackWeight + data[i] * audioWeight);
+  }
+
+  return buffer;
 }


### PR DESCRIPTION
### Motivation

- Keep toy experiences dynamic and interactive when microphone audio is silent or unavailable by providing a lightweight synthetic frequency fallback and blending it with any low-level audio present.

### Description

- Add synthetic frequency generation and buffer pooling in `assets/js/core/animation-loop.ts` via `fillSyntheticFrequencyData` and `getFallbackBuffer` with constants `FALLBACK_BIN_COUNT` and `SILENCE_THRESHOLD`.
- Update `getContextFrequencyData` to return synthetic data when `ctx.analyser` is null, when analyser data is empty, or when average audio is below the silence threshold, and blend real and synthetic data by `audioWeight` when audio is present but quiet.
- Reuse existing helpers `getFrequencyData` and `getAverageFrequency` to preserve current APIs and animation loop behavior.
- No documentation files were modified.

### Testing

- Ran `bun run check` (runs `tsc --noEmit` and `bun test`) and it completed successfully.
- Ran the test suite via `bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json`, which reported 74 tests across 21 files with `72 pass`, `2 skip`, and `0 fail`.
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb366f76c8332a6810f5aae68f2d8)