### PR TITLE
Expand agent reference doc pointers

### DIFF
--- a/docs/agents/reference-docs.md
+++ b/docs/agents/reference-docs.md
@@ -1,5 +1,30 @@
 # Reference Documentation
 
+## Core reference docs
+
 - `docs/TOY_DEVELOPMENT.md` - Full toy development playbook.
 - `docs/TOY_TESTING_SPEC.md` - Automated testing specification.
 - `docs/ARCHITECTURE.md` - System architecture overview.
+
+## High-signal code locations
+
+- `assets/js/toys/` - TypeScript toy modules (library-loaded toys).
+- `assets/js/toys-data.js` - Toy registry metadata (slugs, labels, caps).
+- `assets/js/loader.ts` - Toy loader for `toy.html` (routes, query params).
+- `assets/js/core/toy-runtime.ts` - Runtime scaffolding (audio + render loop).
+- `assets/js/utils/start-audio.ts` - Audio unlock + demo audio controls.
+- `toys/` - Standalone HTML toys (page-based).
+- `public/` - Static assets served as-is.
+
+## Config + project entry points
+
+- `vite.config.js` - Build + dev server config.
+- `package.json` - Scripts and Bun package manager config.
+- `index.html` / `toy.html` - Entry points for the library and toy runner.
+
+## Fast triage checklist
+
+1. **Toy missing from UI?** Confirm it exists in `assets/js/toys-data.js`.
+2. **Toy fails to load?** Check query params handling in `assets/js/loader.ts`.
+3. **Audio not reactive?** Validate `startAudio` usage and runtime setup in
+   `assets/js/core/toy-runtime.ts` and `assets/js/utils/start-audio.ts`.


### PR DESCRIPTION
### Motivation

- Improve agent-facing reference docs to help agents quickly locate high-signal code areas and accelerate troubleshooting.
- Surface config and entry points plus a short triage checklist so common toy issues can be diagnosed faster.

### Description

- Updated `docs/agents/reference-docs.md` to add a `Core reference docs` section that consolidates key doc pointers.
- Added a `High-signal code locations` list that calls out `assets/js/toys/`, `assets/js/toys-data.js`, `assets/js/loader.ts`, `assets/js/core/toy-runtime.ts`, `assets/js/utils/start-audio.ts`, `toys/`, and `public/`.
- Added a `Config + project entry points` section referencing `vite.config.js`, `package.json`, `index.html`, and `toy.html`.
- Added a `Fast triage checklist` with three quick diagnostic steps for common toy failures.

### Testing

- Ran `biome lint assets scripts tests` which completed with no issues.
- Ran `biome format --write assets scripts tests` which completed with no changes required.
- This is a documentation-only change so full `bun run check` and code tests were not required per the docs guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b322d6ac83329af03fd538e58114)