### PR TITLE
Add launch-style hero treatment

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -290,6 +290,175 @@ header {
   position: relative;
 }
 
+section.intro {
+  position: relative;
+  padding: clamp(2.2rem, 2.5vw + 1.4rem, 3.2rem);
+  border-radius: calc(var(--radius-lg) + 6px);
+  background:
+    radial-gradient(
+      circle at top left,
+      color-mix(in srgb, var(--accent-purple) 26%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--accent-color) 22%, transparent),
+      transparent 48%
+    ),
+    linear-gradient(
+      160deg,
+      rgba(7, 12, 24, 0.92) 0%,
+      rgba(12, 17, 32, 0.9) 55%,
+      rgba(10, 16, 30, 0.88) 100%
+    );
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 20%, var(--surface-border));
+  box-shadow: var(--shadow-surface);
+  overflow: hidden;
+}
+
+section.intro::before,
+section.intro::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+section.intro::before {
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      color-mix(in srgb, var(--accent-magenta) 16%, transparent),
+      transparent 45%
+    ),
+    linear-gradient(
+      120deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.04) 50%,
+      transparent 100%
+    );
+  opacity: 0.5;
+}
+
+section.intro::after {
+  background-image: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.05) 0,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 1px,
+    transparent 64px
+  );
+  opacity: 0.25;
+}
+
+section.intro > * {
+  position: relative;
+  z-index: 1;
+}
+
+.launch-panel {
+  margin: 1.35rem 0 0.85rem;
+  padding: 1rem 1.15rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    140deg,
+    rgba(12, 18, 32, 0.92) 0%,
+    rgba(18, 24, 40, 0.92) 100%
+  );
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 18%, var(--surface-border));
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.85rem;
+  max-width: 580px;
+}
+
+.launch-panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem 1.5rem;
+}
+
+.launch-panel__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.launch-panel__status {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.launch-meter {
+  position: relative;
+  height: 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(7, 11, 20, 0.75);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.launch-meter__bar {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--accent-color) 80%, #ffffff 10%),
+    color-mix(in srgb, var(--accent-magenta) 70%, #ffffff 10%)
+  );
+  opacity: 0.85;
+}
+
+.launch-meter__pulse {
+  position: absolute;
+  top: -8px;
+  left: -20%;
+  width: 35%;
+  height: 26px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.8) 0%,
+    rgba(255, 255, 255, 0.1) 60%,
+    transparent 100%
+  );
+  animation: launchSweep 3.6s ease-in-out infinite;
+  opacity: 0.7;
+  mix-blend-mode: screen;
+}
+
+.launch-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.launch-badge {
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .launch-meter__pulse {
+    animation: none;
+    opacity: 0.3;
+  }
+}
+
 header.hero {
   min-height: 55vh;
   padding: clamp(2.4rem, 2vw + 1.4rem, 3.2rem);
@@ -978,7 +1147,17 @@ header.hero {
 .hero-cta-row .cta-button.primary {
   padding: 0.85rem 1.6rem;
   font-size: 1.05rem;
-  box-shadow: var(--shadow-strong);
+  background: linear-gradient(
+    125deg,
+    var(--accent-color) 0%,
+    var(--accent-magenta) 100%
+  );
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.18),
+    0 14px 28px rgba(15, 23, 42, 0.45),
+    0 0 18px var(--glow-color);
 }
 
 .cta-button.ghost {
@@ -1007,6 +1186,20 @@ header.hero {
 
 .cta-button::after {
   content: none;
+}
+
+@keyframes launchSweep {
+  0% {
+    transform: translateX(-30%);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.75;
+  }
+  100% {
+    transform: translateX(360%);
+    opacity: 0;
+  }
 }
 
 .hero-highlights {

--- a/index.html
+++ b/index.html
@@ -73,12 +73,27 @@
       <section class="intro">
         <div class="section-heading">
           <p class="eyebrow">
-            Open-source stims • Quick to try • No accounts
+            Launch-ready stims • Quick to arm • No accounts
           </p>
-          <h1>Audio-reactive visuals for calm focus.</h1>
+          <h1>Launch into audio-reactive play.</h1>
           <p class="section-description">
-            Tap a stim and go. Light, fast, and built for instant immersion.
+            Arm a stim, lock in your controls, and drop straight into motion.
           </p>
+        </div>
+        <div class="launch-panel" aria-label="Launch sequence status">
+          <div class="launch-panel__header">
+            <p class="launch-panel__eyebrow">Launch sequence</p>
+            <p class="launch-panel__status">All systems green</p>
+          </div>
+          <div class="launch-meter" role="presentation">
+            <span class="launch-meter__bar" aria-hidden="true"></span>
+            <span class="launch-meter__pulse" aria-hidden="true"></span>
+          </div>
+          <div class="launch-badges">
+            <span class="launch-badge">Mic armed</span>
+            <span class="launch-badge">Visuals synced</span>
+            <span class="launch-badge">Controller ready</span>
+          </div>
         </div>
         <div class="cta-row hero-cta-row">
           <a
@@ -86,9 +101,9 @@
             class="cta-button primary"
             data-quickstart-slug="holy"
           >
-            Start with Halo Flow
+            Launch Halo Flow
           </a>
-          <a href="#toy-list" class="cta-button ghost">Browse library</a>
+          <a href="#toy-list" class="cta-button ghost">Choose a stim</a>
           <a
             href="https://github.com/zz-plant/stims"
             target="_blank"
@@ -98,7 +113,7 @@
           >
         </div>
         <p class="cta-helper">
-          No accounts. Audio reactivity needs microphone access.
+          No accounts. Microphone access arms audio-reactive mode.
         </p>
       </section>
 


### PR DESCRIPTION
### Motivation
- Make the library intro feel like a game-style launch deck so visitors can jump into audio-reactive play quickly and with a clear "armed" state.

### Description
- Update `index.html` copy and CTAs to emphasize a launch/arm flow and add a `launch-panel` with badges and a visual launch meter for status feedback.
- Add styles to `assets/css/index.css` for `section.intro`, the launch panel, meter animation, badges, and an enhanced primary CTA treatment.
- Include basic accessibility attributes on the new panel and decorative elements such as `aria-label`, `role="presentation"`, and `aria-hidden` on non-interactive visuals.
- No documentation files were changed.

### Testing
- Ran `biome lint assets scripts tests` and the linter completed successfully.
- Ran `biome format --write assets scripts tests` and formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f8c433808332b60e75ee971d9c75)