### PR TITLE
Refine intro and system check details

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1249,6 +1249,40 @@ html.light .hero-metric {
   line-height: 1.5;
 }
 
+.details-panel {
+  display: none;
+}
+
+body[data-details-open] .details-panel {
+  display: block;
+}
+
+.details-toggle {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  gap: 0.35rem;
+}
+
+body[data-details-open] [data-details-label="open"] {
+  display: none;
+}
+
+body:not([data-details-open]) [data-details-label="close"] {
+  display: none;
+}
+
+body:not([data-details-open]) .readiness-note {
+  display: none;
+}
+
+body[data-details-open] .readiness-note {
+  display: block;
+}
+
+.intro-details {
+  margin-top: 1rem;
+}
+
 .text-link {
   display: inline-flex;
   align-items: center;

--- a/assets/js/utils/init-hero-readiness.ts
+++ b/assets/js/utils/init-hero-readiness.ts
@@ -25,7 +25,7 @@ export const initHeroReadinessSummary = () => {
 
   const updateSummary = (performanceLabel: string) => {
     const compatibilityLabel = buildCompatibilityLabel();
-    text.textContent = `Performance: ${performanceLabel} • ${compatibilityLabel}`;
+    text.textContent = `Ready • ${performanceLabel} • ${compatibilityLabel}`;
   };
 
   updateSummary(getPerformanceSummaryLabel());

--- a/assets/js/utils/init-system-check.ts
+++ b/assets/js/utils/init-system-check.ts
@@ -8,6 +8,44 @@ export const initSystemCheck = () => {
     initReadinessProbe();
   }
 
+  const detailsToggles = Array.from(
+    document.querySelectorAll('[data-details-toggle]'),
+  ).filter((element): element is HTMLElement => element instanceof HTMLElement);
+  const setDetailsOpen = (open: boolean) => {
+    if (open) {
+      document.body.setAttribute('data-details-open', 'true');
+    } else {
+      document.body.removeAttribute('data-details-open');
+    }
+    detailsToggles.forEach((toggle) => {
+      toggle.setAttribute('aria-expanded', String(open));
+    });
+  };
+
+  const syncDetailsFromHash = () => {
+    setDetailsOpen(window.location.hash === '#system-check');
+  };
+
+  syncDetailsFromHash();
+  window.addEventListener('hashchange', syncDetailsFromHash);
+
+  detailsToggles.forEach((toggle) => {
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      const open = !document.body.hasAttribute('data-details-open');
+      setDetailsOpen(open);
+      if (open) {
+        window.location.hash = 'system-check';
+      } else if (window.location.hash === '#system-check') {
+        window.history.replaceState(
+          null,
+          '',
+          window.location.pathname + window.location.search,
+        );
+      }
+    });
+  });
+
   const controlsHost = document.querySelector('[data-system-controls]');
   if (controlsHost instanceof HTMLElement) {
     initSystemControls(controlsHost, {
@@ -34,6 +72,10 @@ export const initSystemCheck = () => {
   triggers.forEach((trigger) => {
     trigger.addEventListener('click', (event) => {
       event.preventDefault();
+      setDetailsOpen(true);
+      if (window.location.hash !== '#system-check') {
+        window.location.hash = 'system-check';
+      }
       preflight.open(trigger);
     });
   });

--- a/index.html
+++ b/index.html
@@ -85,14 +85,23 @@
           </p>
           <h1>Stim library.</h1>
           <p class="section-description">
-            A curated set of responsive visuals built for flow state, clarity, and
-            calm. Audio input options and performance controls live in the toy panel.
+            Feel-first visuals that sync with sound, touch, and motion.
           </p>
+          <a
+            href="#system-check"
+            class="text-link details-toggle"
+            data-details-toggle
+            aria-expanded="false"
+            aria-controls="intro-details system-check-details"
+          >
+            <span data-details-label="open">Learn more</span>
+            <span data-details-label="close">Hide details</span>
+          </a>
         </div>
         <div class="launch-panel" aria-label="Launch sequence status">
           <div class="launch-panel__header">
             <p class="launch-panel__eyebrow">Quick start status</p>
-            <p class="launch-panel__status">Status details below</p>
+            <p class="launch-panel__status">Ready • Live checks running</p>
           </div>
           <div class="launch-meter" role="presentation">
             <span class="launch-meter__bar" aria-hidden="true"></span>
@@ -131,7 +140,7 @@
         </div>
         <div class="hero-readiness" data-hero-readiness-summary>
           <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
-            Performance: Balanced • Checking compatibility…
+            Ready • Checking compatibility…
           </p>
           <a
             href="#system-check"
@@ -144,20 +153,26 @@
         <dl class="hero-metrics">
           <div class="hero-metric">
             <dt>Adaptive visuals</dt>
-            <dd>Breathes with live audio, demo tracks, or ambient sound.</dd>
+            <dd>Breathes with live or demo audio.</dd>
           </div>
           <div class="hero-metric">
             <dt>Touch + motion</dt>
-            <dd>Gesture-driven control layers designed for hands-on play.</dd>
+            <dd>Gesture-driven controls for hands-on play.</dd>
           </div>
           <div class="hero-metric">
             <dt>Open-source</dt>
-            <dd>Built in public with gentle defaults and accessibility in mind.</dd>
+            <dd>Built in public with gentle defaults.</dd>
           </div>
         </dl>
-        <p class="cta-helper">
-          No account required. Mic access enables live audio.
-        </p>
+        <div class="intro-details details-panel" data-details-panel id="intro-details">
+          <p class="section-description">
+            A curated set of responsive visuals built for flow state, clarity, and
+            calm. Audio input options and performance controls live in the toy panel.
+          </p>
+          <p class="cta-helper">
+            No account required. Mic access enables live audio.
+          </p>
+        </div>
       </section>
 
       <section class="system-check" id="system-check">
@@ -165,17 +180,34 @@
           <p class="eyebrow">System check</p>
           <h2>Confirm your device is ready</h2>
           <p class="section-description">
+            Ready status updates live. Open details for compatibility notes.
+          </p>
+          <p
+            class="section-description details-panel"
+            data-details-panel
+            id="system-check-details"
+          >
             Live readiness updates automatically. Open the system check for a
             deeper read on graphics, microphone access, and performance
             presets before launching a stim. If mic access is blocked, demo,
             tab, and YouTube audio are available in the toy controls.
           </p>
+          <a
+            href="#system-check"
+            class="text-link details-toggle"
+            data-details-toggle
+            aria-expanded="false"
+            aria-controls="intro-details system-check-details"
+          >
+            <span data-details-label="open">Details</span>
+            <span data-details-label="close">Hide details</span>
+          </a>
         </div>
         <div class="system-grid">
           <div class="readiness-panel" data-readiness-panel>
             <div class="readiness-header">
               <h3 class="readiness-title">Live readiness</h3>
-              <p class="readiness-subtitle">
+              <p class="readiness-subtitle" data-details-panel>
                 We’ll keep these signals updated so you know what’s available.
               </p>
             </div>


### PR DESCRIPTION
### Motivation
- Simplify the landing intro and system-check presentation so the default view is minimal and easier to scan. 
- Expose the original, verbose readiness and compatibility notes only when the user explicitly requests them via a “Learn more” / “Details” toggle. 
- Use existing discovery anchors (`data-open-preflight` and the `#system-check` hash) so the expanded state is discoverable and can be triggered by system-check actions.

### Description
- Shortened the hero copy and metric text and moved the longer paragraphs into collapsible detail panels in `index.html`.
- Added a compact `details-toggle` control wired with `data-details-toggle` and two hidden panels (`data-details-panel` / `#intro-details` and `#system-check-details`) to reveal the expanded content on demand in `index.html`.
- Implemented CSS rules in `assets/css/index.css` to hide `details-panel` by default and show it when `body[data-details-open]` is set, and to hide per-item `readiness-note` lines unless details are open.
- Wired interactivity in `assets/js/utils/init-system-check.ts` to toggle the expanded state, sync it with the `#system-check` hash, and open the capability preflight when appropriate, and updated the hero readiness summary text in `assets/js/utils/init-hero-readiness.ts` to reflect the new minimal copy.

### Testing
- Ran the project quality and tests with `bun run check`, which runs `biome` checks, TypeScript typecheck, and the test suite; the run completed successfully with all automated tests passing (76 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768514b870833283a2763b217dd4bf)