### PR TITLE
Sync CSS viewport vars with visualViewport for mobile

### DIFF
--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -152,18 +152,24 @@ export default class WebToy {
 
   handleResize() {
     const visualViewport = window.visualViewport;
-    let width = visualViewport?.width ?? window.innerWidth;
-    let height = visualViewport?.height ?? window.innerHeight;
+    const viewportWidth = visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
+    let width = viewportWidth;
+    let height = viewportHeight;
 
     if (this.container && this.container !== document.body) {
       width = this.container.clientWidth;
       height = this.container.clientHeight;
     }
 
-    if (!this.container || this.container === document.body) {
-      document.documentElement.style.setProperty('--app-height', `${height}px`);
-      document.documentElement.style.setProperty('--app-width', `${width}px`);
-    }
+    document.documentElement.style.setProperty(
+      '--app-height',
+      `${viewportHeight}px`,
+    );
+    document.documentElement.style.setProperty(
+      '--app-width',
+      `${viewportWidth}px`,
+    );
 
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();


### PR DESCRIPTION
### Motivation
- Keep the app-level CSS viewport sizing aligned with the browser visual viewport so mobile sessions remain stable when the browser chrome or on-screen keyboard changes size.

### Description
- Use `window.visualViewport` dimensions for `--app-width`/`--app-height` in `handleResize` and compute camera aspect from the container (or visual viewport) to improve layout and rendering on contemporary smartphones.

### Testing
- Ran the project checks with `bun run check`, which executed the test suite and lint/type checks successfully (tests completed: 76 passed, 2 skipped); Docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976983eb7308332b6200fa3b8be195c)