### PR TITLE
Defer hints to interaction/idle and add manual "Need tips?" trigger

### DIFF
--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -226,6 +226,11 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   });
   dampingRow.appendChild(dampingSlider);
 
+  const hintsRow = panel.addSection(
+    'Tips',
+    'Bring back the quick guide whenever you need it.',
+  );
+
   const gravityRow = panel.addSection(
     'Gravity',
     'Lock to the default downward pull on desktop, or let device tilt steer the sand.',
@@ -393,6 +398,12 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
       'Tilt your phone or tablet to steer the gravity vector.',
       'Lock gravity on desktop to keep the table steady, or unlock when using a motion-capable device.',
     ],
+    trigger: 'idle',
+    manualButton: {
+      container: hintsRow,
+      label: 'Need tips?',
+      className: 'control-panel__chip',
+    },
   });
 
   function addRipple(strength: number) {

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -56,7 +56,7 @@
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
 
-      initToyPageShell();
+      const toyNav = initToyPageShell();
 
       const canvas = document.getElementById('webglCanvas');
       const capabilityBanner = document.getElementById('capability-banner');
@@ -74,6 +74,9 @@
         capabilityBanner.style.display = 'block';
       }
 
+      const hintsButtonHost =
+        toyNav?.querySelector('.active-toy-nav__actions') ?? null;
+
       initHints({
         id: 'multi-visualizer',
         tips: [
@@ -81,6 +84,11 @@
           'Switch to Party Mode for bigger motion.',
           'Tilt or move your device to shove the shapes around.',
         ],
+        trigger: 'idle',
+        manualButton: {
+          container: hintsButtonHost,
+          label: 'Need tips?',
+        },
       });
 
       const toy = new WebToy({

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -65,7 +65,7 @@
         updateEnergyPeak,
       } from '../assets/js/utils/audio-reactivity.ts';
 
-      initToyPageShell();
+      const toyNav = initToyPageShell();
       const errorDisplayId = 'error-message';
       initErrorDisplay(errorDisplayId);
 
@@ -90,6 +90,9 @@
       let lastRenderTime = 0;
       let renderElapsed = 0;
 
+      const hintsButtonHost =
+        toyNav?.querySelector('.active-toy-nav__actions') ?? null;
+
       initHints({
         id: 'seary-visualizer',
         tips: [
@@ -97,6 +100,11 @@
           'Switch to Party Mode for bigger motion.',
           'Use the audio source menu to swap between mic and device audio.',
         ],
+        trigger: 'idle',
+        manualButton: {
+          container: hintsButtonHost,
+          label: 'Need tips?',
+        },
       });
 
       const adapter = createSearyFunAdapter();

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -72,7 +72,7 @@
       import { initHints } from '../assets/ui/hints.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
 
-      initToyPageShell();
+      const toyNav = initToyPageShell();
 
       const glCanvasElement = document.getElementById('glCanvas');
       const overlayCanvas = document.getElementById('overlayCanvas');
@@ -86,6 +86,9 @@
       }
       const ctx2d = overlayCanvas.getContext('2d');
 
+      const hintsButtonHost =
+        toyNav?.querySelector('.active-toy-nav__actions') ?? null;
+
       initHints({
         id: 'symph-visualizer',
         tips: [
@@ -93,6 +96,11 @@
           'Switch to Party Mode for bigger motion.',
           'Drag across the canvas to nudge the spectrograph ripples.',
         ],
+        trigger: 'idle',
+        manualButton: {
+          container: hintsButtonHost,
+          label: 'Need tips?',
+        },
       });
 
       let resolutionUniformLocation = null;


### PR DESCRIPTION
### Motivation
- Avoid showing the hint overlay on initial load and make tips discoverable through interaction or an explicit control. 
- Provide flexible hint triggers so toys can either surface tips after the user's first interaction, after a short idle delay, or only via a manual button. 
- Add a lightweight way for toy UIs to re-open the quick guide on demand from existing UI chrome (nav / settings). 

### Description
- Added new options to `HintOptions` in `assets/ui/hints.ts`: `trigger?: 'idle' | 'interaction' | 'manual'`, `idleDelayMs?: number`, and `manualButton?` to host a manual trigger button; implemented default idle delay and styles. 
- Reworked hint rendering so it does not show immediately: the hint now renders on first pointer/keyboard interaction for `interaction`, or on a short idle timeout after interaction for `idle`, and exposes an optional manual `Need tips?` button that renders the hint when clicked. 
- Updated call sites to use the new behavior and to provide discoverable entry points: added a `Tips` section and manual host in `assets/js/toys/tactile-sand-table.ts`, and wired the toy nav actions as the manual host in `toys/seary.html`, `toys/multi.html`, and `toys/symph.html`. 
- Added small styling for the manual trigger and ensured hint dismissal persists via existing localStorage behavior. 

### Testing
- Ran the full project check with `bun run check` (Biome lint/format, `tsc --noEmit`, and tests); the suite completed successfully. 
- Unit/integration tests: 76 passed, 2 skipped, 0 failed (test run from `bun run check`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976835628808332a1309d21587839f7)