### PR TITLE
Add architecture diagrams to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ Use these entry points to find the right docs quickly:
 
 If you add new scripts, toys, or deployment options, update the relevant doc above so the workflows stay discoverable.
 
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+  Entry[HTML shells<br/>toy.html, brand.html...] --> Loader[loader.ts]
+  Loader --> Router[router.ts]
+  Loader --> Views[toy-view.ts<br/>library-view.js]
+  Loader --> Manifest[manifest-client.ts]
+  Manifest --> ToyModule[assets/js/toys/<slug>.ts]
+  ToyModule --> WebToy[core/web-toy.ts]
+  WebToy --> Renderer[render-service.ts]
+  WebToy --> Audio[audio-service.ts]
+```
+
+```mermaid
+flowchart TD
+  Settings[settings-panel.ts<br/>iframe-quality-sync.ts] --> WebToy[core/web-toy.ts]
+  WebToy --> Loop[animation-loop.ts]
+  WebToy --> Scene[scene-setup.ts]
+  WebToy --> Camera[camera-setup.ts]
+  WebToy --> Lighting[lighting-setup.ts]
+  WebToy --> Renderer[render-service.ts<br/>pooled renderer]
+  WebToy --> Audio[audio-service.ts<br/>pooled microphone]
+```
+
 ### When to update docs
 
 | Change type                   | Docs to touch                                                                 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,27 @@ This folder contains resources for contributors who are building or maintaining 
 
 If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.
 
+## Architecture quick diagrams
+
+```mermaid
+flowchart LR
+  Entry[HTML entry points] --> Loader[loader + router]
+  Loader --> Views[UI views]
+  Loader --> Manifest[manifest client]
+  Manifest --> Toys[Toy modules]
+  Toys --> Core[core/web-toy.ts]
+  Core --> Services[render + audio pools]
+```
+
+```mermaid
+flowchart TD
+  Prewarm[prewarmMicrophone + renderer probe] --> Loader[loader.ts]
+  Loader --> ViewState[toy-view.ts]
+  Loader --> Import[dynamic import]
+  Import --> Start[start()/default export]
+  Start --> Cleanup[dispose + release pools]
+```
+
 ## How to add a new guide
 
 1. Create the Markdown file under `docs/` with a clear title and a short purpose statement in the first paragraph.


### PR DESCRIPTION
### Motivation
- Surface a compact, visual overview of the app loader/runtime and core services so contributors can quickly understand module flow, pooling, and lifecycle responsibilities.

### Description
- Add Mermaid architecture diagrams to the root `README.md` (new "Architecture at a glance" section) and to `docs/README.md` (new "Architecture quick diagrams" section); files changed: `README.md`, `docs/README.md`.

### Testing
- Pre-commit hooks executed `biome lint` and `biome format` during the commit and reported no fixes needed, and no unit or integration tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697999715f688332bdd962617cd2f3f1)