### PR TITLE
Fix TDZ initialization errors in symph, seary, and geom stims

### DIFF
--- a/toys/geom.html
+++ b/toys/geom.html
@@ -133,6 +133,9 @@
       let densityMultiplier = 1;
       let speedMultiplier = 1;
       let trailBlend = 0.25;
+      const particles = [];
+      const baseParticleCount = 800;
+      let particleCount = baseParticleCount;
 
       function applyQualityPreset(preset) {
         activeQuality = preset;
@@ -204,10 +207,6 @@
       }
 
       const toy = new CanvasToy(canvas);
-
-      const particles = [];
-      const baseParticleCount = 800;
-      let particleCount = baseParticleCount;
 
       function createParticle() {
         return {

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -91,6 +91,14 @@
       });
 
       const adapter = createSearyFunAdapter();
+      let peakDetector = null;
+      let lastVibrateTime = 0;
+      let currentFreqs = adapter.transformFrequencies({
+        low: 0,
+        mid: 0,
+        high: 0,
+      });
+      const audioSelect = document.getElementById('audioSelect');
       const funControls = initFunControls({
         paletteOptions: adapter.paletteOptions,
         onPaletteChange: (palette, colors) =>
@@ -364,11 +372,6 @@
         'u_burst_intensity'
       );
 
-      currentFreqs = adapter.transformFrequencies({
-        low: 0,
-        mid: 0,
-        high: 0,
-      });
       const orientation = { alpha: 0, beta: 0, gamma: 0 };
       const touches = [
         { x: 0.0, y: 0.0 },
@@ -469,14 +472,6 @@
       }
 
       // Audio setup for beat detection and frequency analysis
-      let peakDetector = null;
-      let lastVibrateTime = 0;
-      let currentFreqs = adapter.transformFrequencies({
-        low: 0,
-        mid: 0,
-        high: 0,
-      });
-      const audioSelect = document.getElementById('audioSelect');
 
       function vibrateBasedOnAudio(lowFreq, midFreq, highFreq) {
         const intensity = Math.max(lowFreq, midFreq, highFreq);

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -237,6 +237,34 @@
       });
 
       const adapter = createSymphFunAdapter();
+      let gradientStops = adapter.paletteOptions.bright;
+      let colorOffset = [...adapter.paletteAccent];
+      let time = 0.0;
+      let audioData = adapter.transformAudioValue(0);
+      let touchPoint = [0.0, 0.0];
+      let smoothedLevel = 0;
+      let burstEnergy = 0;
+      let lastTransientTime = 0;
+      const defaultSensitivity = 0.7;
+      let transientSensitivity = defaultSensitivity;
+      let sparklesEnabled = true;
+      let burstsEnabled = true;
+      let analyserRef = null;
+      const rippleBase = 0.15;
+      const SPARKLE_POOL_SIZE = 120;
+      const sparklePool = Array.from({ length: SPARKLE_POOL_SIZE }, () => ({
+        active: false,
+        x: 0,
+        y: 0,
+        vx: 0,
+        vy: 0,
+        life: 0,
+        maxLife: 0,
+        size: 0,
+        alpha: 0,
+        color: [255, 255, 255],
+      }));
+
       const funControls = initFunControls({
         paletteOptions: adapter.paletteOptions,
         onPaletteChange: (palette, colors) => {
@@ -247,8 +275,6 @@
         onMotionChange: (intensity, mode) => adapter.setMotion(intensity, mode),
         onAudioToggle: (enabled) => adapter.setAudioReactive(enabled),
       });
-
-      const defaultSensitivity = 0.7;
       const extraControls = document.createElement('div');
       extraControls.className = 'fun-subsection';
       extraControls.innerHTML = `
@@ -315,33 +341,6 @@
       }
 
       const toy = new CanvasToy(canvas);
-
-      let gradientStops = adapter.paletteOptions.bright;
-      let time = 0.0;
-      let audioData = adapter.transformAudioValue(0);
-      let colorOffset = [...adapter.paletteAccent];
-      let touchPoint = [0.0, 0.0];
-      let smoothedLevel = 0;
-      let burstEnergy = 0;
-      let lastTransientTime = 0;
-      let transientSensitivity = defaultSensitivity;
-      let sparklesEnabled = true;
-      let burstsEnabled = true;
-      let analyserRef = null;
-      const rippleBase = 0.15;
-      const SPARKLE_POOL_SIZE = 120;
-      const sparklePool = Array.from({ length: SPARKLE_POOL_SIZE }, () => ({
-        active: false,
-        x: 0,
-        y: 0,
-        vx: 0,
-        vy: 0,
-        life: 0,
-        maxLife: 0,
-        size: 0,
-        alpha: 0,
-        color: [255, 255, 255],
-      }));
 
       const sparkleToggle = extraControls.querySelector('.fun-sparkles');
       sparkleToggle?.addEventListener('change', (event) => {


### PR DESCRIPTION
### Motivation
- Prevent runtime temporal-dead-zone (TDZ) errors that occur when UI wiring references variables before they are initialized in several toy HTML entry points.
- Ensure controls and callbacks can safely reference audio and particle state on startup without relying on load ordering.

### Description
- Initialize Symph palette/audio/render state (palette stops, color offset, audio/touch/sparkle state, and sparkle pool) before calling `initFunControls` so callbacks cannot access uninitialized variables (`toys/symph.html`).
- Move Seary audio-related state (`peakDetector`, `currentFreqs`, `audioSelect`, and vibration timers) above the fun control initialization so peak detector callbacks do not hit TDZ on startup (`toys/seary.html`).
- Relocate Geom particle constants (`particles`, `baseParticleCount`, `particleCount`) above the quality preset registration so `applyQualityPreset` and the iframe quality sync do not reference uninitialized particle counts (`toys/geom.html`).

### Testing
- Ran `bun run check` (includes project tests and linters) and it completed successfully.
- Ran `bun run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729f49f69c8332a42cbf38146dd8cb)