### PR TITLE
Refine library layout and preflight panel

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1353,6 +1353,8 @@ body {
 
 .preflight-dialog {
   margin: 0;
+  clip-path: none;
+  border-radius: 18px;
 }
 
 .preflight-dialog::backdrop {
@@ -1376,7 +1378,7 @@ body {
 .preflight-panel__statuses {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 8px;
+  gap: 10px;
   margin: 8px 0;
 }
 
@@ -1390,6 +1392,13 @@ body {
     rgba(255, 255, 255, 0.01)
   );
   box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);
+}
+
+.preflight-dialog .control-panel__actions {
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 12px;
 }
 
 .preflight-status__label {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1167,6 +1167,20 @@ header.hero {
   margin: 1.1rem 0;
 }
 
+.hero-cta-row {
+  gap: 0.9rem 0.85rem;
+  align-items: center;
+}
+
+.hero-cta-row .cta-button.primary {
+  flex: 1 1 240px;
+  justify-content: center;
+}
+
+.hero-cta-row .cta-button.ghost {
+  flex: 0 1 auto;
+}
+
 .hero-readiness {
   display: flex;
   flex-wrap: wrap;
@@ -1991,6 +2005,7 @@ html.light .experience-card {
   position: relative;
   overflow: hidden;
   touch-action: manipulation;
+  min-height: clamp(220px, 24vw, 260px);
 }
 
 .webtoy-card__link {
@@ -2069,7 +2084,8 @@ html.light .experience-card {
   align-items: center;
   justify-content: flex-start;
   gap: 0.5rem;
-  margin-top: 0.9rem;
+  margin-top: auto;
+  padding-top: 0.9rem;
   position: relative;
   z-index: 2;
 }


### PR DESCRIPTION
### Motivation
- Improve clarity and visual hierarchy on the library landing so the primary hero CTA reads as the obvious next step.  
- Stabilize card grid alignment so capability badges don't jump when descriptions wrap.  
- Fix clipping and cramped spacing in the capability preflight dialog so status badges and actions are readable on small and large viewports.

### Description
- Added a `.hero-cta-row` layout in `assets/css/index.css` and made the primary CTA grow to emphasize the main action.  
- Set a consistent minimum height for library cards and anchored the capability badge row by changing `.webtoy-card` and `.webtoy-card-meta` in `assets/css/index.css`.  
- Removed `clip-path` and added `border-radius` for `.preflight-dialog` and increased spacing for status grid and dialog actions in `assets/css/base.css`.  
- Minor spacing/tuning tweaks for responsive behavior of CTA and dialog action clusters in the same CSS files.

### Testing
- Ran `bun run check` which executes `biome check`, `tsc --noEmit`, and the test suite, and the run completed successfully with all tests passing (76 pass, 2 skip, 0 fail).  
- Captured refreshed screenshots of the updated pages during a local dev server session to verify layout changes (library hero, library grid, and toy preflight dialog were captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69767cffb90c8332a0a97ce5d04927be)