### PR TITLE
Fix picture-in-picture canvas lookup for standalone toys

### DIFF
--- a/assets/js/utils/picture-in-picture.ts
+++ b/assets/js/utils/picture-in-picture.ts
@@ -18,7 +18,10 @@ export function isToyPictureInPictureActive(doc: Document) {
 }
 
 export function getActiveToyCanvas(doc: Document) {
-  return doc.querySelector<HTMLCanvasElement>('#active-toy-container canvas');
+  return (
+    doc.querySelector<HTMLCanvasElement>('#active-toy-container canvas') ??
+    doc.querySelector<HTMLCanvasElement>('.toy-canvas')
+  );
 }
 
 function ensureVideoElement(doc: Document) {


### PR DESCRIPTION
### Motivation
- Picture-in-picture controls were enabled for toy pages but the PIP lookup only targeted `#active-toy-container canvas`, causing standalone toy pages that use `.toy-canvas` to fail with “Unable to use picture in picture.”

### Description
- Update `getActiveToyCanvas` to first look for `#active-toy-container canvas` and fall back to `.toy-canvas` so PIP works on standalone toy pages (change made in `assets/js/utils/picture-in-picture.ts`).

### Testing
- Ran `bun run check` (Biome lint/format, typecheck, and the test suite) and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975c606eb1c8332ac67bc915470b16d)