### PR TITLE
Migrate toys to shared ToyRuntime (createToyRuntime)

### DIFF
--- a/assets/js/core/toy-runtime.ts
+++ b/assets/js/core/toy-runtime.ts
@@ -1,0 +1,224 @@
+import type {
+  AudioInitOptions,
+  FrequencyAnalyser,
+} from '../utils/audio-handler';
+import type { ToyAudioRequest } from '../utils/audio-start';
+import { resolveToyAudioOptions } from '../utils/audio-start';
+import { startToyAudio } from '../utils/start-audio';
+import {
+  createUnifiedInput,
+  type UnifiedInputOptions,
+  type UnifiedInputState,
+} from '../utils/unified-input';
+import type { AnimationContext } from './animation-loop';
+import { getContextFrequencyData } from './animation-loop';
+import {
+  getActivePerformanceSettings,
+  type PerformanceSettings,
+  subscribeToPerformanceSettings,
+} from './performance-panel';
+import { registerToyGlobals } from './toy-globals';
+import type { ToyInstance } from './toy-interface';
+import WebToy, { type WebToyOptions } from './web-toy';
+
+export type ToyRuntimeFrame = {
+  toy: WebToy;
+  time: number;
+  deltaMs: number;
+  analyser: FrequencyAnalyser | null;
+  frequencyData: Uint8Array;
+  input: UnifiedInputState | null;
+  performance: PerformanceSettings;
+};
+
+export type ToyRuntimePlugin = {
+  name?: string;
+  setup?: (runtime: ToyRuntimeInstance) => void;
+  update?: (frame: ToyRuntimeFrame) => void;
+  onInput?: (state: UnifiedInputState, frame: ToyRuntimeFrame) => void;
+  onPerformanceChange?: (
+    settings: PerformanceSettings,
+    runtime: ToyRuntimeInstance,
+  ) => void;
+  dispose?: () => void;
+};
+
+export type ToyRuntimeOptions = {
+  container?: HTMLElement | null;
+  canvas?: HTMLCanvasElement | null;
+  toyOptions?: WebToyOptions;
+  audio?: {
+    fftSize?: number;
+    options?: AudioInitOptions;
+  };
+  input?: Partial<Omit<UnifiedInputOptions, 'target'>> & {
+    enabled?: boolean;
+    target?: HTMLElement | null;
+  };
+  performance?: {
+    enabled?: boolean;
+    storageKey?: string;
+    applyRendererSettings?: boolean;
+  };
+  plugins?: ToyRuntimePlugin[];
+};
+
+export type ToyRuntimeInstance = ToyInstance & {
+  toy: WebToy;
+  startAudio: (request?: ToyAudioRequest) => Promise<AnimationContext>;
+  addPlugin: (plugin: ToyRuntimePlugin) => void;
+  getInputState: () => UnifiedInputState | null;
+  getPerformanceSettings: () => PerformanceSettings;
+};
+
+const defaultInputOptions = (
+  target: HTMLElement,
+  overrides?: ToyRuntimeOptions['input'],
+): UnifiedInputOptions => ({
+  target,
+  boundsElement: overrides?.boundsElement,
+  onInput: overrides?.onInput,
+  keyboardEnabled: overrides?.keyboardEnabled,
+  gamepadEnabled: overrides?.gamepadEnabled,
+  keyboardSpeed: overrides?.keyboardSpeed,
+  keyboardBoost: overrides?.keyboardBoost,
+  gamepadSpeed: overrides?.gamepadSpeed,
+  gamepadDeadzone: overrides?.gamepadDeadzone,
+  focusOnPress: overrides?.focusOnPress,
+  micProvider: overrides?.micProvider,
+});
+
+export function createToyRuntime({
+  container = null,
+  canvas = null,
+  toyOptions,
+  audio,
+  input,
+  performance,
+  plugins = [],
+}: ToyRuntimeOptions = {}): ToyRuntimeInstance {
+  const toy = new WebToy({
+    ...toyOptions,
+    container,
+    canvas,
+  });
+  const runtimePlugins = [...plugins];
+  let inputState: UnifiedInputState | null = null;
+  let analyser: FrequencyAnalyser | null = null;
+  let lastFrameTime = 0;
+  let performanceSettings = getActivePerformanceSettings({
+    storageKey: performance?.storageKey,
+  });
+
+  if (performance?.applyRendererSettings !== false) {
+    toy.updateRendererSettings({
+      maxPixelRatio: performanceSettings.maxPixelRatio,
+    });
+  }
+
+  let runtime: ToyRuntimeInstance | null = null;
+
+  const applyPerformanceSettings = (settings: PerformanceSettings) => {
+    performanceSettings = settings;
+    if (performance?.applyRendererSettings !== false) {
+      toy.updateRendererSettings({ maxPixelRatio: settings.maxPixelRatio });
+    }
+    if (runtime) {
+      runtimePlugins.forEach((plugin) =>
+        plugin.onPerformanceChange?.(settings, runtime as ToyRuntimeInstance),
+      );
+    }
+  };
+
+  const performanceUnsubscribe =
+    performance?.enabled === false
+      ? null
+      : subscribeToPerformanceSettings(applyPerformanceSettings);
+
+  const inputTarget =
+    input?.enabled === false
+      ? null
+      : (input?.target ??
+        (toy.canvas instanceof HTMLElement ? toy.canvas : null) ??
+        toy.container);
+
+  if (inputTarget instanceof HTMLElement) {
+    inputTarget.style.touchAction = 'manipulation';
+  }
+
+  const inputAdapter =
+    inputTarget && inputTarget instanceof HTMLElement
+      ? createUnifiedInput({
+          ...defaultInputOptions(inputTarget, input),
+          onInput: (state) => {
+            inputState = state;
+            runtimePlugins.forEach((plugin) =>
+              plugin.onInput?.(state, frameState),
+            );
+            input?.onInput?.(state);
+          },
+          micProvider: () => ({
+            level: analyser?.getRmsLevel() ?? 0,
+            available: Boolean(analyser),
+          }),
+        })
+      : null;
+
+  const frameState: ToyRuntimeFrame = {
+    toy,
+    time: 0,
+    deltaMs: 0,
+    analyser: null,
+    frequencyData: new Uint8Array(0),
+    input: null,
+    performance: performanceSettings,
+  };
+
+  const startAudio = async (request?: ToyAudioRequest) => {
+    return startToyAudio(
+      toy,
+      (ctx) => {
+        analyser = ctx.analyser;
+        const now = ctx.time;
+        frameState.deltaMs = lastFrameTime ? (now - lastFrameTime) * 1000 : 0;
+        lastFrameTime = now;
+        frameState.time = now;
+        frameState.analyser = analyser;
+        frameState.frequencyData = getContextFrequencyData(ctx);
+        frameState.input = inputState;
+        frameState.performance = performanceSettings;
+        runtimePlugins.forEach((plugin) => plugin.update?.(frameState));
+      },
+      resolveToyAudioOptions(request, {
+        fftSize: audio?.fftSize,
+        ...audio?.options,
+      }),
+    );
+  };
+
+  const unregisterGlobals = registerToyGlobals(container, startAudio);
+
+  runtime = {
+    toy,
+    startAudio,
+    addPlugin: (plugin) => {
+      runtimePlugins.push(plugin);
+      plugin.setup?.(runtime as ToyRuntimeInstance);
+    },
+    getInputState: () => inputState,
+    getPerformanceSettings: () => performanceSettings,
+    dispose: () => {
+      runtimePlugins.forEach((plugin) => plugin.dispose?.());
+      inputAdapter?.dispose();
+      performanceUnsubscribe?.();
+      unregisterGlobals();
+      toy.dispose();
+    },
+  };
+
+  runtimePlugins.forEach((plugin) =>
+    plugin.setup?.(runtime as ToyRuntimeInstance),
+  );
+
+  return runtime as ToyRuntimeInstance;
+}

--- a/assets/js/toys/milkdrop-toy.ts
+++ b/assets/js/toys/milkdrop-toy.ts
@@ -1,149 +1,146 @@
 import * as THREE from 'three';
-import type { AnimationContext } from '../core/animation-loop';
 import {
   DEFAULT_QUALITY_PRESETS,
   getSettingsPanel,
 } from '../core/settings-panel';
-import { registerToyGlobals } from '../core/toy-globals';
-import WebToy from '../core/web-toy';
-import {
-  resolveToyAudioOptions,
-  type ToyAudioRequest,
-} from '../utils/audio-start';
+import { createToyRuntime } from '../core/toy-runtime';
 import FeedbackManager from '../utils/feedback-manager';
-import { startToyAudio } from '../utils/start-audio';
 import WarpShader from '../utils/warp-shader';
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const toy = new WebToy({
-    cameraOptions: { position: { x: 0, y: 0, z: 5 } },
-    rendererOptions: { antialias: true },
-    canvas: container?.querySelector('canvas'),
-  });
-
   let feedback: FeedbackManager | null = null;
   let warpMaterial: THREE.ShaderMaterial | null = null;
   let warpMesh: THREE.Mesh | null = null;
   const overlayScene = new THREE.Scene();
   const overlayCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
-  // Main scene elements
-  const particles = new THREE.Group();
-  toy.scene.add(particles);
-
   const particleCount = 100;
   const particleGeometry = new THREE.SphereGeometry(0.05, 8, 8);
   const particleMaterials: THREE.MeshBasicMaterial[] = [];
 
-  for (let i = 0; i < particleCount; i++) {
-    const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
-    const mesh = new THREE.Mesh(particleGeometry, material);
-    mesh.position.set(
-      (Math.random() - 0.5) * 10,
-      (Math.random() - 0.5) * 10,
-      (Math.random() - 0.5) * 5,
-    );
-    particles.add(mesh);
-    particleMaterials.push(material);
-  }
+  const particles = new THREE.Group();
 
-  function initFeedback() {
-    toy.rendererReady.then((handle) => {
-      if (!handle) return;
-      const renderer = handle.renderer as THREE.WebGLRenderer;
-      feedback = new FeedbackManager({ renderer });
+  const runtime = createToyRuntime({
+    container,
+    canvas: container?.querySelector('canvas'),
+    toyOptions: {
+      cameraOptions: { position: { x: 0, y: 0, z: 5 } },
+      rendererOptions: { antialias: true },
+    },
+    audio: { fftSize: 512 },
+    plugins: [
+      {
+        name: 'milkdrop-core',
+        setup: ({ toy }) => {
+          toy.scene.add(particles);
+          for (let i = 0; i < particleCount; i += 1) {
+            const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
+            const mesh = new THREE.Mesh(particleGeometry, material);
+            mesh.position.set(
+              (Math.random() - 0.5) * 10,
+              (Math.random() - 0.5) * 10,
+              (Math.random() - 0.5) * 5,
+            );
+            particles.add(mesh);
+            particleMaterials.push(material);
+          }
 
-      warpMaterial = new THREE.ShaderMaterial({
-        ...WarpShader,
-        uniforms: THREE.UniformsUtils.clone(WarpShader.uniforms),
-      });
-      warpMaterial.uniforms.tDiffuse.value = feedback.texture;
-      warpMaterial.uniforms.uResolution.value.set(
-        window.innerWidth,
-        window.innerHeight,
-      );
+          toy.rendererReady.then((handle) => {
+            if (!handle) return;
+            const renderer = handle.renderer as THREE.WebGLRenderer;
+            feedback = new FeedbackManager({ renderer });
 
-      warpMesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), warpMaterial);
-      overlayScene.add(warpMesh);
-    });
-  }
+            warpMaterial = new THREE.ShaderMaterial({
+              ...WarpShader,
+              uniforms: THREE.UniformsUtils.clone(WarpShader.uniforms),
+            });
+            warpMaterial.uniforms.tDiffuse.value = feedback.texture;
+            warpMaterial.uniforms.uResolution.value.set(
+              window.innerWidth,
+              window.innerHeight,
+            );
 
-  function animate(ctx: AnimationContext) {
-    const time = ctx.time;
+            warpMesh = new THREE.Mesh(
+              new THREE.PlaneGeometry(2, 2),
+              warpMaterial,
+            );
+            overlayScene.add(warpMesh);
+          });
+        },
+        update: ({ time, analyser, toy }) => {
+          // Multi-band analysis
+          const energy = analyser
+            ? analyser.getMultiBandEnergy()
+            : { bass: 0, mid: 0, treble: 0 };
 
-    // Multi-band analysis
-    const energy = ctx.analyser
-      ? ctx.analyser.getMultiBandEnergy()
-      : { bass: 0, mid: 0, treble: 0 };
+          // Update particles based on audio
+          particles.children.forEach((child, i) => {
+            const mesh = child as THREE.Mesh;
+            const speed = 0.01 + energy.bass * 0.1;
+            mesh.position.y -= speed;
+            if (mesh.position.y < -5) mesh.position.y = 5;
 
-    // Update particles based on audio
-    particles.children.forEach((child, i) => {
-      const mesh = child as THREE.Mesh;
-      const speed = 0.01 + energy.bass * 0.1;
-      mesh.position.y -= speed;
-      if (mesh.position.y < -5) mesh.position.y = 5;
+            const scale = 1 + energy.mid * 2;
+            mesh.scale.setScalar(scale);
 
-      const scale = 1 + energy.mid * 2;
-      mesh.scale.setScalar(scale);
+            const hue = (i / particleCount + time * 0.1) % 1;
+            (mesh.material as THREE.MeshBasicMaterial).color.setHSL(
+              hue,
+              0.8,
+              0.5 + energy.treble * 0.5,
+            );
+          });
 
-      const hue = (i / particleCount + time * 0.1) % 1;
-      (mesh.material as THREE.MeshBasicMaterial).color.setHSL(
-        hue,
-        0.8,
-        0.5 + energy.treble * 0.5,
-      );
-    });
+          // Feedback and Warp
+          if (feedback && warpMaterial && toy.renderer) {
+            const renderer = toy.renderer as THREE.WebGLRenderer;
 
-    // Feedback and Warp
-    if (feedback && warpMaterial && toy.renderer) {
-      const renderer = toy.renderer as THREE.WebGLRenderer;
+            // 1. Update warp uniforms
+            warpMaterial.uniforms.uTime.value = time;
+            warpMaterial.uniforms.uAudioIntensity.value = energy.bass;
+            warpMaterial.uniforms.uZoom.value =
+              1.0 + Math.sin(time * 0.5) * 0.02;
+            warpMaterial.uniforms.uRotation.value = Math.sin(time * 0.2) * 0.01;
 
-      // 1. Update warp uniforms
-      warpMaterial.uniforms.uTime.value = time;
-      warpMaterial.uniforms.uAudioIntensity.value = energy.bass;
-      warpMaterial.uniforms.uZoom.value = 1.0 + Math.sin(time * 0.5) * 0.02;
-      warpMaterial.uniforms.uRotation.value = Math.sin(time * 0.2) * 0.01;
+            // 2. Render main scene + feedback into write buffer
+            // In MilkDrop, we render the PREVIOUS frame (distorted) and then overlay new graphics
+            renderer.setRenderTarget(null); // Clear default
 
-      // 2. Render main scene + feedback into write buffer
-      // In MilkDrop, we render the PREVIOUS frame (distorted) and then overlay new graphics
-      renderer.setRenderTarget(null); // Clear default
+            // Actually, we need to render the warped texture BACK into the feedback buffer
+            // or render the scene ON TOP of the warped texture.
 
-      // Actually, we need to render the warped texture BACK into the feedback buffer
-      // or render the scene ON TOP of the warped texture.
+            // Sequence:
+            // a. Render overlay (warpMesh showing feedback.texture) into writeBuffer
+            // b. Render main scene (particles) into writeBuffer (no clear)
+            // c. Render writeBuffer to screen
+            // d. Swap
 
-      // Sequence:
-      // a. Render overlay (warpMesh showing feedback.texture) into writeBuffer
-      // b. Render main scene (particles) into writeBuffer (no clear)
-      // c. Render writeBuffer to screen
-      // d. Swap
+            renderer.setRenderTarget(feedback.writeTarget);
+            renderer.clear();
+            renderer.render(overlayScene, overlayCamera); // Draw the warped previous frame
+            renderer.autoClear = false;
+            renderer.render(toy.scene, toy.camera); // Draw new elements on top
+            renderer.autoClear = true;
 
-      renderer.setRenderTarget(feedback.writeTarget);
-      renderer.clear();
-      renderer.render(overlayScene, overlayCamera); // Draw the warped previous frame
-      renderer.autoClear = false;
-      renderer.render(toy.scene, toy.camera); // Draw new elements on top
-      renderer.autoClear = true;
+            renderer.setRenderTarget(null);
+            renderer.render(overlayScene, overlayCamera); // Final output to screen
 
-      renderer.setRenderTarget(null);
-      renderer.render(overlayScene, overlayCamera); // Final output to screen
-
-      feedback.swap();
-      warpMaterial.uniforms.tDiffuse.value = feedback.texture;
-    } else {
-      ctx.toy.render();
-    }
-  }
-
-  async function startAudio(request: ToyAudioRequest = false) {
-    return startToyAudio(
-      toy,
-      animate,
-      resolveToyAudioOptions(request, { fftSize: 512 }),
-    );
-  }
-
-  // Initialize
-  initFeedback();
+            feedback.swap();
+            warpMaterial.uniforms.tDiffuse.value = feedback.texture;
+          } else {
+            toy.render();
+          }
+        },
+        dispose: () => {
+          feedback?.dispose();
+          particleGeometry.dispose();
+          particleMaterials.forEach((m) => m.dispose());
+          warpMaterial?.dispose();
+          warpMesh?.geometry.dispose();
+        },
+      },
+    ],
+  });
 
   const settingsPanel = getSettingsPanel();
   settingsPanel.configure({
@@ -154,21 +151,9 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     presets: DEFAULT_QUALITY_PRESETS,
     defaultPresetId: 'medium',
     onChange: (preset) => {
-      toy.updateRendererSettings({ renderScale: preset.renderScale });
+      runtime.toy.updateRendererSettings({ renderScale: preset.renderScale });
     },
   });
 
-  const unregisterGlobals = registerToyGlobals(container, startAudio);
-
-  return {
-    dispose: () => {
-      toy.dispose();
-      feedback?.dispose();
-      particleGeometry.dispose();
-      particleMaterials.forEach((m) => m.dispose());
-      warpMaterial?.dispose();
-      warpMesh?.geometry.dispose();
-      unregisterGlobals();
-    },
-  };
+  return runtime;
 }

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -417,7 +417,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     plugins: [
       {
         name: 'three-d-toy',
-        setup: () => {
+        setup: (runtimeInstance) => {
           setupSettingsPanel();
           const controlPanel = createControlPanel();
           controlState = controlPanel.getState();
@@ -425,7 +425,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
             controlState = state;
           });
           rebuildSceneContents();
-          runtime.toy.rendererReady.then((handle) => {
+          runtimeInstance.toy.rendererReady.then((handle) => {
             if (!handle) return;
             rendererBackend = handle.backend;
             rebuildSceneContents();

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -1,9 +1,5 @@
 import * as THREE from 'three';
 import {
-  type AnimationContext,
-  getContextFrequencyData,
-} from '../core/animation-loop';
-import {
   createBloomComposer,
   isWebGLRenderer,
   type PostprocessingPipeline,
@@ -16,40 +12,20 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { registerToyGlobals } from '../core/toy-globals';
-import type { ToyConfig } from '../core/types';
-import WebToy from '../core/web-toy';
+import { createToyRuntime } from '../core/toy-runtime';
 import { getAverageFrequency } from '../utils/audio-handler';
-import {
-  resolveToyAudioOptions,
-  type ToyAudioRequest,
-} from '../utils/audio-start';
+import type { ToyAudioRequest } from '../utils/audio-start';
 import {
   type ControlPanelState,
   createControlPanel,
 } from '../utils/control-panel';
 import { createIdleDetector } from '../utils/idle-detector';
-import { startToyAudio } from '../utils/start-audio';
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
   let errorElement: HTMLElement | null = null;
   const settingsPanel = getSettingsPanel();
   let activeQuality: QualityPreset = getActiveQualityPreset();
-
-  const toy = new WebToy({
-    cameraOptions: { position: { x: 0, y: 0, z: 80 } },
-    lightingOptions: {
-      type: 'PointLight',
-      color: 0xff00ff,
-      intensity: 2,
-      position: { x: 20, y: 30, z: 20 },
-    },
-    ambientLightOptions: { color: 0x404040, intensity: 0.8 },
-    rendererOptions: {
-      maxPixelRatio: activeQuality.maxPixelRatio,
-      renderScale: activeQuality.renderScale,
-    },
-    canvas: container?.querySelector('canvas'),
-  } as ToyConfig);
+  let runtime: ReturnType<typeof createToyRuntime>;
 
   let torusKnot: THREE.Mesh | null = null;
   let particles: THREE.Points | null = null;
@@ -91,7 +67,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function disposeMesh(mesh: THREE.Mesh | null) {
     if (!mesh) return;
-    toy.scene.remove(mesh);
+    runtime.toy.scene.remove(mesh);
     mesh.geometry?.dispose();
     if (Array.isArray(mesh.material)) {
       mesh.material.forEach((material) => material?.dispose());
@@ -102,7 +78,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function disposeInstancedShapes() {
     instancedShapes.splice(0).forEach(({ mesh }) => {
-      toy.scene.remove(mesh);
+      runtime.toy.scene.remove(mesh);
       mesh.geometry?.dispose();
       if (Array.isArray(mesh.material)) {
         mesh.material.forEach((material) => material?.dispose());
@@ -145,7 +121,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
       });
       const mesh = new THREE.InstancedMesh(geometry, material, count);
       mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
-      toy.scene.add(mesh);
+      runtime.toy.scene.add(mesh);
 
       const instances: ShapeInstance[] = [];
 
@@ -232,7 +208,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
       new THREE.TorusKnotGeometry(10, 3, torusSegments, torusTubularSegments),
       torusMaterial,
     );
-    toy.scene.add(torusKnot);
+    runtime.toy.scene.add(torusKnot);
 
     const particlesGeometry = new THREE.BufferGeometry();
     const particlesPosition = new Float32Array(particleCount * 3);
@@ -248,21 +224,21 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
       size: 1.8,
     });
     particles = new THREE.Points(particlesGeometry, particlesMaterial);
-    toy.scene.add(particles);
+    runtime.toy.scene.add(particles);
 
     createInstancedShapes(shapeCount);
   }
 
   function setupPostProcessing() {
     if (postprocessing) return;
-    toy.rendererReady.then((result) => {
+    runtime.toy.rendererReady.then((result) => {
       if (!result || postprocessing) return;
       if (!isWebGLRenderer(result.renderer)) return;
 
       postprocessing = createBloomComposer({
         renderer: result.renderer,
-        scene: toy.scene,
-        camera: toy.camera,
+        scene: runtime.toy.scene,
+        camera: runtime.toy.camera,
         bloomStrength: 0.65,
         bloomRadius: 0.45,
         bloomThreshold: 0.88,
@@ -294,9 +270,8 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     }
   }
 
-  function animate(ctx: AnimationContext) {
+  function animate(dataArray: Uint8Array, _time: number) {
     if (!torusKnot || !particles) return;
-    const dataArray = getContextFrequencyData(ctx);
     const avgFrequency = getAverageFrequency(dataArray);
 
     const { idle, idleProgress } = idleDetector.update(dataArray);
@@ -305,7 +280,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     const idleStrength = controlState.mobilePreset ? 0.55 : 1;
     const idleOffset = idleBlend * idleStrength;
 
-    const time = clock.getElapsedTime();
+    const elapsed = clock.getElapsedTime();
     const paletteEnabled = controlState.paletteCycle;
     const paletteSpeedBase = controlState.mobilePreset ? 0.003 : 0.006;
     const activityDamp = idle ? 1 : 0.2;
@@ -319,7 +294,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
       0.4,
       0.08 + idleBlend * 0.1,
     );
-    toy.scene.background = backgroundColor;
+    runtime.toy.scene.background = backgroundColor;
     const body = (container?.ownerDocument ?? document).body;
     body.style.backgroundImage = `radial-gradient(circle at 20% 20%, hsla(${
       (paletteHue + 0.08) * 360
@@ -330,7 +305,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     torusKnot.rotation.x += avgFrequency / 5000;
     torusKnot.rotation.y += avgFrequency / 7000;
 
-    const wobble = 1 + Math.sin(time * 0.6) * 0.15 * idleOffset;
+    const wobble = 1 + Math.sin(elapsed * 0.6) * 0.15 * idleOffset;
     const wobbleVec = new THREE.Vector3(wobble, wobble, wobble);
     torusKnot.scale.lerp(wobbleVec, 0.08);
 
@@ -353,7 +328,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
           colorNeedsUpdate = true;
         }
         const wobbleAmt =
-          1 + Math.sin(time * 0.9 + instance.wobbleSeed) * 0.08 * idleOffset;
+          1 + Math.sin(elapsed * 0.9 + instance.wobbleSeed) * 0.08 * idleOffset;
         const scaled = instance.scale * wobbleAmt;
         instanceTempObject.position.copy(instance.position);
         instanceTempObject.rotation.copy(instance.rotation);
@@ -374,21 +349,21 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     torusKnot.scale.set(randomScale, randomScale, randomScale);
 
     const driftAmount = idleOffset * (controlState.mobilePreset ? 2.5 : 4.2);
-    toy.camera.position.x = Math.sin(time * 0.25) * driftAmount;
-    toy.camera.position.y = Math.cos(time * 0.2) * driftAmount * 0.6;
-    toy.camera.lookAt(0, 0, 0);
+    runtime.toy.camera.position.x = Math.sin(elapsed * 0.25) * driftAmount;
+    runtime.toy.camera.position.y = Math.cos(elapsed * 0.2) * driftAmount * 0.6;
+    runtime.toy.camera.lookAt(0, 0, 0);
 
     if (postprocessing) {
       postprocessing.updateSize();
       postprocessing.render();
     } else {
-      ctx.toy.render();
+      runtime.toy.render();
     }
   }
 
   function applyQualityPreset(preset: QualityPreset) {
     activeQuality = preset;
-    toy.updateRendererSettings({
+    runtime.toy.updateRendererSettings({
       maxPixelRatio: preset.maxPixelRatio,
       renderScale: preset.renderScale,
     });
@@ -410,7 +385,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   async function startAudio(request: ToyAudioRequest = false) {
     try {
-      await startToyAudio(toy, animate, resolveToyAudioOptions(request));
+      await runtime.startAudio(request);
       hideError();
       return true;
     } catch (e) {
@@ -421,31 +396,60 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     }
   }
 
-  setupSettingsPanel();
-  const controlPanel = createControlPanel();
-  controlState = controlPanel.getState();
-  const _controlPanelUnsub = controlPanel.onChange((state) => {
-    controlState = state;
-  });
-  rebuildSceneContents();
-  toy.rendererReady.then((handle) => {
-    if (!handle) return;
-    rendererBackend = handle.backend;
-    rebuildSceneContents();
-    setupPostProcessing();
+  runtime = createToyRuntime({
+    container,
+    canvas: container?.querySelector('canvas'),
+    toyOptions: {
+      cameraOptions: { position: { x: 0, y: 0, z: 80 } },
+      lightingOptions: {
+        type: 'PointLight',
+        color: 0xff00ff,
+        intensity: 2,
+        position: { x: 20, y: 30, z: 20 },
+      },
+      ambientLightOptions: { color: 0x404040, intensity: 0.8 },
+      rendererOptions: {
+        maxPixelRatio: activeQuality.maxPixelRatio,
+        renderScale: activeQuality.renderScale,
+      },
+    },
+    audio: { fftSize: 512 },
+    plugins: [
+      {
+        name: 'three-d-toy',
+        setup: () => {
+          setupSettingsPanel();
+          const controlPanel = createControlPanel();
+          controlState = controlPanel.getState();
+          controlPanel.onChange((state) => {
+            controlState = state;
+          });
+          rebuildSceneContents();
+          runtime.toy.rendererReady.then((handle) => {
+            if (!handle) return;
+            rendererBackend = handle.backend;
+            rebuildSceneContents();
+            setupPostProcessing();
+          });
+        },
+        update: ({ frequencyData, time }) => {
+          animate(frequencyData, time);
+        },
+        dispose: () => {
+          errorElement?.remove();
+          postprocessing?.dispose();
+        },
+      },
+    ],
   });
 
-  // Register globals for toy.html buttons
-  // Register globals for toy.html buttons
   const unregisterGlobals = registerToyGlobals(container, startAudio);
 
   return {
+    ...runtime,
     dispose: () => {
-      toy.dispose();
-      errorElement?.remove();
-      errorElement?.remove();
-      postprocessing?.dispose();
       unregisterGlobals();
+      runtime.dispose();
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Centralize scene, audio, input, and performance wiring so toys can be authored as lightweight plugins and avoid duplicated boilerplate. 
- Provide a per-frame runtime API with frequency and input data for consistent animation loops and to enable shared features (audio fallback, performance presets, unified input). 

### Description
- Add `assets/js/core/toy-runtime.ts` with `createToyRuntime`, `ToyRuntimeInstance`, `ToyRuntimeFrame` and plugin hooks for `setup`, `update`, `onInput`, `onPerformanceChange`, and `dispose`. 
- Migrate module toys to use `createToyRuntime` and runtime plugins (animations now receive `(frequencyData, time)` or runtime analyser where applicable) and replace scattered `WebToy`/`startToyAudio`/`createUnifiedInput` wiring with the runtime options (audio, input, performance, plugins). 
- Updated toys include: `aurora-painter`, `bubble-harmonics`, `cube-wave`, `cosmic-particles`, `fractal-kite-garden`, `neon-wave`, `rainbow-tunnel`, `spiral-burst`, `star-field`, `tactile-sand-table`, `three-d-toy`, `bioluminescent-tidepools`, and the existing `milkdrop-toy` integration was adapted to a `milkdrop-core` plugin. 
- Adjusted a few type/option shapes (lighting options normalized to `color`/`intensity`/`position`) and hooked up performance subscription and input handlers through the runtime API. 

### Testing
- Ran `bun run check` (biome lint/format + typecheck) and fixes were applied where needed and the command completed successfully. 
- Ran `bun run typecheck` / `tsc --noEmit` and it passed without errors. 
- Ran `bun test` which executed 75 tests with 73 passing and 2 skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb328e7dc8332b71ee867daac48fa)