### PR TITLE
Move mobile control panel overrides below base styles

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -592,111 +592,6 @@ body {
   pointer-events: none;
 }
 
-@media (max-width: 720px) {
-  .active-toy-nav {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 10px 12px;
-  }
-
-  .active-toy-nav__actions {
-    width: 100%;
-  }
-
-  .toy-nav__share-wrapper,
-  .toy-nav__pip-wrapper {
-    width: 100%;
-    justify-items: stretch;
-  }
-
-  .toy-nav__share,
-  .toy-nav__pip {
-    width: 100%;
-  }
-
-  .toy-nav__back {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .control-panel {
-    left: max(12px, env(safe-area-inset-left));
-    right: max(12px, env(safe-area-inset-right));
-    width: auto;
-    padding: 12px;
-    clip-path: none;
-    border-radius: 18px;
-  }
-
-  .control-panel::after {
-    clip-path: none;
-  }
-
-  .control-panel__row {
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 6px 0;
-  }
-
-  .control-panel__value {
-    min-width: auto;
-    text-align: left;
-  }
-
-  .control-panel__actions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 6px;
-  }
-}
-
-@media (max-width: 520px) {
-  .active-toy-nav__actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .active-toy-nav {
-    top: calc(env(safe-area-inset-top) + 8px);
-    width: calc(100% - 20px);
-    padding: 8px 10px;
-    border-radius: 14px;
-  }
-
-  .active-toy-nav__eyebrow {
-    font-size: 0.7rem;
-  }
-
-  .active-toy-nav__title {
-    font-size: 0.95rem;
-  }
-
-  .renderer-status {
-    width: 100%;
-  }
-
-  .renderer-pill__detail {
-    max-width: 100%;
-  }
-
-  .control-panel {
-    padding: 10px;
-  }
-
-  .control-panel__actions--inline {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .control-panel__mode {
-    flex: 1 1 auto;
-    padding: 6px 10px;
-    font-size: 0.8rem;
-  }
-}
-
 .rendering-overlay {
   position: fixed;
   inset: 0;
@@ -1369,6 +1264,111 @@ body {
   box-shadow:
     0 0 18px rgba(255, 0, 153, 0.4),
     0 0 10px rgba(111, 247, 255, 0.35);
+}
+
+@media (max-width: 720px) {
+  .active-toy-nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .active-toy-nav__actions {
+    width: 100%;
+  }
+
+  .toy-nav__share-wrapper,
+  .toy-nav__pip-wrapper {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .toy-nav__share,
+  .toy-nav__pip {
+    width: 100%;
+  }
+
+  .toy-nav__back {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .control-panel {
+    left: max(12px, env(safe-area-inset-left));
+    right: max(12px, env(safe-area-inset-right));
+    width: auto;
+    padding: 12px;
+    clip-path: none;
+    border-radius: 18px;
+  }
+
+  .control-panel::after {
+    clip-path: none;
+  }
+
+  .control-panel__row {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 0;
+  }
+
+  .control-panel__value {
+    min-width: auto;
+    text-align: left;
+  }
+
+  .control-panel__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 520px) {
+  .active-toy-nav__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .active-toy-nav {
+    top: calc(env(safe-area-inset-top) + 8px);
+    width: calc(100% - 20px);
+    padding: 8px 10px;
+    border-radius: 14px;
+  }
+
+  .active-toy-nav__eyebrow {
+    font-size: 0.7rem;
+  }
+
+  .active-toy-nav__title {
+    font-size: 0.95rem;
+  }
+
+  .renderer-status {
+    width: 100%;
+  }
+
+  .renderer-pill__detail {
+    max-width: 100%;
+  }
+
+  .control-panel {
+    padding: 10px;
+  }
+
+  .control-panel__actions--inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-panel__mode {
+    flex: 1 1 auto;
+    padding: 6px 10px;
+    font-size: 0.8rem;
+  }
 }
 
 .cta-button[data-loading="true"] {


### PR DESCRIPTION
### Motivation
- Mobile-specific sizing and `clip-path` for `.control-panel` were being overridden by a later base `.control-panel` rule with the same specificity, preventing intended mobile decluttering.
- Move the small-screen overrides so they appear after the base control-panel styles so the mobile rules take effect without changing specificity.

### Description
- Relocated the `@media (max-width: 720px)` and `@media (max-width: 520px)` blocks that adjust navigation and `.control-panel` layout to immediately follow the control-panel base definitions in `assets/css/base.css`.
- Kept the same rules (left/right/sizing/padding/clip-path and related layout changes) but changed ordering so mobile overrides win.
- No other style or behavioral changes were introduced beyond reordering.

### Testing
- Ran `biome lint assets scripts tests` and it completed successfully.
- Ran `biome format --write assets scripts tests` and it completed successfully.
- Executed an automated Playwright capture of a mobile (700×900) viewport which produced `artifacts/control-panel-mobile.png` for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979baa0bcec8332bd8c828b226a5290)