### PR TITLE
Improve agent docs quickstart

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,6 +1,22 @@
 # Agent Guidance Index
 
-Start with the root [AGENTS.md](../../AGENTS.md) for the essentials, then use these deeper references as needed:
+Start with the root [AGENTS.md](../../AGENTS.md) for the essentials, then use these deeper references as needed.
+
+## Quickstart (agent-facing)
+
+- Check for additional `AGENTS.md` files when you move into a new subdirectory.
+- Prefer Bun for installs and scripts (`bun install --frozen-lockfile`, `bun run ...`).
+- If you touch JS/TS, run `bun run check` before committing.
+- If you only edit docs, you can skip typechecking/tests.
+
+## Fast navigation map
+
+- `assets/js/` - Core runtime, toy modules, and UI logic.
+- `assets/js/toys/` - Toy implementations (TypeScript).
+- `assets/js/toys-data.js` - Toy registry metadata.
+- `toys/` - Standalone HTML toy pages.
+- `tests/` - Automated tests.
+- `docs/` - Documentation and architecture references.
 
 - [Tooling & quality checks](./tooling-and-quality.md)
 - [Metadata & documentation expectations](./metadata-and-docs.md)

--- a/docs/agents/metadata-and-docs.md
+++ b/docs/agents/metadata-and-docs.md
@@ -5,6 +5,19 @@
 - **Commit messages:** concise, descriptive titles in sentence case (no trailing period), e.g., `Add docs on data flow`.
 - **PR summaries:** include a short summary plus explicit lists of tests run and any docs touched or added so reviewers can verify coverage.
 
+### Suggested PR summary format
+
+```
+Summary:
+- <short summary>
+
+Tests:
+- <test command or "Not run (reason)">
+
+Docs:
+- <doc path(s) touched, or "None">
+```
+
 ## Documentation expectations
 
 - Refer to `docs/README.md` for the documentation map when adding or updating docs.


### PR DESCRIPTION
### Motivation
- Make agent-facing docs faster to use and standardize PR metadata so contributors can onboard and produce consistent PR summaries.

### Description
- Add a short `Quickstart (agent-facing)` checklist and a fast navigation map to `docs/agents/README.md`.
- Add a `Suggested PR summary format` snippet to `docs/agents/metadata-and-docs.md` to standardize summary, tests, and docs reporting.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b322d6ac83329af03fd538e58114)