### PR TITLE
Polish library surface styling

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -15,6 +15,13 @@
   --highlight-glow: color-mix(in srgb, var(--accent-magenta) 10%, transparent);
   --surface-gradient: var(--card-bg);
   --surface-border: rgba(255, 255, 255, 0.08);
+  --glass-bg: color-mix(in srgb, var(--card-bg) 88%, transparent);
+  --glass-border: color-mix(
+    in srgb,
+    var(--accent-color) 16%,
+    var(--surface-border)
+  );
+  --surface-highlight: color-mix(in srgb, var(--accent-color) 18%, transparent);
   --shadow-strong: 0 12px 26px rgba(0, 0, 0, 0.25);
   --shadow-soft: 0 6px 16px rgba(0, 0, 0, 0.18);
   --shadow-surface: 0 10px 22px rgba(0, 0, 0, 0.28);
@@ -44,6 +51,13 @@ html.light {
   --highlight-glow: color-mix(in srgb, var(--accent-magenta) 10%, transparent);
   --surface-gradient: var(--card-bg);
   --surface-border: rgba(11, 16, 48, 0.1);
+  --glass-bg: color-mix(in srgb, var(--card-bg) 92%, transparent);
+  --glass-border: color-mix(
+    in srgb,
+    var(--accent-color) 22%,
+    var(--surface-border)
+  );
+  --surface-highlight: color-mix(in srgb, var(--accent-color) 16%, transparent);
   color-scheme: light;
 }
 
@@ -167,9 +181,10 @@ h6 {
   top: clamp(0.5rem, 1vw, 1rem);
   z-index: 10;
   border-radius: var(--radius-pill);
-  background: var(--card-bg);
-  border: 1px solid var(--surface-border);
-  backdrop-filter: none;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   box-shadow: var(--shadow-soft);
   transition:
     box-shadow 0.3s ease,
@@ -410,25 +425,37 @@ section.intro > * {
   border-radius: var(--radius-lg);
   background: linear-gradient(
     140deg,
-    rgba(12, 18, 32, 0.92) 0%,
-    rgba(18, 24, 40, 0.92) 100%
+    color-mix(in srgb, var(--card-bg) 92%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 10%, var(--card-bg)) 100%
   );
-  border: 1px solid
-    color-mix(in srgb, var(--accent-color) 18%, var(--surface-border));
+  border: 1px solid var(--glass-border);
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 0.85rem;
   max-width: 580px;
+  position: relative;
+  overflow: hidden;
 }
 
 html.light .launch-panel {
   background: linear-gradient(
     140deg,
-    rgba(255, 255, 255, 0.92) 0%,
-    rgba(236, 242, 252, 0.92) 100%
+    color-mix(in srgb, var(--card-bg) 96%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 12%, var(--card-bg)) 100%
   );
-  border: 1px solid
-    color-mix(in srgb, var(--accent-color) 22%, var(--surface-border));
+}
+
+.launch-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 120% at 15% 0%,
+    var(--surface-highlight),
+    transparent 58%
+  );
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 .launch-panel__header {
@@ -1495,10 +1522,12 @@ h1 {
   gap: 0.25rem;
   padding: 0.75rem 0.95rem;
   border-radius: var(--radius-md);
-  border: 1px solid var(--surface-border);
-  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--card-bg) 82%, transparent);
   min-width: 220px;
   color: var(--text-muted);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .search-meta__results {
@@ -1519,13 +1548,14 @@ h1 {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.6rem;
-  background: rgba(10, 18, 32, 0.92);
-  border: 1px solid
-    color-mix(in srgb, var(--accent-color) 22%, var(--surface-border));
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-pill);
   padding: 0.5rem 0.95rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   position: relative;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .search-field__icon {
@@ -1767,7 +1797,11 @@ h1 {
 }
 
 .webtoy-card {
-  background: var(--surface-gradient);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--card-bg) 92%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 10%, var(--card-bg)) 100%
+  );
   border-radius: var(--radius-lg);
   padding: 1.35rem 1.25rem;
   transition:
@@ -1777,9 +1811,12 @@ h1 {
     background 0.3s ease;
   text-align: left;
   cursor: pointer;
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: none;
-  border: 1px solid var(--surface-border);
+  box-shadow:
+    var(--shadow-soft),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
   color: inherit;
   width: 100%;
   display: flex;
@@ -1800,7 +1837,7 @@ h1 {
   inset: 0;
   border-radius: var(--radius-lg);
   cursor: pointer;
-  z-index: 1;
+  z-index: 3;
 }
 
 .webtoy-card__link:focus-visible {
@@ -1817,21 +1854,46 @@ h1 {
   gap: 0.6rem;
   width: 100%;
   position: relative;
-  z-index: 0;
+  z-index: 2;
   pointer-events: none;
 }
 
-/* Gradient shimmer overlay */
 .webtoy-card::before,
 .webtoy-card::after {
-  content: none;
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.webtoy-card::before {
+  background: radial-gradient(
+    140% 120% at 0% 0%,
+    var(--surface-highlight),
+    transparent 60%
+  );
+  opacity: 0.55;
+  transition: opacity 0.3s ease;
+  z-index: 0;
+}
+
+.webtoy-card::after {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  opacity: 0.8;
+  z-index: 1;
 }
 
 .webtoy-card:hover {
-  background: var(--surface-gradient);
   transform: translateY(-2px);
-  box-shadow: var(--shadow-strong);
-  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow:
+    var(--shadow-strong),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  border-color: color-mix(in srgb, var(--accent-color) 35%, transparent);
+}
+
+.webtoy-card:hover::before {
+  opacity: 0.8;
 }
 
 .webtoy-card:focus-visible {


### PR DESCRIPTION
### Motivation
- Improve the visual polish and perceived depth of the library UI by introducing a subtle glassy surface treatment and highlight sheen for cards and controls.
- Unify surface look-and-feel across navigation, launch panel, search, and library cards via shared variables to simplify future theming tweaks.

### Description
- Add new CSS custom properties `--glass-bg`, `--glass-border`, and `--surface-highlight` and use them to drive translucent surfaces and accents in `assets/css/index.css`.
- Apply blurred, glass-like backgrounds and softened borders to `.top-nav`, `.launch-panel`, `.search-meta`, and `.search-field` using `backdrop-filter` and the new variables.
- Enhance library cards (`.webtoy-card`) with a subtle gradient base, radial highlight `::before` sheen, inset stroke `::after`, increased z-indexing for links/content, and refined hover shadow/border behavior.
- Tidy related layout details (overflow/z-index) to ensure the new overlays and focus styles render correctly.

### Testing
- Ran `biome lint assets scripts tests` as part of pre-commit hooks and the lint check completed successfully. 
- Ran `biome format --write assets scripts tests` via pre-commit hooks and formatting completed successfully. 
- Launched the dev server and produced a Playwright screenshot for a visual smoke check which completed and yielded `artifacts/stims-home-polish.png`. 
- Docs touched: none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697287acafa08332bb572e00296bd9cc)