### PR TITLE
Update agent guidance for current checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Stim Webtoys Library is a collection of interactive, audio-reactive web toys bui
 ## Essentials
 
 - **Package manager:** Bun (use `bun install --frozen-lockfile` when dependencies change; run scripts with `bun run ...`).
-- **Non-standard quality gates for JS/TS changes:** run `bun run check` (Biome + tests) and `bun run typecheck` before committing.
+- **Non-standard quality gates for JS/TS changes:** run `bun run check` (Biome + typecheck + tests) before committing.
 - **Metadata:** commit messages use sentence case with no trailing period; PR summaries include a short summary plus explicit lists of tests run and docs touched/added.
 
 ## More detailed guidance

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -13,10 +13,10 @@
 ## Required checks
 
 - For JavaScript/TypeScript changes, run the relevant quality checks before committing:
-  - `bun run check` (Biome + tests)
-  - `bun run typecheck`
+  - `bun run check` (Biome + typecheck + tests)
+  - Optional quick pass: `bun run check:quick` (Biome + typecheck, skips tests)
 
 ## Documentation-only changes
 
 - For Markdown/prose-only changes, you can skip `bun run typecheck` and `bun run test`.
-- Still run `bun run format` on touched docs.
+- Formatting docs is optional; there is no dedicated script for docs, but you can run `bunx biome format --write docs` if you want to normalize Markdown formatting.


### PR DESCRIPTION
### Motivation
- Refresh agent-facing guidance to reflect that `bun run check` now covers Biome, typecheck, and tests, and to clarify optional quick checks and doc-formatting workflow.

### Description
- Update `AGENTS.md` to state `bun run check` includes typecheck and tests, and update `docs/agents/tooling-and-quality.md` to consolidate the canonical `bun run check` invocation, add an optional `bun run check:quick` note, and suggest an optional doc formatting command (`bunx biome format --write docs`).

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b0507e3c8332b47ea8ef79700eeb)