### PR TITLE
Fix Windows build env handling

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -30,8 +30,11 @@ if (isCloudflarePages && hasReusableArtifacts()) {
 }
 
 const hasBunRuntime = typeof process.versions?.bun === 'string';
-const installCommand =
-  'STIMS_SKIP_POSTINSTALL_BUILD=1 bun install --frozen-lockfile';
+const installCommand = 'bun install --frozen-lockfile';
+const installEnv = {
+  ...process.env,
+  STIMS_SKIP_POSTINSTALL_BUILD: '1',
+};
 const viteCommand = 'bunx vite build';
 
 if (!hasBunRuntime) {
@@ -43,7 +46,7 @@ if (!hasBunRuntime) {
 
 if (!existsSync(vitePackagePath)) {
   console.log(`[build] Installing dependencies with "${installCommand}"...`);
-  execSync(installCommand, { stdio: 'inherit' });
+  execSync(installCommand, { env: installEnv, stdio: 'inherit' });
 
   if (isCloudflarePages && hasReusableArtifacts()) {
     console.log(


### PR DESCRIPTION
### Motivation
- Windows `cmd.exe` does not support POSIX-style environment prefixes like `VAR=1 command`, causing the install step to fail when `execSync` is given a single concatenated command string; making the install step set the env via `execSync` options ensures cross-platform behavior.

### Description
- Update `scripts/build.mjs` to remove the `STIMS_SKIP_POSTINSTALL_BUILD=1` prefix and set `installCommand` to `bun install --frozen-lockfile` while creating an `installEnv` object that includes `STIMS_SKIP_POSTINSTALL_BUILD: '1'`.
- Invoke `execSync(installCommand, { env: installEnv, stdio: 'inherit' })` when installing dependencies so the environment variable is passed portably to the child process.
- No changes to the Vite build invocation or other logic in `scripts/build.mjs`.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc`, and the test suite); the check completed successfully with all tests passing (76 passed, 2 skipped, 0 failed).
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697648bbd7408332a14bf10e03abc167)