### PR TITLE
Add toy lifecycle metadata and featured sorting

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1153,6 +1153,10 @@ export function createLibraryView({
   };
 
   const getOriginalIndex = (toy) => originalOrder.get(toy.slug) ?? 0;
+  const getFeaturedRank = (toy) =>
+    Number.isFinite(toy.featuredRank)
+      ? toy.featuredRank
+      : Number.POSITIVE_INFINITY;
 
   const updateResultsMeta = (visibleCount) => {
     const meta = ensureMetaNode();
@@ -1226,7 +1230,11 @@ export function createLibraryView({
             getOriginalIndex(a) - getOriginalIndex(b),
         );
       default:
-        return sorted.sort((a, b) => getOriginalIndex(a) - getOriginalIndex(b));
+        return sorted.sort(
+          (a, b) =>
+            getFeaturedRank(a) - getFeaturedRank(b) ||
+            getOriginalIndex(a) - getOriginalIndex(b),
+        );
     }
   };
 

--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -6,6 +6,7 @@ export default [
     module: 'assets/js/toys/three-d-toy.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'aurora-painter',
@@ -15,6 +16,8 @@ export default [
     module: 'assets/js/toys/aurora-painter.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 1,
     moods: ['dreamy', 'ethereal', 'luminous'],
     tags: ['aurora', 'ribbons', 'gestural'],
     controls: [
@@ -31,6 +34,7 @@ export default [
     module: 'assets/js/toys/clay.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'evol',
@@ -40,6 +44,7 @@ export default [
     module: 'assets/js/toys/evol.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'geom',
@@ -49,6 +54,7 @@ export default [
     module: 'assets/js/toys/geom.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'holy',
@@ -58,6 +64,7 @@ export default [
     module: 'assets/js/toys/holy.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'multi',
@@ -67,6 +74,7 @@ export default [
     type: 'module',
     requiresWebGPU: true,
     allowWebGLFallback: true,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'seary',
@@ -75,6 +83,7 @@ export default [
     module: 'assets/js/toys/seary.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'legible',
@@ -84,6 +93,7 @@ export default [
     module: 'assets/js/toys/legible.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'symph',
@@ -92,6 +102,7 @@ export default [
     module: 'assets/js/toys/symph.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'cube-wave',
@@ -101,6 +112,7 @@ export default [
     module: 'assets/js/toys/cube-wave.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'bubble-harmonics',
@@ -110,6 +122,8 @@ export default [
     module: 'assets/js/toys/bubble-harmonics.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 7,
   },
   {
     slug: 'cosmic-particles',
@@ -119,6 +133,8 @@ export default [
     module: 'assets/js/toys/cosmic-particles.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 5,
   },
   {
     slug: 'lights',
@@ -128,6 +144,7 @@ export default [
     module: 'assets/js/toys/lights.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'spiral-burst',
@@ -136,6 +153,8 @@ export default [
     module: 'assets/js/toys/spiral-burst.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 4,
     moods: ['energetic', 'pulsing', 'cosmic'],
     tags: ['spirals', 'burst', 'gestural'],
     controls: ['Mode buttons', 'Pinch/rotate gestures', 'Arrow-key mode swap'],
@@ -147,6 +166,7 @@ export default [
     module: 'assets/js/toys/rainbow-tunnel.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
   },
   {
     slug: 'star-field',
@@ -155,6 +175,7 @@ export default [
     module: 'assets/js/toys/star-field.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
     moods: ['serene', 'drifting', 'celestial'],
     tags: ['stars', 'nebula', 'gestural'],
     controls: ['Pinch/rotate gestures', 'Arrow-key mood switching'],
@@ -167,6 +188,7 @@ export default [
     module: 'assets/js/toys/fractal-kite-garden.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'archived',
     controls: ['Pattern density slider', 'Palette switches'],
   },
   {
@@ -177,6 +199,8 @@ export default [
     module: 'assets/js/toys/tactile-sand-table.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 3,
     controls: ['Grain size slider', 'Damping slider', 'Gravity lock toggle'],
   },
   {
@@ -187,6 +211,8 @@ export default [
     module: 'assets/js/toys/bioluminescent-tidepools.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 2,
     moods: ['serene', 'ethereal', 'fiery', 'dreamy'],
     tags: ['ocean', 'bioluminescent', 'caustics', 'gestural'],
     controls: [
@@ -205,6 +231,8 @@ export default [
     module: 'assets/js/toys/neon-wave.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'featured',
+    featuredRank: 6,
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -221,6 +249,7 @@ export default [
     module: 'assets/js/toys/milkdrop-toy.ts',
     type: 'module',
     requiresWebGPU: false,
+    lifecycleStage: 'prototype',
     capabilities: {
       microphone: true,
       demoAudio: true,

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -12,6 +12,18 @@ Use this playbook when adding or modifying toys so new experiences integrate cle
 - Run `bun run check:toys` before committing to confirm every module in `assets/js/toys/` is registered and page-backed toys have matching HTML entry points.
 - Run `bun run check:quick` to validate types and code quality with Biome before opening a PR.
 
+## Toy lifecycle and featured rotation
+
+Treat toys like live game content and keep their status explicit in metadata:
+
+- **Lifecycle stages** live in `assets/js/toys-data.js` as `lifecycleStage`:
+  - `prototype`: new or experimental toys that need fast iteration.
+  - `featured`: curated experiences that get the most attention and polish.
+  - `archived`: stable toys that stay available but are not actively promoted.
+- **Featured curation** uses `featuredRank` (lower = higher priority) to drive the default “Featured” sort in the library. Keep the set intentionally small (roughly 5–8 toys) so the landing grid stays focused.
+- **Rotation cadence**: revisit the featured set on a regular schedule (every 4–6 weeks). When rotating, update `featuredRank` and `lifecycleStage` in `assets/js/toys-data.js` so the UI reflects the new lineup.
+- **Polish passes**: schedule periodic quality passes on `featured` toys (monthly) and `prototype` toys (as needed). Each pass should include performance verification, accessibility checks, and a quick review of controls/labels against the latest UI conventions.
+
 ## Add-and-test checklist (fast path)
 
 Use this sequence when you want to stand up a fresh toy quickly (you can also run `bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test` to automate steps 1–3):

--- a/index.html
+++ b/index.html
@@ -362,6 +362,7 @@
         const SORT_PARAM = 'sort';
         let cachedQuery = '';
         let sortBy = 'featured';
+        const originalOrder = new Map();
         const activeFilters = new Set();
         let lastCommittedQuery = '';
         let pendingRender;
@@ -414,19 +415,33 @@
           Number(toy.capabilities?.motion) +
           Number(toy.capabilities?.demoAudio);
 
+        const getOriginalIndex = (toy) => originalOrder.get(toy.slug) ?? 0;
+        const getFeaturedRank = (toy) =>
+          Number.isFinite(toy.featuredRank)
+            ? toy.featuredRank
+            : Number.POSITIVE_INFINITY;
+
         const sortList = (list) => {
           const sorted = [...list];
           switch (sortBy) {
             case 'newest':
-              return sorted.reverse();
+              return sorted.sort(
+                (a, b) => getOriginalIndex(b) - getOriginalIndex(a)
+              );
             case 'az':
               return sorted.sort((a, b) => a.title.localeCompare(b.title));
             case 'immersive':
               return sorted.sort(
-                (a, b) => capabilityScore(b) - capabilityScore(a)
+                (a, b) =>
+                  capabilityScore(b) - capabilityScore(a) ||
+                  getOriginalIndex(a) - getOriginalIndex(b)
               );
             default:
-              return sorted;
+              return sorted.sort(
+                (a, b) =>
+                  getFeaturedRank(a) - getFeaturedRank(b) ||
+                  getOriginalIndex(a) - getOriginalIndex(b)
+              );
           }
         };
         let allToys = [];
@@ -771,6 +786,9 @@
             if (!toys || list.childElementCount > 0) return;
 
             allToys = toys;
+            allToys.forEach((toy, index) => {
+              originalOrder.set(toy.slug, index);
+            });
             updateSearchSuggestions(allToys);
             const urlState = getStateFromUrl();
             const hasUrlState =


### PR DESCRIPTION
### Motivation

- Make toy status explicit and support a curated, rotating featured set so the library can promote a small set of experiences and track lifecycle (prototype → featured → archived).
- Surface curated ordering in the default “Featured” view so maintainers can control promotion without changing UI code.

### Description

- Added `lifecycleStage` and optional `featuredRank` fields to `assets/js/toys-data.js` for toys to represent `prototype`, `featured`, and `archived` stages and prioritized featured ordering.
- Updated library sorting to honor `featuredRank` (lower = higher priority) and fall back to original index ordering in both the enhanced view (`assets/js/library-view.js`) and the static fallback (`index.html`), and populated an `originalOrder` map when loading toys.
- Tuned `newest` and `immersive` sorts to consistently use `originalOrder` as a deterministic tie-breaker.
- Documented the lifecycle model, rotation cadence, and polish pass expectations in `docs/TOY_DEVELOPMENT.md`.

Files changed: `assets/js/toys-data.js`, `assets/js/library-view.js`, `index.html`, `docs/TOY_DEVELOPMENT.md`.

### Testing

- Ran `bun run check` (Biome + test runner) which completed successfully and reported the test suite as: `73 pass`, `2 skip`, `0 fail`.
- Ran `bun run typecheck` (`tsc --noEmit`) which completed with no type errors.
- All automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fdc6792bc83328aa401a726c34348)