### PR TITLE
Pass demo-audio preference to page toys and honor demo audio on standalone pages

### DIFF
--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -209,7 +209,11 @@ export function createLoader({
       const { moduleUrl, starter } = moduleResult;
 
       try {
-        const active = await starter({ container, slug: toy.slug });
+        const active = await starter({
+          container,
+          slug: toy.slug,
+          preferDemoAudio,
+        });
         lifecycle.adoptActiveToy(active ?? lifecycle.getActiveToy()?.ref);
       } catch (error) {
         console.error('Error starting toy module:', error);

--- a/assets/js/toys/clay.ts
+++ b/assets/js/toys/clay.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/clay.html',
+    preferDemoAudio,
     title: 'Pottery Wheel Sculptor',
     description:
       'Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.',

--- a/assets/js/toys/evol.ts
+++ b/assets/js/toys/evol.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/evol.html',
+    preferDemoAudio,
     title: 'Evolutionary Weirdcore',
   });
 }

--- a/assets/js/toys/geom.ts
+++ b/assets/js/toys/geom.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/geom.html',
+    preferDemoAudio,
     title: 'Microphone Geometry Visualizer',
     description: 'Cap resolution or boost fidelity for the 2D particle grid.',
   });

--- a/assets/js/toys/holy.ts
+++ b/assets/js/toys/holy.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/holy.html',
+    preferDemoAudio,
     title: 'Ultimate Satisfying Visualizer',
     description: 'Adjust render scale for halo layers and particle bursts.',
   });

--- a/assets/js/toys/legible.ts
+++ b/assets/js/toys/legible.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/legible.html',
+    preferDemoAudio,
     title: 'Terminal Word Grid',
   });
 }

--- a/assets/js/toys/lights.ts
+++ b/assets/js/toys/lights.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: 'toys/lights.html',
+    preferDemoAudio,
     title: 'Audio Light Show',
     description: 'Dial quality for the cube lighting playground.',
   });

--- a/assets/js/toys/multi.ts
+++ b/assets/js/toys/multi.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/multi.html',
+    preferDemoAudio,
     title: 'Multi-Capability Visualizer',
     description:
       'Balance performance with render scale before joining the multi-mode scene.',

--- a/assets/js/toys/page-toy.ts
+++ b/assets/js/toys/page-toy.ts
@@ -10,6 +10,7 @@ type StartOptions = {
   path: string;
   title?: string;
   description?: string;
+  preferDemoAudio?: boolean;
 };
 
 function resolvePageSrc(path: string) {
@@ -22,6 +23,7 @@ export function startPageToy({
   path,
   title,
   description,
+  preferDemoAudio = false,
 }: StartOptions) {
   const target = container ?? document.getElementById('active-toy-container');
 
@@ -44,7 +46,10 @@ export function startPageToy({
     defaultPresetId: initialQuality.id,
   });
 
-  const pageUrl = resolvePageSrc(path);
+  const pageUrl = new URL(resolvePageSrc(path));
+  if (preferDemoAudio) {
+    pageUrl.searchParams.set('audio', 'demo');
+  }
 
   const statusElement = document.createElement('div');
   statusElement.className = 'active-toy-status is-warning';
@@ -74,15 +79,17 @@ export function startPageToy({
   const openButton = document.createElement('button');
   openButton.type = 'button';
   openButton.className = 'cta-button primary';
-  openButton.textContent = 'Open toy';
+  openButton.textContent = preferDemoAudio
+    ? 'Open toy with demo audio'
+    : 'Open toy';
   openButton.addEventListener('click', () => {
-    window.location.href = pageUrl;
+    window.location.href = pageUrl.toString();
   });
 
   const newTabLink = document.createElement('a');
   newTabLink.className = 'cta-button';
   newTabLink.textContent = 'Open in new tab';
-  newTabLink.href = pageUrl;
+  newTabLink.href = pageUrl.toString();
   newTabLink.target = '_blank';
   newTabLink.rel = 'noopener noreferrer';
 

--- a/assets/js/toys/seary.ts
+++ b/assets/js/toys/seary.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/seary.html',
+    preferDemoAudio,
     title: 'Trippy Synesthetic Visualizer',
     description: 'Tune pixel ratio and density for sparkles and bursts.',
   });

--- a/assets/js/toys/symph.ts
+++ b/assets/js/toys/symph.ts
@@ -1,9 +1,16 @@
 import { startPageToy } from './page-toy';
 
-export function start({ container }: { container?: HTMLElement | null } = {}) {
+export function start({
+  container,
+  preferDemoAudio,
+}: {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+} = {}) {
   return startPageToy({
     container,
     path: './toys/symph.html',
+    preferDemoAudio,
     title: 'Dreamy Spectrograph',
     description:
       'Adjust render quality for the flowing spectrograph and sparkles.',

--- a/assets/js/utils/toy-module-loader.ts
+++ b/assets/js/utils/toy-module-loader.ts
@@ -3,6 +3,7 @@ import type { createManifestClient } from './manifest-client.ts';
 export type ToyModuleStarter = (args: {
   container: HTMLElement;
   slug: string;
+  preferDemoAudio?: boolean;
 }) => Promise<unknown> | unknown;
 
 export type ToyModuleLoadFailureType = 'resolve' | 'import' | 'missing_start';

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -309,6 +309,8 @@
       const particleScaleSlider = document.getElementById('particleScale');
       const particleScaleValue = document.getElementById('particleScaleValue');
       const errorEl = document.getElementById('error-message');
+      const preferDemoAudio =
+        new URLSearchParams(window.location.search).get('audio') === 'demo';
 
       function showError(message) {
         if (errorEl) {
@@ -322,6 +324,10 @@
           errorEl.style.display = 'none';
           errorEl.textContent = '';
         }
+      }
+
+      if (preferDemoAudio && startButton instanceof HTMLButtonElement) {
+        startButton.textContent = 'Start Demo Visualizer';
       }
 
       // Initialize Visualizer
@@ -755,13 +761,16 @@
           await startToyAudio(toy, animate, {
             fftSize: 1024,
             fallbackToSynthetic: true,
+            preferSynthetic: preferDemoAudio,
           });
           hideError();
           loadingOverlay.style.display = 'none';
         } catch (err) {
           console.error('Error accessing microphone:', err);
           showError(
-            'Microphone access is required for the visualizer to work.'
+            preferDemoAudio
+              ? 'Demo audio could not be loaded. Please try again.'
+              : 'Microphone access is required for the visualizer to work.'
           );
           startButton.style.display = 'block';
         }


### PR DESCRIPTION
### Motivation
- Users launching standalone (page) toys via the library could not start them in demo-audio mode, which prevented the demo audio escape hatch from working for page-based toys.
- The change ensures a demo-audio preference flows from the library quickstart/launcher into standalone toy pages so the toys can start with synthetic/demo audio when requested.

### Description
- Add an optional `preferDemoAudio` argument to the `ToyModuleStarter` type and forward `preferDemoAudio` when invoking module starters from the loader. 
- Extend `startPageToy` to accept `preferDemoAudio`, append `audio=demo` to the standalone page launch URL when requested, and adjust launch button labels/links accordingly. 
- Update all page-toy wrappers (examples: `assets/js/toys/holy.ts`, `lights.ts`, `clay.ts`, `evol.ts`, `geom.ts`, `legible.ts`, `multi.ts`, `seary.ts`, `symph.ts`) to accept and forward `preferDemoAudio`. 
- Update the Holy standalone page (`toys/holy.html`) to read the `audio=demo` query flag, prefer synthetic/demo audio when present, change the start button copy for clarity, and show an appropriate error message when demo audio fails.

### Testing
- Ran `bun run check` (runs `biome` checks, `tsc` typecheck, and the test suite) which completed successfully. 
- Test suite summary: 73 passed, 2 skipped, 0 failed. 
- Performed a Playwright smoke navigation that clicks the "Start with demo audio" quickstart and captured a screenshot showing the page launch UI updated for demo audio (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738b12c8f083328802c0f01b4ce419)