### PR TITLE
Add toy audio bootstrap helper and wire toys to it

### DIFF
--- a/assets/js/utils/start-audio.ts
+++ b/assets/js/utils/start-audio.ts
@@ -3,7 +3,7 @@ import type WebToy from '../core/web-toy';
 import type { AudioInitOptions } from './audio-handler';
 import { AudioAccessError, getCachedDemoAudioStream } from './audio-handler';
 
-type StartAudioOptions =
+export type StartAudioOptions =
   | (AudioInitOptions & {
       fallbackToSynthetic?: boolean;
       preferSynthetic?: boolean;

--- a/assets/js/utils/toy-audio-bootstrap.ts
+++ b/assets/js/utils/toy-audio-bootstrap.ts
@@ -1,0 +1,58 @@
+import type { AnimationContext } from '../core/animation-loop';
+import type { AudioInitOptions } from './audio-handler';
+import { initAudio } from './audio-handler';
+import { type StartAudioOptions, startToyAudio } from './start-audio';
+
+type ToyAudioErrorHandler = (error: unknown) => void;
+
+interface ToyAudioBootstrapOptions {
+  onAudioInit?: (audio: Awaited<ReturnType<typeof initAudio>>) => void;
+  onAudioError?: ToyAudioErrorHandler;
+}
+
+interface ToyAudioStartHandlers {
+  onSuccess?: (ctx: AnimationContext) => void;
+  onError?: ToyAudioErrorHandler;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: flexible toy instances in HTML modules
+type ToyWithAudio = any;
+
+export function createToyAudioBootstrap(
+  toy: ToyWithAudio,
+  options: ToyAudioBootstrapOptions = {},
+) {
+  const { onAudioInit, onAudioError } = options;
+
+  const initAudioForToy = async (audioOptions: AudioInitOptions = {}) => {
+    const audio = await initAudio(audioOptions);
+    toy.analyser = audio.analyser;
+    toy.audioCleanup = audio.cleanup;
+    onAudioInit?.(audio);
+    return audio;
+  };
+
+  const startAudio = async (
+    animate: (ctx: AnimationContext) => void,
+    audioOptions?: StartAudioOptions,
+    handlers: ToyAudioStartHandlers = {},
+  ): Promise<AnimationContext> => {
+    try {
+      const ctx = await startToyAudio(toy, animate, audioOptions);
+      handlers.onSuccess?.(ctx);
+      return ctx;
+    } catch (error) {
+      const handleError = handlers.onError ?? onAudioError;
+      if (handleError) {
+        handleError(error);
+      } else {
+        console.error('Error starting audio:', error);
+      }
+      throw error;
+    }
+  };
+
+  toy.initAudio = initAudioForToy;
+
+  return { initAudio: initAudioForToy, startAudio };
+}

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -71,10 +71,9 @@
       import {
         getFrequencyData,
         getWeightedAverageFrequency,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
 
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
@@ -320,13 +319,6 @@
           };
         }
 
-        async initAudio(options = {}) {
-          const audio = await initAudio(options);
-          this.analyser = audio.analyser;
-          this.audioCleanup = audio.cleanup;
-          return audio;
-        }
-
         dispose() {
           if (this.loopId) {
             cancelAnimationFrame(this.loopId);
@@ -339,6 +331,7 @@
       }
 
       const toy = new CanvasToy(canvas);
+      const { startAudio } = createToyAudioBootstrap(toy);
 
       let time = 0.0;
       let audioData = 0.0;
@@ -390,15 +383,16 @@
         gl.drawArrays(gl.TRIANGLES, 0, 6);
       }
 
-      startToyAudio(toy, render, { fallbackToSynthetic: true })
-        .then(() => hideError())
-        .catch((err) => {
+      void startAudio(render, { fallbackToSynthetic: true }, {
+        onSuccess: () => hideError(),
+        onError: (err) => {
           console.error('Error capturing audio: ', err);
           displayError(
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           toy.renderer.setAnimationLoop(() => render({ toy, analyser: null }));
-        });
+        },
+      }).catch(() => {});
 
       window.addEventListener('pagehide', () => {
         disposeResize();

--- a/toys/geom.html
+++ b/toys/geom.html
@@ -106,7 +106,6 @@
       import { setupIframeQualitySync } from '../assets/js/core/iframe-quality-sync.ts';
       import {
         AudioAccessError,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import {
         getBandLevels,
@@ -118,7 +117,7 @@
         clearError,
         showError,
       } from '../assets/js/utils/error-display.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
 
       const canvas = document.getElementById('gameCanvas');
       const ctx = canvas.getContext('2d');
@@ -196,13 +195,6 @@
           };
         }
 
-        async initAudio(options = {}) {
-          const audio = await initAudio(options);
-          this.analyser = audio.analyser;
-          this.audioCleanup = audio.cleanup;
-          return audio;
-        }
-
         dispose() {
           if (this.loopId) {
             cancelAnimationFrame(this.loopId);
@@ -215,6 +207,7 @@
       }
 
       const toy = new CanvasToy(canvas);
+      const { startAudio } = createToyAudioBootstrap(toy);
 
       function createParticle() {
         return {
@@ -361,10 +354,18 @@
         clearError('error-message');
 
         try {
-          await startToyAudio(toy, animate, {
-            fftSize: 1024,
-            fallbackToSynthetic: true,
-          });
+          await startAudio(
+            animate,
+            {
+              fftSize: 1024,
+              fallbackToSynthetic: true,
+            },
+            {
+              onError: (error) => {
+                console.error('Error starting audio:', error);
+              },
+            }
+          );
         } catch (error) {
           startButton.disabled = false;
           startButton.style.display = 'inline-block';
@@ -377,7 +378,6 @@
               'Error accessing microphone. Please check your settings and try again.'
             );
           }
-          console.error('Error starting audio:', error);
         }
       });
 

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -262,14 +262,13 @@
       import { FXAAShader } from 'three/examples/jsm/shaders/FXAAShader.js';
       import {
         getFrequencyData,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import {
         getBandLevels,
         getWeightedEnergy,
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
       import { ensureWebGL } from '../assets/js/utils/webgl-check.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
 
@@ -769,27 +768,29 @@
           renderer,
           analyser: null,
           audioCleanup: null,
-          async initAudio(options = {}) {
-            const audio = await initAudio(options);
-            this.analyser = audio.analyser;
-            this.audioCleanup = audio.cleanup;
-            return audio;
-          },
           dispose() {
             this.audioCleanup?.();
           },
         };
+        const { startAudio } = createToyAudioBootstrap(toy);
 
         try {
-          await startToyAudio(toy, animate, {
-            fftSize: 1024,
-            fallbackToSynthetic: true,
-            preferSynthetic: preferDemoAudio,
-          });
+          await startAudio(
+            animate,
+            {
+              fftSize: 1024,
+              fallbackToSynthetic: true,
+              preferSynthetic: preferDemoAudio,
+            },
+            {
+              onError: (err) => {
+                console.error('Error accessing microphone:', err);
+              },
+            }
+          );
           hideError();
           loadingOverlay.style.display = 'none';
         } catch (err) {
-          console.error('Error accessing microphone:', err);
           showError(
             preferDemoAudio
               ? 'Demo audio could not be loaded. Please try again.'

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -161,9 +161,8 @@
     <script type="module">
       import {
         getFrequencyData,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
       import {
         getBandLevels,
         getWeightedEnergy,
@@ -372,14 +371,6 @@
           };
         }
 
-        async initAudio(options = {}) {
-          const audio = await initAudio(options);
-          this.analyser = audio.analyser;
-          this.audioCleanup = audio.cleanup;
-          analyser = this.analyser;
-          return audio;
-        }
-
         dispose() {
           if (this.loopId) {
             cancelAnimationFrame(this.loopId);
@@ -390,22 +381,33 @@
       }
 
       const toy = new GridToy();
+      const { startAudio } = createToyAudioBootstrap(toy, {
+        onAudioInit: (audio) => {
+          analyser = audio.analyser;
+        },
+      });
 
       function startMicAudio() {
         startButton.disabled = true;
-        startToyAudio(toy, render, { fftSize: 512, fallbackToSynthetic: true })
-          .then(() => {
-            isMicrophoneEnabled = true;
-            startButton.textContent = 'Microphone Active';
-            hideError();
-          })
-          .catch(() => {
-            showError(
-              'Microphone access denied. Please allow microphone access to enable the visualizer.'
-            );
-            startButton.disabled = false;
-            startButton.textContent = 'Enable Microphone';
-          });
+        void startAudio(
+          render,
+          { fftSize: 512, fallbackToSynthetic: true },
+          {
+            onSuccess: () => {
+              isMicrophoneEnabled = true;
+              startButton.textContent = 'Microphone Active';
+              hideError();
+            },
+            onError: () => {
+              showError(
+                'Microphone access denied. Please allow microphone access to enable the visualizer.'
+              );
+            },
+          }
+        ).catch(() => {
+          startButton.disabled = false;
+          startButton.textContent = 'Enable Microphone';
+        });
       }
 
       function getBeat() {

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -46,12 +46,11 @@
     <script type="module">
       import {
         getFrequencyData,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
       import { showError } from '../assets/js/utils/error-display.ts';
       import { createPeakDetector } from '../assets/js/utils/peak-detector.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
       import { createSearyFunAdapter } from '../assets/seary/fun-adapter.ts';
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
@@ -193,13 +192,6 @@
           };
         }
 
-        async initAudio(options = {}) {
-          const audio = await initAudio(options);
-          this.analyser = audio.analyser;
-          this.audioCleanup = audio.cleanup;
-          return audio;
-        }
-
         dispose() {
           if (this.loopId) {
             cancelAnimationFrame(this.loopId);
@@ -213,6 +205,7 @@
       }
 
       const toy = new CanvasToy(canvas);
+      const { startAudio } = createToyAudioBootstrap(toy);
 
       // Compile shader
       function compileShader(source, type) {
@@ -588,11 +581,14 @@
             : { fftSize: 256, fallbackToSynthetic: true };
 
         try {
-          await startToyAudio(toy, animate, options);
+          await startAudio(animate, options, {
+            onError: (err) => {
+              console.error('Error accessing microphone: ' + err);
+            },
+          });
           funControls.setAudioAvailable(true);
           rebuildPeakDetector(toy);
         } catch (err) {
-          console.error('Error accessing microphone: ' + err);
           funControls.setAudioAvailable(false);
           peakDetector = null;
           currentFreqs = adapter.transformFrequencies({

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -54,7 +54,6 @@
       import {
         getWeightedAverageFrequency,
         getFrequencyData,
-        initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import {
         getBandLevels,
@@ -66,7 +65,7 @@
         clearError,
         showError,
       } from '../assets/js/utils/error-display.ts';
-      import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import { createToyAudioBootstrap } from '../assets/js/utils/toy-audio-bootstrap.ts';
       import { createSymphFunAdapter } from '../assets/symph/fun-adapter.ts';
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
@@ -332,13 +331,6 @@
           };
         }
 
-        async initAudio(options = {}) {
-          const audio = await initAudio(options);
-          this.analyser = audio.analyser;
-          this.audioCleanup = audio.cleanup;
-          return audio;
-        }
-
         dispose() {
           if (this.loopId) {
             cancelAnimationFrame(this.loopId);
@@ -351,6 +343,7 @@
       }
 
       const toy = new CanvasToy(canvas);
+      const { startAudio } = createToyAudioBootstrap(toy);
 
       const sparkleToggle = extraControls.querySelector('.fun-sparkles');
       sparkleToggle?.addEventListener('change', (event) => {
@@ -559,12 +552,12 @@
         updateSparkles();
       }
 
-      startToyAudio(toy, animate, { fallbackToSynthetic: true })
-        .then((ctx) => {
+      void startAudio(animate, { fallbackToSynthetic: true }, {
+        onSuccess: (ctx) => {
           analyserRef = ctx.analyser;
           clearError('error-message');
-        })
-        .catch((err) => {
+        },
+        onError: (err) => {
           showError(
             'error-message',
             'Microphone access is unavailable. Visuals will run without audio reactivity.'
@@ -573,7 +566,8 @@
           audioData = adapter.transformAudioValue(0);
           console.error('Error capturing audio: ', err);
           toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));
-        });
+        },
+      }).catch(() => {});
 
       const unifiedInput = createUnifiedInput({
         target: canvas,


### PR DESCRIPTION
### Motivation
- Centralize repetitive audio initialization and start logic so toy pages no longer duplicate `initAudio`/`startToyAudio` wiring and error handling.
- Provide a small, testable helper that preserves per-toy audio options (e.g., `fftSize`, `fallbackToSynthetic`, `preferSynthetic`) and exposes hooks for success/error handling.

### Description
- Add `assets/js/utils/toy-audio-bootstrap.ts` which exports `createToyAudioBootstrap(toy, options)` returning `{ initAudio, startAudio }` and standardizes error handling and optional `onAudioInit`/`onAudioError` hooks.
- Export `StartAudioOptions` from `assets/js/utils/start-audio.ts` (changed to `export type StartAudioOptions`) so the bootstrap helper can type audio start options.
- Update HTML toy pages (`toys/evol.html`, `toys/seary.html`, `toys/holy.html`, `toys/legible.html`, `toys/symph.html`, `toys/geom.html`) to use the new bootstrap helper, remove duplicated `initAudio` implementations, and wire `startAudio` with preserved toy-specific options and per-page success/error handlers.

### Testing
- Ran `bun run check` (Biome lint/format, TypeScript typecheck, and the test suite) and it completed successfully with all tests passing.
- No documentation files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bb6ae2708332aa07d4e3151b9e42)