### PR TITLE
Update canvas resize viewport handling

### DIFF
--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -19,12 +19,24 @@ export function setupCanvasResize(
   context: CanvasContext,
   { maxPixelRatio, onResize }: CanvasResizeOptions = {},
 ) {
+  const getViewportSize = () => {
+    const visualViewport = window.visualViewport;
+    const documentElement = document.documentElement;
+    const cssWidth =
+      visualViewport?.width ?? documentElement.clientWidth ?? window.innerWidth;
+    const cssHeight =
+      visualViewport?.height ??
+      documentElement.clientHeight ??
+      window.innerHeight;
+
+    return { cssWidth, cssHeight };
+  };
+
   const resize = () => {
     const devicePixelRatio = window.devicePixelRatio || 1;
     const maxSupportedPixelRatio = maxPixelRatio ?? devicePixelRatio;
     const pixelRatio = Math.min(devicePixelRatio, maxSupportedPixelRatio);
-    const cssWidth = window.innerWidth;
-    const cssHeight = window.innerHeight;
+    const { cssWidth, cssHeight } = getViewportSize();
     const width = Math.max(1, Math.floor(cssWidth * pixelRatio));
     const height = Math.max(1, Math.floor(cssHeight * pixelRatio));
 
@@ -60,5 +72,13 @@ export function setupCanvasResize(
   const observer = new ResizeObserver(() => resize());
   observer.observe(canvas.parentElement ?? canvas);
 
-  return () => observer.disconnect();
+  const visualViewport = window.visualViewport;
+  visualViewport?.addEventListener('resize', resize);
+  visualViewport?.addEventListener('scroll', resize);
+
+  return () => {
+    observer.disconnect();
+    visualViewport?.removeEventListener('resize', resize);
+    visualViewport?.removeEventListener('scroll', resize);
+  };
 }


### PR DESCRIPTION
### Motivation
- Prefer `visualViewport` dimensions so canvas sizing responds correctly to mobile UI changes like the URL bar, with fallbacks for environments without `visualViewport`.
- Ensure canvas updates when the visual viewport changes (including URL bar show/hide) by listening to relevant events.
- Prevent leaks by removing added listeners when the resize handler is torn down.

### Description
- Add `getViewportSize` which prefers `window.visualViewport?.width/height` and falls back to `document.documentElement.clientWidth/clientHeight` or `window.innerWidth/innerHeight`.
- Use `getViewportSize` inside the `resize` routine while preserving pixel-ratio calculation and existing `context.viewport` / `context.setTransform` behavior and `onResize` callback payload.
- Register `visualViewport` `resize` and `scroll` listeners to invoke `resize`, and remove those listeners in the returned cleanup function along with disconnecting the `ResizeObserver`.

### Testing
- Ran `bun run check` (runs `biome check`, typecheck, and tests) and it completed successfully.
- Unit tests executed as part of the check ran 75 tests with 73 passed, 2 skipped, and 0 failed.
- `tsc --noEmit` and `biome` checks/formatting passed as part of the verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ed0a094483329163f0eee3a3b5dd)