### PR TITLE
Refine text contrast and complete hint touch affordances

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -287,8 +287,8 @@ body {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  font-size: 0.75rem;
-  color: rgba(233, 251, 255, 0.75);
+  font-size: 0.85rem;
+  color: rgba(233, 251, 255, 0.88);
 }
 
 .active-toy-nav__title {
@@ -301,8 +301,8 @@ body {
 
 .active-toy-nav__hint {
   margin: 0;
-  color: rgba(233, 251, 255, 0.8);
-  font-size: 0.92rem;
+  color: rgba(233, 251, 255, 0.9);
+  font-size: 1rem;
 }
 
 .active-toy-nav__pill {
@@ -946,8 +946,8 @@ body {
 
 .control-panel__note {
   margin: 6px 0 0;
-  font-size: 0.85rem;
-  color: rgba(233, 251, 255, 0.75);
+  font-size: 0.95rem;
+  color: rgba(233, 251, 255, 0.88);
 }
 
 .control-panel__value {
@@ -958,10 +958,10 @@ body {
 }
 
 .control-panel__label.small {
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  opacity: 0.8;
+  opacity: 0.9;
 }
 
 .control-panel__input {
@@ -1000,7 +1000,7 @@ body {
   background: rgba(111, 247, 255, 0.1);
   border: 1px solid rgba(111, 247, 255, 0.3);
   color: #9bf3ff;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   font-family: inherit;
   cursor: pointer;
   transition: all 0.2s ease;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -832,8 +832,8 @@ header.hero {
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 0.8rem;
-  opacity: 0.7;
+  font-size: 0.95rem;
+  opacity: 0.85;
   margin: 0 0 0.5rem;
 }
 
@@ -855,7 +855,7 @@ header.hero {
 .cta-helper {
   margin: -0.5rem 0 1.5rem;
   max-width: 720px;
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--text-muted);
   line-height: 1.5;
 }

--- a/assets/ui/hints.ts
+++ b/assets/ui/hints.ts
@@ -25,7 +25,7 @@ function injectHintStyles() {
       border-radius: 12px;
       padding: 12px 14px 10px;
       font-family: 'Inter', 'SF Pro Text', system-ui, -apple-system, sans-serif;
-      font-size: 14px;
+      font-size: 0.95rem;
       line-height: 1.4;
       box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
       backdrop-filter: blur(8px);
@@ -35,10 +35,10 @@ function injectHintStyles() {
 
     .stims-hint__title {
       margin: 0 0 6px 0;
-      font-size: 12px;
+      font-size: 0.85rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: #67e8f9;
+      color: #7dd3fc;
     }
 
     .stims-hint__list {
@@ -48,7 +48,7 @@ function injectHintStyles() {
 
     .stims-hint__item {
       margin-bottom: 6px;
-      color: #e2e8f0;
+      color: #f1f5f9;
     }
 
     .stims-hint__actions {
@@ -62,9 +62,11 @@ function injectHintStyles() {
       border: none;
       cursor: pointer;
       border-radius: 8px;
-      font-size: 12px;
+      font-size: 0.9rem;
       font-weight: 600;
-      padding: 8px 10px;
+      padding: 10px 12px;
+      min-height: 44px;
+      touch-action: manipulation;
       transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
     }
 


### PR DESCRIPTION
### Motivation
- Improve legibility and visual hierarchy for small UI copy across the hero, navigation, and control panels. 
- Ensure interactive hint actions meet mobile touch-target and interaction requirements from the design guidelines.

### Description
- Increased small copy sizes and contrast for `.eyebrow`, `.cta-helper`, `.active-toy-nav__eyebrow`, and `.active-toy-nav__hint` in `assets/css/index.css` and `assets/css/base.css` and bumped opacities for clearer hierarchy. 
- Raised the font-size and contrast for control panel helper text and labels and increased the `.control-panel__chip` font-size in `assets/css/base.css` to improve readability and touch affordance. 
- Updated `assets/ui/hints.ts` injected styles to use rem-based sizing, brighter title/body colors, larger action button padding, added `min-height: 44px`, and `touch-action: manipulation` to make hint actions meet mobile target and interaction rules. 
- These changes are visual/UX only and do not alter runtime logic.

### Testing
- Ran `bun run check` (lint + typecheck + tests), which completed successfully with `73 pass`, `2 skip`, `0 fail`.
- Ran `bun run typecheck` (`tsc --noEmit`), which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3af9f90083328e6080f19d536dc3)