### PR TITLE
Add shared Three.js postprocessing helpers and instanced shapes

### DIFF
--- a/assets/js/core/postprocessing.ts
+++ b/assets/js/core/postprocessing.ts
@@ -1,0 +1,70 @@
+import type { Camera, Scene, WebGLRenderer } from 'three';
+import { Vector2 } from 'three';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+
+export type PostprocessingPipeline = {
+  composer: EffectComposer;
+  bloomPass?: UnrealBloomPass;
+  render: () => void;
+  updateSize: () => void;
+  dispose: () => void;
+};
+
+export function isWebGLRenderer(renderer: unknown): renderer is WebGLRenderer {
+  return (
+    !!renderer &&
+    typeof renderer === 'object' &&
+    'capabilities' in renderer &&
+    'extensions' in renderer
+  );
+}
+
+export function createBloomComposer({
+  renderer,
+  scene,
+  camera,
+  bloomStrength,
+  bloomRadius = 0.4,
+  bloomThreshold = 0.85,
+}: {
+  renderer: WebGLRenderer;
+  scene: Scene;
+  camera: Camera;
+  bloomStrength: number;
+  bloomRadius?: number;
+  bloomThreshold?: number;
+}): PostprocessingPipeline {
+  const composer = new EffectComposer(renderer);
+  const renderPass = new RenderPass(scene, camera);
+  composer.addPass(renderPass);
+
+  const size = renderer.getSize(new Vector2());
+  const bloomPass = new UnrealBloomPass(
+    new Vector2(size.x, size.y),
+    bloomStrength,
+    bloomRadius,
+    bloomThreshold,
+  );
+  composer.addPass(bloomPass);
+
+  const lastSize = size.clone();
+  const sizeScratch = new Vector2();
+
+  const updateSize = () => {
+    renderer.getSize(sizeScratch);
+    if (sizeScratch.x !== lastSize.x || sizeScratch.y !== lastSize.y) {
+      composer.setSize(sizeScratch.x, sizeScratch.y);
+      lastSize.copy(sizeScratch);
+    }
+  };
+
+  return {
+    composer,
+    bloomPass,
+    render: () => composer.render(),
+    updateSize,
+    dispose: () => composer.dispose(),
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable, size-aware bloom postprocessing pipeline to avoid duplicated postprocessing setup across toys. 
- Improve performance and rendering quality in the 3D toy by moving from separate dynamic meshes to GPU-friendly instanced meshes. 
- Allow toys to adapt their materials and postprocessing depending on the active renderer backend (WebGL vs WebGPU).

### Description

- Add `assets/js/core/postprocessing.ts` which exports `createBloomComposer`, `isWebGLRenderer`, and a `PostprocessingPipeline` type that wraps `EffectComposer` + `UnrealBloomPass` and exposes `updateSize`/`dispose` helpers. 
- Replace ad-hoc postprocessing in `neon-wave.ts` with the shared pipeline and update bloom strength and render flow to call `updateSize()` before rendering. 
- Refactor `three-d-toy.ts` to use instanced meshes for floating shapes, track instance state, and update instance matrices/colors each frame to reduce draw overhead. 
- Detect renderer backend in `three-d-toy.ts` and choose an enhanced `MeshPhysicalMaterial` when `WebGPU` is active, and wire the shared bloom pipeline with dynamic sizing and proper disposal.

### Testing

- Ran `bun run check` (includes lint/format/typecheck) and it completed successfully. 
- Ran the test suite via `bun test` which executed the project tests and reported `73 passed`, `2 skipped`, and `0 failed`.
- `tsc --noEmit` (typecheck) was also exercised as part of the checks and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f357952f0833285708b6bb8eb8fc0)