### PR TITLE
Skip redundant Cloudflare postinstall builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -30,7 +30,8 @@ if (isCloudflarePages && hasReusableArtifacts()) {
 }
 
 const hasBunRuntime = typeof process.versions?.bun === 'string';
-const installCommand = 'bun install --frozen-lockfile';
+const installCommand =
+  'STIMS_SKIP_POSTINSTALL_BUILD=1 bun install --frozen-lockfile';
 const viteCommand = 'bunx vite build';
 
 if (!hasBunRuntime) {

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -10,6 +10,7 @@ const isCloudflarePages = (() => {
   const value = process.env.CF_PAGES?.toLowerCase?.();
   return value === '1' || value === 'true';
 })();
+const skipCloudflareBuild = process.env.STIMS_SKIP_POSTINSTALL_BUILD === '1';
 
 const run = (command) => {
   execSync(command, { stdio: 'inherit' });
@@ -26,16 +27,22 @@ const hasBun = (() => {
 })();
 
 if (isCloudflarePages) {
-  if (!hasBun) {
-    console.error(
-      '[postinstall] Bun is required to build dist/ on Cloudflare Pages.',
+  if (skipCloudflareBuild) {
+    console.log(
+      '[postinstall] Skipping Cloudflare Pages build (postinstall build disabled).',
     );
-    process.exit(1);
+  } else {
+    if (!hasBun) {
+      console.error(
+        '[postinstall] Bun is required to build dist/ on Cloudflare Pages.',
+      );
+      process.exit(1);
+    }
+    console.log(
+      '[postinstall] Cloudflare Pages detected; running "bun run build" to produce dist/.',
+    );
+    run('bun run build');
   }
-  console.log(
-    '[postinstall] Cloudflare Pages detected; running "bun run build" to produce dist/.',
-  );
-  run('bun run build');
 } else {
   console.log('[postinstall] CF_PAGES not set; skipping build.');
 }


### PR DESCRIPTION
### Motivation
- Prevent nested Cloudflare Pages builds that occur when the build script runs `bun install` and the postinstall script also triggers a Vite build, reducing redundant work and CI time.

### Description
- Prefix the install command in `scripts/build.mjs` with `STIMS_SKIP_POSTINSTALL_BUILD=1` to disable the postinstall build during dependency installation.
- Add a `skipCloudflareBuild` guard to `scripts/postinstall.mjs` that skips running `bun run build` when the environment flag is set.
- Keep the existing Cloudflare and Husky behaviors unchanged when the flag is not present.

### Testing
- Ran `bun run check` which runs `biome check`, `tsc --noEmit`, and the test suite; result: 76 passed, 2 skipped, 0 failed.
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d99b1afc83328f3603865ffda0d3)