### PR TITLE
Refactor rendering capability checks

### DIFF
--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -1,5 +1,5 @@
-import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 import { isMobileDevice } from '../utils/device-detect.ts';
+import { getRenderingSupport } from '../utils/rendering-support.ts';
 import {
   getActiveRenderPreferences,
   setRenderPreferences,
@@ -84,14 +84,6 @@ async function getMicrophonePermissionState() {
   }
 }
 
-function checkWebGLAvailability() {
-  const hasWebGL =
-    typeof WebGL !== 'undefined' &&
-    (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
-
-  return Boolean(hasWebGL);
-}
-
 const isMobileUserAgent = isMobileDevice();
 
 function getPerformanceProfile() {
@@ -137,7 +129,7 @@ export async function runCapabilityPreflight(): Promise<CapabilityPreflightResul
     getMicrophonePermissionState(),
   ]);
 
-  const hasWebGL = checkWebGLAvailability();
+  const { hasWebGL } = getRenderingSupport();
 
   const renderingBackend =
     capabilities?.preferredBackend ?? (hasWebGL ? 'webgl' : null);

--- a/assets/js/readiness-probe.ts
+++ b/assets/js/readiness-probe.ts
@@ -1,4 +1,4 @@
-import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+import { getRenderingSupport } from './utils/rendering-support.ts';
 
 const STATUS = {
   success: 'success',
@@ -103,17 +103,8 @@ const probeMicrophone = async () => {
   };
 };
 
-const getRenderCapabilities = () => {
-  const hasWebGPU = Boolean(navigator?.gpu);
-  const hasWebGL =
-    typeof WebGL !== 'undefined' &&
-    (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
-
-  return { hasWebGPU, hasWebGL };
-};
-
 export const getRenderCompatibilitySummary = () => {
-  const { hasWebGPU, hasWebGL } = getRenderCapabilities();
+  const { hasWebGPU, hasWebGL } = getRenderingSupport();
 
   if (hasWebGPU) {
     return {
@@ -136,7 +127,7 @@ export const getRenderCompatibilitySummary = () => {
 };
 
 const probeRendering = () => {
-  const { hasWebGPU, hasWebGL } = getRenderCapabilities();
+  const { hasWebGPU, hasWebGL } = getRenderingSupport();
 
   if (hasWebGPU) {
     return {

--- a/assets/js/utils/rendering-support.ts
+++ b/assets/js/utils/rendering-support.ts
@@ -1,0 +1,15 @@
+import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+
+export type RenderingSupport = {
+  hasWebGPU: boolean;
+  hasWebGL: boolean;
+};
+
+export const getRenderingSupport = (): RenderingSupport => {
+  const hasWebGPU = typeof navigator !== 'undefined' && Boolean(navigator.gpu);
+  const hasWebGL =
+    typeof WebGL !== 'undefined' &&
+    (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
+
+  return { hasWebGPU, hasWebGL: Boolean(hasWebGL) };
+};

--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -1,4 +1,4 @@
-import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+import { getRenderingSupport } from './rendering-support.ts';
 
 const OVERLAY_ID = 'rendering-capability-overlay';
 const MODAL_PARAM = 'modal';
@@ -278,10 +278,7 @@ export function ensureWebGL(options: EnsureOptions = {}) {
     return false;
   }
 
-  const hasWebGPU = Boolean(navigator?.gpu);
-  const hasWebGL =
-    typeof WebGL !== 'undefined' &&
-    (WebGL as { isWebGLAvailable?: () => boolean }).isWebGLAvailable?.();
+  const { hasWebGPU, hasWebGL } = getRenderingSupport();
 
   if (hasWebGPU || hasWebGL) {
     removeExistingOverlay();


### PR DESCRIPTION
### Motivation
- Centralize WebGL/WebGPU availability detection to remove duplication and ensure consistent gating and messaging across readiness, preflight, and overlay logic.

### Description
- Add `assets/js/utils/rendering-support.ts` which exports `getRenderingSupport()` and `RenderingSupport` to report `hasWebGPU`/`hasWebGL`.
- Replace inline capability checks in `assets/js/utils/webgl-check.ts`, `assets/js/readiness-probe.ts`, and `assets/js/core/capability-preflight.ts` to use the new helper.
- No documentation changes were required.

### Testing
- Ran `bun run check` (Biome + tests) which completed and the test suite passed with `73 pass, 2 skip, 0 fail`.
- Ran `bun run typecheck` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750f7a4b2c8332b473592417db70d7)