### PR TITLE
Add shared toy settings helpers and refactor toys to use them

### DIFF
--- a/assets/js/toys/clay.ts
+++ b/assets/js/toys/clay.ts
@@ -1,18 +1,8 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/clay.html',
-    preferDemoAudio,
-    title: 'Pottery Wheel Sculptor',
-    description:
-      'Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/clay.html',
+  title: 'Pottery Wheel Sculptor',
+  description:
+    'Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.',
+});

--- a/assets/js/toys/evol.ts
+++ b/assets/js/toys/evol.ts
@@ -1,16 +1,6 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/evol.html',
-    preferDemoAudio,
-    title: 'Evolutionary Weirdcore',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/evol.html',
+  title: 'Evolutionary Weirdcore',
+});

--- a/assets/js/toys/geom.ts
+++ b/assets/js/toys/geom.ts
@@ -1,17 +1,7 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/geom.html',
-    preferDemoAudio,
-    title: 'Microphone Geometry Visualizer',
-    description: 'Cap resolution or boost fidelity for the 2D particle grid.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/geom.html',
+  title: 'Microphone Geometry Visualizer',
+  description: 'Cap resolution or boost fidelity for the 2D particle grid.',
+});

--- a/assets/js/toys/holy.ts
+++ b/assets/js/toys/holy.ts
@@ -1,17 +1,7 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/holy.html',
-    preferDemoAudio,
-    title: 'Ultimate Satisfying Visualizer',
-    description: 'Adjust render scale for halo layers and particle bursts.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/holy.html',
+  title: 'Ultimate Satisfying Visualizer',
+  description: 'Adjust render scale for halo layers and particle bursts.',
+});

--- a/assets/js/toys/legible.ts
+++ b/assets/js/toys/legible.ts
@@ -1,16 +1,6 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/legible.html',
-    preferDemoAudio,
-    title: 'Terminal Word Grid',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/legible.html',
+  title: 'Terminal Word Grid',
+});

--- a/assets/js/toys/lights.ts
+++ b/assets/js/toys/lights.ts
@@ -1,17 +1,7 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: 'toys/lights.html',
-    preferDemoAudio,
-    title: 'Audio Light Show',
-    description: 'Dial quality for the cube lighting playground.',
-  });
-}
+export const start = createPageToyStarter({
+  path: 'toys/lights.html',
+  title: 'Audio Light Show',
+  description: 'Dial quality for the cube lighting playground.',
+});

--- a/assets/js/toys/milkdrop-toy.ts
+++ b/assets/js/toys/milkdrop-toy.ts
@@ -1,10 +1,10 @@
 import * as THREE from 'three';
-import {
-  DEFAULT_QUALITY_PRESETS,
-  getSettingsPanel,
-} from '../core/settings-panel';
 import { createToyRuntime } from '../core/toy-runtime';
 import FeedbackManager from '../utils/feedback-manager';
+import {
+  configureToySettingsPanel,
+  createQualityPresetManager,
+} from '../utils/toy-settings';
 import WarpShader from '../utils/warp-shader';
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
@@ -142,17 +142,16 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     ],
   });
 
-  const settingsPanel = getSettingsPanel();
-  settingsPanel.configure({
-    title: 'MilkDrop Proto',
-    description: 'A prototype of MilkDrop-style feedback engine.',
-  });
-  settingsPanel.setQualityPresets({
-    presets: DEFAULT_QUALITY_PRESETS,
+  const quality = createQualityPresetManager({
     defaultPresetId: 'medium',
     onChange: (preset) => {
       runtime.toy.updateRendererSettings({ renderScale: preset.renderScale });
     },
+  });
+  configureToySettingsPanel({
+    title: 'MilkDrop Proto',
+    description: 'A prototype of MilkDrop-style feedback engine.',
+    quality,
   });
 
   return runtime;

--- a/assets/js/toys/multi.ts
+++ b/assets/js/toys/multi.ts
@@ -1,18 +1,8 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/multi.html',
-    preferDemoAudio,
-    title: 'Multi-Capability Visualizer',
-    description:
-      'Balance performance with render scale before joining the multi-mode scene.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/multi.html',
+  title: 'Multi-Capability Visualizer',
+  description:
+    'Balance performance with render scale before joining the multi-mode scene.',
+});

--- a/assets/js/toys/page-toy.ts
+++ b/assets/js/toys/page-toy.ts
@@ -13,6 +13,13 @@ type StartOptions = {
   preferDemoAudio?: boolean;
 };
 
+type PageToyStartOptions = {
+  container?: HTMLElement | null;
+  preferDemoAudio?: boolean;
+};
+
+type PageToyConfig = Omit<StartOptions, keyof PageToyStartOptions>;
+
 function resolvePageSrc(path: string) {
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
   return new URL(path, window.location.origin).toString();
@@ -107,4 +114,17 @@ export function startPageToy({
   target.appendChild(statusElement);
 
   return activeToy;
+}
+
+export function createPageToyStarter(config: PageToyConfig) {
+  return function start({
+    container,
+    preferDemoAudio,
+  }: PageToyStartOptions = {}) {
+    return startPageToy({
+      container,
+      preferDemoAudio,
+      ...config,
+    });
+  };
 }

--- a/assets/js/toys/seary.ts
+++ b/assets/js/toys/seary.ts
@@ -1,17 +1,7 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/seary.html',
-    preferDemoAudio,
-    title: 'Trippy Synesthetic Visualizer',
-    description: 'Tune pixel ratio and density for sparkles and bursts.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/seary.html',
+  title: 'Trippy Synesthetic Visualizer',
+  description: 'Tune pixel ratio and density for sparkles and bursts.',
+});

--- a/assets/js/toys/symph.ts
+++ b/assets/js/toys/symph.ts
@@ -1,18 +1,8 @@
-import { startPageToy } from './page-toy';
+import { createPageToyStarter } from './page-toy';
 
-export function start({
-  container,
-  preferDemoAudio,
-}: {
-  container?: HTMLElement | null;
-  preferDemoAudio?: boolean;
-} = {}) {
-  return startPageToy({
-    container,
-    path: './toys/symph.html',
-    preferDemoAudio,
-    title: 'Dreamy Spectrograph',
-    description:
-      'Adjust render quality for the flowing spectrograph and sparkles.',
-  });
-}
+export const start = createPageToyStarter({
+  path: './toys/symph.html',
+  title: 'Dreamy Spectrograph',
+  description:
+    'Adjust render quality for the flowing spectrograph and sparkles.',
+});

--- a/assets/js/utils/toy-settings.ts
+++ b/assets/js/utils/toy-settings.ts
@@ -1,0 +1,84 @@
+import {
+  DEFAULT_QUALITY_PRESETS,
+  getActiveQualityPreset,
+  getSettingsPanel,
+  type PersistentSettingsPanel,
+  type QualityPreset,
+} from '../core/settings-panel';
+
+type QualityPresetManagerOptions = {
+  presets?: QualityPreset[];
+  defaultPresetId?: string;
+  storageKey?: string;
+  onChange?: (preset: QualityPreset) => void;
+  panel?: PersistentSettingsPanel;
+};
+
+export type QualityPresetManager = {
+  readonly activeQuality: QualityPreset;
+  applyQualityPreset: (preset: QualityPreset) => void;
+  configureQualityPresets: (
+    panel?: PersistentSettingsPanel,
+  ) => PersistentSettingsPanel;
+};
+
+export function createQualityPresetManager(
+  options: QualityPresetManagerOptions = {},
+): QualityPresetManager {
+  const {
+    presets = DEFAULT_QUALITY_PRESETS,
+    defaultPresetId = 'balanced',
+    storageKey,
+    onChange,
+    panel,
+  } = options;
+
+  let activeQuality = getActiveQualityPreset({
+    presets,
+    defaultPresetId,
+    storageKey,
+  });
+
+  const applyQualityPreset = (preset: QualityPreset) => {
+    activeQuality = preset;
+    onChange?.(preset);
+  };
+
+  const configureQualityPresets = (
+    targetPanel: PersistentSettingsPanel = panel ?? getSettingsPanel(),
+  ) => {
+    targetPanel.setQualityPresets({
+      presets,
+      defaultPresetId: activeQuality.id,
+      onChange: applyQualityPreset,
+      storageKey,
+    });
+    return targetPanel;
+  };
+
+  return {
+    get activeQuality() {
+      return activeQuality;
+    },
+    applyQualityPreset,
+    configureQualityPresets,
+  };
+}
+
+type ToySettingsPanelOptions = {
+  title: string;
+  description?: string;
+  panel?: PersistentSettingsPanel;
+  quality?: QualityPresetManager;
+};
+
+export function configureToySettingsPanel({
+  title,
+  description,
+  panel = getSettingsPanel(),
+  quality,
+}: ToySettingsPanelOptions): PersistentSettingsPanel {
+  panel.configure({ title, description });
+  quality?.configureQualityPresets(panel);
+  return panel;
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated settings-panel wiring across toys by centralizing quality-preset logic and panel configuration.  
- Make page-based toys simpler to declare by providing a small starter factory.  
- Ensure consistent renderer/update behavior when quality changes across many toys.

### Description

- Add `assets/js/utils/toy-settings.ts` which provides `createQualityPresetManager(...)` and `configureToySettingsPanel(...)` to encapsulate quality preset state and settings panel configuration.  
- Add `createPageToyStarter(...)` to `assets/js/toys/page-toy.ts` to produce compact page-based `start` exports.  
- Update page toys to use `createPageToyStarter(...)` (for example `clay`, `evol`, `geom`, `holy`, `legible`, `lights`, `multi`, `seary`, `symph`).  
- Refactor canvas-based toys to use the quality manager and settings helper (examples: `aurora-painter`, `bubble-harmonics`, `cosmic-particles`, `cube-wave`, `fractal-kite-garden`, `neon-wave`, `rainbow-tunnel`, `star-field`, `spiral-burst`, `three-d-toy`, `tactile-sand-table`, `bioluminescent-tidepools`, `milkdrop-toy`), wiring `onChange` to update `runtime.toy.updateRendererSettings(...)` and rebuild/refresh scene assets; renderer options now read from `quality.activeQuality` where appropriate.

### Testing

- Ran `bun run check` (which runs `biome` checks, `tsc --noEmit`, and the test suite) and it completed successfully.  
- The test run executed the project tests and reported all automated tests passed (tests run as part of `bun run check` succeeded, with the test suite passing and a small number of skips).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b45b2af8833299295837de8d7e4a)