### PR TITLE
Improve library accessibility feedback

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1418,6 +1418,14 @@ h1 {
   z-index: 1;
 }
 
+.webtoy-card__link:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 4px;
+  box-shadow:
+    0 0 0 4px rgba(59, 130, 246, 0.15),
+    0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
 .webtoy-card__content {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -215,7 +215,6 @@
               </button>
               <span
                 id="toy-search-hint"
-                aria-hidden="true"
                 class="search-field__hint"
               >
                 Enter a name, tag, or capability
@@ -587,6 +586,8 @@
                 badge.className = 'capability-badge';
                 badge.type = 'button';
                 badge.textContent = badgeData.label;
+                badge.setAttribute('aria-controls', popoverId);
+                badge.setAttribute('aria-expanded', 'false');
                 badge.setAttribute('popovertarget', popoverId);
                 badge.setAttribute('popovertargetaction', 'toggle');
                 badge.setAttribute('aria-describedby', popoverId);
@@ -594,6 +595,12 @@
                 popover.id = popoverId;
                 popover.setAttribute('popover', 'auto');
                 popover.textContent = badgeData.title;
+                popover.addEventListener('toggle', (event) => {
+                  const isOpen =
+                    event?.newState === 'open' ||
+                    popover.matches(':popover-open');
+                  badge.setAttribute('aria-expanded', String(isOpen));
+                });
                 badgeRow.appendChild(badge);
                 badgeRow.appendChild(popover);
               });


### PR DESCRIPTION
### Motivation
- Make library UI more accessible to screen readers by exposing contextual hints and keeping popover controls semantically accurate. 
- Improve keyboard discoverability by giving visible focus styling to card links so keyboard users can see active focus.

### Description
- Removed `aria-hidden` from the search hint so it is announced to assistive technologies (`index.html`).
- Added `aria-controls` and `aria-expanded` to capability badge buttons and wired a `toggle` listener on the popover to keep `aria-expanded` in sync with the popover state (`index.html`).
- Added a `:focus-visible` rule for `.webtoy-card__link` to provide a clear focus ring and shadow for keyboard navigation (`assets/css/index.css`).

### Testing
- Ran `bun run check` which completed successfully. 
- Ran `bun run typecheck` (`tsc --noEmit`) which completed successfully. 
- Ran the test suite with `bun test` which executed 75 tests with 73 passing and 2 skipped and 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2fd536588332b680f6a301a98c35)