### PR TITLE
Add hero readiness summary and performance link

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1146,6 +1146,29 @@ header.hero {
   margin: 1.1rem 0;
 }
 
+.hero-readiness {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.4rem 0 0.9rem;
+}
+
+.hero-readiness__text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--surface-border);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.hero-readiness__action {
+  font-size: 0.95rem;
+  padding: 0.55rem 1.1rem;
+}
+
 .cta-helper {
   margin: -0.5rem 0 1.5rem;
   max-width: 720px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,6 @@
 import { initNavigation, loadFromQuery, loadToy } from './loader.ts';
 import { initGamepadNavigation } from './utils/gamepad-navigation.ts';
+import { initHeroReadinessSummary } from './utils/init-hero-readiness.ts';
 import { initLibraryView } from './utils/init-library.ts';
 import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
 import { initQuickstartCta } from './utils/init-quickstart.ts';
@@ -20,6 +21,7 @@ const startApp = async () => {
     },
   );
   runInit('quickstart CTA', () => initQuickstartCta({ loadToy }));
+  runInit('hero readiness summary', initHeroReadinessSummary);
   runInit('nav scroll effects', initNavScrollEffects);
   runInit('system check', initSystemCheck);
   runInit('gamepad navigation', initGamepadNavigation);

--- a/assets/js/readiness-probe.ts
+++ b/assets/js/readiness-probe.ts
@@ -103,11 +103,40 @@ const probeMicrophone = async () => {
   };
 };
 
-const probeRendering = () => {
+const getRenderCapabilities = () => {
   const hasWebGPU = Boolean(navigator?.gpu);
   const hasWebGL =
     typeof WebGL !== 'undefined' &&
     (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
+
+  return { hasWebGPU, hasWebGL };
+};
+
+export const getRenderCompatibilitySummary = () => {
+  const { hasWebGPU, hasWebGL } = getRenderCapabilities();
+
+  if (hasWebGPU) {
+    return {
+      state: STATUS.success,
+      label: 'WebGPU ready',
+    };
+  }
+
+  if (hasWebGL) {
+    return {
+      state: STATUS.warn,
+      label: 'WebGL fallback active',
+    };
+  }
+
+  return {
+    state: STATUS.error,
+    label: 'Graphics acceleration unavailable',
+  };
+};
+
+const probeRendering = () => {
+  const { hasWebGPU, hasWebGL } = getRenderCapabilities();
 
   if (hasWebGPU) {
     return {

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -24,6 +24,33 @@ type SystemControlOptions = {
   variant?: 'floating' | 'inline';
 };
 
+const formatQualityLabel = (label: string) =>
+  label.replace(/\s*\(.*?\)\s*/g, '').trim();
+
+type PerformanceSummaryOptions = {
+  qualityPresets?: QualityPreset[];
+  defaultPresetId?: string;
+};
+
+export const getPerformanceSummaryLabel = (
+  options: PerformanceSummaryOptions = {},
+) => {
+  const { qualityPresets = DEFAULT_QUALITY_PRESETS, defaultPresetId } = options;
+  const preset = getActiveQualityPreset({
+    presets: qualityPresets,
+    defaultPresetId,
+  });
+  return formatQualityLabel(preset.label);
+};
+
+export const subscribeToPerformanceSummary = (
+  subscriber: (label: string) => void,
+) => {
+  return subscribeToQualityPreset((preset) => {
+    subscriber(formatQualityLabel(preset.label));
+  });
+};
+
 function createValueLabel(label: string) {
   const value = document.createElement('span');
   value.className = 'control-panel__value';

--- a/assets/js/utils/init-hero-readiness.ts
+++ b/assets/js/utils/init-hero-readiness.ts
@@ -1,0 +1,40 @@
+import {
+  isCompatibilityModeEnabled,
+  subscribeToRenderPreferences,
+} from '../core/render-preferences.ts';
+import { getRenderCompatibilitySummary } from '../readiness-probe.ts';
+import {
+  getPerformanceSummaryLabel,
+  subscribeToPerformanceSummary,
+} from '../ui/system-controls.ts';
+
+const buildCompatibilityLabel = () => {
+  if (isCompatibilityModeEnabled()) {
+    return 'WebGL forced';
+  }
+
+  return getRenderCompatibilitySummary().label;
+};
+
+export const initHeroReadinessSummary = () => {
+  const summary = document.querySelector('[data-hero-readiness-summary]');
+  if (!(summary instanceof HTMLElement)) return;
+
+  const text = summary.querySelector('[data-hero-readiness-text]');
+  if (!(text instanceof HTMLElement)) return;
+
+  const updateSummary = (performanceLabel: string) => {
+    const compatibilityLabel = buildCompatibilityLabel();
+    text.textContent = `Performance: ${performanceLabel} • ${compatibilityLabel}`;
+  };
+
+  updateSummary(getPerformanceSummaryLabel());
+
+  subscribeToPerformanceSummary((label) => {
+    updateSummary(label);
+  });
+
+  subscribeToRenderPreferences(() => {
+    updateSummary(getPerformanceSummaryLabel());
+  });
+};

--- a/assets/js/utils/init-system-check.ts
+++ b/assets/js/utils/init-system-check.ts
@@ -18,8 +18,10 @@ export const initSystemCheck = () => {
     });
   }
 
-  const trigger = document.querySelector('[data-open-preflight]');
-  if (!(trigger instanceof HTMLElement)) return;
+  const triggers = Array.from(
+    document.querySelectorAll('[data-open-preflight]'),
+  ).filter((element): element is HTMLElement => element instanceof HTMLElement);
+  if (triggers.length === 0) return;
 
   const preflight = attachCapabilityPreflight({
     heading: 'System check',
@@ -29,7 +31,10 @@ export const initSystemCheck = () => {
     showCloseButton: true,
   });
 
-  trigger.addEventListener('click', () => {
-    preflight.open(trigger);
+  triggers.forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      preflight.open(trigger);
+    });
   });
 };

--- a/index.html
+++ b/index.html
@@ -112,6 +112,18 @@
             >View the code</a
           >
         </div>
+        <div class="hero-readiness" data-hero-readiness-summary>
+          <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
+            Performance: Balanced • Checking compatibility…
+          </p>
+          <a
+            href="#system-check"
+            class="cta-button ghost hero-readiness__action"
+            data-open-preflight
+          >
+            Adjust performance
+          </a>
+        </div>
         <p class="cta-helper">
           No accounts. Microphone access arms audio-reactive mode.
         </p>


### PR DESCRIPTION
### Motivation

- Surface a compact readiness summary next to the hero CTAs so users immediately see current performance preset and rendering compatibility without opening the system panel.  
- Reuse existing readiness and system-control signals so the summary stays accurate and reacts to changes in quality presets and compatibility overrides.  
- Provide a direct affordance to let users quickly open the existing capability preflight / system check to adjust performance settings.

### Description

- Add a small hero summary UI block with `data-hero-readiness-summary` and an `Adjust performance` action in `index.html`.  
- Create a new initializer `assets/js/utils/init-hero-readiness.ts` that composes `getPerformanceSummaryLabel`, `subscribeToPerformanceSummary`, `getRenderCompatibilitySummary`, and `subscribeToRenderPreferences` to keep the hero summary live.  
- Expose `getRenderCompatibilitySummary` in `assets/js/readiness-probe.ts` and add `getPerformanceSummaryLabel` / `subscribeToPerformanceSummary` helpers in `assets/js/ui/system-controls.ts` to supply compact labels.  
- Wire the initializer into app startup via `assets/js/main.js`, update `assets/js/utils/init-system-check.ts` to attach the capability preflight to all matching triggers, and add styles in `assets/css/index.css` for a compact inline chip/button layout.

### Testing

- Ran `bun run check` (runs `biome check`, `tsc --noEmit`, and the test suite), and the command completed successfully.  
- Test results from the run: `73` tests passed, `2` tests skipped, `0` failed.  
- Formatter and linter passed as part of `bun run check`.  

Docs touched/added: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731ed255248332a4b2d32d193393cf)