### PR TITLE
Add audio control info disclosure

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1036,6 +1036,49 @@ body {
   font-size: 0.95rem;
 }
 
+.control-panel__info-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.control-panel__info {
+  border: none;
+  background: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: rgba(155, 243, 255, 0.85);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.control-panel__info:focus-visible {
+  outline: 2px solid rgba(111, 247, 255, 0.85);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.control-panel__info-text {
+  font-size: 0.85rem;
+  color: rgba(233, 251, 255, 0.75);
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition:
+    opacity 0.2s ease,
+    max-height 0.2s ease;
+}
+
+.control-panel__info-wrap:hover .control-panel__info-text,
+.control-panel__info-wrap:focus-within .control-panel__info-text {
+  opacity: 1;
+  max-height: 80px;
+}
+
 .control-panel__note {
   margin: 6px 0 0;
   font-size: 0.95rem;

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -44,7 +44,19 @@ export function initAudioControls(
     <div class="control-panel__row">
       <div class="control-panel__text">
         <span class="control-panel__label">Tab audio</span>
-        <small>Capture audio from the current browser tab.</small>
+        <span class="control-panel__info-wrap">
+          <button
+            class="control-panel__info"
+            type="button"
+            aria-describedby="tab-audio-info"
+          >
+            More info
+          </button>
+          <span id="tab-audio-info" class="control-panel__info-text">
+            Capture audio from the current browser tab. In the picker, choose “This tab” and
+            enable Share audio.
+          </span>
+        </span>
       </div>
       <button id="use-tab-audio" class="cta-button" type="button">Capture tab audio</button>
     </div>
@@ -58,7 +70,19 @@ export function initAudioControls(
     <div class="control-panel__row control-panel__row--stacked">
       <div class="control-panel__text">
         <span class="control-panel__label">YouTube audio</span>
-        <small>Paste a link and enable audio sharing during capture.</small>
+        <span class="control-panel__info-wrap">
+          <button
+            class="control-panel__info"
+            type="button"
+            aria-describedby="youtube-audio-info"
+          >
+            More info
+          </button>
+          <span id="youtube-audio-info" class="control-panel__info-text">
+            Paste a link, load the video, then start capture. In the picker, choose “This tab” and
+            enable Share audio.
+          </span>
+        </span>
       </div>
       <div class="control-panel__field">
         <label class="sr-only" for="youtube-url">YouTube URL</label>
@@ -189,7 +213,7 @@ export function initAudioControls(
         emphasizeDemoAudio();
         updateStatus(buildMicrophoneErrorMessage(message));
       },
-      'Microphone connected. You can switch sources anytime.',
+      'Mic connected.',
     );
   });
 
@@ -211,14 +235,14 @@ export function initAudioControls(
         if (!navigator.mediaDevices?.getDisplayMedia) {
           throw new Error('Tab audio capture unavailable.');
         }
-        updateStatus('Choose “This tab” and enable audio sharing.', 'success');
+        updateStatus('Select tab to capture audio.', 'success');
         const stream = await navigator.mediaDevices.getDisplayMedia({
           video: true,
           audio: true,
         });
         if (!stream.getAudioTracks().length) {
           stream.getTracks().forEach((track) => track.stop());
-          throw new Error('No audio track detected. Enable “Share audio”.');
+          throw new Error('No audio track detected.');
         }
         await requestTabAudio(stream);
       },
@@ -343,7 +367,7 @@ function setupYouTubeLogic(
 
   useBtn?.addEventListener('click', async () => {
     if (!youtubeReady) {
-      updateStatus('Load a YouTube video before capturing audio.');
+      updateStatus('Load a YouTube video first.');
       input.focus();
       return;
     }
@@ -356,14 +380,14 @@ function setupYouTubeLogic(
       useBtn.disabled = true;
       useBtn.toggleAttribute('data-loading', true);
       useBtn.setAttribute('aria-busy', 'true');
-      updateStatus('Choose “This tab” and enable audio sharing.', 'success');
+      updateStatus('Select tab to capture audio.', 'success');
       const stream = await navigator.mediaDevices.getDisplayMedia({
         video: true,
         audio: true,
       });
       if (!stream.getAudioTracks().length) {
         stream.getTracks().forEach((t) => t.stop());
-        updateStatus('No audio track detected. Enable “Share audio”.');
+        updateStatus('No audio track detected.');
         return;
       }
       await onUse(stream);


### PR DESCRIPTION
### Motivation
- Make the audio controls less noisy by moving longer helper instructions out of inline UI text and into a discoverable disclosure that appears on hover/focus.
- Shorten transient status messages shown via `updateStatus` so they are concise in the main UI while preserving the detailed guidance in the disclosure.

### Description
- Replaced inline `<small>` helper text for Tab and YouTube rows with a `More info` disclosure button and hidden explanatory text in `assets/js/ui/audio-controls.ts`.
- Added new CSS rules in `assets/css/base.css` for `.control-panel__info-wrap`, `.control-panel__info`, and `.control-panel__info-text` to reveal details on hover and focus-within.
- Shortened several status messages used by `updateStatus` (e.g., replaced `Microphone connected. You can switch sources anytime.` with `Mic connected.`, `Choose “This tab” and enable audio sharing.` with `Select tab to capture audio.`, and removed the `Enable “Share audio”` suffix from no-audio-track messages).
- Kept YouTube logic intact while moving its longer instructions into the disclosure and updating status text strings to the shortened variants.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc --noEmit`, and the test suite) and it completed successfully with all tests passing.
- No docs were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697688048c5c833286cf360fc8186c76)