### PR TITLE
Remove backdrop blur from active toy nav

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -274,7 +274,6 @@ body {
     0 0 18px rgba(17, 216, 255, 0.32);
   border-radius: 18px;
   z-index: 1200;
-  backdrop-filter: blur(14px) saturate(125%);
   pointer-events: auto;
 }
 


### PR DESCRIPTION
### Motivation
- The sticky top navigation used a heavy `backdrop-filter: blur(14px)` which can force repeated expensive repaints during scroll and cause jank on lower-end hardware.

### Description
- Remove the `backdrop-filter` declaration from `.active-toy-nav` in `assets/css/base.css` to avoid the blur workload.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both succeeded; an automated Playwright screenshot attempt to visually validate the change failed due to a headless browser crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729793074c8332b4d5cde9a480bfc6)