### PR TITLE
Respect safe-area insets for control panel positioning

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -815,8 +815,8 @@ body {
 
 .control-panel {
   position: fixed;
-  bottom: 16px;
-  left: 16px;
+  bottom: max(16px, env(safe-area-inset-bottom));
+  left: max(16px, env(safe-area-inset-left));
   width: min(320px, 90vw);
   color: #e9fbff;
   padding: 16px;


### PR DESCRIPTION
### Motivation
- Prevent the control panel from being obscured by device notches or rounded corners by honoring safe-area insets for its bottom and left offsets.

### Description
- Update `.control-panel` in `assets/css/base.css` to use `bottom: max(16px, env(safe-area-inset-bottom))` and `left: max(16px, env(safe-area-inset-left))`, leaving `.control-panel--floating` behavior unchanged.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both succeeded; no docs were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ed0d3f108332a3b6122d30372599)