### PR TITLE
Add preflight support links, low-motion preset, and audio-start feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ _Current release status: actively developed. The latest tagged release is **1.0.
 
 ### Added
 
-- Track upcoming tweaks to audio, WebGL, and touch experiences across the library of toys.
+- Capability preflight panel with compatibility checks, retry guidance, and clear fallback messaging.
+- Preflight support links that explain why rendering is blocked and point to supported browsers and demo-audio toys.
+- Performance controls with persistent pixel ratio, particle budget, and shader-quality presets.
+- Low-motion quality preset and inline preset descriptions to clarify performance tradeoffs.
+- Audio source controls that surface demo audio alongside the microphone option with clearer status copy.
+- Immediate “starting” status feedback when launching microphone, demo, or tab audio.
+- Shared touch/gesture handling that normalizes multi-touch input and touch-action defaults across toys.
+
+### Changed
+
+- Clarified the roadmap to distinguish delivered foundations from upcoming priorities.
 
 ## [1.0.0] - 2025-02-04
 

--- a/README.md
+++ b/README.md
@@ -98,31 +98,20 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 
 ---
 
-## What’s in the Pipeline
+## Roadmap
 
-### **Compatibility + onboarding**
+### Delivered foundations
 
-- **Issue**: Some users with older or unsupported browsers/devices run into WebGL or WebGPU gating with unclear recovery steps.
-- **Fix**: Add a richer compatibility preflight with clear next steps, plus a “why this won’t run here” state that links to supported browsers and fallback toys. Include a no-mic path in the primary CTA flow so first-time users always see a successful start option.
+- **Compatibility + onboarding**: Capability preflight with status details, retry actions, fallback guidance, and a “why this won’t run here” section that links to supported browsers and fallback toys.
+- **Performance + quality controls**: Performance panel with persistent pixel ratio caps, quality presets (including low-motion), and inline explanations so mid-tier devices can stay smooth.
+- **Audio permission clarity**: Audio controls surface demo audio alongside the microphone CTA by default, plus immediate “starting” feedback and fallback guidance when mic access fails.
+- **Touch + gesture consistency**: Shared input helpers normalize multi-touch gestures and enforce touch-action defaults while keeping control targets sized for reliable taps.
+- **Library discovery**: Search supports tags/capabilities, empty-state guidance, and capability badges (mic/motion/demo audio) on toy cards.
 
-### **Performance + quality controls**
+### Next priorities
 
-- **Issue**: Heavier toys can stutter on mid-tier devices, which breaks the intended sensory flow.
-- **Fix**: Add a quality control panel (pixel ratio cap, particle density presets, and a “low motion” mode) that persists per device and defaults to a safe mid-tier profile. Provide a short “performance profile” explanation so users understand what each preset changes.
-
-If you want to reduce GPU load on high-DPI screens without degrading visuals too much, pass a `maxPixelRatio` option to
-`initRenderer` (defaults to `2`). This caps the renderer to `Math.min(window.devicePixelRatio, maxPixelRatio)`, so setting
-`maxPixelRatio` to `1.5` or `1` can significantly cut per-frame work while retaining clarity.
-
-### **Audio permission clarity**
-
-- **Issue**: Users who deny mic access often get stuck or miss the demo audio escape hatch.
-- **Fix**: Expand the status copy and inline guidance so the demo audio path is always visible, clearly recommended when mic access is blocked, and explains how to re-enable permissions.
-
-### **Mobile touch + gesture polish**
-
-- **Issue**: Touch interactions feel inconsistent across devices, especially for multi-touch toys.
-- **Fix**: Improve touch handling, add clearer gesture hints, and confirm touch targets meet the minimum size for reliable taps. Add explicit “tap to start” feedback within 100ms so touch users see immediate response.
+- **Toy onboarding quick wins**: Add lightweight presets or first-time hints for toys with multiple controls so the “wow” moment is immediate.
+- **Touch polish**: Add clearer gesture hints and input affordances on the toy page.
 
 ---
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1524,6 +1524,44 @@ body {
   gap: 4px;
 }
 
+.preflight-panel__support {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 14, 28, 0.6);
+}
+
+.preflight-panel__support-title {
+  margin: 0 0 4px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 196, 105, 0.85);
+}
+
+.preflight-panel__support-text {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+  color: rgba(233, 251, 255, 0.78);
+}
+
+.preflight-panel__support-links {
+  margin: 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.preflight-panel__support-links a {
+  color: #7dd3fc;
+}
+
+.preflight-panel__support-links a:hover {
+  color: #bae6fd;
+}
+
 .preflight-panel__success {
   margin: 0;
   color: rgba(111, 247, 255, 0.96);

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -413,6 +413,44 @@ function renderIssueList(
     list.appendChild(item);
   });
   container.appendChild(list);
+
+  if (result.blockingIssues.length) {
+    const support = document.createElement('div');
+    support.className = 'preflight-panel__support';
+
+    const supportTitle = document.createElement('p');
+    supportTitle.className = 'preflight-panel__support-title';
+    supportTitle.textContent = 'Why this won’t run here';
+    support.appendChild(supportTitle);
+
+    const supportText = document.createElement('p');
+    supportText.className = 'preflight-panel__support-text';
+    supportText.textContent =
+      'This device cannot access WebGL/WebGPU, so 3D visuals cannot render. Try a supported browser or jump back to toys that can run with demo audio.';
+    support.appendChild(supportText);
+
+    const linkList = document.createElement('ul');
+    linkList.className = 'preflight-panel__support-links';
+
+    const browserItem = document.createElement('li');
+    const browserLink = document.createElement('a');
+    browserLink.href = 'https://webglreport.com/';
+    browserLink.target = '_blank';
+    browserLink.rel = 'noreferrer';
+    browserLink.textContent = 'Check supported browsers (WebGL report)';
+    browserItem.appendChild(browserLink);
+    linkList.appendChild(browserItem);
+
+    const fallbackItem = document.createElement('li');
+    const fallbackLink = document.createElement('a');
+    fallbackLink.href = 'index.html?filters=capability:demoaudio';
+    fallbackLink.textContent = 'Browse demo-audio toys';
+    fallbackItem.appendChild(fallbackLink);
+    linkList.appendChild(fallbackItem);
+
+    support.appendChild(linkList);
+    container.appendChild(support);
+  }
 }
 
 export function attachCapabilityPreflight({

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -443,7 +443,7 @@ function renderIssueList(
 
     const fallbackItem = document.createElement('li');
     const fallbackLink = document.createElement('a');
-    fallbackLink.href = 'index.html?filters=capability:demoaudio';
+    fallbackLink.href = 'index.html?filters=capability:demoAudio';
     fallbackLink.textContent = 'Browse demo-audio toys';
     fallbackItem.appendChild(fallbackLink);
     linkList.appendChild(fallbackItem);

--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -19,6 +19,14 @@ export const DEFAULT_QUALITY_PRESETS: QualityPreset[] = [
     particleScale: 0.65,
   },
   {
+    id: 'low-motion',
+    label: 'Low motion',
+    description: 'Reduce particle density and shimmer for calmer motion.',
+    maxPixelRatio: 1.5,
+    renderScale: 0.95,
+    particleScale: 0.5,
+  },
+  {
     id: 'balanced',
     label: 'Balanced (default)',
     description: 'Native look with capped DPI for most laptops and desktops.',
@@ -125,6 +133,7 @@ export class PersistentSettingsPanel {
   private description?: HTMLParagraphElement;
   private qualityRow?: HTMLDivElement;
   private qualitySelect?: HTMLSelectElement;
+  private qualityHint?: HTMLElement;
   private qualityPresets: QualityPreset[] = [];
   private qualityChangeHandler?: (preset: QualityPreset) => void;
   private sectionHost: HTMLDivElement;
@@ -198,6 +207,7 @@ export class PersistentSettingsPanel {
 
       const hint = document.createElement('small');
       hint.textContent = 'Adjust resolution and particle density.';
+      this.qualityHint = hint;
 
       text.append(label, hint);
 
@@ -225,6 +235,7 @@ export class PersistentSettingsPanel {
 
     const initialPreset = this.getInitialPreset(defaultPresetId);
     this.qualitySelect.value = initialPreset.id;
+    this.updateQualityHint(initialPreset);
 
     if (!hadActivePreset) {
       this.handleQualityChange(initialPreset.id);
@@ -318,7 +329,14 @@ export class PersistentSettingsPanel {
     activeQualityPreset = preset;
     activeQualityPresetStorageKey = this.qualityStorageKey;
     qualitySubscribers.forEach((subscriber) => subscriber(preset));
+    this.updateQualityHint(preset);
     this.qualityChangeHandler?.(preset);
+  }
+
+  private updateQualityHint(preset: QualityPreset) {
+    if (!this.qualityHint) return;
+    this.qualityHint.textContent =
+      preset.description ?? 'Adjust resolution and particle density.';
   }
 }
 

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -205,7 +205,11 @@ export function initAudioControls(
     errorMessage: string,
     onError?: (message: string) => void,
     successMessage?: string,
+    pendingMessage?: string,
   ) => {
+    if (pendingMessage) {
+      updateStatus(pendingMessage, 'success');
+    }
     setPending(button, true);
     try {
       await action();
@@ -235,6 +239,7 @@ export function initAudioControls(
         updateStatus(buildMicrophoneErrorMessage(message));
       },
       'Mic connected.',
+      'Starting microphone…',
     );
   });
 
@@ -248,6 +253,7 @@ export function initAudioControls(
       'Demo audio failed to load.',
       undefined,
       'Demo audio started.',
+      'Starting demo audio…',
     );
   });
 
@@ -273,6 +279,7 @@ export function initAudioControls(
       'Tab audio capture failed.',
       undefined,
       'Tab audio connected.',
+      'Starting tab audio…',
     );
   });
 


### PR DESCRIPTION
### Motivation
- Improve onboarding for users on unsupported or low-power devices by explaining why visuals may be blocked and offering clear fallbacks. 
- Surface a low-motion/low-cost quality preset and inline preset descriptions so users can choose performance tradeoffs without guessing. 
- Provide immediate UI feedback when starting microphone, demo, or tab audio so users see progress and clearer status when actions begin.

### Description
- Add a “Why this won’t run here” support block to the capability preflight panel with explanatory text and links to a WebGL report and demo-audio filter, implemented in `assets/js/core/capability-preflight.ts` and styled in `assets/css/base.css`.
- Introduce a `low-motion` quality preset and dynamic preset hint text in the performance settings panel, implemented in `assets/js/core/settings-panel.ts` by adding the preset to `DEFAULT_QUALITY_PRESETS` and showing the preset description inline.
- Enhance audio controls to show immediate "starting" status messages while requests are in flight by extending the `handleRequest` helper with an optional `pendingMessage` parameter in `assets/js/ui/audio-controls.ts` and wiring it for mic, demo, and tab audio actions.
- Update documentation to reflect delivered work by editing `README.md` (Roadmap) and `CHANGELOG.md` (Unreleased entries) to list the new preflight guidance, low-motion preset, and audio feedback.

### Testing
- Ran `bun run check` (which runs `biome check`, TypeScript `tsc`, and the test suite) and the command completed successfully. 
- Test results: ran 78 tests with `bun test`, yielding 76 passed, 2 skipped, and 0 failed. 
- Docs touched: `README.md` and `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697787d00b0c83329177a5fc8613c32e)