### PR TITLE
Adjust skip link and preflight dialog positioning

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -835,9 +835,19 @@ body {
 .control-panel--floating {
   bottom: auto;
   left: auto;
-  top: 12px;
-  right: 12px;
+  top: max(12px, env(safe-area-inset-top));
+  right: max(12px, env(safe-area-inset-right));
   width: min(360px, 92vw);
+  max-height: min(
+    calc(
+      100dvh -
+      24px -
+      env(safe-area-inset-top) -
+      env(safe-area-inset-bottom)
+    ),
+    90vh
+  );
+  overflow: auto;
 }
 
 .control-panel::before,

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -85,9 +85,9 @@ html.light .hero-background-canvas {
 }
 
 .skip-link {
-  position: absolute;
+  position: fixed;
   left: 1.5rem;
-  top: 1.25rem;
+  top: -6rem;
   padding: 0.65rem 1rem;
   border-radius: var(--radius-pill);
   background: var(--card-bg);
@@ -95,9 +95,9 @@ html.light .hero-background-canvas {
   text-decoration: none;
   box-shadow: var(--shadow-soft);
   border: 1px solid var(--surface-border);
-  transform: translateY(-140%);
   transition:
-    transform 0.2s ease,
+    top 0.2s ease,
+    opacity 0.2s ease,
     box-shadow 0.2s ease,
     background 0.2s ease,
     border-color 0.2s ease;
@@ -107,10 +107,12 @@ html.light .hero-background-canvas {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  opacity: 0;
 }
 
 .skip-link:focus-visible {
-  transform: translateY(0);
+  top: max(1.25rem, env(safe-area-inset-top));
+  opacity: 1;
   outline: 2px solid var(--accent-color);
   outline-offset: 3px;
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);


### PR DESCRIPTION
### Motivation
- Ensure the skip link remains visually hidden unless intentionally focused to avoid it appearing visible by default.
- Prevent the floating capability/preflight dialog from clipping against viewport edges on narrow or safe-area devices.

### Description
- Update `.skip-link` to use `position: fixed`, move it off-canvas (`top: -6rem`) with `opacity: 0`, and animate `top`/`opacity` so it only becomes visible on `:focus-visible` where `top` is set to `max(1.25rem, env(safe-area-inset-top))` and `opacity: 1`.
- Make `.control-panel--floating` respect safe-area insets by using `top: max(12px, env(safe-area-inset-top))` and `right: max(12px, env(safe-area-inset-right))`.
- Add `max-height` (computed with `100dvh` minus safe-area insets and a fallback `90vh`) and `overflow: auto` to the floating panel so the preflight dialog can scroll instead of clipping.

### Testing
- Ran `biome lint assets scripts tests` which completed without errors.
- Ran `biome format --write assets scripts tests` which applied formatting changes.
- Launched the dev server and ran a Playwright script to open the page, open the preflight dialog, and capture a screenshot which confirmed the dialog is positioned with safe-area spacing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b35ac2c8833286c7e51dc5e0be7b)