### PR TITLE
Improve visual polish and UI across toys

### DIFF
--- a/assets/js/toys/clay-toy.ts
+++ b/assets/js/toys/clay-toy.ts
@@ -230,11 +230,11 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
       window.clearTimeout(uiTimeout);
     }
     if (uiElement) {
-      uiElement.style.opacity = '1';
+      uiElement.style.opacity = '0.95';
     }
     uiTimeout = window.setTimeout(() => {
       if (uiElement) {
-        uiElement.style.opacity = '0';
+        uiElement.style.opacity = '0.2';
       }
     }, 3000);
   }

--- a/assets/js/toys/lights/lighting.ts
+++ b/assets/js/toys/lights/lighting.ts
@@ -103,6 +103,20 @@ export const createLightsScene = async ({
   );
   toy.scene.add(cube);
 
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(60, 60),
+    new THREE.MeshStandardMaterial({
+      color: 0x0b0b0b,
+      metalness: 0.1,
+      roughness: 0.9,
+      transparent: true,
+      opacity: 0.85,
+    }),
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = -2;
+  toy.scene.add(floor);
+
   await toy.rendererReady;
 
   return { toy, lightingGroup, cube };

--- a/toys/clay.html
+++ b/toys/clay.html
@@ -21,11 +21,13 @@
         left: 10px;
         color: #fff;
         z-index: 1;
-        background: rgba(0, 0, 0, 0.5);
+        background: rgba(0, 0, 0, 0.65);
         padding: 10px;
-        border-radius: 5px;
-        opacity: 0; /* Start hidden */
-        transition: opacity 0.5s;
+        border-radius: 8px;
+        opacity: 0.2; /* Start subtle but visible */
+        transition: opacity 0.4s ease;
+        backdrop-filter: blur(6px);
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
       }
       #ui button {
         margin-top: 5px;

--- a/toys/evol.html
+++ b/toys/evol.html
@@ -187,8 +187,13 @@
                 color += scanline;
                 color += vhsNoise;
                 
+                // Focal glow to anchor the composition
+                float focal = exp(-dot(pos, pos) * 1.4);
+                vec3 focalTint = vec3(0.35, 0.18, 0.5) * (0.6 + u_audioData * 0.8);
+                color += focalTint * focal;
+
                 // Vignette
-                float vignette = 1.0 - length(pos) * 0.4;
+                float vignette = 1.0 - length(pos) * 0.45;
                 color *= vignette;
                 
                 gl_FragColor = vec4(color, 1.0);

--- a/toys/geom.html
+++ b/toys/geom.html
@@ -214,13 +214,17 @@
       const { startAudio } = createToyAudioBootstrap(toy);
 
       function createParticle() {
+        const depth = Math.random();
+        const size = Math.random() * 3 + 1;
         return {
           x: Math.random() * viewWidth,
           y: Math.random() * viewHeight,
-          size: Math.random() * 3 + 1,
-          baseSize: Math.random() * 3 + 1,
-          velocityX: (Math.random() - 0.5) * 2,
-          velocityY: (Math.random() - 0.5) * 2,
+          depth,
+          size,
+          baseSize: size,
+          baseAlpha: 0.3 + depth * 0.4,
+          velocityX: (Math.random() - 0.5) * 2 * (0.4 + depth),
+          velocityY: (Math.random() - 0.5) * 2 * (0.4 + depth),
           hue: Math.random() * 360,
           lightness: 50,
           alpha: 0.5,
@@ -274,8 +278,9 @@
         ctx.globalAlpha = 1;
 
         particles.forEach((p, index) => {
-          p.x += p.velocityX * speedMultiplier;
-          p.y += p.velocityY * speedMultiplier;
+          const depthFactor = 0.6 + p.depth * 0.9;
+          p.x += p.velocityX * speedMultiplier * depthFactor;
+          p.y += p.velocityY * speedMultiplier * depthFactor;
           p.rotation += p.angularVelocity;
 
           if (p.x < -p.size) p.x = viewWidth + p.size;
@@ -287,10 +292,15 @@
             const freqIndex = Math.floor(index % frequencyData.length);
             const amplitude = frequencyData[freqIndex] / 255;
             const energyBoost = 0.7 + peakLevel * 1.1 + bassPulse * 0.8;
-            p.size = p.baseSize + amplitude * 12 * energyBoost;
+            p.size =
+              p.baseSize * (0.8 + p.depth) + amplitude * 12 * energyBoost;
             p.hue = (p.hue + amplitude * (6 + trebleGlow * 10)) % 360;
-            p.lightness = 35 + amplitude * 25 + trebleGlow * 15;
-            p.alpha = Math.min(1, 0.25 + amplitude * 0.65 + peakLevel * 0.2);
+            p.lightness = 30 + amplitude * 25 + trebleGlow * 15 + p.depth * 10;
+            p.alpha = Math.min(
+              1,
+              (p.baseAlpha + amplitude * 0.55 + peakLevel * 0.2) *
+                (0.7 + p.depth * 0.6)
+            );
           }
 
           ctx.save();

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -14,17 +14,20 @@
       #settingsButton,
       #fullscreenButton {
         position: absolute;
-        padding: 12px 20px;
-        font-size: 16px;
-        background-color: rgba(76, 175, 80, 0.8);
+        padding: 10px 18px;
+        font-size: 15px;
+        background-color: rgba(76, 175, 80, 0.7);
         color: white;
         border: none;
-        border-radius: 4px;
+        border-radius: 10px;
         cursor: pointer;
         transition:
           background-color 0.3s,
-          transform 0.2s;
+          transform 0.2s,
+          box-shadow 0.3s;
         z-index: 10;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
       }
       #startButton:hover,
       #infoButton:hover,
@@ -41,28 +44,28 @@
       #infoButton {
         top: 15px;
         right: 15px;
-        width: 40px;
-        height: 40px;
+        width: 34px;
+        height: 34px;
         border-radius: 50%;
-        font-size: 20px;
+        font-size: 18px;
         padding: 0;
       }
       #settingsButton {
         top: 15px;
         left: 15px;
-        width: 40px;
-        height: 40px;
+        width: 34px;
+        height: 34px;
         border-radius: 50%;
-        font-size: 20px;
+        font-size: 18px;
         padding: 0;
       }
       #fullscreenButton {
         top: 15px;
         right: 65px;
-        width: 40px;
-        height: 40px;
+        width: 34px;
+        height: 34px;
         border-radius: 50%;
-        font-size: 18px;
+        font-size: 16px;
         padding: 0;
       }
       #infoPanel,
@@ -71,7 +74,7 @@
         top: 70px;
         right: 15px;
         left: 15px;
-        background-color: rgba(0, 0, 0, 0.85);
+        background-color: rgba(0, 0, 0, 0.78);
         color: white;
         padding: 20px;
         border-radius: 8px;

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -44,6 +44,13 @@
         background: #001a00;
         transition: all 0.3s ease;
       }
+      .cell.is-word {
+        font-weight: 600;
+        text-shadow: 0 0 8px currentColor;
+        background: rgba(0, 60, 0, 0.9);
+        box-shadow: inset 0 0 8px rgba(0, 255, 120, 0.35);
+        filter: brightness(1.2);
+      }
       .controls {
         position: absolute;
         top: 10px;
@@ -436,6 +443,7 @@
             const cell = gridCells[randomIndex + i];
             cell.textContent = word[i];
             cell.dataset.fixed = true;
+            cell.classList.add('is-word');
             cell.classList.add('flicker');
 
             wordElements.push(cell);
@@ -471,6 +479,7 @@
               Math.floor(Math.random() * 26)
             ); // Revert to gibberish
             cell.classList.remove('flicker');
+            cell.classList.remove('is-word');
             delete cell.dataset.fixed; // Allow it to cycle again
           });
         });

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -124,12 +124,14 @@
         : THREE.MeshStandardMaterial;
 
       const torusKnot = new THREE.Mesh(
-        new THREE.TorusKnotGeometry(10, 3, 100, 16),
+        new THREE.TorusKnotGeometry(12, 4, 120, 16),
         new baseMaterial({
-          color: 0x00ff00,
+          color: 0x00f5ff,
           ...(useWebGLFallback
             ? {}
             : {
+                emissive: 0x003344,
+                emissiveIntensity: 0.7,
                 metalness: 0.5,
                 roughness: 0.2,
               }),
@@ -145,6 +147,14 @@
       pointLight.position.set(10, 20, 20);
       toy.scene.add(pointLight);
 
+      const keyLight = new THREE.PointLight(
+        0x00f5ff,
+        useWebGLFallback ? 0.8 : 1.3,
+        140
+      );
+      keyLight.position.set(0, 0, 35);
+      toy.scene.add(keyLight);
+
       const particlesGeometry = new THREE.BufferGeometry();
       const particlesCount = useWebGLFallback ? 320 : 1200;
       const particlesPosition = new Float32Array(particlesCount * 3);
@@ -156,8 +166,10 @@
         new THREE.BufferAttribute(particlesPosition, 3)
       );
       const particlesMaterial = new THREE.PointsMaterial({
-        color: 0x00ff00,
+        color: 0x00ff99,
         size: useWebGLFallback ? 0.6 : 0.5,
+        transparent: true,
+        opacity: useWebGLFallback ? 0.45 : 0.35,
       });
       const particles = new THREE.Points(particlesGeometry, particlesMaterial);
       toy.scene.add(particles);
@@ -172,6 +184,8 @@
         let shape;
         const shapeMaterial = new baseMaterial({
           color: Math.random() * 0xffffff,
+          transparent: true,
+          opacity: useWebGLFallback ? 0.6 : 0.7,
           ...(useWebGLFallback
             ? {}
             : {

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -308,9 +308,17 @@
                 float glow = exp(-10.0 * dist) * (u_low_freq + u_mid_freq + u_high_freq);
                 color += vec3(glow * 0.4, glow * 0.6, glow * 0.8);
 
+                // Accent ring to add sharper contrast
+                float accentRing = smoothstep(0.38, 0.33, dist) - smoothstep(0.5, 0.45, dist);
+                color += u_palette_accent * accentRing * (0.45 + u_high_freq);
+
                 color = mix(color, color * u_palette_accent, 0.35);
                 color *= 1.0 + u_burst_intensity * 0.6;
                 color += u_palette_accent * (u_burst_intensity * 0.25);
+
+                float vignette = smoothstep(1.15, 0.35, dist);
+                color *= vignette;
+                color = mix(color, pow(color, vec3(1.08)), 0.35);
 
                 gl_FragColor = vec4(color, 1.0);
             }

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -377,9 +377,10 @@
         }
       });
 
-      function updateSpectrograph(dataArray) {
+      function updateSpectrograph(dataArray, energy = 0) {
         if (!ctx2d) return;
-        ctx2d.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+        ctx2d.fillStyle = 'rgba(0, 0, 0, 0.18)';
+        ctx2d.fillRect(0, 0, overlayCanvas.width, overlayCanvas.height);
         const gradient = ctx2d.createLinearGradient(
           0,
           0,
@@ -390,12 +391,14 @@
         gradient.addColorStop(0.5, gradientStops[1]);
         gradient.addColorStop(1, gradientStops[2]);
         ctx2d.fillStyle = gradient;
+        ctx2d.shadowColor = gradientStops[1];
+        ctx2d.shadowBlur = 12 + energy * 14;
         const barWidth = (overlayCanvas.width / dataArray.length) * 1.5;
         let barHeight;
         let x = 0;
 
         for (let i = 0; i < dataArray.length; i++) {
-          barHeight = dataArray[i] / 2;
+          barHeight = (dataArray[i] / 2) * (0.8 + energy * 0.8);
           ctx2d.fillRect(
             x,
             overlayCanvas.height - barHeight,
@@ -404,6 +407,7 @@
           );
           x += barWidth + 1;
         }
+        ctx2d.shadowBlur = 0;
       }
 
       function hexToRgbTuple(hex) {
@@ -520,7 +524,7 @@
           if (sparklesEnabled && trebleShimmer > 0.6 && Math.random() < 0.08) {
             spawnSparkles(Math.min(1, trebleShimmer));
           }
-          updateSpectrograph(dataArray);
+          updateSpectrograph(dataArray, normalized);
           funControls.setAudioAvailable(true);
         } else {
           audioData = adapter.transformAudioValue(0);


### PR DESCRIPTION
### Motivation
- Improve UI legibility and subtle visibility of controls so tools are discoverable without distracting from visuals.
- Add depth, focal, and contrast tweaks in several shaders to strengthen visual hierarchy and readability of audio-reactive effects.
- Ground 3D scenes and refine lighting/particle materials for clearer scene hierarchy and better fallback behavior.

### Description
- Refined clay UI styling and behavior by updating `toys/clay.html` and `assets/js/toys/clay-toy.ts` to use a subtle translucent panel and adjust `resetUITimeout` opacity transitions for improved discoverability.
- Polished control and panel styles in `toys/holy.html` (smaller buttons, rounded corners, subtle shadows and backdrop blur) for a sleeker, less obtrusive UI.
- Made highlighted words in `toys/legible.html` more legible by adding a `.cell.is-word` style and toggling that class in the reveal/dissolve logic.
- Added focal glow and vignette tuning to the `toys/evol.html` fragment shader to anchor composition and respond to audio.
- Introduced particle depth, base alpha, depth-scaled motion, and size/alpha adjustments in `toys/geom.html` to create parallax-like depth cues.
- Added a floor plane to `assets/js/toys/lights/lighting.ts` to ground the scene and improve perceived scale.
- Improved scene lighting, particle materials, and emissive accents in `toys/multi.html` by tweaking geometry, colors, an added key light, and transparency settings for particles and shapes.
- Enhanced `toys/seary.html` shader with an accent ring, vignette and contrast tweak for crisper highlights and depth.
- Improved `toys/symph.html` spectrograph rendering by adding an `energy` parameter to `updateSpectrograph`, soft background fill, shadow blur, and using the `normalized` energy when calling it for more responsive trails.

### Testing
- Ran the repository quality checks with `bun run check`, which runs `biome` linters, `tsc`, and the test suite, and completed successfully.
- Test results: `76` passed, `2` skipped, `0` failed across the automated test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ae6c74c88332bcdc6757b7fda416)