### PR TITLE
Clarify dev server guidance and reference contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you add new scripts, toys, or deployment options, update the relevant doc abo
 2. Choose your runtime (the repo records `bun@1.2.14` in `package.json` via `packageManager`):
    - **Bun 1.2+**: install from [bun.sh](https://bun.sh/) for the fastest install/test cycle and the supported workflow.
 3. Install dependencies with `bun install`. The repository tracks `bun.lock` for reproducible installs—use `bun install --frozen-lockfile` to respect it.
-4. Start the dev server with `bun run dev`, then open `http://localhost:5173` in your browser. The dev server already binds to all interfaces for easy forwarding and mobile checks; `bun run dev:host` remains available as an explicit alternative.
+4. Start the dev server with `bun run dev`, then open `http://localhost:5173` in your browser. Use `bun run dev:host` when you need the server bound to all interfaces for mobile/LAN testing.
 
 See the [Deployment Guide](./docs/DEPLOYMENT.md) for build, preview, static hosting, and Cloudflare Worker instructions. That playbook also covers PR preview validation and multi-entry-point checks before merging.
 
@@ -214,7 +214,7 @@ All JavaScript dependencies are installed via Bun and bundled locally with Vite,
 
 ## Code of Conduct and Contributions
 
-Please review our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating in the project. By contributing, you agree to uphold these community standards. A full contributing guide will live alongside the Code of Conduct so expectations are always clear.
+Please review our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating in the project. By contributing, you agree to uphold these community standards. The contributor expectations and workflow checklist live in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Running Tests
 


### PR DESCRIPTION
### Motivation
- Make the Quick Start instructions clearer about when to bind the dev server to all interfaces for mobile/LAN testing.
- Point the Code of Conduct / contribution guidance to the existing contributing guide so contributors can find the workflow checklist.

### Description
- Update `README.md` Quick Start text to recommend using `bun run dev:host` only when you need the server bound to all interfaces for mobile/LAN testing.
- Replace the Code of Conduct wording to reference the existing `CONTRIBUTING.md` instead of a future doc.

### Testing
- Ran `biome lint assets scripts tests` and it completed successfully.
- Ran `biome format --write assets scripts tests` and it completed successfully.
- Docs touched: `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ae7d9a5083328ccc3c691ed9290a)