### PR TITLE
Use shared runtime starter, renderer-aware quality manager, and Three.js disposal helpers across toys

### DIFF
--- a/assets/js/utils/three-dispose.ts
+++ b/assets/js/utils/three-dispose.ts
@@ -1,0 +1,62 @@
+import type * as THREE from 'three';
+
+type DisposeMeshOptions = {
+  removeFromParent?: boolean;
+};
+
+type DisposeObjectOptions = {
+  removeFromParent?: boolean;
+  clearChildren?: boolean;
+};
+
+export function disposeMaterial(
+  material: THREE.Material | THREE.Material[] | null | undefined,
+) {
+  if (!material) return;
+  if (Array.isArray(material)) {
+    material.forEach((item) => item?.dispose());
+    return;
+  }
+  material.dispose();
+}
+
+export function disposeGeometry(
+  geometry:
+    | THREE.BufferGeometry
+    | THREE.InstancedBufferGeometry
+    | null
+    | undefined,
+) {
+  geometry?.dispose();
+}
+
+export function disposeMesh(
+  mesh: THREE.Mesh | null | undefined,
+  { removeFromParent = true }: DisposeMeshOptions = {},
+) {
+  if (!mesh) return;
+  if (removeFromParent) {
+    mesh.removeFromParent();
+  }
+  disposeGeometry(mesh.geometry);
+  disposeMaterial(mesh.material as THREE.Material | THREE.Material[]);
+}
+
+export function disposeObject3D(
+  object: THREE.Object3D | null | undefined,
+  { removeFromParent = true, clearChildren = false }: DisposeObjectOptions = {},
+) {
+  if (!object) return;
+  object.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if ((mesh as { isMesh?: boolean }).isMesh) {
+      disposeMesh(mesh, { removeFromParent: false });
+    }
+  });
+  if (clearChildren) {
+    object.clear();
+  }
+  if (removeFromParent) {
+    object.removeFromParent();
+  }
+}

--- a/assets/js/utils/toy-runtime-starter.ts
+++ b/assets/js/utils/toy-runtime-starter.ts
@@ -1,0 +1,59 @@
+import { createToyRuntime, type ToyRuntimeOptions } from '../core/toy-runtime';
+import {
+  configureToySettingsPanel,
+  type QualityPresetManager,
+} from './toy-settings';
+
+type ToyRuntimeStarterSettings = {
+  title: string;
+  description?: string;
+  quality?: QualityPresetManager;
+};
+
+export type ToyRuntimeStarterOptions = Omit<
+  ToyRuntimeOptions,
+  'container' | 'canvas'
+> & {
+  canvasSelector?: string;
+  boundsSelector?: string;
+  settingsPanel?: ToyRuntimeStarterSettings;
+};
+
+export function createToyRuntimeStarter({
+  canvasSelector = 'canvas',
+  boundsSelector = 'canvas',
+  settingsPanel,
+  input,
+  ...runtimeOptions
+}: ToyRuntimeStarterOptions) {
+  return function start({
+    container,
+  }: {
+    container?: HTMLElement | null;
+  } = {}) {
+    const canvas =
+      container?.querySelector<HTMLCanvasElement>(canvasSelector) ?? undefined;
+    const boundsElement =
+      input?.boundsElement ??
+      container?.querySelector<HTMLElement>(boundsSelector);
+    const resolvedInput = input
+      ? {
+          ...input,
+          boundsElement: boundsElement ?? undefined,
+        }
+      : undefined;
+
+    const runtime = createToyRuntime({
+      ...runtimeOptions,
+      container,
+      canvas,
+      input: resolvedInput,
+    });
+
+    if (settingsPanel) {
+      configureToySettingsPanel(settingsPanel);
+    }
+
+    return runtime;
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated toy setup/teardown and make quality presets update renderers consistently by centralizing startup and disposal logic. 
- Replace many ad-hoc Three.js `.dispose()` calls with safe helpers to avoid missed cleanup and to standardize removal patterns. 
- Make quality preset changes renderer-aware so changing presets updates the active toy renderer without copy-pasting update logic in each toy.

### Description
- Add Three.js disposal utilities in `assets/js/utils/three-dispose.ts` (`disposeGeometry`, `disposeMaterial`, `disposeMesh`, `disposeObject3D`) and replace inline disposal code in multiple toys to use these helpers. 
- Add a runtime starter helper in `assets/js/utils/toy-runtime-starter.ts` (`createToyRuntimeStarter`) that wraps `createToyRuntime` and resolves `canvas`/`boundsElement` selectors and optional settings-panel wiring. 
- Introduce `createRendererQualityManager` in `assets/js/utils/toy-settings.ts` which extends quality preset management with `getRuntime`/`getRendererSettings` hooks so presets update the renderer directly and call a toy-specific `onChange` callback. 
- Refactor numerous toy modules (e.g., `aurora-painter`, `bioluminescent-tidepools`, `bubble-harmonics`, `cosmic-particles`, `fractal-kite-garden`, `milkdrop-toy`, `neon-wave`, `rainbow-tunnel`, `spiral-burst`, `star-field`, `tactile-sand-table`, `three-d-toy`, `cube-wave`) to use the runtime starter, the renderer-aware quality manager, typed `ToyRuntimeInstance` and the disposal helpers, and to wire settings panels consistently.

### Testing
- Ran `bunx biome check --write` to apply import/format fixes, which updated imports where needed and organized imports automatically and successfully. 
- Ran `bun run check` (runs `biome check`, `tsc --noEmit`, and the test suite); the typecheck and test suite completed successfully. 
- Ran the test suite via `bun test` as part of `bun run check`, and all automated tests passed (76 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697701992a3c8332819ad916847465a2)