### PR TITLE
Add toy page shell navigation helper

### DIFF
--- a/assets/js/utils/toy-page-shell.ts
+++ b/assets/js/utils/toy-page-shell.ts
@@ -1,0 +1,34 @@
+import { initNavigation } from '../ui/nav.ts';
+
+export interface ToyPageShellOptions {
+  container?: HTMLElement | null;
+  backHref?: string;
+  title?: string;
+  slug?: string;
+}
+
+export const initToyPageShell = (options: ToyPageShellOptions = {}) => {
+  const doc = options.container?.ownerDocument ?? document;
+  const win = doc.defaultView ?? window;
+  const backHref = options.backHref ?? '../index.html';
+  const title = options.title ?? doc.title;
+  let container =
+    options.container ?? doc.querySelector<HTMLElement>('[data-toy-nav]');
+
+  if (!container) {
+    container = doc.createElement('div');
+    container.dataset.toyNav = 'true';
+    doc.body.insertAdjacentElement('afterbegin', container);
+  }
+
+  initNavigation(container, {
+    mode: 'toy',
+    title,
+    slug: options.slug,
+    onBack: () => {
+      win.location.href = backHref;
+    },
+  });
+
+  return container;
+};

--- a/toys/clay.html
+++ b/toys/clay.html
@@ -42,7 +42,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="ui">
       <button id="resetButton">Reset Clay</button>
       <div id="toolPanel">
@@ -52,8 +52,10 @@
       </div>
     </div>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import { bootstrapClayPage } from '../assets/js/toys/clay-toy.ts';
 
+      initToyPageShell();
       bootstrapClayPage();
     </script>
   </body>

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="../assets/css/base.css" />
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="error-message"></div>
     <canvas id="glCanvas" class="toy-canvas"></canvas>
     <div class="control-panel">
@@ -68,6 +68,7 @@
       </div>
     </div>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import {
         getFrequencyData,
         getWeightedAverageFrequency,
@@ -75,6 +76,8 @@
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+
+      initToyPageShell();
 
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');

--- a/toys/geom.html
+++ b/toys/geom.html
@@ -53,7 +53,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="controls">
       <button id="startButton">Start Microphone Visualizer</button>
       <div class="control-group">
@@ -102,6 +102,7 @@
     <div id="error-message" style="display: none"></div>
     <canvas id="gameCanvas" class="toy-canvas"></canvas>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import { getContextFrequencyData } from '../assets/js/core/animation-loop.ts';
       import { setupIframeQualitySync } from '../assets/js/core/iframe-quality-sync.ts';
       import {
@@ -118,6 +119,8 @@
         clearError,
         showError,
       } from '../assets/js/utils/error-display.ts';
+
+      initToyPageShell();
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
 
       const canvas = document.getElementById('gameCanvas');

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -153,7 +153,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="error-message" style="display: none"></div>
     <!-- Loading Overlay -->
     <div id="loadingOverlay">
@@ -254,6 +254,7 @@
 
     <!-- Main Visualizer Script -->
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import * as THREE from 'three';
       import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
       import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
@@ -272,6 +273,8 @@
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
       import { ensureWebGL } from '../assets/js/utils/webgl-check.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
+
+      initToyPageShell();
 
       if (!ensureWebGL()) {
         throw new Error('WebGL support is required for the Holy visualizer.');

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -125,7 +125,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="error-message" style="display: none"></div>
     <div class="controls">
       <button id="start-button">Start Microphone</button>
@@ -159,6 +159,7 @@
     <div class="grid" id="grid"></div>
 
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import {
         getFrequencyData,
         initAudio,
@@ -169,6 +170,8 @@
         getWeightedEnergy,
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
+
+      initToyPageShell();
 
       let analyser,
         dataArray = new Uint8Array(0),

--- a/toys/lights.html
+++ b/toys/lights.html
@@ -57,7 +57,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <!-- Controls for light type and starting audio -->
     <div class="control-panel">
       <div class="control-panel__heading">Lighting controls</div>
@@ -105,6 +105,11 @@
     <!-- WebGL Canvas -->
     <canvas id="toy-canvas" class="toy-canvas"></canvas>
 
+    <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
+
+      initToyPageShell();
+    </script>
     <script type="module" src="../assets/js/toys/lights/index.ts"></script>
   </body>
 </html>

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -35,7 +35,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <canvas id="webglCanvas" class="toy-canvas"></canvas>
     <div
       id="capability-banner"
@@ -44,6 +44,7 @@
     ></div>
     <div id="error-message" style="display: none"></div>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import * as THREE from 'three';
       import { getContextFrequencyData } from '../assets/js/core/animation-loop.ts';
       import WebToy from '../assets/js/core/web-toy.ts';
@@ -54,6 +55,8 @@
       import { createMultiFunAdapter } from '../assets/multi/fun-adapter.ts';
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
+
+      initToyPageShell();
 
       const canvas = document.getElementById('webglCanvas');
       const capabilityBanner = document.getElementById('capability-banner');

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -29,7 +29,7 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <canvas id="gpuCanvas" class="toy-canvas"></canvas>
     <canvas id="sparkleCanvas" class="toy-canvas"></canvas>
     <div id="error-message" style="display: none"></div>
@@ -44,6 +44,7 @@
       </div>
     </div>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import {
         getFrequencyData,
         initAudio,
@@ -61,6 +62,8 @@
         getWeightedEnergy,
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
+
+      initToyPageShell();
 
       // Fallback to WebGL
       const canvas = document.getElementById('gpuCanvas');

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -44,13 +44,14 @@
     </style>
   </head>
   <body>
-    <a href="../index.html" class="home-link">Back to Library</a>
+    <div data-toy-nav></div>
     <div id="error-message" style="display: none"></div>
     <div class="canvas-stack">
       <canvas id="glCanvas" class="toy-canvas canvas-gl"></canvas>
       <canvas id="overlayCanvas" class="toy-canvas canvas-overlay"></canvas>
     </div>
     <script type="module">
+      import { initToyPageShell } from '../assets/js/utils/toy-page-shell.ts';
       import {
         getWeightedAverageFrequency,
         getFrequencyData,
@@ -71,6 +72,8 @@
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
+
+      initToyPageShell();
 
       const canvas = document.getElementById('glCanvas');
       const overlayCanvas = document.getElementById('overlayCanvas');


### PR DESCRIPTION
### Motivation
- Consolidate the per-toy "Back to Library" link and navigation rendering into a single reusable helper to reduce duplication and make navigation behavior consistent across standalone toy pages.
- Provide a small, testable API to wire toy-mode navigation and a configurable back target while preserving toy-specific page content.

### Description
- Add `assets/js/utils/toy-page-shell.ts` which exports `initToyPageShell` that creates or uses a `[data-toy-nav]` container and calls `initNavigation(..., { mode: 'toy', ... })` with an `onBack` handler that navigates to a configurable `backHref` (default `../index.html`).
- Update all standalone toy HTML pages in `toys/` to remove the hard-coded `<a class="home-link">` anchors, add a `<div data-toy-nav></div>` placeholder, and import + call `initToyPageShell()` in their module scripts to render the shared nav.
- Keep all toy-specific UI and scripts untouched so only the shared nav/back link behavior is abstracted.

### Testing
- Ran `bun run check` (Biome lint/format, TypeScript typecheck, and test suite) which completed successfully.
- Test summary: `bun test` results show 76 passed, 2 skipped, and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bb7827008332a3d7fe4cf2f33f2b)