### PR TITLE
Refine readiness and preflight messaging

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1438,6 +1438,33 @@ body {
   margin-top: 4px;
 }
 
+.preflight-panel__details {
+  margin: 6px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.preflight-panel__details-summary {
+  cursor: pointer;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(233, 251, 255, 0.72);
+}
+
+.preflight-panel__details-content {
+  margin-top: 6px;
+}
+
+.preflight-panel__details-list {
+  margin: 0;
+  padding-left: 16px;
+  color: rgba(233, 251, 255, 0.78);
+  display: grid;
+  gap: 6px;
+  font-size: 0.88rem;
+}
+
 .preflight-panel__eyebrow {
   margin: 0 0 4px;
   text-transform: uppercase;


### PR DESCRIPTION
### Motivation

- Make status indicators concise and scannable by replacing multi-clause status messages with short labels and surfacing longer guidance only on interaction.
- Reduce clutter in the preflight panel by turning verbose inline notes into short phrases and providing a single expandable “Why?” section for detailed guidance.

### Description

- Shortened readiness probe messages in `assets/js/readiness-probe.ts`, added a `StatusResult` type with optional `detail`, and updated `applyStatus` to set `aria-label` and optional `title` for hover/click details.
- Condensed `rendererNote`, `microphoneNote`, `environmentNote`, and `performanceNote` to short phrases in `assets/js/core/capability-preflight.ts`, and added a `details`/`summary` block plus `updateWhyDetails()` to populate a unified expandable “Why?” list with the longer guidance.
- Added styles for the new details block and list in `assets/css/base.css` to match the preflight panel layout.
- Files changed: `assets/js/readiness-probe.ts`, `assets/js/core/capability-preflight.ts`, `assets/css/base.css`.

### Testing

- Ran the full project check with `bun run check`, which runs `biome` checks, `tsc` typecheck, and the test suite, and it completed successfully.
- Test run results (part of `bun run check`): `76` tests passed, `2` skipped, `0` failed (see automated test run summary produced by the test runner).
- Verified the preflight UI with an automated Playwright script that opened the preflight modal and expanded the `Why?` details and produced a screenshot artifact during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697687ff48cc8332a5ef968051573fc9)