### PR TITLE
Add Pocket Pulse stim and improve stim creation guide

### DIFF
--- a/assets/js/toys-data.js
+++ b/assets/js/toys-data.js
@@ -139,6 +139,19 @@ export default [
     featuredRank: 7,
   }),
   withAudio({
+    slug: 'pocket-pulse',
+    title: 'Pocket Pulse',
+    description:
+      'A mobile-optimized pulse field that responds to audio and touch gestures.',
+    module: 'assets/js/toys/pocket-pulse.ts',
+    type: 'module',
+    requiresWebGPU: false,
+    lifecycleStage: 'prototype',
+    moods: ['uplifting', 'focus', 'minimal'],
+    tags: ['mobile', 'pulses', 'touch'],
+    controls: ['Quality presets', 'Touch drift'],
+  }),
+  withAudio({
     slug: 'cosmic-particles',
     title: 'Cosmic Particles',
     description:

--- a/assets/js/toys/pocket-pulse.ts
+++ b/assets/js/toys/pocket-pulse.ts
@@ -1,0 +1,203 @@
+import * as THREE from 'three';
+import {
+  DEFAULT_QUALITY_PRESETS,
+  type QualityPreset,
+} from '../core/settings-panel';
+import type { ToyRuntimeInstance } from '../core/toy-runtime';
+import { getBandAverage } from '../utils/audio-bands';
+import { getWeightedAverageFrequency } from '../utils/audio-handler';
+import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
+import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
+import {
+  configureToySettingsPanel,
+  createRendererQualityManager,
+} from '../utils/toy-settings';
+
+const MOBILE_QUALITY_PRESET: QualityPreset = {
+  id: 'mobile',
+  label: 'Mobile saver',
+  description: 'Reduced pixel density and fewer particles for handheld GPUs.',
+  maxPixelRatio: 1.15,
+  renderScale: 0.85,
+  particleScale: 0.6,
+};
+
+const QUALITY_PRESETS: QualityPreset[] = [
+  MOBILE_QUALITY_PRESET,
+  ...DEFAULT_QUALITY_PRESETS,
+];
+
+const isCompactDevice = () => {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return (
+    window.matchMedia('(max-width: 720px)').matches ||
+    window.matchMedia('(pointer: coarse)').matches
+  );
+};
+
+export function start({ container }: { container?: HTMLElement | null } = {}) {
+  const quality = createRendererQualityManager({
+    presets: QUALITY_PRESETS,
+    defaultPresetId: isCompactDevice() ? 'mobile' : 'balanced',
+    storageKey: 'stims:pocket-pulse:quality',
+    getRuntime: () => runtime,
+    onChange: () => {
+      rebuildField();
+    },
+  });
+
+  let runtime: ToyRuntimeInstance;
+  let points: THREE.Points | null = null;
+  let geometry: THREE.BufferGeometry | null = null;
+  let material: THREE.PointsMaterial | null = null;
+  let basePositions: Float32Array | null = null;
+  let activeSize = 0.65;
+
+  const palette = {
+    background: new THREE.Color('#050611'),
+    baseHue: 0.62,
+    saturation: 0.7,
+  };
+
+  function getFieldConfig() {
+    const scale = quality.activeQuality.particleScale ?? 1;
+    const count = Math.max(90, Math.round(260 * scale));
+    const radius = 8 + 6 * Math.max(0.7, scale);
+    const depth = 18 + 8 * Math.max(0.6, scale);
+    const size = 0.45 + 0.3 * Math.max(0.7, scale);
+    return { count, radius, depth, size };
+  }
+
+  function disposeField() {
+    if (points) {
+      runtime.toy.scene.remove(points);
+    }
+    points = null;
+    disposeGeometry(geometry);
+    disposeMaterial(material);
+    geometry = null;
+    material = null;
+    basePositions = null;
+  }
+
+  function rebuildField() {
+    disposeField();
+    const { count, radius, depth, size } = getFieldConfig();
+    activeSize = size;
+
+    geometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(count * 3);
+
+    for (let i = 0; i < count; i += 1) {
+      const angle = (i / count) * Math.PI * 2;
+      const ring = 0.35 + Math.random() * 0.65;
+      const offset = Math.random() * 2 - 1;
+      const orbitRadius = radius * ring + offset;
+
+      positions[i * 3] = Math.cos(angle) * orbitRadius;
+      positions[i * 3 + 1] = Math.sin(angle) * orbitRadius;
+      positions[i * 3 + 2] = (Math.random() - 0.5) * depth;
+    }
+
+    basePositions = positions.slice();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+    material = new THREE.PointsMaterial({
+      color: new THREE.Color().setHSL(palette.baseHue, palette.saturation, 0.6),
+      size,
+      transparent: true,
+      opacity: 0.8,
+      depthWrite: false,
+    });
+
+    points = new THREE.Points(geometry, material);
+    runtime.toy.scene.add(points);
+  }
+
+  function animate(
+    data: Uint8Array,
+    time: number,
+    input: { normalizedCentroid: { x: number; y: number } } | null,
+  ) {
+    if (!geometry || !basePositions || !material || !points) return;
+
+    const avg = getWeightedAverageFrequency(data) / 255;
+    const bass = getBandAverage(data, 0, 0.28) / 255;
+    const mids = getBandAverage(data, 0.28, 0.7) / 255;
+    const treble = getBandAverage(data, 0.7, 1) / 255;
+    const pulse = 0.8 + bass * 1.1;
+    const swirl = time * (0.35 + mids * 0.4);
+
+    const offsetX = (input?.normalizedCentroid.x ?? 0) * 5.5;
+    const offsetY = (input?.normalizedCentroid.y ?? 0) * 4.2;
+
+    const positionAttribute = geometry.getAttribute(
+      'position',
+    ) as THREE.BufferAttribute;
+    const positions = positionAttribute.array as Float32Array;
+
+    for (let i = 0; i < basePositions.length; i += 3) {
+      const baseX = basePositions[i];
+      const baseY = basePositions[i + 1];
+      const baseZ = basePositions[i + 2];
+      const wobble =
+        Math.sin(swirl + baseZ * 0.08 + baseX * 0.04) * (0.6 + treble);
+      const lift = Math.cos(swirl * 0.7 + baseY * 0.05) * (0.4 + mids);
+
+      positions[i] = baseX * pulse + offsetX + wobble;
+      positions[i + 1] = baseY * pulse + offsetY + lift;
+      positions[i + 2] = baseZ + Math.sin(time * 0.6 + baseX * 0.06) * 1.6;
+    }
+
+    positionAttribute.needsUpdate = true;
+
+    const hue = (palette.baseHue + avg * 0.2 + time * 0.02) % 1;
+    material.color.setHSL(hue, palette.saturation, 0.55 + avg * 0.25);
+    material.opacity = 0.6 + avg * 0.35;
+    material.size = activeSize * (0.7 + treble * 0.8);
+
+    points.rotation.z = time * 0.12;
+  }
+
+  function setupSettingsPanel() {
+    configureToySettingsPanel({
+      title: 'Pocket Pulse',
+      description: 'Mobile-tuned pulses that drift with touch and audio.',
+      quality,
+    });
+  }
+
+  const startRuntime = createToyRuntimeStarter({
+    toyOptions: {
+      cameraOptions: { position: { x: 0, y: 0, z: 24 } },
+      sceneOptions: { background: palette.background },
+      rendererOptions: {
+        maxPixelRatio: quality.activeQuality.maxPixelRatio,
+        renderScale: quality.activeQuality.renderScale,
+      },
+    },
+    audio: { fftSize: 256 },
+    input: { touchAction: 'manipulation' },
+    plugins: [
+      {
+        name: 'pocket-pulse',
+        setup: () => {
+          setupSettingsPanel();
+          rebuildField();
+        },
+        update: ({ frequencyData, time, input }) => {
+          animate(frequencyData, time, input);
+        },
+        dispose: () => {
+          disposeField();
+        },
+      },
+    ],
+  });
+
+  runtime = startRuntime({ container });
+
+  return () => {
+    runtime.dispose();
+  };
+}

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -28,6 +28,23 @@ Treat toys like live game content and keep their status explicit in metadata:
 
 Use this sequence when you want to stand up a fresh toy quickly (you can also run `bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test` to automate steps 1–3):
 
+### Add a new stim (step-by-step)
+
+Use the scaffold script whenever possible; it wires up metadata, docs, and optional tests for you. If you prefer manual edits, follow the checklist below and keep the file paths aligned.
+
+1. **Pick a slug**: choose a short, kebab-case slug (for example `pocket-pulse`) that will become the `toy.html?toy=<slug>` route.
+2. **Scaffold the module** (recommended):
+   ```bash
+   bun run scripts/scaffold-toy.ts --slug pocket-pulse --title "Pocket Pulse" --type module --with-test
+   ```
+   The script creates `assets/js/toys/<slug>.ts`, appends the metadata entry in `assets/js/toys-data.js`, updates `docs/TOY_SCRIPT_INDEX.md`, and generates a minimal test in `tests/`.
+3. **Manual alternative** (if you skipped the scaffold):
+   - Create `assets/js/toys/<slug>.ts` and export `start({ container, canvas?, audioContext? })`.
+   - Add the entry to `assets/js/toys-data.js` (include `title`, `description`, `module`, `type`, and any `lifecycleStage` metadata).
+   - Add the slug row to `docs/TOY_SCRIPT_INDEX.md` so the loader docs stay in sync.
+   - Create `toys/<slug>.html` only if the toy uses a standalone page.
+4. **Verify locally**: run `bun run dev` and load `http://localhost:5173/toy.html?toy=<slug>` to confirm the new card loads, starts audio, and cleans up on exit.
+
 1. **Create a module** in `assets/js/toys/<slug>.ts` using the starter template below. Export `start({ container, canvas?, audioContext? })`. Use `container` to scope your DOM operations (settings panels, etc.) and `WebToy` to handle the canvas and resize logic within that container.
 2. **Register the slug** in `assets/js/toys-data.js` with a short title/description. Set `requiresWebGPU` or `allowWebGLFallback` if you depend on WebGPU features. The scaffold script validates that metadata entries live under `assets/js/toys/` and that slugs remain unique.
 3. **Create entry points**: module-based toys use `toy.html?toy=<slug>`; page-backed toys also need an HTML page (`toys/<slug>.html`). The scaffold script writes a starter page if one does not already exist.

--- a/docs/TOY_SCRIPT_INDEX.md
+++ b/docs/TOY_SCRIPT_INDEX.md
@@ -20,6 +20,7 @@ This index maps each toy slug to the module that powers it and how the experienc
 | `symph`                    | `assets/js/toys/symph.ts`                    | Standalone page launcher for `toys/symph.html`.                   |
 | `cube-wave`                | `assets/js/toys/cube-wave.ts`                | Direct module; load with `toy.html?toy=cube-wave`.                |
 | `bubble-harmonics`         | `assets/js/toys/bubble-harmonics.ts`         | Direct module; load with `toy.html?toy=bubble-harmonics`.         |
+| `pocket-pulse`             | `assets/js/toys/pocket-pulse.ts`             | Direct module; load with `toy.html?toy=pocket-pulse`.             |
 | `cosmic-particles`         | `assets/js/toys/cosmic-particles.ts`         | Direct module; load with `toy.html?toy=cosmic-particles`.         |
 | `lights`                   | `assets/js/toys/lights.ts`                   | Standalone page launcher for `toys/lights.html`.                  |
 | `spiral-burst`             | `assets/js/toys/spiral-burst.ts`             | Direct module; load with `toy.html?toy=spiral-burst`.             |

--- a/tests/pocket-pulse.test.ts
+++ b/tests/pocket-pulse.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test';
+import { start } from '../assets/js/toys/pocket-pulse.ts';
+
+describe('pocket-pulse toy module', () => {
+  test('exports a start function', () => {
+    expect(typeof start).toBe('function');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a mobile-optimized, touch-aware audio-reactive stim with a low-cost quality preset for handheld devices.
- Make it easier and less error-prone to add new stims by documenting a clear step-by-step scaffolding and manual-registration workflow.

### Description
- Add `assets/js/toys/pocket-pulse.ts`, a module implementing a mobile-tuned pulse field with touch input, audio reactivity, and a `mobile` `QualityPreset` that lowers `maxPixelRatio`, `renderScale`, and `particleScale`.
- Register the toy in the registry by adding a `pocket-pulse` entry to `assets/js/toys-data.js` and add the slug to `docs/TOY_SCRIPT_INDEX.md` so the loader docs stay in sync.
- Add a minimal Bun spec `tests/pocket-pulse.test.ts` that asserts the module exports `start`.
- Improve developer docs by adding an explicit `Add a new stim (step-by-step)` section to `docs/TOY_DEVELOPMENT.md` describing how to use the scaffold (`bun run scripts/scaffold-toy.ts`) or perform manual registration and local verification.

### Testing
- Ran `biome lint assets scripts tests`, which completed successfully.
- Ran `biome format --write assets scripts tests`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69799ca7b938833297822648347b2b9b)