### PR TITLE
Expand results metadata summaries

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1531,6 +1531,8 @@ h1 {
   font-size: 0.95rem;
   color: var(--text-muted);
   font-weight: 600;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .search-meta__note {

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1158,13 +1158,46 @@ export function createLibraryView({
       ? toy.featuredRank
       : Number.POSITIVE_INFINITY;
 
+  const getSortLabel = () => {
+    const sortControl = document.querySelector('[data-sort-control]');
+    if (sortControl && sortControl.tagName === 'SELECT') {
+      const selected = sortControl.selectedOptions?.[0];
+      const label = selected?.textContent?.trim();
+      if (label) return label;
+    }
+    const sortLabels = {
+      featured: 'Featured',
+      newest: 'Newest',
+      immersive: 'Most immersive',
+      az: 'A → Z',
+    };
+    return sortLabels[sortBy] ?? sortBy;
+  };
+
+  const getActiveFilterLabels = () =>
+    Array.from(
+      document.querySelectorAll('[data-filter-chip].is-active'),
+    ).flatMap((chip) => {
+      const label = chip.textContent?.trim();
+      return label ? [label] : [];
+    });
+
   const updateResultsMeta = (visibleCount) => {
     const meta = ensureMetaNode();
     if (!meta) return;
-    const total = allToys.length;
     const hasFilters = searchQuery.trim() || activeFilters.size > 0;
     const descriptor = hasFilters ? 'matching stims' : 'total stims';
-    meta.textContent = `${visibleCount} ${descriptor} • ${total} in library`;
+    const parts = [`${visibleCount} ${descriptor}`];
+    const trimmedQuery = searchQuery.trim();
+    if (trimmedQuery) {
+      parts.push(`Search: “${trimmedQuery}”`);
+    }
+    const filterLabels = getActiveFilterLabels();
+    if (filterLabels.length > 0) {
+      parts.push(`Filters: ${filterLabels.join(', ')}`);
+    }
+    parts.push(`Sort: ${getSortLabel()}`);
+    meta.textContent = parts.join(' • ');
   };
 
   const resetFiltersAndSearch = () => {

--- a/index.html
+++ b/index.html
@@ -484,13 +484,45 @@
         };
         let allToys = [];
 
-        const updateResultsMeta = (count, total, query = '') => {
+        const getSortLabel = () => {
+          const sortControl = document.querySelector('[data-sort-control]');
+          if (sortControl && sortControl.tagName === 'SELECT') {
+            const selected = sortControl.selectedOptions?.[0];
+            const label = selected?.textContent?.trim();
+            if (label) return label;
+          }
+          const sortLabels = {
+            featured: 'Featured',
+            newest: 'Newest',
+            immersive: 'Most immersive',
+            az: 'A → Z',
+          };
+          return sortLabels[sortBy] ?? sortBy;
+        };
+
+        const getActiveFilterLabels = () =>
+          Array.from(
+            document.querySelectorAll('[data-filter-chip].is-active')
+          ).flatMap((chip) => {
+            const label = chip.textContent?.trim();
+            return label ? [label] : [];
+          });
+
+        const updateResultsMeta = (count, _total, query = '') => {
           if (!(searchResults instanceof HTMLElement)) return;
-          const countLabel = `${count} ${count === 1 ? 'match' : 'matches'}`;
-          const totalLabel = `${total} ${total === 1 ? 'stim' : 'stims'}`;
-          searchResults.textContent = query
-            ? `${countLabel} for “${query}”`
-            : `Showing all ${totalLabel}`;
+          const hasFilters = query.trim() || activeFilters.size > 0;
+          const descriptor = hasFilters ? 'matching stims' : 'total stims';
+          const parts = [`${count} ${descriptor}`];
+          const trimmedQuery = query.trim();
+          if (trimmedQuery) {
+            parts.push(`Search: “${trimmedQuery}”`);
+          }
+          const filterLabels = getActiveFilterLabels();
+          if (filterLabels.length > 0) {
+            parts.push(`Filters: ${filterLabels.join(', ')}`);
+          }
+          parts.push(`Sort: ${getSortLabel()}`);
+          searchResults.textContent = parts.join(' • ');
         };
 
         const renderEmptyState = () => {


### PR DESCRIPTION
### Motivation
- Make the search/results status more informative by exposing the active search query, active filter chips, and the current sort choice to assistive and sighted users.
- Keep the no-JS fallback consistent with the JS-driven UI so users without JS see the same summary information.
- Ensure the live status line remains accessible as `role="status"`/`aria-live="polite"` while allowing long summaries to wrap cleanly.

### Description
- Enhanced `updateResultsMeta` in `assets/js/library-view.js` to include the trimmed search query, active filter labels, and the sort label, and added helper functions `getSortLabel` and `getActiveFilterLabels` to derive those values.
- Mirrored the same summary-building logic in the inline no-JS fallback `updateResultsMeta` in `index.html`, using the same helpers to read active chips and sort text.
- Updated `assets/css/index.css` `.search-meta__results` to `white-space: normal` and `overflow-wrap: anywhere` to prevent truncation and allow long summaries to wrap.
- The update reads the visible chip text for filters and uses the select option text (with a small fallback map) for the sort label to keep human-friendly labels.

### Testing
- Ran `bun run check` (Biome lint/format + tests + typecheck) and the test suite passed: 73 passed, 2 skipped, 0 failed.
- Ran `bun run typecheck` (`tsc --noEmit`) and type checking passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69732172ff948332849e0ecd4f5afd43)