### PR TITLE
Preserve safe-area padding on small screens

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1802,7 +1802,7 @@ footer {
 
 @media (max-width: 1024px) {
   .content {
-    padding: clamp(1.25rem, 2.5vw, 2.4rem);
+    --content-padding: clamp(1.25rem, 2.5vw, 2.4rem);
   }
 
   .hero-grid {


### PR DESCRIPTION
### Motivation
- Ensure the safe-area insets declared in the base `.content` rule (via `env(safe-area-inset-*)`) continue to apply for viewports ≤1024px by avoiding an override of the padding properties in the breakpoint.

### Description
- Replace the explicit `padding` assignment with `--content-padding` inside the `@media (max-width: 1024px)` block in `assets/css/index.css` so the base `.content` `padding-*: max(var(--content-padding), env(...))` rules still take effect.

### Testing
- Ran `biome lint assets scripts tests` and it succeeded.
- Ran `biome format --write assets scripts tests` and it succeeded.
- No docs were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703069a09883329919255483d05ad6)