### PR TITLE
Improve SVG icon reuse and theming

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1048,6 +1048,14 @@ h1 {
   transform-style: preserve-3d;
 }
 
+.toy-icon-sprite {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
 .repo-status {
   margin: 1.25rem 0 0.25rem;
   padding: 1.1rem 1.2rem;

--- a/assets/ui/mic-off.svg
+++ b/assets/ui/mic-off.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9a2f2f" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="#f5b7b1" stroke="#9a2f2f"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="var(--icon-stroke, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="var(--icon-fill, currentColor)" stroke="var(--icon-accent, currentColor)"/>
   <path d="M12 18v4" />
   <path d="M9 22h6" />
   <path d="M5 11v1a7 7 0 0 0 9.5 6.5" />

--- a/assets/ui/mic-on.svg
+++ b/assets/ui/mic-on.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="#57d38c" stroke="#1c7c4b"/>
-  <path d="M12 2v4" stroke="#1c7c4b"/>
-  <path d="M5 11v1a7 7 0 0 0 14 0v-1" stroke="#1c7c4b"/>
-  <path d="M12 18v4" stroke="#1c7c4b"/>
-  <path d="M9 22h6" stroke="#1c7c4b"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="var(--icon-stroke, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="4" width="8" height="12" rx="4" ry="4" fill="var(--icon-fill, currentColor)" stroke="var(--icon-accent, currentColor)"/>
+  <path d="M12 2v4" stroke="var(--icon-accent, currentColor)"/>
+  <path d="M5 11v1a7 7 0 0 0 14 0v-1" stroke="var(--icon-accent, currentColor)"/>
+  <path d="M12 18v4" stroke="var(--icon-accent, currentColor)"/>
+  <path d="M9 22h6" stroke="var(--icon-accent, currentColor)"/>
 </svg>

--- a/assets/ui/speech-off.svg
+++ b/assets/ui/speech-off.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7a2b87" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M6 6h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V9a3 3 0 0 1 3-3z" fill="#f2d9f8" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="var(--icon-stroke, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 6h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V9a3 3 0 0 1 3-3z" fill="var(--icon-fill, currentColor)" />
   <path d="M15 16v1a3 3 0 0 1-3 3h-2l-3 2v-5" />
   <line x1="5" y1="5" x2="19" y2="19" />
 </svg>

--- a/assets/ui/speech-on.svg
+++ b/assets/ui/speech-on.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1b5fad" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M6 5h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V8a3 3 0 0 1 3-3z" fill="#b6d4ff" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="var(--icon-stroke, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 5h8a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3H9l-4 3V8a3 3 0 0 1 3-3z" fill="var(--icon-fill, currentColor)" />
   <path d="M15 15v1a3 3 0 0 1-3 3h-2l-3 2v-5" />
-  <circle cx="18" cy="8" r="3" fill="#1b5fad" stroke="none" />
-  <path d="M18 6v4" stroke="#fff" />
-  <path d="M16 8h4" stroke="#fff" />
+  <circle cx="18" cy="8" r="3" fill="var(--icon-accent, currentColor)" stroke="none" />
+  <path d="M18 6v4" stroke="var(--icon-contrast, #fff)" />
+  <path d="M16 8h4" stroke="var(--icon-contrast, #fff)" />
 </svg>


### PR DESCRIPTION
### Motivation

- Reduce repeated SVG markup and DOM size for library cards by reusing icon definitions.  
- Simplify and optimize grid-based icon rendering using SVG patterns instead of many DOM nodes.  
- Make UI microphone/speech icons themeable so their colors can match the site theme via CSS.

### Description

- Introduced `createPattern` and updated `addGrid` to render tiled icon grids via an SVG `<pattern>` (accepts `patternId`), reducing per-tile DOM churn.  
- Implemented an SVG symbol sprite system (`ensureIconSprite`, `ensureIconSymbol`, `createSymbolFromTemplate`) and switched library cards to render icons with an inline `<svg><use href="#..."/></svg>` instead of cloning and rewriting IDs.  
- Removed the prior ID-rewriting clone approach and associated instance counter, and added `.toy-icon-sprite` CSS to hide the sprite.  
- Updated UI mic/speech SVG assets to use `currentColor`/CSS variables (`--icon-stroke`, `--icon-fill`, `--icon-accent`, `--icon-contrast`) so their colors can be themed by CSS.

### Testing

- Ran the full repo check with `bun run check`, which completed successfully and executed the test suite.  
- Test summary: 73 tests passed, 2 skipped, 0 failed (all automated tests green).  
- Formatting and type checks ran as part of `bun run check` and reported no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f35abde1c8332954791e95ae4060c)