### PR TITLE
Resume demo audio contexts

### DIFF
--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -254,6 +254,12 @@ export function createSyntheticAudioStream({
 } = {}) {
   const context = new AudioContext();
 
+  if (context.state === 'suspended') {
+    void context.resume().catch((error) => {
+      console.warn('Unable to resume synthetic audio context', error);
+    });
+  }
+
   const oscillator = context.createOscillator();
   oscillator.frequency.value = frequency;
   oscillator.type = type;
@@ -291,6 +297,12 @@ let cachedDemoUsers = 0;
 
 function createProceduralDemoAudio() {
   const context = new AudioContext();
+
+  if (context.state === 'suspended') {
+    void context.resume().catch((error) => {
+      console.warn('Unable to resume demo audio context', error);
+    });
+  }
 
   const carrier = context.createOscillator();
   carrier.type = 'triangle';


### PR DESCRIPTION
### Motivation
- Demo audio sometimes failed to start because newly-created `AudioContext` instances can be `'suspended'` by default in some browsers, preventing procedural/demo audio from producing usable streams.

### Description
- Resume any `AudioContext` that is created in `createSyntheticAudioStream` by calling `context.resume()` when `context.state === 'suspended'` and log a warning on failure.
- Resume any `AudioContext` that is created in `createProceduralDemoAudio` using the same approach and warning.
- Change is localized to `assets/js/utils/audio-handler.ts` and does not alter existing teardown or caching logic.

### Testing
- Ran the full check suite with `bun run check`, which runs linting, typechecks, and tests, and it completed successfully with all automated tests passing (`73 pass`, `2 skip`, `0 fail`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738b12c8f083328802c0f01b4ce419)