### PR TITLE
Improve mobile layout spacing

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -144,7 +144,12 @@ h6 {
 .content {
   position: relative;
   z-index: 1;
-  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+  --content-padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+  padding: var(--content-padding);
+  padding-top: max(var(--content-padding), env(safe-area-inset-top));
+  padding-right: max(var(--content-padding), env(safe-area-inset-right));
+  padding-bottom: max(var(--content-padding), env(safe-area-inset-bottom));
+  padding-left: max(var(--content-padding), env(safe-area-inset-left));
   max-width: var(--content-width);
   margin: 0 auto;
   display: flex;
@@ -1900,6 +1905,13 @@ footer {
 
   .nav-actions {
     width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .nav-link {
+    width: 100%;
   }
 
   .theme-toggle {
@@ -1932,7 +1944,8 @@ footer {
   }
 
   .top-nav {
-    position: static;
+    position: sticky;
+    top: calc(env(safe-area-inset-top) + 0.4rem);
     border-radius: 14px;
   }
 


### PR DESCRIPTION
### Motivation
- Improve mobile user experience by preventing content from being obscured by device notches and rounded corners. 
- Make top navigation actions easier to tap on small screens by turning them into full-width touch targets. 
- Keep the top navigation accessible on small screens by ensuring it remains sticky with a safe-area offset. 

### Description
- Add a `--content-padding` CSS variable and apply `env(safe-area-inset-*)`-aware padding to the main `.content` container in `assets/css/index.css` so the layout respects device safe areas. 
- Stack `.nav-actions` as a responsive grid with `repeat(auto-fit, minmax(140px, 1fr))` and make `.nav-link` full-width under the `@media (max-width: 520px)` breakpoint to improve touch targets. 
- Keep the top navigation sticky on narrower viewports by setting `.top-nav` to `position: sticky` with `top: calc(env(safe-area-inset-top) + 0.4rem)` under the `@media (max-width: 768px)` breakpoint. 

### Testing
- Ran `biome lint assets scripts tests` which completed successfully. 
- Ran `biome format --write assets scripts tests` which completed successfully. 
- Launched the dev server with `bun run dev` (Vite) and captured a mobile viewport screenshot using Playwright which completed successfully and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970276a5a648332b1e325940a372501)