### PR TITLE
Declutter mobile layouts

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -596,7 +596,8 @@ body {
   .active-toy-nav {
     flex-direction: column;
     align-items: flex-start;
-    gap: 10px;
+    gap: 8px;
+    padding: 10px 12px;
   }
 
   .active-toy-nav__actions {
@@ -618,6 +619,37 @@ body {
     width: 100%;
     justify-content: center;
   }
+
+  .control-panel {
+    left: max(12px, env(safe-area-inset-left));
+    right: max(12px, env(safe-area-inset-right));
+    width: auto;
+    padding: 12px;
+    clip-path: none;
+    border-radius: 18px;
+  }
+
+  .control-panel::after {
+    clip-path: none;
+  }
+
+  .control-panel__row {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 0;
+  }
+
+  .control-panel__value {
+    min-width: auto;
+    text-align: left;
+  }
+
+  .control-panel__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
 }
 
 @media (max-width: 520px) {
@@ -626,12 +658,42 @@ body {
     align-items: stretch;
   }
 
+  .active-toy-nav {
+    top: calc(env(safe-area-inset-top) + 8px);
+    width: calc(100% - 20px);
+    padding: 8px 10px;
+    border-radius: 14px;
+  }
+
+  .active-toy-nav__eyebrow {
+    font-size: 0.7rem;
+  }
+
+  .active-toy-nav__title {
+    font-size: 0.95rem;
+  }
+
   .renderer-status {
     width: 100%;
   }
 
   .renderer-pill__detail {
     max-width: 100%;
+  }
+
+  .control-panel {
+    padding: 10px;
+  }
+
+  .control-panel__actions--inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-panel__mode {
+    flex: 1 1 auto;
+    padding: 6px 10px;
+    font-size: 0.8rem;
   }
 }
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2401,7 +2401,7 @@ footer {
 
 @media (max-width: 680px) {
   section.intro {
-    padding: 1.6rem 1.4rem;
+    padding: 1.4rem 1.2rem;
     border-radius: 18px;
   }
 
@@ -2420,7 +2420,7 @@ footer {
   }
 
   .hero-copy {
-    gap: 0.65rem;
+    gap: 0.5rem;
   }
 
   .search-row {
@@ -2457,7 +2457,7 @@ footer {
 
   .preview-controls {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
   }
 
   .preview-control-buttons {
@@ -2467,7 +2467,7 @@ footer {
 
   .preview-dots {
     width: 100%;
-    justify-content: center;
+    justify-content: space-between;
   }
 
   .system-grid {
@@ -2475,17 +2475,36 @@ footer {
   }
 
   .cta-helper {
-    margin: 0 0 1.2rem;
+    margin: 0 0 1rem;
+  }
+
+  .hero-readiness {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-readiness__text,
+  .hero-readiness__action {
+    width: 100%;
+    justify-content: center;
+  }
+
+  header.hero {
+    min-height: auto;
+  }
+
+  .preview-track {
+    min-height: 240px;
   }
 }
 
 @media (max-width: 768px) {
   h1 {
-    font-size: 2rem;
+    font-size: 1.9rem;
   }
 
   .content {
-    gap: 1.8rem;
+    gap: 1.5rem;
   }
 
   .webtoy-container {
@@ -2495,7 +2514,7 @@ footer {
   .top-nav {
     position: sticky;
     top: calc(env(safe-area-inset-top) + 0.4rem);
-    border-radius: 14px;
+    border-radius: 12px;
   }
 
   .hero-grid {
@@ -2514,7 +2533,7 @@ footer {
 @media (max-width: 520px) {
   .content {
     --content-padding: clamp(1rem, 4vw, 1.4rem);
-    gap: 1.5rem;
+    gap: 1.25rem;
   }
 
   .brand {
@@ -2525,13 +2544,13 @@ footer {
   .nav-actions {
     width: 100%;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.6rem;
   }
 
   .top-nav {
-    padding: 0.85rem;
-    border-radius: 16px;
+    padding: 0.7rem;
+    border-radius: 12px;
   }
 
   .nav-link {
@@ -2551,13 +2570,14 @@ footer {
   .cta-row {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.6rem;
   }
 
   .cta-button {
     width: 100%;
     justify-content: center;
-    padding: 0.85rem 1rem;
-    font-size: 1rem;
+    padding: 0.75rem 0.95rem;
+    font-size: 0.95rem;
   }
 
   .signal-grid {
@@ -2565,10 +2585,34 @@ footer {
   }
 
   .section-heading h2 {
-    font-size: 1.65rem;
+    font-size: 1.5rem;
   }
 
   .section-description {
-    font-size: 0.98rem;
+    font-size: 0.92rem;
+  }
+
+  .search-field {
+    padding: 0.4rem 0.6rem;
+    gap: 0.4rem;
+  }
+
+  .search-field__icon {
+    width: 1.8rem;
+    height: 1.8rem;
+    font-size: 0.85rem;
+  }
+
+  .search-field input {
+    font-size: 0.9rem;
+    padding-right: 2.8rem;
+  }
+
+  .search-clear {
+    right: 0.35rem;
+  }
+
+  .hero-metric {
+    padding: 0.65rem 0.75rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce the visual footprint of the library and toy pages on small viewports by tightening spacing, reducing padding, and lowering some typographic sizes. 
- Make the toy navigation and control panel more compact so controls and previews fit without feeling cramped on narrow screens.

### Description
- Updated `assets/css/index.css` to reduce paddings, gaps, and font sizes across mobile breakpoints (notable edits in `@media (max-width: 680px)`, `@media (max-width: 768px)`, and `@media (max-width: 520px)`), including `section.intro`, `.hero-copy`, `.preview-controls`, `.preview-dots`, `.preview-track`, `.top-nav`, `.nav-actions`, `.cta-button`, and search field sizing. 
- Adjusted hero/layout spacing so readiness/preview areas stack and occupy less height on small screens. 
- Updated `assets/css/base.css` mobile rules to compact `.active-toy-nav` and `.control-panel` spacing and sizing, remove clip-path on the panel at small sizes, tighten `.control-panel__row` gaps/padding, stack actions, and shrink `.control-panel__mode` font/padding. 
- Kept changes scoped to small-screen media queries to avoid impacting desktop layouts.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully. 
- Ran `biome format --write assets scripts tests` which completed successfully. 
- Started the dev server with `bun run dev --host 0.0.0.0 --port 4173` and ran a Playwright script to capture mobile screenshots (library and toy pages at 390×844), which completed and produced screenshots as artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979a7eb5ba48332add6f165e72c22e3)