### PR TITLE
Respect configurable touch-action in toy runtime

### DIFF
--- a/assets/js/core/toy-runtime.ts
+++ b/assets/js/core/toy-runtime.ts
@@ -54,6 +54,7 @@ export type ToyRuntimeOptions = {
   input?: Partial<Omit<UnifiedInputOptions, 'target'>> & {
     enabled?: boolean;
     target?: HTMLElement | null;
+    touchAction?: 'none' | 'manipulation' | 'auto';
   };
   performance?: {
     enabled?: boolean;
@@ -142,8 +143,14 @@ export function createToyRuntime({
         (toy.canvas instanceof HTMLElement ? toy.canvas : null) ??
         toy.container);
 
-  if (inputTarget instanceof HTMLElement) {
-    inputTarget.style.touchAction = 'manipulation';
+  const resolvedTouchAction =
+    input?.touchAction ??
+    (inputTarget === toy.canvas && inputTarget instanceof HTMLElement
+      ? 'none'
+      : undefined);
+
+  if (inputTarget instanceof HTMLElement && resolvedTouchAction) {
+    inputTarget.style.touchAction = resolvedTouchAction;
   }
 
   const inputAdapter =


### PR DESCRIPTION
### Motivation
- Some canvas-based toys rely on pinch/rotate gestures and were having their touch behavior overwritten by the runtime.
- Provide a way to configure `touch-action` per runtime input target while defaulting canvas targets to `none` to preserve gesture support.

### Description
- Added `touchAction?: 'none' | 'manipulation' | 'auto'` to `ToyRuntimeOptions.input` in `assets/js/core/toy-runtime.ts`.
- Resolve `touch-action` with `input?.touchAction` taking precedence and default to `'none'` when the resolved target is the runtime canvas element.
- Only apply `inputTarget.style.touchAction` when a resolved value is present so non-canvas elements are not overwritten unintentionally.

### Testing
- Ran `bun run check` (which executes `biome check`, `bun run typecheck`, and the test suite) and it completed successfully.
- Ran `bun run typecheck` and `tsc --noEmit` with no errors.
- Ran `bun test` which reported `73 pass, 2 skip, 0 fail` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ed0c645483329e76751752083571)