### PR TITLE
Refine homepage hero copy for progressive disclosure

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,26 +73,26 @@
       <section class="intro">
         <div class="section-heading">
           <p class="eyebrow">
-            Launch-ready stims • Quick to arm • No accounts
+            Library • Audio-reactive visuals • Controls available
           </p>
-          <h1>Launch into audio-reactive play.</h1>
+          <h1>Stim library.</h1>
           <p class="section-description">
-            Arm a stim, lock in your controls, and drop straight into motion.
+            Audio input options and performance controls live in the toy panel.
           </p>
         </div>
         <div class="launch-panel" aria-label="Launch sequence status">
           <div class="launch-panel__header">
-            <p class="launch-panel__eyebrow">Launch sequence</p>
-            <p class="launch-panel__status">All systems green</p>
+            <p class="launch-panel__eyebrow">Quick start status</p>
+            <p class="launch-panel__status">Status details below</p>
           </div>
           <div class="launch-meter" role="presentation">
             <span class="launch-meter__bar" aria-hidden="true"></span>
             <span class="launch-meter__pulse" aria-hidden="true"></span>
           </div>
           <div class="launch-badges">
-            <span class="launch-badge">Mic armed</span>
-            <span class="launch-badge">Visuals synced</span>
-            <span class="launch-badge">Controller ready</span>
+            <span class="launch-badge">Mic optional</span>
+            <span class="launch-badge">Visuals active</span>
+            <span class="launch-badge">Controls available</span>
           </div>
         </div>
         <div class="cta-row hero-cta-row">
@@ -101,7 +101,7 @@
             class="cta-button primary"
             data-quickstart-slug="holy"
           >
-            Launch Halo Flow
+            Open Halo Flow
           </a>
           <a
             href="toy.html?toy=holy"
@@ -109,15 +109,15 @@
             data-quickstart-slug="holy"
             data-quickstart-mode="demo"
           >
-            Start with demo audio
+            Use demo audio
           </a>
-          <a href="#toy-list" class="cta-button ghost">Choose a stim</a>
+          <a href="#toy-list" class="cta-button ghost">Library</a>
           <a
             href="https://github.com/zz-plant/stims"
             target="_blank"
             rel="noopener noreferrer"
             class="cta-button ghost"
-            >View the code</a
+            >View source</a
           >
         </div>
         <div class="hero-readiness" data-hero-readiness-summary>
@@ -133,7 +133,7 @@
           </a>
         </div>
         <p class="cta-helper">
-          No accounts. Microphone access arms audio-reactive mode.
+          No account required. Mic access enables live audio.
         </p>
       </section>
 


### PR DESCRIPTION
### Motivation
- Reduce directive and promotional language in the homepage hero and surface controls/status with neutral, discovery-oriented phrasing to encourage progressive disclosure.

### Description
- Updated copy in `index.html` for the hero section, including the eyebrow, main heading, section description, launch-panel eyebrow/status, launch badges, CTA labels, and helper line to use neutral, discovery-focused wording.
- Changes are text-only and preserve existing markup, data attributes, and JS behavior with no structural or script modifications.
- The single modified file is `index.html` and the new copy emphasizes that audio input options and performance controls are available in the toy panel.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully.
- Ran `biome format --write assets scripts tests` which completed successfully.
- Started a local server and ran a Playwright script to load `http://127.0.0.1:4173/` and capture a screenshot to visually verify the updated hero text, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697510fe466483328f408bb5cd506470)