### PR TITLE
Add shared toy canvas setup

### DIFF
--- a/assets/js/utils/toy-canvas.ts
+++ b/assets/js/utils/toy-canvas.ts
@@ -1,0 +1,70 @@
+import {
+  type CanvasResizeOptions,
+  setupCanvasResize,
+} from './canvas-resize.ts';
+import { clearError, showError } from './error-display.ts';
+
+export type WebGLContextId = 'webgl' | 'webgl2' | 'experimental-webgl';
+
+export interface ToyCanvasOptions extends CanvasResizeOptions {
+  contextTypes?: WebGLContextId[];
+  contextAttributes?: WebGLContextAttributes;
+  errorElementId?: string;
+  onError?: (message: string) => void;
+}
+
+export function createToyCanvas(
+  canvasId: string,
+  {
+    contextTypes = ['webgl', 'experimental-webgl'],
+    contextAttributes,
+    errorElementId,
+    onError,
+    maxPixelRatio,
+    onResize,
+  }: ToyCanvasOptions = {},
+) {
+  const canvas = document.getElementById(canvasId);
+
+  const reportError = (message: string) => {
+    if (onError) {
+      onError(message);
+      return;
+    }
+
+    if (errorElementId) {
+      showError(errorElementId, message);
+    }
+  };
+
+  if (!(canvas instanceof HTMLCanvasElement)) {
+    reportError('Canvas element is missing.');
+    throw new Error(`Canvas element not found: ${canvasId}`);
+  }
+
+  const gl = contextTypes.reduce<
+    WebGLRenderingContext | WebGL2RenderingContext | null
+  >((context, type) => {
+    if (context) return context;
+    return canvas.getContext(type, contextAttributes) as
+      | WebGLRenderingContext
+      | WebGL2RenderingContext
+      | null;
+  }, null);
+
+  if (!gl) {
+    reportError('Unable to initialize WebGL. Your browser may not support it.');
+    throw new Error('WebGL not supported');
+  }
+
+  if (errorElementId && !onError) {
+    clearError(errorElementId);
+  }
+
+  const disposeResize = setupCanvasResize(canvas, gl, {
+    maxPixelRatio,
+    onResize,
+  });
+
+  return { canvas, gl, disposeResize };
+}

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -73,33 +73,23 @@
         getWeightedAverageFrequency,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
-      import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
+      import { createToyCanvas } from '../assets/js/utils/toy-canvas.ts';
+      import {
+        clearError,
+        showError,
+      } from '../assets/js/utils/error-display.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
 
-      const canvas = document.getElementById('glCanvas');
-      const gl = canvas.getContext('webgl');
-      const errorEl = document.getElementById('error-message');
-
-      function displayError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
-
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
-
-      if (!gl) {
-        displayError(
-          'Unable to initialize WebGL. Your browser may not support it.'
-        );
-        throw new Error('WebGL not supported');
-      }
+      let resolutionUniformLocation = null;
+      const { canvas, gl, disposeResize } = createToyCanvas('glCanvas', {
+        errorElementId: 'error-message',
+        maxPixelRatio: 2,
+        onResize: ({ width, height }) => {
+          if (resolutionUniformLocation) {
+            gl.uniform2f(resolutionUniformLocation, width, height);
+          }
+        },
+      });
 
       const vertexShaderSource = `
             attribute vec4 a_position;
@@ -260,7 +250,7 @@
         0
       );
 
-      const resolutionUniformLocation = gl.getUniformLocation(
+      resolutionUniformLocation = gl.getUniformLocation(
         program,
         'u_resolution'
       );
@@ -285,13 +275,6 @@
         program,
         'u_glitchStrength'
       );
-
-      const disposeResize = setupCanvasResize(canvas, gl, {
-        maxPixelRatio: 2,
-        onResize: ({ width, height }) => {
-          gl.uniform2f(resolutionUniformLocation, width, height);
-        },
-      });
 
       class CanvasToy {
         constructor(canvasEl) {
@@ -373,7 +356,7 @@
           const dataArray = getFrequencyData(ctxAudio.analyser);
           const average = getWeightedAverageFrequency(dataArray);
           audioData = average / 128.0;
-          hideError();
+          clearError('error-message');
         } else {
           audioData = 0;
         }
@@ -391,10 +374,11 @@
       }
 
       startToyAudio(toy, render, { fallbackToSynthetic: true })
-        .then(() => hideError())
+        .then(() => clearError('error-message'))
         .catch((err) => {
           console.error('Error capturing audio: ', err);
-          displayError(
+          showError(
+            'error-message',
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           toy.renderer.setAnimationLoop(() => render({ toy, analyser: null }));

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -48,7 +48,7 @@
         getFrequencyData,
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
-      import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
+      import { createToyCanvas } from '../assets/js/utils/toy-canvas.ts';
       import { showError } from '../assets/js/utils/error-display.ts';
       import { createPeakDetector } from '../assets/js/utils/peak-detector.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
@@ -63,9 +63,14 @@
       } from '../assets/js/utils/audio-reactivity.ts';
 
       // Fallback to WebGL
-      const canvas = document.getElementById('gpuCanvas');
       const sparkleCanvas = document.getElementById('sparkleCanvas');
-      const sparkleCtx = sparkleCanvas?.getContext('2d');
+
+      if (!(sparkleCanvas instanceof HTMLCanvasElement)) {
+        showError('error-message', 'Canvas element is missing.');
+        throw new Error('Canvas element not found');
+      }
+
+      const sparkleCtx = sparkleCanvas.getContext('2d');
 
       const sparkles = [];
       const maxSparkles = 160;
@@ -77,14 +82,6 @@
       let peakSensitivity = 0.35;
       let lastRenderTime = 0;
       let renderElapsed = 0;
-
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
 
       initHints({
         id: 'seary-visualizer',
@@ -133,38 +130,21 @@
         initialPeakSensitivity: peakSensitivity,
       });
 
-      const gl =
-        canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-
-      if (!gl) {
-        console.error('WebGL not supported');
-        throw new Error('WebGL not supported');
-      }
-
-      // Resize canvas
-      function resizeCanvas() {
-        const dpr = window.devicePixelRatio || 1;
-        viewWidth = window.innerWidth;
-        viewHeight = window.innerHeight;
-
-        canvas.width = viewWidth * dpr;
-        canvas.height = viewHeight * dpr;
-        canvas.style.width = '100vw';
-        canvas.style.height = '100vh';
-        gl.viewport(0, 0, canvas.width, canvas.height);
-
-        if (sparkleCanvas && sparkleCtx) {
-          sparkleCanvas.width = viewWidth * dpr;
-          sparkleCanvas.height = viewHeight * dpr;
-          sparkleCanvas.style.width = '100vw';
-          sparkleCanvas.style.height = '100vh';
-          sparkleCtx.setTransform(1, 0, 0, 1, 0, 0);
-          sparkleCtx.scale(dpr, dpr);
-        }
-      }
-      window.addEventListener('resize', resizeCanvas);
-      resizeCanvas();
-      const disposeResize = setupCanvasResize(canvas, gl, { maxPixelRatio: 2 });
+      const { canvas, gl, disposeResize } = createToyCanvas('gpuCanvas', {
+        contextTypes: ['webgl', 'experimental-webgl'],
+        errorElementId: 'error-message',
+        maxPixelRatio: 2,
+        onResize: ({ width, height, cssWidth, cssHeight, pixelRatio }) => {
+          viewWidth = cssWidth;
+          viewHeight = cssHeight;
+          sparkleCanvas.width = width;
+          sparkleCanvas.height = height;
+          sparkleCanvas.style.width = `${cssWidth}px`;
+          sparkleCanvas.style.height = `${cssHeight}px`;
+          sparkleCtx?.setTransform(1, 0, 0, 1, 0, 0);
+          sparkleCtx?.scale(pixelRatio, pixelRatio);
+        },
+      });
 
       class CanvasToy {
         constructor(canvasEl) {

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -61,7 +61,7 @@
         getWeightedEnergy,
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
-      import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
+      import { createToyCanvas } from '../assets/js/utils/toy-canvas.ts';
       import {
         clearError,
         showError,
@@ -72,17 +72,14 @@
       import { initHints } from '../assets/ui/hints.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
 
-      const canvas = document.getElementById('glCanvas');
       const overlayCanvas = document.getElementById('overlayCanvas');
 
       if (
-        !(canvas instanceof HTMLCanvasElement) ||
         !(overlayCanvas instanceof HTMLCanvasElement)
       ) {
         showError('error-message', 'Canvas element is missing.');
         throw new Error('Canvas element not found');
       }
-      const gl = canvas.getContext('webgl');
       const ctx2d = overlayCanvas.getContext('2d');
 
       initHints({
@@ -94,13 +91,20 @@
         ],
       });
 
-      if (!gl) {
-        showError(
-          'error-message',
-          'Unable to initialize WebGL. Your browser may not support it.'
-        );
-        throw new Error('WebGL not supported');
-      }
+      let resolutionUniformLocation = null;
+      const { canvas, gl, disposeResize } = createToyCanvas('glCanvas', {
+        errorElementId: 'error-message',
+        maxPixelRatio: 2,
+        onResize: ({ width, height, cssWidth, cssHeight }) => {
+          if (resolutionUniformLocation) {
+            gl.uniform2f(resolutionUniformLocation, width, height);
+          }
+          overlayCanvas.width = width;
+          overlayCanvas.height = height;
+          overlayCanvas.style.width = `${cssWidth}px`;
+          overlayCanvas.style.height = `${cssHeight}px`;
+        },
+      });
 
       const vertexShaderSource = `
             attribute vec4 a_position;
@@ -207,7 +211,7 @@
         0
       );
 
-      const resolutionUniformLocation = gl.getUniformLocation(
+      resolutionUniformLocation = gl.getUniformLocation(
         program,
         'u_resolution'
       );
@@ -229,17 +233,6 @@
         program,
         'u_rippleAmp'
       );
-
-      const disposeResize = setupCanvasResize(canvas, gl, {
-        maxPixelRatio: 2,
-        onResize: ({ width, height, cssWidth, cssHeight }) => {
-          gl.uniform2f(resolutionUniformLocation, width, height);
-          overlayCanvas.width = width;
-          overlayCanvas.height = height;
-          overlayCanvas.style.width = `${cssWidth}px`;
-          overlayCanvas.style.height = `${cssHeight}px`;
-        },
-      });
 
       const adapter = createSymphFunAdapter();
       let gradientStops = adapter.paletteOptions.bright;


### PR DESCRIPTION
### Motivation

- Reduce duplicated WebGL/canvas initialization across toys and centralize error reporting and resize wiring.
- Provide a single helper that can expose resize disposal and per-toy hooks so each toy can continue to customize behavior.

### Description

- Add `assets/js/utils/toy-canvas.ts` which exports `createToyCanvas(canvasId, options)` and returns `{ canvas, gl, disposeResize }`, tries multiple WebGL context types, reports errors via an optional `onError` or `errorElementId`, and wires `setupCanvasResize` with configurable `onResize` and `maxPixelRatio`.
- Update `toys/evol.html`, `toys/symph.html`, and `toys/seary.html` to use `createToyCanvas`, passing per-toy `onResize` callbacks to update uniforms, overlay canvas sizing, or sparkle canvas transforms as needed.
- Replace local error-display implementations with `clearError`/`showError` from `assets/js/utils/error-display.ts` when appropriate, while preserving existing fallback and synthetic-audio behaviors.

### Testing

- Ran `bun run check` which runs `biome check`, `tsc --noEmit`, and the test suite via `bun test`, and the command completed successfully.
- Test summary: the automated test run shows all specs passing with `76 pass`, `2 skip`, and `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bb623b74833293c4ea65a5ff5a07)