### PR TITLE
Improve library search and capability cues; expose demo audio control

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,12 +478,13 @@
           empty.className = 'empty-state';
           const message = document.createElement('p');
           message.className = 'empty-state__message';
-          message.textContent = 'No stims match your search.';
+          message.textContent =
+            'No stims match your search or filters. Try clearing your search or removing filters.';
 
           const reset = document.createElement('button');
           reset.type = 'button';
           reset.className = 'cta-button ghost';
-          reset.textContent = 'Clear search';
+          reset.textContent = 'Reset search and filters';
           reset.addEventListener('click', () => {
             if (search instanceof HTMLInputElement) {
               search.value = '';
@@ -492,7 +493,10 @@
             activeFilters.clear();
             sortBy = 'featured';
             const chips = document.querySelectorAll('[data-filter-chip]');
-            chips.forEach((chip) => chip.classList.remove('is-active'));
+            chips.forEach((chip) => {
+              chip.classList.remove('is-active');
+              chip.setAttribute('aria-pressed', 'false');
+            });
             const sortControl = document.querySelector('[data-sort-control]');
             if (sortControl && sortControl.tagName === 'SELECT') {
               sortControl.value = sortBy;
@@ -522,11 +526,20 @@
           }
         };
 
+        const getQueryTokens = (query) =>
+          (query || '')
+            .trim()
+            .toLowerCase()
+            .split(/[\s,]+/)
+            .filter(Boolean);
+
         const applyFilters = (query = cachedQuery) => {
-          const normalized = (query || '').toLowerCase();
+          const queryTokens = getQueryTokens(query);
           const filtered = allToys.filter((toy) => {
+            const haystack = getHaystack(toy);
             const matchesQuery =
-              !normalized || getHaystack(toy).includes(normalized);
+              queryTokens.length === 0 ||
+              queryTokens.every((token) => haystack.includes(token));
             return matchesQuery && matchesFilters(toy);
           });
 

--- a/toys/lights.html
+++ b/toys/lights.html
@@ -85,17 +85,21 @@
           Start Audio &amp; Visualization
         </button>
       </div>
+      <div class="control-panel__row">
+        <div class="control-panel__text">
+          <span class="control-panel__label">Demo audio</span>
+          <small>Try the visuals without microphone access.</small>
+        </div>
+        <button id="use-demo-audio" class="cta-button">
+          Use demo audio
+        </button>
+      </div>
       <div
         id="audio-status"
         class="control-panel__status"
         role="status"
         hidden
       ></div>
-      <div class="control-panel__actions">
-        <button id="use-demo-audio" class="cta-button" hidden>
-          Load demo audio
-        </button>
-      </div>
     </div>
 
     <!-- WebGL Canvas -->


### PR DESCRIPTION
### Motivation
- Make library filtering less surprising by matching multi-word queries and avoiding an empty disappearing grid when filters return zero results.
- Surface required capabilities (microphone, demo audio, motion) on library cards so users see upfront what inputs a toy needs.
- Provide a first-class "Use demo audio" alternative in the lights toy UI for people who prefer not to grant mic access.

### Description
- Enhanced the search logic in the enhanced library view by adding `getQueryTokens` and matching every token against the toy `haystack` instead of a single substring check (updated `assets/js/library-view.js`).
- Mirrored tokenized query matching in the no-JS fallback renderer in `index.html` to keep search behavior consistent for both render paths.
- Reworked the empty-state markup/text in both renderers to use the existing `.empty-state` styling, improved messaging, and added a reset button labeled `Reset search and filters` that clears search and filter chips (also sets `aria-pressed` to `false`).
- Added capability badges for `Mic`, `Demo audio`, and `Motion` alongside the existing `WebGPU` badge in the enhanced card renderer, with proper `aria-label`/`title` and warning state for missing WebGPU (in `assets/js/library-view.js`).
- Exposed the demo-audio action in the lights toy control panel as a visible, parallel control in `toys/lights.html` so users can choose demo audio without first attempting the microphone.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc --noEmit`, and the test suite); the command completed successfully with all automated tests passing (73 passed, 2 skipped).
- Formatted and linted files as part of the pre-commit hooks during the run; no formatting or lint errors remained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972fed972b48332b4255d9cbd8e5bc2)