### PR TITLE
Refactor control panel toggle setup

### DIFF
--- a/assets/js/utils/control-panel.ts
+++ b/assets/js/utils/control-panel.ts
@@ -8,6 +8,11 @@ export type ControlPanelState = {
 };
 
 type ChangeHandler = (state: ControlPanelState) => void;
+type ToggleConfig = {
+  key: keyof ControlPanelState;
+  label: string;
+  description: string;
+};
 
 const isMobile = isMobileDevice();
 
@@ -26,36 +31,38 @@ export function createControlPanel(initial: Partial<ControlPanelState> = {}) {
     title: 'Toy settings',
   });
 
-  settingsPanel.addToggle({
-    label: 'Idle visuals',
-    description:
-      'Tweak how the scene behaves when the mic is quiet. Desktop defaults stay vivid; mobile trims intensity.',
-    defaultValue: state.idleEnabled,
-    onChange: (value) => {
-      state.idleEnabled = value;
-      emit();
+  const toggleConfigs: ToggleConfig[] = [
+    {
+      key: 'idleEnabled',
+      label: 'Idle visuals',
+      description:
+        'Tweak how the scene behaves when the mic is quiet. Desktop defaults stay vivid; mobile trims intensity.',
     },
-  });
+    {
+      key: 'paletteCycle',
+      label: 'Palette drift',
+      description: 'Slow hue cycling that eases when sound returns.',
+    },
+    {
+      key: 'mobilePreset',
+      label: 'Mobile-friendly idle',
+      description: 'Lowers drift and wobble for handheld devices.',
+    },
+  ];
 
-  settingsPanel.addToggle({
-    label: 'Palette drift',
-    description: 'Slow hue cycling that eases when sound returns.',
-    defaultValue: state.paletteCycle,
-    onChange: (value) => {
-      state.paletteCycle = value;
-      emit();
-    },
-  });
+  function addToggle({ key, label, description }: ToggleConfig) {
+    settingsPanel.addToggle({
+      label,
+      description,
+      defaultValue: state[key],
+      onChange: (value) => {
+        state[key] = value;
+        emit();
+      },
+    });
+  }
 
-  settingsPanel.addToggle({
-    label: 'Mobile-friendly idle',
-    description: 'Lowers drift and wobble for handheld devices.',
-    defaultValue: state.mobilePreset,
-    onChange: (value) => {
-      state.mobilePreset = value;
-      emit();
-    },
-  });
+  toggleConfigs.forEach(addToggle);
 
   function emit() {
     listeners.forEach((cb) => cb({ ...state }));


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize toggle definitions so control panel toggles are easier to maintain and extend.

### Description
- Replace inlined `settingsPanel.addToggle` calls with a `ToggleConfig` type, a `toggleConfigs` array, and a reusable `addToggle` helper that wires `defaultValue` and `onChange` into the shared `state` without changing behavior.

### Testing
- Ran `bun run check` (Biome + typecheck + `bun test`) and the repo tests completed successfully; `biome lint` and `biome format --write` also ran as part of pre-commit and passed; docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff757fb0c8332b9f73ae5bc77f743)