### PR TITLE
Refactor mouse pointer handling

### DIFF
--- a/assets/js/utils/pointer-input.ts
+++ b/assets/js/utils/pointer-input.ts
@@ -228,13 +228,7 @@ export function createPointerInput({
     updateAndNotify();
   };
 
-  const handleMouseMove = (event: Event) => {
-    const mouseEvent = event as MouseEvent;
-    upsertPointer(1, mouseEvent.clientX, mouseEvent.clientY);
-    updateAndNotify();
-  };
-
-  const handleMouseDown = (event: Event) => {
+  const handleMouseEvent = (event: Event) => {
     const mouseEvent = event as MouseEvent;
     upsertPointer(1, mouseEvent.clientX, mouseEvent.clientY);
     updateAndNotify();
@@ -273,8 +267,8 @@ export function createPointerInput({
       handleTouchEvent,
       touchListenerOptions,
     );
-    listenerTarget.addEventListener('mousemove', handleMouseMove);
-    listenerTarget.addEventListener('mousedown', handleMouseDown);
+    listenerTarget.addEventListener('mousemove', handleMouseEvent);
+    listenerTarget.addEventListener('mousedown', handleMouseEvent);
     listenerTarget.addEventListener('mouseup', handleMouseEnd);
     listenerTarget.addEventListener('mouseleave', handleMouseEnd);
   }
@@ -308,8 +302,8 @@ export function createPointerInput({
         handleTouchEvent,
         touchListenerOptions,
       );
-      listenerTarget.removeEventListener('mousemove', handleMouseMove);
-      listenerTarget.removeEventListener('mousedown', handleMouseDown);
+      listenerTarget.removeEventListener('mousemove', handleMouseEvent);
+      listenerTarget.removeEventListener('mousedown', handleMouseEvent);
       listenerTarget.removeEventListener('mouseup', handleMouseEnd);
       listenerTarget.removeEventListener('mouseleave', handleMouseEnd);
     }


### PR DESCRIPTION
### Motivation
- Reduce duplication and simplify mouse event handling for the pointer input utility by consolidating separate mouse move/down handlers into a single shared handler.

### Description
- Replace `handleMouseMove` and `handleMouseDown` with a single `handleMouseEvent` that is registered for both `mousemove` and `mousedown` and update corresponding removal calls.

### Testing
- Ran `bun run check` (Biome lint/format + `tsc` typecheck + `bun test`) and the test suite completed with 73 passed, 2 skipped, and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff757fb0c8332b9f73ae5bc77f743)