### PR TITLE
Resolve toy nav title from toys-data with humanized fallback

### DIFF
--- a/toy.html
+++ b/toy.html
@@ -15,6 +15,7 @@
     <script type="module">
       import { attachCapabilityPreflight } from './assets/js/core/capability-preflight.ts';
       import { startToyPage } from './assets/js/toyMain.ts';
+      import toysData from './assets/js/toys-data.js';
       import { initNavigation } from './assets/js/ui/nav.ts';
       import { initAudioControls } from './assets/js/ui/audio-controls.ts';
       import { initSystemControls } from './assets/js/ui/system-controls.ts';
@@ -41,14 +42,27 @@
         return null;
       };
 
+      const humanizeSlug = (slug) => {
+        if (!slug) return 'Web toy';
+        return slug
+          .split('-')
+          .filter(Boolean)
+          .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+          .join(' ');
+      };
+
+      const getToyTitle = (slug) =>
+        toysData.find((toy) => toy.slug === slug)?.title;
+
       // Get toy slug from URL for navigation
-      const toySlug = new URLSearchParams(window.location.search).get('toy') || 'Web toy';
+      const toySlug = new URLSearchParams(window.location.search).get('toy');
+      const toyTitle = getToyTitle(toySlug) ?? humanizeSlug(toySlug);
 
       if (navContainer) {
         initNavigation(navContainer, {
           mode: 'toy',
-          title: toySlug.charAt(0).toUpperCase() + toySlug.slice(1),
-          slug: toySlug,
+          title: toyTitle,
+          slug: toySlug ?? undefined,
           onBack: () => { window.location.href = 'index.html'; }
         });
       }


### PR DESCRIPTION
### Motivation
- Show a human-friendly toy title in the active toy navigation by preferring registered metadata when available and falling back to a readable slug label otherwise.
- Preserve existing slug display and back-navigation behavior so sharing and routing remain unchanged.

### Description
- Import `toysData` in the inline module of `toy.html` and add `getToyTitle` and `humanizeSlug` helpers to map `slug → title` with a readable fallback.
- Compute `toyTitle` from metadata and pass `title: toyTitle` to `initNavigation`, while continuing to pass the original `slug` so the slug pill and back control remain intact.
- No other UI or routing logic was modified.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc`, and `bun test`) and the test suite completed successfully with all tests passing; the run shows `73 pass`, `2 skip`, and `0 fail`.
- No documentation files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731eea62d483328246ddc8a47e23c0)