### PR TITLE
Remove duplicate keydown listener

### DIFF
--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -669,8 +669,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     }
   }
 
-  window.addEventListener('keydown', handleKeydown);
-
   runtime = createToyRuntime({
     container,
     canvas: container?.querySelector('canvas'),


### PR DESCRIPTION
### Motivation
- Prevent the `handleKeydown` handler from being registered twice which caused shortcuts to trigger twice by removing the redundant `window.addEventListener('keydown', handleKeydown)` call.

### Description
- Remove the extra `window.addEventListener('keydown', handleKeydown)` invocation in `assets/js/toys/spiral-burst.ts` so the listener is only attached in the plugin `setup` and removed in `dispose`.

### Testing
- Ran `bun run check` (includes Biome lint/format and the test suite) and `bun run typecheck`; the test suite passed (73 pass, 2 skip) and type checking completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714848d00c8332840075a83ec1e7ab)