### PR TITLE
Request motion permissions on mobile toys

### DIFF
--- a/assets/js/utils/motion-permission.ts
+++ b/assets/js/utils/motion-permission.ts
@@ -1,0 +1,45 @@
+export type MotionPermissionState =
+  | 'granted'
+  | 'denied'
+  | 'prompt'
+  | 'unsupported';
+
+type MotionPermissionRequest = {
+  requestPermission?: () => Promise<PermissionState>;
+};
+
+export const supportsDeviceOrientation = () =>
+  typeof window !== 'undefined' && 'DeviceOrientationEvent' in window;
+
+export const requiresMotionPermission = () =>
+  supportsDeviceOrientation() &&
+  typeof DeviceOrientationEvent !== 'undefined' &&
+  'requestPermission' in DeviceOrientationEvent;
+
+export const requestMotionPermission =
+  async (): Promise<MotionPermissionState> => {
+    if (!supportsDeviceOrientation()) return 'unsupported';
+
+    if (!requiresMotionPermission()) {
+      return 'granted';
+    }
+
+    try {
+      const response = await (
+        DeviceOrientationEvent as unknown as MotionPermissionRequest
+      ).requestPermission?.();
+
+      if (response === 'granted') {
+        return 'granted';
+      }
+
+      if (response === 'denied') {
+        return 'denied';
+      }
+
+      return 'prompt';
+    } catch (error) {
+      console.warn('Motion permission request failed', error);
+      return 'denied';
+    }
+  };

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -55,6 +55,11 @@
       import { createMultiFunAdapter } from '../assets/multi/fun-adapter.ts';
       import { initFunControls } from '../assets/ui/fun-controls.ts';
       import { initHints } from '../assets/ui/hints.ts';
+      import {
+        requestMotionPermission,
+        requiresMotionPermission,
+        supportsDeviceOrientation,
+      } from '../assets/js/utils/motion-permission.ts';
 
       const toyNav = initToyPageShell();
 
@@ -245,10 +250,35 @@
 
       funControls.container.appendChild(extras);
 
-      window.addEventListener('deviceorientation', (event) => {
+      let motionEnabled = false;
+      const handleDeviceOrientation = (event) => {
         toy.camera.rotation.x = (event.beta / 180) * Math.PI;
         toy.camera.rotation.y = (event.gamma / 90) * Math.PI;
-      });
+      };
+
+      const enableMotion = async () => {
+        if (motionEnabled) return;
+        const permission = await requestMotionPermission();
+        if (permission !== 'granted') return;
+        motionEnabled = true;
+        window.addEventListener('deviceorientation', handleDeviceOrientation);
+      };
+
+      if (supportsDeviceOrientation()) {
+        if (requiresMotionPermission()) {
+          const requestOnFirstInteraction = () => {
+            void enableMotion();
+          };
+          window.addEventListener('pointerdown', requestOnFirstInteraction, {
+            once: true,
+          });
+          window.addEventListener('touchstart', requestOnFirstInteraction, {
+            once: true,
+          });
+        } else {
+          void enableMotion();
+        }
+      }
 
       const clock = new THREE.Clock();
       const sparkleGroup = new THREE.Group();

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -60,6 +60,11 @@
       import { initHints } from '../assets/ui/hints.ts';
       import { createUnifiedInput } from '../assets/js/utils/unified-input.ts';
       import {
+        requestMotionPermission,
+        requiresMotionPermission,
+        supportsDeviceOrientation,
+      } from '../assets/js/utils/motion-permission.ts';
+      import {
         getBandLevels,
         getWeightedEnergy,
         updateEnergyPeak,
@@ -509,11 +514,36 @@
         });
       }
 
-      window.addEventListener('deviceorientation', (event) => {
+      let motionEnabled = false;
+      const handleDeviceOrientation = (event) => {
         orientation.alpha = event.alpha;
         orientation.beta = event.beta;
         orientation.gamma = event.gamma;
-      });
+      };
+
+      const enableMotion = async () => {
+        if (motionEnabled) return;
+        const permission = await requestMotionPermission();
+        if (permission !== 'granted') return;
+        motionEnabled = true;
+        window.addEventListener('deviceorientation', handleDeviceOrientation);
+      };
+
+      if (supportsDeviceOrientation()) {
+        if (requiresMotionPermission()) {
+          const requestOnFirstInteraction = () => {
+            void enableMotion();
+          };
+          window.addEventListener('pointerdown', requestOnFirstInteraction, {
+            once: true,
+          });
+          window.addEventListener('touchstart', requestOnFirstInteraction, {
+            once: true,
+          });
+        } else {
+          void enableMotion();
+        }
+      }
 
       function processAudio(ctxAudio) {
         if (!ctxAudio.analyser) {


### PR DESCRIPTION
### Motivation
- Ensure motion-based toys behave correctly on contemporary smartphones by requesting device-orientation permission before subscribing to `deviceorientation`, and by deferring the request to a first user interaction when required by the platform.

### Description
- Add a shared helper `assets/js/utils/motion-permission.ts` that exposes `supportsDeviceOrientation`, `requiresMotionPermission`, and `requestMotionPermission` for consistent motion-permission probing and requests.
- Update `toys/multi.html` and `toys/seary.html` to defer registering `deviceorientation` listeners until `requestMotionPermission()` returns `granted`, and to trigger the permission request on first interaction when needed.
- Add platform guards so motion is skipped cleanly on unsupported devices.

### Testing
- Ran `bun run check` (Biome + typecheck + tests) to validate changes.
- Automated checks passed: linters/typecheck succeeded and the test suite completed with 76 passed and 2 skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976983eb7308332b6200fa3b8be195c)