### PR TITLE
Improve nav and audio control polish

### DIFF
--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -15,7 +15,6 @@ export function initAudioControls(
   container: HTMLElement,
   options: AudioControlsOptions,
 ) {
-  const _doc = container.ownerDocument;
   const youtubeController = new YouTubeController();
   const STORAGE_KEY = 'stims-audio-source';
   const readStoredSource = () => {
@@ -142,6 +141,7 @@ export function initAudioControls(
     if (!(button instanceof HTMLElement)) return;
     button.toggleAttribute('data-loading', pending);
     button.setAttribute('aria-busy', pending ? 'true' : 'false');
+    button.setAttribute('aria-disabled', pending ? 'true' : 'false');
     if (button instanceof HTMLButtonElement) {
       button.disabled = pending;
     }
@@ -167,8 +167,9 @@ export function initAudioControls(
   };
 
   const buildMicrophoneErrorMessage = (message: string) => {
+    const helperText = 'Use demo audio to keep exploring.';
     if (!message) {
-      return 'Microphone access failed. Use demo audio to keep exploring.';
+      return `Microphone access failed. ${helperText}`;
     }
 
     if (/demo audio/i.test(message)) {
@@ -176,10 +177,10 @@ export function initAudioControls(
     }
 
     if (/microphone|audio/i.test(message)) {
-      return `${message} Use demo audio to keep exploring.`;
+      return `${message} ${helperText}`;
     }
 
-    return `${message} Use demo audio to keep exploring.`;
+    return `${message} ${helperText}`;
   };
 
   const preferDemoAudio =
@@ -301,6 +302,7 @@ function setupYouTubeLogic(
   updateStatus: (msg: string, v?: 'success' | 'error') => void,
   onSuccess?: () => void,
 ) {
+  const doc = container.ownerDocument;
   const input = container.querySelector('#youtube-url') as HTMLInputElement;
   const loadBtn = container.querySelector('#load-youtube');
   const useBtn = container.querySelector(
@@ -339,10 +341,12 @@ function setupYouTubeLogic(
     recentContainer.hidden = false;
     recentList.innerHTML = '';
     recent.forEach((v) => {
-      const chip = document.createElement('button');
+      const chip = doc.createElement('button');
       chip.className = 'control-panel__chip';
       chip.textContent = v.id;
       chip.title = `Load video ${v.id}`;
+      chip.type = 'button';
+      chip.setAttribute('aria-label', `Load video ${v.id}`);
       chip.addEventListener('click', () => {
         input.value = `https://www.youtube.com/watch?v=${v.id}`;
         loadVideo(v.id);
@@ -355,7 +359,7 @@ function setupYouTubeLogic(
     try {
       playerContainer.hidden = false;
       youtubeReady = false;
-      updateStatus('Loading player...', 'success');
+      updateStatus('Loading player…', 'success');
       await controller.loadVideo('youtube-player', id, (state) => {
         if (state === 1) {
           // Playing

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -35,7 +35,7 @@ export function initNavigation(container: HTMLElement, options: NavOptions) {
 
 function renderLibraryNav(container: HTMLElement, _doc: Document) {
   container.innerHTML = `
-    <nav class="top-nav" data-top-nav>
+    <nav class="top-nav" data-top-nav aria-label="Primary">
       <div class="brand">
         <span class="brand-mark"></span>
         <div class="brand-copy">
@@ -46,7 +46,7 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
       <div class="nav-actions">
         <a class="nav-link" href="#toy-list">Library</a>
         <a class="nav-link" href="https://github.com/zz-plant/stims" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <button id="theme-toggle" class="theme-toggle" aria-pressed="false" aria-label="Switch to dark mode">
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" aria-label="Switch to dark mode">
           <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
           <span class="theme-toggle__label" data-theme-label>Dark mode</span>
         </button>
@@ -256,6 +256,7 @@ function renderRendererStatus(
 }
 
 function setupThemeToggle(container: HTMLElement) {
+  const doc = container.ownerDocument;
   const toggle = container.querySelector('#theme-toggle');
   if (!toggle) return;
 
@@ -274,26 +275,26 @@ function setupThemeToggle(container: HTMLElement) {
   };
 
   // Initial state
-  const currentTheme = document.documentElement.classList.contains('light')
-    ? 'light'
-    : 'dark';
+  const root = doc.documentElement;
+  const currentTheme = root.classList.contains('light') ? 'light' : 'dark';
   updateUI(currentTheme);
 
   toggle.addEventListener('click', () => {
-    const isLight = document.documentElement.classList.contains('light');
+    const isLight = root.classList.contains('light');
     const nextTheme = isLight ? 'dark' : 'light';
+    const win = doc.defaultView ?? window;
 
     // Use the global helper if available
-    if (window.__stimsTheme) {
-      window.__stimsTheme.applyTheme(nextTheme, true);
+    if (win.__stimsTheme) {
+      win.__stimsTheme.applyTheme(nextTheme, true);
     } else {
       if (nextTheme === 'light') {
-        document.documentElement.classList.add('light');
+        root.classList.add('light');
       } else {
-        document.documentElement.classList.remove('light');
+        root.classList.remove('light');
       }
       try {
-        localStorage.setItem('theme', nextTheme);
+        win.localStorage.setItem('theme', nextTheme);
       } catch (_error) {
         // Ignore storage errors.
       }


### PR DESCRIPTION
### Motivation
- Improve navigation accessibility and robustness by ensuring markup and theme toggling operate within the container document context.
- Make audio control UX clearer and more accessible by surfacing consistent status text and ARIA states while requests are pending or fail.
- Harden YouTube recent-item buttons so they are proper buttons with semantics and labels for assistive tech.

### Description
- Add `aria-label="Primary"` to the library nav and mark the theme toggle as `type="button"` to avoid implicit form behavior.
- Make theme toggle use the container `document`/`window` (`doc`/`win`) and the container `documentElement` (`root`) when reading or updating theme state and storage via `win.localStorage`.
- Add `aria-disabled` on pending control buttons and set `aria-busy` consistently while toggling `disabled` so assistive tech sees transient states.
- Consolidate microphone helper text into a `helperText` constant and update status copy, change the YouTube recent chips to be created from `doc.createElement`, set `type="button"`, and add `aria-label` to each chip, and tweak a status string to use an ellipsis glyph.

### Testing
- Ran `bun run check` which runs Biome lint/format, TypeScript (`tsc --noEmit`), and the test suite; the check completed successfully.
- Test summary: `76` passed, `2` skipped, `0` failed across the test suite. 
- Docs touched: None
- Docs added: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979725534f0833298be46550da2efd1)