### PR TITLE
Modernize pointer capture handling

### DIFF
--- a/assets/js/utils/pointer-input.ts
+++ b/assets/js/utils/pointer-input.ts
@@ -168,10 +168,7 @@ export function createPointerInput({
   }
 
   function handlePointerDown(event: PointerEvent) {
-    if (
-      event.target instanceof Element &&
-      typeof event.target.hasPointerCapture === 'function'
-    ) {
+    if (event.target instanceof Element) {
       try {
         event.target.setPointerCapture(event.pointerId);
       } catch {
@@ -183,6 +180,20 @@ export function createPointerInput({
   }
 
   function handlePointerEnd(event: PointerEvent) {
+    if (event.target instanceof Element) {
+      try {
+        if (event.target.hasPointerCapture(event.pointerId)) {
+          event.target.releasePointerCapture(event.pointerId);
+        }
+      } catch {
+        // Ignore release errors for non-capturing elements.
+      }
+    }
+    activePointers.delete(event.pointerId);
+    updateAndNotify();
+  }
+
+  function handlePointerLost(event: PointerEvent) {
     activePointers.delete(event.pointerId);
     updateAndNotify();
   }
@@ -246,6 +257,7 @@ export function createPointerInput({
     addPointerListener('pointercancel', handlePointerEnd);
     addPointerListener('pointerout', handlePointerEnd);
     addPointerListener('pointerleave', handlePointerEnd);
+    addPointerListener('lostpointercapture', handlePointerLost);
   } else {
     listenerTarget.addEventListener(
       'touchstart',
@@ -281,6 +293,7 @@ export function createPointerInput({
       removePointerListener('pointercancel', handlePointerEnd);
       removePointerListener('pointerout', handlePointerEnd);
       removePointerListener('pointerleave', handlePointerEnd);
+      removePointerListener('lostpointercapture', handlePointerLost);
     } else {
       listenerTarget.removeEventListener(
         'touchstart',


### PR DESCRIPTION
### Motivation
- Improve robustness of pointer interactions by ensuring pointer capture is attempted on down events and released on up, and by cleaning up when capture is lost to avoid stale pointer state.
- Make unified input handling consistent with low-level pointer input to reduce interaction edge cases across toys.

### Description
- In `assets/js/utils/pointer-input.ts` attempt `setPointerCapture` for element targets on `pointerdown`, attempt `releasePointerCapture` on end, add a `lostpointercapture` handler to remove stale pointers, and wire the new handler to listener registration and disposal. 
- In `assets/js/utils/unified-input.ts` call `setPointerCapture` on `pointerdown`, attempt `releasePointerCapture` on `pointerup`, add a `lostpointercapture` handler that queues lost events for processing, and remove the listener in `dispose`.
- Use defensive `try/catch` around capture/release calls to ignore browsers/elements that do not support capture.

### Testing
- Ran `bun run check` (Biome lint/format + `bun run typecheck` + `bun test`) and TypeScript type check, which completed successfully. 
- Test run summary: `73 pass`, `2 skip`, `0 fail` across the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f69b1c5483329222b1367b5c8a3e)