### PR TITLE
Unify toy error display handling

### DIFF
--- a/assets/js/utils/error-display.ts
+++ b/assets/js/utils/error-display.ts
@@ -1,15 +1,30 @@
-export function showError(id: string, message: string) {
+export function initErrorDisplay(id: string) {
   const el = document.getElementById(id);
-  if (!el) return;
-
-  el.textContent = message;
-  el.style.display = 'block';
-}
-
-export function clearError(id: string) {
-  const el = document.getElementById(id);
-  if (!el) return;
+  if (!el) return null;
 
   el.textContent = '';
   el.style.display = 'none';
+  return el;
+}
+
+export function setErrorVisible(id: string, message?: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  if (message) {
+    el.textContent = message;
+    el.style.display = 'block';
+    return;
+  }
+
+  el.textContent = '';
+  el.style.display = 'none';
+}
+
+export function showError(id: string, message: string) {
+  setErrorVisible(id, message);
+}
+
+export function clearError(id: string) {
+  setErrorVisible(id);
 }

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <a href="../index.html" class="home-link">Back to Library</a>
-    <div id="error-message"></div>
+    <div id="error-message" style="display: none"></div>
     <canvas id="glCanvas" class="toy-canvas"></canvas>
     <div class="control-panel">
       <div class="control-panel__row">
@@ -75,27 +75,19 @@
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
+      import {
+        initErrorDisplay,
+        setErrorVisible,
+      } from '../assets/js/utils/error-display.ts';
 
       const canvas = document.getElementById('glCanvas');
       const gl = canvas.getContext('webgl');
-      const errorEl = document.getElementById('error-message');
-
-      function displayError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
-
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
+      const errorDisplayId = 'error-message';
+      initErrorDisplay(errorDisplayId);
 
       if (!gl) {
-        displayError(
+        setErrorVisible(
+          errorDisplayId,
           'Unable to initialize WebGL. Your browser may not support it.'
         );
         throw new Error('WebGL not supported');
@@ -373,7 +365,7 @@
           const dataArray = getFrequencyData(ctxAudio.analyser);
           const average = getWeightedAverageFrequency(dataArray);
           audioData = average / 128.0;
-          hideError();
+          setErrorVisible(errorDisplayId);
         } else {
           audioData = 0;
         }
@@ -391,10 +383,11 @@
       }
 
       startToyAudio(toy, render, { fallbackToSynthetic: true })
-        .then(() => hideError())
+        .then(() => setErrorVisible(errorDisplayId))
         .catch((err) => {
           console.error('Error capturing audio: ', err);
-          displayError(
+          setErrorVisible(
+            errorDisplayId,
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           toy.renderer.setAnimationLoop(() => render({ toy, analyser: null }));

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -272,6 +272,10 @@
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
       import { ensureWebGL } from '../assets/js/utils/webgl-check.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
+      import {
+        initErrorDisplay,
+        setErrorVisible,
+      } from '../assets/js/utils/error-display.ts';
 
       if (!ensureWebGL()) {
         throw new Error('WebGL support is required for the Holy visualizer.');
@@ -316,23 +320,10 @@
       const bloomStrengthValue = document.getElementById('bloomStrengthValue');
       const particleScaleSlider = document.getElementById('particleScale');
       const particleScaleValue = document.getElementById('particleScaleValue');
-      const errorEl = document.getElementById('error-message');
+      const errorDisplayId = 'error-message';
+      initErrorDisplay(errorDisplayId);
       const preferDemoAudio =
         new URLSearchParams(window.location.search).get('audio') === 'demo';
-
-      function showError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
-
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
 
       if (preferDemoAudio && startButton instanceof HTMLButtonElement) {
         startButton.textContent = 'Start Demo Visualizer';
@@ -713,7 +704,8 @@
       function toggleFullscreen() {
         if (!document.fullscreenElement) {
           document.documentElement.requestFullscreen().catch((err) => {
-            showError(
+            setErrorVisible(
+              errorDisplayId,
               `Error attempting to enable fullscreen mode: ${err.message} (${err.name})`
             );
           });
@@ -786,11 +778,12 @@
             fallbackToSynthetic: true,
             preferSynthetic: preferDemoAudio,
           });
-          hideError();
+          setErrorVisible(errorDisplayId);
           loadingOverlay.style.display = 'none';
         } catch (err) {
           console.error('Error accessing microphone:', err);
-          showError(
+          setErrorVisible(
+            errorDisplayId,
             preferDemoAudio
               ? 'Demo audio could not be loaded. Please try again.'
               : 'Microphone access is required for the visualizer to work.'

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -169,6 +169,10 @@
         getWeightedEnergy,
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
+      import {
+        initErrorDisplay,
+        setErrorVisible,
+      } from '../assets/js/utils/error-display.ts';
 
       let analyser,
         dataArray = new Uint8Array(0),
@@ -183,21 +187,8 @@
       let beatPeak = 0.12;
       let trebleGlow = 0;
 
-      const errorEl = document.getElementById('error-message');
-
-      function showError(message) {
-        if (errorEl) {
-          errorEl.textContent = message;
-          errorEl.style.display = 'block';
-        }
-      }
-
-      function hideError() {
-        if (errorEl) {
-          errorEl.style.display = 'none';
-          errorEl.textContent = '';
-        }
-      }
+      const errorDisplayId = 'error-message';
+      initErrorDisplay(errorDisplayId);
 
       const gridElement = document.getElementById('grid');
       let words = [];
@@ -397,10 +388,11 @@
           .then(() => {
             isMicrophoneEnabled = true;
             startButton.textContent = 'Microphone Active';
-            hideError();
+            setErrorVisible(errorDisplayId);
           })
           .catch(() => {
-            showError(
+            setErrorVisible(
+              errorDisplayId,
               'Microphone access denied. Please allow microphone access to enable the visualizer.'
             );
             startButton.disabled = false;

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -49,7 +49,10 @@
         initAudio,
       } from '../assets/js/utils/audio-handler.ts';
       import { setupCanvasResize } from '../assets/js/utils/canvas-resize.ts';
-      import { showError } from '../assets/js/utils/error-display.ts';
+      import {
+        initErrorDisplay,
+        setErrorVisible,
+      } from '../assets/js/utils/error-display.ts';
       import { createPeakDetector } from '../assets/js/utils/peak-detector.ts';
       import { startToyAudio } from '../assets/js/utils/start-audio.ts';
       import { createSearyFunAdapter } from '../assets/seary/fun-adapter.ts';
@@ -78,13 +81,8 @@
       let lastRenderTime = 0;
       let renderElapsed = 0;
 
-      function displayError(message) {
-        const el = document.getElementById('error-message');
-        if (el) {
-          el.innerText = message;
-          el.style.display = 'block';
-        }
-      }
+      const errorDisplayId = 'error-message';
+      initErrorDisplay(errorDisplayId);
 
       initHints({
         id: 'seary-visualizer',
@@ -138,6 +136,10 @@
 
       if (!gl) {
         console.error('WebGL not supported');
+        setErrorVisible(
+          errorDisplayId,
+          'Unable to initialize WebGL. Your browser may not support it.'
+        );
         throw new Error('WebGL not supported');
       }
 
@@ -600,8 +602,8 @@
             mid: 0,
             high: 0,
           });
-          showError(
-            'error-message',
+          setErrorVisible(
+            errorDisplayId,
             'Microphone access is required for the visualization to work. Please allow microphone access.'
           );
           toy.renderer.setAnimationLoop(() => animate({ toy, analyser: null }));


### PR DESCRIPTION
### Motivation
- Provide a consistent, shared way to initialize and show/hide per-page error UI so toys don't reimplement the same logic. 
- Ensure error elements start hidden by default and that message visibility is managed via a single helper API.

### Description
- Add `initErrorDisplay(id)` and `setErrorVisible(id, message?)` (plus `showError`/`clearError` aliases) in `assets/js/utils/error-display.ts` to initialize and control toy error elements. 
- Update `toys/legible.html`, `toys/evol.html`, `toys/holy.html`, and `toys/seary.html` to import `initErrorDisplay`/`setErrorVisible`, remove local `showError`/`hideError` duplicates, and use `setErrorVisible(errorDisplayId, message)` or `setErrorVisible(errorDisplayId)` in place of the previous functions. 
- Ensure toy pages' error containers default to hidden (add `style="display: none"` where applicable) and call `initErrorDisplay(errorDisplayId)` during startup.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc --noEmit`, and `bun test`); the test suite completed with `76 pass`, `2 skip`, and `0 fail`. 
- Formatting/linting steps in the pre-commit checks (`biome lint` / `biome format`) were executed as part of the verification and reported no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bb5a63dc833285786593394b7202)