### PR TITLE
Adjust preflight dialog clipping on mobile

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1283,6 +1283,19 @@ body {
   backdrop-filter: blur(2px);
 }
 
+@media (max-width: 600px) {
+  .preflight-dialog {
+    left: max(12px, env(safe-area-inset-left));
+    right: max(12px, env(safe-area-inset-right));
+    width: auto;
+    clip-path: none;
+  }
+
+  .preflight-dialog::after {
+    clip-path: none;
+  }
+}
+
 .preflight-panel__statuses {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));


### PR DESCRIPTION
### Motivation
- On small screens the preflight (capability) dialog used a decorative cut-out mask that could clip header and controls and make the toy unusable, so the dialog needs to fit the viewport and respect safe-area insets.

### Description
- Add a mobile media query (`@media (max-width: 600px)`) that sets `.preflight-dialog` `left`/`right` to `max(12px, env(safe-area-inset-*))`, `width: auto`, and removes `clip-path` on the dialog and its `::after` pseudo-element to eliminate the cut-out mask on narrow viewports.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69713671d99c8332b2930458a5afa4f2)