### PR TITLE
Fix library UI readiness, theme toggle accessibility, and storage hardening

### DIFF
--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -265,6 +265,10 @@ function setupThemeToggle(container: HTMLElement) {
   const updateUI = (theme: string) => {
     const isDark = theme === 'dark';
     toggle.setAttribute('aria-pressed', String(isDark));
+    toggle.setAttribute(
+      'aria-label',
+      isDark ? 'Switch to light mode' : 'Switch to dark mode',
+    );
     if (label) label.textContent = isDark ? 'Light mode' : 'Dark mode';
     if (icon) icon.textContent = isDark ? '☀️' : '🌙';
   };
@@ -288,7 +292,11 @@ function setupThemeToggle(container: HTMLElement) {
       } else {
         document.documentElement.classList.remove('light');
       }
-      localStorage.setItem('theme', nextTheme);
+      try {
+        localStorage.setItem('theme', nextTheme);
+      } catch (_error) {
+        // Ignore storage errors.
+      }
     }
 
     updateUI(nextTheme);

--- a/assets/js/ui/youtube-controller.ts
+++ b/assets/js/ui/youtube-controller.ts
@@ -163,6 +163,13 @@ export class YouTubeController {
     recent = recent.filter((v) => v.id !== id);
     recent.unshift({ id, title: `Video ${id}`, timestamp: Date.now() });
     recent = recent.slice(0, YouTubeController.MAX_RECENT);
-    localStorage.setItem(YouTubeController.STORAGE_KEY, JSON.stringify(recent));
+    try {
+      localStorage.setItem(
+        YouTubeController.STORAGE_KEY,
+        JSON.stringify(recent),
+      );
+    } catch {
+      // Ignore storage errors.
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -888,6 +888,7 @@
               }
             }
             renderCards(applyFilters());
+            updateControlVisibility();
 
             if (searchForm instanceof HTMLFormElement) {
               searchForm.addEventListener('submit', (event) => {

--- a/toy.html
+++ b/toy.html
@@ -171,6 +171,5 @@
         // Cleanup if needed
       });
     </script>
-    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure the library landing UI reflects control state immediately after initial render so search/clear/filter controls show correctly.
- Improve theme toggle accessibility by keeping its `aria-label` in sync with the active theme and avoid runtime exceptions when persisting theme preference.
- Harden recent-YouTube storage to avoid unhandled exceptions in environments where `localStorage` may fail and remove a stray closing tag in the toy page.

### Description
- Keep the theme toggle `aria-label` in sync with the current theme in `assets/js/ui/nav.ts`. 
- Wrap `localStorage.setItem('theme', ...)` in a `try/catch` to ignore storage errors when persisting theme in `assets/js/ui/nav.ts`.
- Wrap writes to `localStorage` for YouTube recent videos in `assets/js/ui/youtube-controller.ts` with a `try/catch` to avoid exceptions when storage is unavailable.
- Call `updateControlVisibility()` after the initial `renderCards(...)` in `index.html` so search/clear/reset UI visibility is correct on first load.
- Remove an extra stray `</script>` closing tag from `toy.html` to clean up markup.

### Testing
- Ran the repository quality and test pipeline with `bun run check` which runs `biome check`, `tsc --noEmit`, and the test suite; the command completed successfully.
- Test results: `bun test` ran and reported 73 passing tests and 2 skipped tests; there were 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d9b57e388332bcc8f8d476118575)