### PR TITLE
Skip CF Pages rebuild after install

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -13,7 +13,8 @@ const isCloudflarePages = ['1', 'true'].includes(
 const distDir = join(process.cwd(), 'dist');
 const distIndex = join(distDir, 'index.html');
 const manifest = join(distDir, '.vite', 'manifest.json');
-const hasReusableArtifacts = existsSync(distIndex) && existsSync(manifest);
+const hasReusableArtifacts = () =>
+  existsSync(distIndex) && existsSync(manifest);
 const vitePackagePath = join(
   process.cwd(),
   'node_modules',
@@ -21,7 +22,7 @@ const vitePackagePath = join(
   'package.json',
 );
 
-if (isCloudflarePages && hasReusableArtifacts) {
+if (isCloudflarePages && hasReusableArtifacts()) {
   console.log(
     '[build] CF_PAGES detected and dist/ already populated; skipping Vite rebuild.',
   );
@@ -42,6 +43,13 @@ if (!hasBunRuntime) {
 if (!existsSync(vitePackagePath)) {
   console.log(`[build] Installing dependencies with "${installCommand}"...`);
   execSync(installCommand, { stdio: 'inherit' });
+
+  if (isCloudflarePages && hasReusableArtifacts()) {
+    console.log(
+      '[build] CF_PAGES detected and dist/ already populated after install; skipping Vite rebuild.',
+    );
+    process.exit(0);
+  }
 }
 
 console.log(`[build] Running Vite build with "${viteCommand}"...`);


### PR DESCRIPTION
### Motivation
- Avoid redundant Vite rebuilds on Cloudflare Pages when `dist/` artifacts are already present by re-checking for reusable artifacts after dependency installation.

### Description
- Update `scripts/build.mjs` to make `hasReusableArtifacts` a function and re-evaluate it after running `bun install`, exiting early when `CF_PAGES` is set and `dist/` is populated.

### Testing
- Ran `bun run check` (Biome lint, TypeScript typecheck, and tests); the test run executed 78 tests with 76 passed, 2 skipped, and 0 failed, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d738c35c8332b0227f67c5440bcb)