### PR TITLE
Fix symph canvas element check

### DIFF
--- a/toys/symph.html
+++ b/toys/symph.html
@@ -74,11 +74,12 @@
 
       initToyPageShell();
 
-      const canvas = document.getElementById('glCanvas');
+      const glCanvasElement = document.getElementById('glCanvas');
       const overlayCanvas = document.getElementById('overlayCanvas');
 
       if (
-        !(overlayCanvas instanceof HTMLCanvasElement)
+        !(glCanvasElement instanceof HTMLCanvasElement)
+        || !(overlayCanvas instanceof HTMLCanvasElement)
       ) {
         showError('error-message', 'Canvas element is missing.');
         throw new Error('Canvas element not found');


### PR DESCRIPTION
### Motivation
- Prevent a duplicate `canvas` identifier and the resulting build-time error by ensuring the page validates both canvas DOM elements before bootstrapping the toy.

### Description
- Rename the initial `canvas` variable to `glCanvasElement` and update the DOM check to verify both `glCanvasElement` and `overlayCanvas` are `HTMLCanvasElement`, leaving the `createToyCanvas` returned `canvas` as the single source of truth.

### Testing
- Ran `bun run check` (Biome lint/format + `tsc --noEmit` + `bun test`) and all automated checks passed (76 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975cdf2840c8332a2c5777ba22b77e7)