### PR TITLE
Update toy development agent guidance

### DIFF
--- a/docs/agents/toy-development.md
+++ b/docs/agents/toy-development.md
@@ -2,15 +2,20 @@
 
 ## Project structure
 
-- Toy modules: `assets/js/toys/` (TypeScript modules exporting `start()`)
-- Toy registry: `assets/js/toys-data.js` (slugs, metadata, capabilities)
-- Legacy HTML toys: `toys/` directory (standalone pages)
-- Loader logic: `toy.html` + `assets/js/loader.ts`
-- Audio handling: `assets/js/core/audio-handler.ts`
+- Toy modules: `assets/js/toys/` (TypeScript modules exporting `start()`).
+- Toy registry: `assets/js/toys-data.js` (slugs, metadata, capabilities).
+- Standalone HTML toys: `toys/` directory (standalone pages launched from the library UI).
+- Loader logic: `toy.html` + `assets/js/loader.ts`.
+- Audio/runtime helpers: `assets/js/core/toy-runtime.ts` and `assets/js/utils/start-audio.ts`.
 
 ## Key patterns
 
-- Every toy module exports `start({ container, canvas?, audioContext? })`.
-- `start()` returns a cleanup function that removes all DOM nodes.
-- Audio reactivity uses `registerToyGlobals` to expose `startAudio` and `startAudioFallback`.
-- Toys support microphone input or demo audio fallback.
+- Every toy module exports `start({ container?, preferDemoAudio? })` for library cards or
+  `start({ container? })` when embedding a Three.js scene directly.
+- Page-based toys should call `startPageToy({ container, path, title, description, preferDemoAudio })`
+  to render the launch panel that opens the standalone HTML file.
+- Canvas-based toys should use `createToyRuntime(...)` to wire up WebGL, audio, input, and performance
+  settings in one place.
+- `start()` returns a disposable object (from `createToyRuntime` or `startPageToy`) that handles cleanup.
+- Audio reactivity uses `registerToyGlobals` to expose `startAudio` to the standalone toy pages.
+- Toys support microphone input or demo audio fallback by passing `preferDemoAudio` or `audio=demo`.


### PR DESCRIPTION
### Motivation

- Refresh agent-facing toy development docs to reflect the current runtime APIs and the page-vs-canvas toy patterns (page launch panels, runtime audio helpers, and global audio entry points).

### Description

- Rewrite `docs/agents/toy-development.md` to update Project structure and Key patterns to document `start({ container?, preferDemoAudio? })`, `startPageToy(...)` for standalone pages, `createToyRuntime(...)` for canvas-based toys, call out `registerToyGlobals`/`startAudio`, and reference `assets/js/core/toy-runtime.ts` and `assets/js/utils/start-audio.ts`; touched file: `docs/agents/toy-development.md`.

### Testing

- Ran `bun run format` (invokes `biome format`) and `biome lint assets scripts tests` and `biome format --write assets scripts tests`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b0507e3c8332b47ea8ef79700eeb)