### PR TITLE
Remove experience promo section

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,43 +160,6 @@
         </p>
       </section>
 
-      <section class="experience" aria-label="Experience highlights">
-        <div class="section-heading">
-          <p class="eyebrow">Design ethos</p>
-          <h2>Built for flow, clarity, and wonder</h2>
-          <p class="section-description">
-            Every toy is tuned for a calm launch, cinematic color, and quick
-            performance adjustments so you can stay immersed.
-          </p>
-        </div>
-        <div class="experience-grid">
-          <article class="experience-card">
-            <p class="experience-card__eyebrow">Visual craft</p>
-            <h3>Signature light and motion</h3>
-            <p>
-              Subtle glows, responsive gradients, and depth cues keep the visuals
-              feeling dimensional without overwhelming the senses.
-            </p>
-          </article>
-          <article class="experience-card">
-            <p class="experience-card__eyebrow">Audio intelligence</p>
-            <h3>Sound that shapes the scene</h3>
-            <p>
-              Live, demo, and tab audio sources map to movement so every loop feels
-              like a new performance.
-            </p>
-          </article>
-          <article class="experience-card">
-            <p class="experience-card__eyebrow">Performance control</p>
-            <h3>Graceful on every device</h3>
-            <p>
-              Adaptive quality presets and system checks keep the experience smooth,
-              whether you are on mobile or a high-end display.
-            </p>
-          </article>
-        </div>
-      </section>
-
       <section class="system-check" id="system-check">
         <div class="section-heading">
           <p class="eyebrow">System check</p>


### PR DESCRIPTION
### Motivation
- Remove the homepage promotional "Design ethos"/experience block so the system check follows the hero content directly and the page is less promotional.

### Description
- Deleted the `<section class="experience" ...>` promo markup from `index.html`, removing the design ethos, experience cards, and related copy.

### Testing
- Ran `biome lint assets scripts tests`, `biome format --write assets scripts tests`, and captured a homepage screenshot with Playwright against the running dev server; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ae46be54833293fba82b96cdde2b)