### PR TITLE
Remove redundant font imports for faster CSS delivery

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap");
-
 html,
 body {
   margin: 0;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap");
-
 :root {
   --bg-color: #0b0f1a;
   --bg-color-secondary: #111827;


### PR DESCRIPTION
### Motivation
- Remove duplicate Google Fonts `@import` rules to reduce render-blocking requests and improve Lighthouse performance for page and toy loads.

### Description
- Deleted the `@import` lines from `assets/css/base.css` and `assets/css/index.css`; font usage remains via `font-family` and the single `<link>` in `index.html`.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully.
- Ran `biome format --write assets scripts tests` which completed successfully.
- Docs touched: none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975aaaf18a48332bca461259979ca18)