### PR TITLE
Improve lighthouse metadata and preload hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
     <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
@@ -29,6 +31,8 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
     />
+    <link rel="preload" href="assets/css/base.css" as="style" />
+    <link rel="preload" href="assets/css/index.css" as="style" />
     <link
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap"
       rel="stylesheet"

--- a/toy.html
+++ b/toy.html
@@ -3,11 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="description"
+      content="Play a responsive, audio-reactive visual toy. Tune visuals, audio inputs, and performance settings in one immersive canvas."
+    />
+    <meta name="theme-color" content="#0b0f1a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Web Toy</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
     <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="preload" href="assets/css/base.css" as="style" />
+    <link rel="preload" href="assets/css/index.css" as="style" />
     <link rel="stylesheet" href="assets/css/base.css" />
     <link rel="stylesheet" href="assets/css/index.css" />
   </head>


### PR DESCRIPTION
### Motivation
- Improve Lighthouse performance, SEO, and PWA signals by adding resource hints and richer page metadata to speed and surface-critical assets.
- Reduce render-blocking and improve first-contentful-paint by preconnecting to third-party hosts and preloading critical CSS.

### Description
- Add `preconnect` and `dns-prefetch` for `https://cdnjs.cloudflare.com` to `index.html` to prime the CDN used for `normalize.css`.
- Add `preload` links for `assets/css/base.css` and `assets/css/index.css` to `index.html` to prioritize critical styles.
- Add richer metadata and PWA assets to `toy.html`, including `description`, `theme-color`, `apple-mobile-web-app` tags, `manifest`, and icon links to improve SEO and Lighthouse PWA checks.
- Add `preload` links for `assets/css/base.css` and `assets/css/index.css` to `toy.html` to prioritize toy page styles.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully with no lint errors.
- Ran `biome format --write assets scripts tests` which completed successfully with no formatting changes required.
- No documentation files were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975aaaf18a48332bca461259979ca18)