### PR TITLE
Boost audio reactivity across toys

### DIFF
--- a/assets/js/toys/aurora-painter.ts
+++ b/assets/js/toys/aurora-painter.ts
@@ -6,7 +6,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import type { UnifiedInputState } from '../utils/unified-input';
 
 type AuroraPalette = {
@@ -176,7 +176,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     data: Uint8Array,
     time: number,
   ) {
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const bass = averageRange(data, 0, 0.32);
     const treble = averageRange(data, 0.65, 1);
 

--- a/assets/js/toys/bubble-harmonics.ts
+++ b/assets/js/toys/bubble-harmonics.ts
@@ -6,7 +6,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { mapFrequencyToItems } from '../utils/audio-mapper';
 
 type Bubble = {
@@ -277,7 +277,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function animate(data: Uint8Array, time: number) {
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const scaledTime = time;
 
     animateBubbles(data, avg, scaledTime);

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -11,7 +11,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor } from '../utils/color-audio';
 
 type PresetKey = 'orbit' | 'nebula';
@@ -83,7 +83,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
     return {
       animate(data, _time) {
-        const avg = getAverageFrequency(data);
+        const avg = getWeightedAverageFrequency(data);
         const rotationSpeed = 0.001 + avg / 100000;
         particles.rotation.y += rotationSpeed;
         particles.rotation.x += rotationSpeed / 2;
@@ -223,7 +223,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
     return {
       animate(data, time) {
-        const avg = getAverageFrequency(data);
+        const avg = getWeightedAverageFrequency(data);
         const normalizedAvg = avg / 255;
 
         const positions = stars.geometry.attributes.position

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -6,7 +6,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { type AudioColorParams, applyAudioColor } from '../utils/color-audio';
 
 type ShapeMode = 'cubes' | 'spheres';
@@ -333,7 +333,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function animate(dataArray: Uint8Array, time: number) {
-    const avg = getAverageFrequency(dataArray);
+    const avg = getWeightedAverageFrequency(dataArray);
 
     const binsPerItem = dataArray.length / Math.max(gridItems.length, 1);
 

--- a/assets/js/toys/lights/audio.ts
+++ b/assets/js/toys/lights/audio.ts
@@ -7,6 +7,7 @@ import {
   applyAudioRotation,
   applyAudioScale,
 } from '../../utils/animation-utils.ts';
+import { getWeightedAverageFrequency } from '../../utils/audio-handler.ts';
 import PatternRecognizer from '../../utils/patternRecognition.ts';
 import { startToyAudio } from '../../utils/start-audio.ts';
 
@@ -65,8 +66,10 @@ export const createAudioController = ({
     }
 
     const audioData = getContextFrequencyData(ctx);
-    applyAudioRotation(cube, audioData, 0.05);
-    applyAudioScale(cube, audioData, 50);
+    const avg = getWeightedAverageFrequency(audioData);
+    const intensity = Math.min(1, avg / 180);
+    applyAudioRotation(cube, audioData, 0.05 + intensity * 0.08);
+    applyAudioScale(cube, audioData, 50 - intensity * 20);
 
     patternRecognizer?.updatePatternBuffer();
     const detectedPattern = patternRecognizer?.detectPattern();

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -6,7 +6,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 
 interface RingData {
   outer: THREE.Mesh;
@@ -143,7 +143,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function animate(data: Uint8Array, time: number) {
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const normalizedAvg = avg / 255;
 
     const binsPerRing = Math.max(

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -12,7 +12,7 @@ import {
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
 import type { FrequencyAnalyser } from '../utils/audio-handler';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { mapFrequencyToItems } from '../utils/audio-mapper';
 import { applyAudioColor } from '../utils/color-audio';
 import type { UnifiedInputState } from '../utils/unified-input';
@@ -402,7 +402,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     time: number,
     analyser: FrequencyAnalyser | null,
   ) {
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const normalizedAvg = avg / 255;
 
     // Multi-band frequency analysis using FrequencyAnalyser

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -11,7 +11,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor } from '../utils/color-audio';
 import type { UnifiedInputState } from '../utils/unified-input';
 
@@ -279,7 +279,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function animate(data: Uint8Array, time: number) {
     if (!starField) return;
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const normalizedAvg = avg / 255;
 
     controls.drift = THREE.MathUtils.lerp(controls.drift, targetDrift, 0.08);

--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -11,7 +11,7 @@ import {
   type QualityPreset,
 } from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 
 type GravityState = {
   vector: THREE.Vector3;
@@ -474,7 +474,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function animate(data: Uint8Array) {
     const delta = clock.getDelta();
-    const avg = getAverageFrequency(data);
+    const avg = getWeightedAverageFrequency(data);
     const low = bandAverage(data, 0, Math.floor(data.length * 0.16));
     const mids = bandAverage(
       data,

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -13,7 +13,7 @@ import {
 } from '../core/settings-panel';
 import { registerToyGlobals } from '../core/toy-globals';
 import { createToyRuntime } from '../core/toy-runtime';
-import { getAverageFrequency } from '../utils/audio-handler';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import type { ToyAudioRequest } from '../utils/audio-start';
 import {
   type ControlPanelState,
@@ -272,7 +272,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function animate(dataArray: Uint8Array, _time: number) {
     if (!torusKnot || !particles) return;
-    const avgFrequency = getAverageFrequency(dataArray);
+    const avgFrequency = getWeightedAverageFrequency(dataArray);
 
     const { idle, idleProgress } = idleDetector.update(dataArray);
     const idleTarget = controlState.idleEnabled ? idleProgress : 0;

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -579,3 +579,39 @@ export function getAverageFrequency(data: Uint8Array): number {
 
   return sum / data.length;
 }
+
+/**
+ * Compute a weighted, slightly boosted average that leans into bass/mid energy.
+ * Useful for more expressive audio-driven motion.
+ */
+export function getWeightedAverageFrequency(data: Uint8Array): number {
+  const len = data.length;
+  if (len === 0) return 0;
+
+  const bassEnd = Math.max(1, Math.floor(len * 0.12));
+  const midEnd = Math.max(bassEnd + 1, Math.floor(len * 0.5));
+
+  let bassSum = 0;
+  for (let i = 0; i < bassEnd; i += 1) {
+    bassSum += data[i];
+  }
+
+  let midSum = 0;
+  for (let i = bassEnd; i < midEnd; i += 1) {
+    midSum += data[i];
+  }
+
+  let trebleSum = 0;
+  for (let i = midEnd; i < len; i += 1) {
+    trebleSum += data[i];
+  }
+
+  const bassAvg = bassSum / bassEnd / 255;
+  const midAvg = midSum / Math.max(1, midEnd - bassEnd) / 255;
+  const trebleAvg = trebleSum / Math.max(1, len - midEnd) / 255;
+
+  const weighted = bassAvg * 0.6 + midAvg * 0.25 + trebleAvg * 0.15;
+  const boosted = Math.min(1, weighted ** 0.78 * 1.05);
+
+  return boosted * 255;
+}

--- a/assets/js/utils/audio-reactivity.ts
+++ b/assets/js/utils/audio-reactivity.ts
@@ -1,0 +1,80 @@
+export type BandLevels = {
+  bass: number;
+  mid: number;
+  treble: number;
+};
+
+export type BandRatios = {
+  bass: number;
+  mid: number;
+};
+
+export type BandWeights = {
+  bass: number;
+  mid: number;
+  treble: number;
+};
+
+const DEFAULT_RATIOS: BandRatios = { bass: 0.12, mid: 0.5 };
+const DEFAULT_WEIGHTS: BandWeights = { bass: 0.6, mid: 0.25, treble: 0.15 };
+
+export function getBandLevels({
+  analyser,
+  data,
+  ratios = DEFAULT_RATIOS,
+}: {
+  analyser?: { getMultiBandEnergy?: () => BandLevels | null } | null;
+  data: Uint8Array;
+  ratios?: BandRatios;
+}): BandLevels {
+  const fromAnalyser = analyser?.getMultiBandEnergy?.();
+  if (fromAnalyser) return fromAnalyser;
+
+  const bass = averageRange(data, 0, ratios.bass) / 255;
+  const mid = averageRange(data, ratios.bass, ratios.mid) / 255;
+  const treble = averageRange(data, ratios.mid, 1) / 255;
+
+  return { bass, mid, treble };
+}
+
+export function getWeightedEnergy(
+  bands: BandLevels,
+  {
+    weights = DEFAULT_WEIGHTS,
+    boost = 1.35,
+  }: { weights?: BandWeights; boost?: number } = {},
+): number {
+  const weighted =
+    bands.bass * weights.bass +
+    bands.mid * weights.mid +
+    bands.treble * weights.treble;
+
+  return Math.min(1, weighted * boost);
+}
+
+export function updateEnergyPeak(
+  currentPeak: number,
+  weightedEnergy: number,
+  { decay = 0.96, floor = 0.05 }: { decay?: number; floor?: number } = {},
+): number {
+  return Math.max(currentPeak * decay, weightedEnergy, floor);
+}
+
+function averageRange(
+  dataArray: Uint8Array,
+  startRatio: number,
+  endRatio: number,
+) {
+  if (!dataArray.length) return 0;
+  const startIndex = Math.floor(dataArray.length * startRatio);
+  const endIndex = Math.max(
+    startIndex + 1,
+    Math.floor(dataArray.length * endRatio),
+  );
+  let sum = 0;
+  const count = endIndex - startIndex;
+  for (let i = startIndex; i < endIndex; i += 1) {
+    sum += dataArray[i];
+  }
+  return sum / count;
+}

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -70,6 +70,7 @@
     <script type="module">
       import {
         getFrequencyData,
+        getWeightedAverageFrequency,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
@@ -370,8 +371,7 @@
       function render(ctxAudio) {
         if (ctxAudio.analyser) {
           const dataArray = getFrequencyData(ctxAudio.analyser);
-          const average =
-            dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
+          const average = getWeightedAverageFrequency(dataArray);
           audioData = average / 128.0;
           hideError();
         } else {

--- a/toys/geom.html
+++ b/toys/geom.html
@@ -136,6 +136,9 @@
       const particles = [];
       const baseParticleCount = 800;
       let particleCount = baseParticleCount;
+      let peakLevel = 0.12;
+      let bassPulse = 0;
+      let trebleGlow = 0;
 
       function applyQualityPreset(preset) {
         activeQuality = preset;
@@ -235,8 +238,23 @@
         const frequencyData = getContextFrequencyData(ctxAudio);
 
         if (ctxAudio.analyser) {
-          const bass = getBass(frequencyData);
-          const hue = (bass / 255) * 360;
+          const fallbackBands = {
+            bass: getBandAverage(frequencyData, 0, 0.12) / 255,
+            mid: getBandAverage(frequencyData, 0.12, 0.5) / 255,
+            treble: getBandAverage(frequencyData, 0.5, 1) / 255,
+          };
+          const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? fallbackBands;
+          const weightedEnergy = Math.min(
+            1,
+            (bands.bass * 0.6 + bands.mid * 0.25 + bands.treble * 0.15) * 1.4
+          );
+          peakLevel = Math.max(peakLevel * 0.96, weightedEnergy, 0.05);
+          const normalized = peakLevel ? weightedEnergy / peakLevel : 0;
+          bassPulse = Math.max(bassPulse * 0.85, bands.bass);
+          trebleGlow = Math.max(trebleGlow * 0.8, bands.treble);
+          const hue = ((bassPulse * 0.7 + normalized * 0.3) * 360) % 360;
+          const innerLightness = 25 + bassPulse * 30 + trebleGlow * 12;
+          const outerLightness = 8 + normalized * 12;
           const gradient = ctx.createRadialGradient(
             viewWidth / 2,
             viewHeight / 2,
@@ -245,8 +263,11 @@
             viewHeight / 2,
             viewWidth
           );
-          gradient.addColorStop(0, `hsl(${hue}, 100%, 30%)`);
-          gradient.addColorStop(1, `hsl(${(hue + 60) % 360}, 100%, 10%)`);
+          gradient.addColorStop(0, `hsl(${hue}, 100%, ${innerLightness}%)`);
+          gradient.addColorStop(
+            1,
+            `hsl(${(hue + 60) % 360}, 100%, ${outerLightness}%)`
+          );
           ctx.fillStyle = gradient;
         } else {
           ctx.fillStyle = '#000';
@@ -268,10 +289,11 @@
           if (ctxAudio.analyser && frequencyData.length) {
             const freqIndex = Math.floor(index % frequencyData.length);
             const amplitude = frequencyData[freqIndex] / 255;
-            p.size = p.baseSize + amplitude * 15;
-            p.hue = (p.hue + amplitude * 10) % 360;
-            p.lightness = 40 + amplitude * 20;
-            p.alpha = 0.3 + amplitude * 0.7;
+            const energyBoost = 0.7 + peakLevel * 1.1 + bassPulse * 0.8;
+            p.size = p.baseSize + amplitude * 12 * energyBoost;
+            p.hue = (p.hue + amplitude * (6 + trebleGlow * 10)) % 360;
+            p.lightness = 35 + amplitude * 25 + trebleGlow * 15;
+            p.alpha = Math.min(1, 0.25 + amplitude * 0.65 + peakLevel * 0.2);
           }
 
           ctx.save();
@@ -299,7 +321,7 @@
           const barWidth = (viewWidth / frequencyData.length) * 2.5;
           let x = 0;
           for (let i = 0; i < frequencyData.length; i++) {
-            const barHeight = frequencyData[i] * 1.2;
+            const barHeight = frequencyData[i] * (1.1 + peakLevel * 0.6);
             const hue = (i / frequencyData.length) * 360;
             ctx.fillStyle = `hsla(${hue}, 100%, 50%, 0.7)`;
             ctx.fillRect(x, viewHeight - barHeight, barWidth, barHeight);
@@ -311,7 +333,7 @@
           const timeData = new Uint8Array(ctxAudio.analyser.fftSize);
           ctxAudio.analyser.getByteTimeDomainData(timeData);
           ctx.lineWidth = 2;
-          ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
+          ctx.strokeStyle = `rgba(255, 255, 255, ${0.3 + peakLevel * 0.6})`;
           ctx.beginPath();
           const sliceWidth = viewWidth / timeData.length;
           let x = 0;
@@ -328,6 +350,24 @@
           ctx.lineTo(viewWidth, viewHeight / 2);
           ctx.stroke();
         }
+
+        bassPulse *= 0.9;
+        trebleGlow *= 0.9;
+      }
+
+      function getBandAverage(dataArray, startRatio, endRatio) {
+        if (!dataArray.length) return 0;
+        const startIndex = Math.floor(dataArray.length * startRatio);
+        const endIndex = Math.max(
+          startIndex + 1,
+          Math.floor(dataArray.length * endRatio)
+        );
+        let sum = 0;
+        const count = endIndex - startIndex;
+        for (let i = startIndex; i < endIndex; i++) {
+          sum += dataArray[i];
+        }
+        return sum / count;
       }
 
       function getBass(dataArray) {

--- a/toys/geom.html
+++ b/toys/geom.html
@@ -108,6 +108,11 @@
         AudioAccessError,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
+      import {
+        getBandLevels,
+        getWeightedEnergy,
+        updateEnergyPeak,
+      } from '../assets/js/utils/audio-reactivity.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
       import {
         clearError,
@@ -238,17 +243,12 @@
         const frequencyData = getContextFrequencyData(ctxAudio);
 
         if (ctxAudio.analyser) {
-          const fallbackBands = {
-            bass: getBandAverage(frequencyData, 0, 0.12) / 255,
-            mid: getBandAverage(frequencyData, 0.12, 0.5) / 255,
-            treble: getBandAverage(frequencyData, 0.5, 1) / 255,
-          };
-          const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? fallbackBands;
-          const weightedEnergy = Math.min(
-            1,
-            (bands.bass * 0.6 + bands.mid * 0.25 + bands.treble * 0.15) * 1.4
-          );
-          peakLevel = Math.max(peakLevel * 0.96, weightedEnergy, 0.05);
+          const bands = getBandLevels({
+            analyser: ctxAudio.analyser,
+            data: frequencyData,
+          });
+          const weightedEnergy = getWeightedEnergy(bands, { boost: 1.4 });
+          peakLevel = updateEnergyPeak(peakLevel, weightedEnergy);
           const normalized = peakLevel ? weightedEnergy / peakLevel : 0;
           bassPulse = Math.max(bassPulse * 0.85, bands.bass);
           trebleGlow = Math.max(trebleGlow * 0.8, bands.treble);
@@ -353,31 +353,6 @@
 
         bassPulse *= 0.9;
         trebleGlow *= 0.9;
-      }
-
-      function getBandAverage(dataArray, startRatio, endRatio) {
-        if (!dataArray.length) return 0;
-        const startIndex = Math.floor(dataArray.length * startRatio);
-        const endIndex = Math.max(
-          startIndex + 1,
-          Math.floor(dataArray.length * endRatio)
-        );
-        let sum = 0;
-        const count = endIndex - startIndex;
-        for (let i = startIndex; i < endIndex; i++) {
-          sum += dataArray[i];
-        }
-        return sum / count;
-      }
-
-      function getBass(dataArray) {
-        if (!dataArray.length) return 0;
-        let sum = 0;
-        const bassCount = dataArray.length / 8;
-        for (let i = 0; i < bassCount; i++) {
-          sum += dataArray[i];
-        }
-        return sum / bassCount;
       }
 
       startButton.addEventListener('click', async () => {

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -264,6 +264,11 @@
         getFrequencyData,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
+      import {
+        getBandLevels,
+        getWeightedEnergy,
+        updateEnergyPeak,
+      } from '../assets/js/utils/audio-reactivity.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
       import { ensureWebGL } from '../assets/js/utils/webgl-check.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
@@ -591,15 +596,12 @@
         const treble = getFrequencyRange(2000, 16000);
 
         // Calculate Average Frequencies
-        const bands = analyser?.getMultiBandEnergy?.();
-        const bassAvg = bands?.bass ?? average(bass) / 255;
-        const midAvg = bands?.mid ?? average(mid) / 255;
-        const trebleAvg = bands?.treble ?? average(treble) / 255;
-        const weightedEnergy = Math.min(
-          1,
-          (bassAvg * 0.6 + midAvg * 0.25 + trebleAvg * 0.15) * 1.35
-        );
-        energyPeak = Math.max(energyPeak * 0.96, weightedEnergy, 0.05);
+        const bands = getBandLevels({ analyser, data: dataArray });
+        const bassAvg = bands.bass ?? average(bass) / 255;
+        const midAvg = bands.mid ?? average(mid) / 255;
+        const trebleAvg = bands.treble ?? average(treble) / 255;
+        const weightedEnergy = getWeightedEnergy(bands);
+        energyPeak = updateEnergyPeak(energyPeak, weightedEnergy);
         const normalized = weightedEnergy / energyPeak;
         bassPulse = Math.max(bassPulse * 0.85, bassAvg);
         trebleShimmer = Math.max(trebleShimmer * 0.8, trebleAvg);

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -289,6 +289,9 @@
       let particleMaterial;
       let particleGeometry;
       let unifiedInput = null;
+      let energyPeak = 0.12;
+      let bassPulse = 0;
+      let trebleShimmer = 0;
 
       // UI Elements
       const loadingOverlay = document.getElementById('loadingOverlay');
@@ -588,23 +591,34 @@
         const treble = getFrequencyRange(2000, 16000);
 
         // Calculate Average Frequencies
-        const bassAvg = average(bass) / 255;
-        const midAvg = average(mid) / 255;
-        const trebleAvg = average(treble) / 255;
+        const bands = analyser?.getMultiBandEnergy?.();
+        const bassAvg = bands?.bass ?? average(bass) / 255;
+        const midAvg = bands?.mid ?? average(mid) / 255;
+        const trebleAvg = bands?.treble ?? average(treble) / 255;
+        const weightedEnergy = Math.min(
+          1,
+          (bassAvg * 0.6 + midAvg * 0.25 + trebleAvg * 0.15) * 1.35
+        );
+        energyPeak = Math.max(energyPeak * 0.96, weightedEnergy, 0.05);
+        const normalized = weightedEnergy / energyPeak;
+        bassPulse = Math.max(bassPulse * 0.85, bassAvg);
+        trebleShimmer = Math.max(trebleShimmer * 0.8, trebleAvg);
 
         // Scale Shape Smoothly
-        const scale = 1 + bassAvg * 0.5;
+        const scale = 1 + bassAvg * 0.55 + normalized * 0.2;
         visualizerShape.scale.lerp(
           new THREE.Vector3(scale, scale, scale),
           0.05
         );
 
         // Rotate Shape Smoothly
-        visualizerShape.rotation.x += 0.002 + midAvg * 0.001;
-        visualizerShape.rotation.y += 0.003 + trebleAvg * 0.001;
+        visualizerShape.rotation.x += 0.002 + midAvg * 0.002 + normalized * 0.001;
+        visualizerShape.rotation.y += 0.003 + trebleAvg * 0.002 + normalized * 0.0012;
 
         // Update Shape Color
-        const hue = (bassAvg + midAvg + trebleAvg) / 3;
+        const hue =
+          (bassAvg * 0.5 + midAvg * 0.3 + trebleAvg * 0.2 + normalized * 0.1) %
+          1;
         visualizerShape.material.color.setHSL(hue, 1, 0.5);
         visualizerShape.material.emissive.setHSL(hue, 1, 0.2);
 
@@ -613,25 +627,32 @@
         for (let i = 0; i < particleCount; i++) {
           const freqIndex = Math.floor((i / particleCount) * dataArray.length);
           const audioValue = dataArray[freqIndex] / 255;
+          const reactiveValue = Math.min(
+            1,
+            audioValue * (0.75 + normalized * 0.9 + trebleShimmer * 0.4)
+          );
 
           // Position Update with Smooth Movement
           instancedParticles.getMatrixAt(i, dummy.matrix);
           dummy.matrix.decompose(dummy.position, dummy.quaternion, dummy.scale);
 
-          dummy.position.y += (audioValue - 0.5) * 0.1;
-          dummy.rotation.x += 0.01 * audioValue;
-          dummy.rotation.y += 0.01 * audioValue;
-          dummy.scale.setScalar(particleScale);
+          dummy.position.y += (reactiveValue - 0.5) * 0.12;
+          dummy.rotation.x += 0.012 * reactiveValue;
+          dummy.rotation.y += 0.012 * reactiveValue;
+          dummy.scale.setScalar(particleScale * (1 + bassPulse * 0.2));
           dummy.updateMatrix();
           instancedParticles.setMatrixAt(i, dummy.matrix);
 
           // Color Update based on Audio
           const color = new THREE.Color();
-          color.setHSL(hue, 1, 0.5 + 0.5 * audioValue);
+          color.setHSL(hue, 1, 0.5 + 0.5 * reactiveValue);
           instancedParticles.instanceColor.setXYZ(i, color.r, color.g, color.b);
         }
         instancedParticles.instanceMatrix.needsUpdate = true;
         instancedParticles.instanceColor.needsUpdate = true;
+
+        bassPulse *= 0.9;
+        trebleShimmer *= 0.9;
       }
 
       // Get Frequencies within a Range

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -164,6 +164,11 @@
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import {
+        getBandLevels,
+        getWeightedEnergy,
+        updateEnergyPeak,
+      } from '../assets/js/utils/audio-reactivity.ts';
 
       let analyser,
         dataArray = new Uint8Array(0),
@@ -405,24 +410,14 @@
 
       function getBeat() {
         if (!dataArray.length) return 0;
-        const low = getBandAverage(dataArray, 0, 0.2) / 255;
-        beatPeak = Math.max(beatPeak * 0.96, low, 0.05);
-        return low / beatPeak;
-      }
-
-      function getBandAverage(dataArray, startRatio, endRatio) {
-        if (!dataArray.length) return 0;
-        const startIndex = Math.floor(dataArray.length * startRatio);
-        const endIndex = Math.max(
-          startIndex + 1,
-          Math.floor(dataArray.length * endRatio)
-        );
-        let sum = 0;
-        const count = endIndex - startIndex;
-        for (let i = startIndex; i < endIndex; i++) {
-          sum += dataArray[i];
-        }
-        return sum / count;
+        const bands = getBandLevels({
+          analyser,
+          data: dataArray,
+          ratios: { bass: 0.2, mid: 0.55 },
+        });
+        const weightedEnergy = getWeightedEnergy(bands, { boost: 1.4 });
+        beatPeak = updateEnergyPeak(beatPeak, weightedEnergy);
+        return bands.bass / beatPeak;
       }
 
       function revealWordAtRandomLocation() {
@@ -497,19 +492,21 @@
           analyser = ctx.analyser;
           dataArray = getFrequencyData(ctx.analyser);
           isMicrophoneEnabled = true;
-          const bands = ctx.analyser.getMultiBandEnergy?.();
+          const bands = getBandLevels({
+            analyser: ctx.analyser,
+            data: dataArray,
+            ratios: { bass: 0.2, mid: 0.55 },
+          });
+          const weightedEnergy = getWeightedEnergy(bands, { boost: 1.4 });
           if (bands) {
-            const weightedEnergy = Math.min(
-              1,
-              (bands.bass * 0.65 + bands.mid * 0.25 + bands.treble * 0.1) * 1.4
-            );
-            beatPeak = Math.max(beatPeak * 0.96, weightedEnergy, 0.05);
+            beatPeak = updateEnergyPeak(beatPeak, weightedEnergy);
             trebleGlow = Math.max(trebleGlow * 0.88, bands.treble);
             gridElement.style.filter = `brightness(${1 + trebleGlow * 0.4})`;
           }
-          const beatStrength = bands
-            ? Math.min(1, (bands.bass + bands.mid * 0.3) / beatPeak)
-            : getBeat();
+          const beatStrength = Math.min(
+            1,
+            (bands.bass + bands.mid * 0.3) / beatPeak
+          );
 
           if (beatStrength > sensitivity) {
             revealWordAtRandomLocation();

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -175,6 +175,8 @@
       let sensitivity = parseFloat(sensitivitySlider.value);
       let wordIndex = 0;
       const cyclingActive = true;
+      let beatPeak = 0.12;
+      let trebleGlow = 0;
 
       const errorEl = document.getElementById('error-message');
 
@@ -403,13 +405,24 @@
 
       function getBeat() {
         if (!dataArray.length) return 0;
-        let sumLow = 0;
-        const lowEnd = Math.floor(dataArray.length * 0.2);
+        const low = getBandAverage(dataArray, 0, 0.2) / 255;
+        beatPeak = Math.max(beatPeak * 0.96, low, 0.05);
+        return low / beatPeak;
+      }
 
-        for (let i = 0; i < lowEnd; i++) {
-          sumLow += dataArray[i];
+      function getBandAverage(dataArray, startRatio, endRatio) {
+        if (!dataArray.length) return 0;
+        const startIndex = Math.floor(dataArray.length * startRatio);
+        const endIndex = Math.max(
+          startIndex + 1,
+          Math.floor(dataArray.length * endRatio)
+        );
+        let sum = 0;
+        const count = endIndex - startIndex;
+        for (let i = startIndex; i < endIndex; i++) {
+          sum += dataArray[i];
         }
-        return sumLow / lowEnd / 255; // Return normalized beat strength for the low range
+        return sum / count;
       }
 
       function revealWordAtRandomLocation() {
@@ -484,7 +497,19 @@
           analyser = ctx.analyser;
           dataArray = getFrequencyData(ctx.analyser);
           isMicrophoneEnabled = true;
-          const beatStrength = getBeat();
+          const bands = ctx.analyser.getMultiBandEnergy?.();
+          if (bands) {
+            const weightedEnergy = Math.min(
+              1,
+              (bands.bass * 0.65 + bands.mid * 0.25 + bands.treble * 0.1) * 1.4
+            );
+            beatPeak = Math.max(beatPeak * 0.96, weightedEnergy, 0.05);
+            trebleGlow = Math.max(trebleGlow * 0.88, bands.treble);
+            gridElement.style.filter = `brightness(${1 + trebleGlow * 0.4})`;
+          }
+          const beatStrength = bands
+            ? Math.min(1, (bands.bass + bands.mid * 0.3) / beatPeak)
+            : getBeat();
 
           if (beatStrength > sensitivity) {
             revealWordAtRandomLocation();
@@ -494,6 +519,7 @@
           }
         } else {
           isMicrophoneEnabled = false;
+          gridElement.style.filter = '';
         }
       }
 

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -47,7 +47,7 @@
       import * as THREE from 'three';
       import { getContextFrequencyData } from '../assets/js/core/animation-loop.ts';
       import WebToy from '../assets/js/core/web-toy.ts';
-      import { getAverageFrequency } from '../assets/js/utils/audio-handler.ts';
+      import { getWeightedAverageFrequency } from '../assets/js/utils/audio-handler.ts';
       import { showError } from '../assets/js/utils/error-display.ts';
       import createPeakDetector from '../assets/js/utils/peak-detector.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
@@ -429,7 +429,7 @@
       function animate(ctx) {
         const delta = clock.getDelta();
         lastFrequencyData = getContextFrequencyData(ctx);
-        const avgFrequency = getAverageFrequency(lastFrequencyData);
+        const avgFrequency = getWeightedAverageFrequency(lastFrequencyData);
 
         peakDetector.update(lastFrequencyData);
         const spin = adapter.computeMotion(avgFrequency);

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -56,6 +56,11 @@
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
+      import {
+        getBandLevels,
+        getWeightedEnergy,
+        updateEnergyPeak,
+      } from '../assets/js/utils/audio-reactivity.ts';
 
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');
@@ -521,21 +526,6 @@
         orientation.gamma = event.gamma;
       });
 
-      function averageRange(dataArray, startRatio, endRatio) {
-        if (!dataArray.length) return 0;
-        const startIndex = Math.floor(dataArray.length * startRatio);
-        const endIndex = Math.max(
-          startIndex + 1,
-          Math.floor(dataArray.length * endRatio)
-        );
-        let sum = 0;
-        const count = endIndex - startIndex;
-        for (let i = startIndex; i < endIndex; i++) {
-          sum += dataArray[i];
-        }
-        return sum / count;
-      }
-
       function processAudio(ctxAudio) {
         if (!ctxAudio.analyser) {
           peakDetector = null;
@@ -548,17 +538,13 @@
         }
 
         const dataArray = getFrequencyData(ctxAudio.analyser);
-        const fallbackBands = {
-          bass: averageRange(dataArray, 0, 0.2) / 255,
-          mid: averageRange(dataArray, 0.2, 0.55) / 255,
-          treble: averageRange(dataArray, 0.55, 1) / 255,
-        };
-        const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? fallbackBands;
-        const weightedEnergy = Math.min(
-          1,
-          (bands.bass * 0.6 + bands.mid * 0.25 + bands.treble * 0.15) * 1.35
-        );
-        energyPeak = Math.max(energyPeak * 0.96, weightedEnergy, 0.05);
+        const bands = getBandLevels({
+          analyser: ctxAudio.analyser,
+          data: dataArray,
+          ratios: { bass: 0.2, mid: 0.55 },
+        });
+        const weightedEnergy = getWeightedEnergy(bands);
+        energyPeak = updateEnergyPeak(energyPeak, weightedEnergy);
         bassPulse = Math.max(bassPulse * 0.85, bands.bass);
         trebleShimmer = Math.max(trebleShimmer * 0.8, bands.treble);
         const boost = 0.75 + weightedEnergy * 0.9 + bassPulse * 0.6;

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -93,6 +93,9 @@
       const adapter = createSearyFunAdapter();
       let peakDetector = null;
       let lastVibrateTime = 0;
+      let energyPeak = 0.12;
+      let bassPulse = 0;
+      let trebleShimmer = 0;
       let currentFreqs = adapter.transformFrequencies({
         low: 0,
         mid: 0,
@@ -518,6 +521,21 @@
         orientation.gamma = event.gamma;
       });
 
+      function averageRange(dataArray, startRatio, endRatio) {
+        if (!dataArray.length) return 0;
+        const startIndex = Math.floor(dataArray.length * startRatio);
+        const endIndex = Math.max(
+          startIndex + 1,
+          Math.floor(dataArray.length * endRatio)
+        );
+        let sum = 0;
+        const count = endIndex - startIndex;
+        for (let i = startIndex; i < endIndex; i++) {
+          sum += dataArray[i];
+        }
+        return sum / count;
+      }
+
       function processAudio(ctxAudio) {
         if (!ctxAudio.analyser) {
           peakDetector = null;
@@ -530,26 +548,23 @@
         }
 
         const dataArray = getFrequencyData(ctxAudio.analyser);
-        const bufferLength = dataArray.length || 1;
-        const bucketSize = bufferLength / 3;
-        const lowFreq =
-          dataArray
-            .slice(0, bucketSize)
-            .reduce((sum, value) => sum + value, 0) /
-          bucketSize /
-          256.0;
-        const midFreq =
-          dataArray
-            .slice(bucketSize, 2 * bucketSize)
-            .reduce((sum, value) => sum + value, 0) /
-          bucketSize /
-          256.0;
-        const highFreq =
-          dataArray
-            .slice(2 * bucketSize)
-            .reduce((sum, value) => sum + value, 0) /
-          bucketSize /
-          256.0;
+        const fallbackBands = {
+          bass: averageRange(dataArray, 0, 0.2) / 255,
+          mid: averageRange(dataArray, 0.2, 0.55) / 255,
+          treble: averageRange(dataArray, 0.55, 1) / 255,
+        };
+        const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? fallbackBands;
+        const weightedEnergy = Math.min(
+          1,
+          (bands.bass * 0.6 + bands.mid * 0.25 + bands.treble * 0.15) * 1.35
+        );
+        energyPeak = Math.max(energyPeak * 0.96, weightedEnergy, 0.05);
+        bassPulse = Math.max(bassPulse * 0.85, bands.bass);
+        trebleShimmer = Math.max(trebleShimmer * 0.8, bands.treble);
+        const boost = 0.75 + weightedEnergy * 0.9 + bassPulse * 0.6;
+        const lowFreq = Math.min(1, bands.bass * boost);
+        const midFreq = Math.min(1, bands.mid * (0.85 + boost * 0.6));
+        const highFreq = Math.min(1, bands.treble * (0.9 + boost * 0.75));
 
         currentFreqs = adapter.transformFrequencies({
           low: lowFreq,
@@ -626,6 +641,9 @@
             canvas.style.transform = 'scale(1)';
           }, 100);
         }
+
+        bassPulse *= 0.9;
+        trebleShimmer *= 0.9;
 
         burstState.scale += (1 - burstState.scale) * Math.min(1, dt * 2.25);
         burstState.rotation *= Math.max(0, 1 - dt * 1.35);

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -56,6 +56,11 @@
         getFrequencyData,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
+      import {
+        getBandLevels,
+        getWeightedEnergy,
+        updateEnergyPeak,
+      } from '../assets/js/utils/audio-reactivity.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
       import {
         clearError,
@@ -473,16 +478,15 @@
         if (ctxAudio.analyser) {
           const dataArray = getFrequencyData(ctxAudio.analyser);
           const average = getWeightedAverageFrequency(dataArray);
-          const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? {
-            bass: 0,
-            mid: 0,
-            treble: 0,
-          };
-          const weightedEnergy = Math.min(
-            1,
-            (bands.bass * 0.65 + bands.mid * 0.25 + bands.treble * 0.1) * 1.4
-          );
-          peakLevel = Math.max(peakLevel * 0.96, weightedEnergy, 0.05);
+          const bands = getBandLevels({
+            analyser: ctxAudio.analyser,
+            data: dataArray,
+          });
+          const weightedEnergy = getWeightedEnergy(bands, {
+            weights: { bass: 0.65, mid: 0.25, treble: 0.1 },
+            boost: 1.4,
+          });
+          peakLevel = updateEnergyPeak(peakLevel, weightedEnergy);
           const normalized = peakLevel ? weightedEnergy / peakLevel : 0;
           smoothedLevel = smoothedLevel
             ? smoothedLevel * 0.82 + normalized * 0.18

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -52,7 +52,7 @@
     </div>
     <script type="module">
       import {
-        getAverageFrequency,
+        getWeightedAverageFrequency,
         getFrequencyData,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
@@ -238,13 +238,17 @@
 
       const adapter = createSymphFunAdapter();
       let gradientStops = adapter.paletteOptions.bright;
-      let colorOffset = [...adapter.paletteAccent];
+      let baseColorOffset = [...adapter.paletteAccent];
+      let reactiveColorOffset = [...baseColorOffset];
       let time = 0.0;
       let audioData = adapter.transformAudioValue(0);
       let touchPoint = [0.0, 0.0];
       let smoothedLevel = 0;
       let burstEnergy = 0;
       let lastTransientTime = 0;
+      let peakLevel = 0.12;
+      let bassPulse = 0;
+      let trebleShimmer = 0;
       const defaultSensitivity = 0.7;
       let transientSensitivity = defaultSensitivity;
       let sparklesEnabled = true;
@@ -269,7 +273,8 @@
         paletteOptions: adapter.paletteOptions,
         onPaletteChange: (palette, colors) => {
           adapter.setPalette(palette, colors);
-          colorOffset = [...adapter.paletteAccent];
+          baseColorOffset = [...adapter.paletteAccent];
+          reactiveColorOffset = [...baseColorOffset];
           gradientStops = colors;
         },
         onMotionChange: (intensity, mode) => adapter.setMotion(intensity, mode),
@@ -467,18 +472,28 @@
       function animate(ctxAudio) {
         if (ctxAudio.analyser) {
           const dataArray = getFrequencyData(ctxAudio.analyser);
-          const average = getAverageFrequency(dataArray);
-          const normalized = average / 255;
+          const average = getWeightedAverageFrequency(dataArray);
+          const bands = ctxAudio.analyser.getMultiBandEnergy?.() ?? {
+            bass: 0,
+            mid: 0,
+            treble: 0,
+          };
+          const weightedEnergy = Math.min(
+            1,
+            (bands.bass * 0.65 + bands.mid * 0.25 + bands.treble * 0.1) * 1.4
+          );
+          peakLevel = Math.max(peakLevel * 0.96, weightedEnergy, 0.05);
+          const normalized = peakLevel ? weightedEnergy / peakLevel : 0;
           smoothedLevel = smoothedLevel
-            ? smoothedLevel * 0.9 + normalized * 0.1
+            ? smoothedLevel * 0.82 + normalized * 0.18
             : normalized;
-          const threshold = 0.08 + (1 - transientSensitivity) * 0.25;
+          const threshold = 0.06 + (1 - transientSensitivity) * 0.22;
           const transientDelta = normalized - smoothedLevel;
           const now = performance.now();
           if (
             transientDelta > threshold &&
             now - lastTransientTime > 110 &&
-            normalized > 0.05
+            normalized > 0.04
           ) {
             const strength = Math.min(
               1,
@@ -488,32 +503,51 @@
             triggerBurst(strength);
           }
 
-          audioData = adapter.transformAudioValue(average);
+          bassPulse = Math.max(bassPulse * 0.84, bands.bass);
+          trebleShimmer = Math.max(trebleShimmer * 0.78, bands.treble);
+          const audioDrive = Math.min(
+            255,
+            average * (0.7 + normalized * 1.1 + bassPulse * 0.8)
+          );
+          audioData = adapter.transformAudioValue(audioDrive);
+          const colorBoost = 1 + trebleShimmer * 0.75 + bassPulse * 0.35;
+          reactiveColorOffset = baseColorOffset.map((value) =>
+            Math.min(1, value * colorBoost + trebleShimmer * 0.08)
+          );
+          if (sparklesEnabled && trebleShimmer > 0.6 && Math.random() < 0.08) {
+            spawnSparkles(Math.min(1, trebleShimmer));
+          }
           updateSpectrograph(dataArray);
           funControls.setAudioAvailable(true);
         } else {
           audioData = adapter.transformAudioValue(0);
+          reactiveColorOffset = [...baseColorOffset];
           funControls.setAudioAvailable(false);
         }
 
         time += 0.02;
         gl.uniform1f(timeUniformLocation, time);
         gl.uniform1f(audioDataUniformLocation, audioData);
-        gl.uniform3fv(colorOffsetUniformLocation, colorOffset);
+        gl.uniform3fv(colorOffsetUniformLocation, reactiveColorOffset);
         gl.uniform2fv(touchUniformLocation, touchPoint);
         const burstTint = burstsEnabled
           ? [
-              colorOffset[0] * burstEnergy * 1.2,
-              colorOffset[1] * burstEnergy * 1.2,
-              colorOffset[2] * burstEnergy * 1.2,
+              baseColorOffset[0] * burstEnergy * 1.2,
+              baseColorOffset[1] * burstEnergy * 1.2,
+              baseColorOffset[2] * burstEnergy * 1.2,
             ]
           : [0, 0, 0];
         const rippleAmp =
-          rippleBase * (1.0 + (burstsEnabled ? burstEnergy * 0.8 : 0));
+          rippleBase *
+          (1.0 +
+            (burstsEnabled ? burstEnergy * 0.8 : 0) +
+            bassPulse * 0.6);
         gl.uniform3fv(burstTintUniformLocation, burstTint);
         gl.uniform1f(rippleUniformLocation, rippleAmp);
 
         burstEnergy = Math.max(0, burstEnergy - 0.015);
+        bassPulse *= 0.92;
+        trebleShimmer *= 0.9;
 
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);


### PR DESCRIPTION
### Motivation
- Make visual toys feel more vibrant and responsive by biasing audio signals toward bass/mid energy and adding adaptive band-driven motion and color reactions. 
- Apply the same audio-reactivity improvements consistently across the library so all toys benefit from stronger transients and a punchier feel. 
- Preserve existing synthetic-fallback behavior while providing an energy-normalized signal for quiet vs loud inputs.

### Description
- Added a new helper `getWeightedAverageFrequency` in `assets/js/utils/audio-handler.ts` that computes a bass-weighted and slightly boosted average for more expressive motion. 
- Switched many toys to use the weighted average (imports updated) including `bubble-harmonics`, `aurora-painter`, `cube-wave`, `cosmic-particles`, `three-d-toy`, `star-field`, `spiral-burst`, `tactile-sand-table`, `rainbow-tunnel`, `multi` and others. 
- Enhanced several HTML toys (`toys/symph.html`, `toys/geom.html`, `toys/seary.html`, `toys/holy.html`, `toys/legible.html`, `toys/evol.html`, `toys/multi.html`) to compute per-band energy (with a `getBandAverage`/`averageRange` fallback), maintain an adaptive `peak`/`energyPeak` for normalization, and drive bass/treble pulses (e.g., `bassPulse`, `trebleShimmer`) to influence size, color, ripple, sparkles, and transient/burst behavior. 
- Updated the Lights toy audio controller (`assets/js/toys/lights/audio.ts`) to derive an `intensity` from the weighted average and scale both rotation and scale responsiveness accordingly; fixed import ordering and small style issues reported by linting.

### Testing
- Ran `bun run check` (runs Biome checks, formatting, and the test suite) and it completed successfully. 
- Ran `bun run typecheck` (TypeScript `tsc --noEmit`) and it completed with no errors. 
- Automated tests summary: test run completed with `73` passed, `2` skipped, and `0` failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975aef3f1fc83329d3fb37ccd772c5d)