### PR TITLE
Refresh library hero and clarify toy & system control copy

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -430,47 +430,26 @@ section.intro > * {
   z-index: 1;
 }
 
-.launch-panel {
+.editorial-panel {
   margin: 1.35rem 0 0.85rem;
-  padding: 1rem 1.15rem;
-  border-radius: var(--radius-lg);
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
   background:
-    var(--surface-highlight), var(--surface-texture),
-    linear-gradient(
-      140deg,
-      rgba(12, 18, 32, 0.92) 0%,
-      rgba(18, 24, 40, 0.92) 100%
-    );
+    var(--surface-highlight), var(--surface-texture), rgba(15, 23, 42, 0.5);
   border: 1px solid
-    color-mix(in srgb, var(--accent-color) 18%, var(--surface-border));
+    color-mix(in srgb, var(--accent-color) 16%, var(--surface-border));
   box-shadow: var(--shadow-soft);
   display: grid;
-  gap: 0.85rem;
-  max-width: 580px;
-  backdrop-filter: blur(10px) saturate(1.1);
+  gap: 0.4rem;
+  max-width: 560px;
 }
 
-html.light .launch-panel {
+html.light .editorial-panel {
   background:
-    var(--surface-highlight), var(--surface-texture),
-    linear-gradient(
-      140deg,
-      rgba(255, 255, 255, 0.92) 0%,
-      rgba(236, 242, 252, 0.92) 100%
-    );
-  border: 1px solid
-    color-mix(in srgb, var(--accent-color) 22%, var(--surface-border));
+    var(--surface-highlight), var(--surface-texture), rgba(255, 255, 255, 0.7);
 }
 
-.launch-panel__header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem 1.5rem;
-}
-
-.launch-panel__eyebrow {
+.editorial-panel__eyebrow {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.16em;
@@ -479,72 +458,17 @@ html.light .launch-panel {
   font-weight: 600;
 }
 
-.launch-panel__status {
+.editorial-panel__title {
   margin: 0;
+  font-size: 1.1rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
 }
 
-.launch-meter {
-  position: relative;
-  height: 10px;
-  border-radius: var(--radius-pill);
-  background: rgba(7, 11, 20, 0.75);
-  overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
-
-.launch-meter__bar {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--accent-color) 80%, #ffffff 10%),
-    color-mix(in srgb, var(--accent-magenta) 70%, #ffffff 10%)
-  );
-  opacity: 0.85;
-}
-
-.launch-meter__pulse {
-  position: absolute;
-  top: -8px;
-  left: -20%;
-  width: 35%;
-  height: 26px;
-  border-radius: 999px;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.8) 0%,
-    rgba(255, 255, 255, 0.1) 60%,
-    transparent 100%
-  );
-  animation: launchSweep 3.6s ease-in-out infinite;
-  opacity: 0.7;
-  mix-blend-mode: screen;
-}
-
-.launch-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.launch-badge {
-  padding: 0.4rem 0.75rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.06);
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--text-color);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .launch-meter__pulse {
-    animation: none;
-    opacity: 0.3;
-  }
+.editorial-panel__copy {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+  font-size: 0.95rem;
 }
 
 header.hero {
@@ -1215,45 +1139,29 @@ header.hero {
   padding: 0.55rem 1.1rem;
 }
 
-.hero-metrics {
+.editorial-notes {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 0.85rem;
-  margin: 0.65rem 0 1.35rem;
+  margin: 0.75rem 0 1.35rem;
   padding: 0;
+  list-style: none;
 }
 
-.hero-metric {
+.editorial-notes li {
   margin: 0;
   padding: 0.85rem 1rem;
-  border-radius: 10px;
-  background: linear-gradient(
-    140deg,
-    rgba(59, 130, 246, 0.08) 0%,
-    rgba(15, 23, 42, 0.4) 70%
-  );
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.35);
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-soft);
-}
-
-html.light .hero-metric {
-  background: rgba(255, 255, 255, 0.7);
-}
-
-.hero-metric dt {
-  margin: 0 0 0.35rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--text-muted);
-}
-
-.hero-metric dd {
-  margin: 0;
   font-size: 0.95rem;
   line-height: 1.45;
   color: var(--text-color);
+}
+
+html.light .editorial-notes li {
+  background: rgba(255, 255, 255, 0.65);
 }
 
 .cta-helper {
@@ -1412,44 +1320,6 @@ body[data-details-open] .readiness-note {
 
 .cta-button::after {
   content: none;
-}
-
-@keyframes launchSweep {
-  0% {
-    transform: translateX(-30%);
-    opacity: 0;
-  }
-  30% {
-    opacity: 0.75;
-  }
-  100% {
-    transform: translateX(360%);
-    opacity: 0;
-  }
-}
-
-.hero-highlights {
-  margin: 0.5rem 0 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.highlight-chip {
-  background: var(--card-bg);
-  border-radius: var(--radius-pill);
-  padding: 0.65rem 0.9rem;
-  border: 1px solid var(--surface-border);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--text-color);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
-  font-weight: 600;
-}
-
-.highlight-chip span {
-  font-size: 1.05rem;
 }
 
 @keyframes hueShift {
@@ -2405,18 +2275,9 @@ footer {
     border-radius: 18px;
   }
 
-  .launch-panel {
+  .editorial-panel {
     max-width: none;
-    padding: 0.95rem 1rem;
-  }
-
-  .launch-panel__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .launch-badge {
-    flex: 1 1 140px;
+    padding: 0.9rem 1rem;
   }
 
   .hero-copy {
@@ -2610,9 +2471,5 @@ footer {
 
   .search-clear {
     right: 0.35rem;
-  }
-
-  .hero-metric {
-    padding: 0.65rem 0.75rem;
   }
 }

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -35,21 +35,21 @@ export function initAudioControls(
   container.className = 'control-panel';
   container.innerHTML = `
     <p class="control-panel__description">
-      Choose an audio source to drive the visuals.
+      Choose how this toy listens.
     </p>
     <div class="control-panel__row">
       <div class="control-panel__text">
-        <span class="control-panel__label">Microphone</span>
+        <span class="control-panel__label">Live mic</span>
       </div>
       <button id="start-audio-btn" class="cta-button primary" type="button">
-        Use microphone
+        Start mic
       </button>
     </div>
     <div class="control-panel__row">
       <div class="control-panel__text">
-        <span class="control-panel__label">Demo audio</span>
+        <span class="control-panel__label">Curated demo</span>
       </div>
-      <button id="use-demo-audio" class="cta-button" type="button">Use demo audio</button>
+      <button id="use-demo-audio" class="cta-button" type="button">Play demo</button>
     </div>
 
     ${
@@ -57,7 +57,7 @@ export function initAudioControls(
         ? `
     <div class="control-panel__row">
       <div class="control-panel__text">
-        <span class="control-panel__label">Tab audio</span>
+        <span class="control-panel__label">Tab capture</span>
         <span class="control-panel__info-wrap">
           <button
             class="control-panel__info"
@@ -67,12 +67,12 @@ export function initAudioControls(
             More info
           </button>
           <span id="tab-audio-info" class="control-panel__info-text">
-            Capture audio from the current browser tab. In the picker, choose “This tab” and
-            enable Share audio.
+            Capture sound from the current tab. In the picker, choose “This tab” and enable
+            Share audio.
           </span>
         </span>
       </div>
-      <button id="use-tab-audio" class="cta-button" type="button">Capture tab audio</button>
+      <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
     </div>
     `
         : ''
@@ -83,7 +83,7 @@ export function initAudioControls(
         ? `
     <div class="control-panel__row control-panel__row--stacked">
       <div class="control-panel__text">
-        <span class="control-panel__label">YouTube audio</span>
+        <span class="control-panel__label">YouTube capture</span>
         <span class="control-panel__info-wrap">
           <button
             class="control-panel__info"
@@ -93,8 +93,8 @@ export function initAudioControls(
             More info
           </button>
           <span id="youtube-audio-info" class="control-panel__info-text">
-            Paste a link, load the video, then start capture. In the picker, choose “This tab” and
-            enable Share audio.
+            Paste a link, load it, then capture. In the picker, choose “This tab” and enable
+            Share audio.
           </span>
         </span>
       </div>
@@ -104,11 +104,11 @@ export function initAudioControls(
           id="youtube-url"
           class="control-panel__input"
           type="url"
-          placeholder="https://www.youtube.com/watch?v=..."
+          placeholder="https://youtube.com/watch?v=..."
           autocomplete="off"
           inputmode="url"
         />
-        <button id="load-youtube" class="cta-button" type="button">Load video</button>
+        <button id="load-youtube" class="cta-button" type="button">Load</button>
       </div>
       <div id="recent-youtube" class="control-panel__recent" hidden>
         <span class="control-panel__label small">Recent</span>
@@ -116,7 +116,7 @@ export function initAudioControls(
       </div>
       <div class="control-panel__actions control-panel__actions--inline">
         <button id="use-youtube-audio" class="cta-button" type="button">
-          Use YouTube audio
+          Capture YouTube
         </button>
       </div>
       <div id="youtube-player-container" class="control-panel__embed" hidden>
@@ -167,7 +167,7 @@ export function initAudioControls(
   };
 
   const buildMicrophoneErrorMessage = (message: string) => {
-    const helperText = 'Use demo audio to keep exploring.';
+    const helperText = 'Use the demo track to keep moving.';
     if (!message) {
       return `Microphone access failed. ${helperText}`;
     }

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -63,8 +63,8 @@ export function initSystemControls(
   options: SystemControlOptions = {},
 ) {
   const {
-    title = 'Performance & compatibility',
-    description = 'Adjust visual fidelity, GPU mode, and motion preferences. Changes persist for this device.',
+    title = 'Performance controls',
+    description = 'Tune visuals, renderer mode, and motion settings for this device.',
     qualityPresets = DEFAULT_QUALITY_PRESETS,
     defaultPresetId = 'balanced',
     variant = 'floating',
@@ -89,9 +89,8 @@ export function initSystemControls(
   });
 
   panel.addToggle({
-    label: 'Compatibility mode (force WebGL)',
-    description:
-      'Disable WebGPU and favor the most compatible renderer for older hardware.',
+    label: 'Compatibility mode (WebGL)',
+    description: 'Favor the most compatible renderer for older hardware.',
     defaultValue: renderPreferences.compatibilityMode,
     onChange: (value) => {
       setCompatibilityMode(value);
@@ -99,8 +98,8 @@ export function initSystemControls(
   });
 
   panel.addToggle({
-    label: 'Allow motion input',
-    description: 'Enable device tilt controls for toys that support motion.',
+    label: 'Enable motion input',
+    description: 'Allow device tilt controls on toys that support motion.',
     defaultValue: getActiveMotionPreference().enabled,
     onChange: (value) => {
       setMotionPreference({ enabled: value });
@@ -109,7 +108,7 @@ export function initSystemControls(
 
   const resolutionRow = panel.addSection(
     'Resolution scale',
-    'Lower values reduce GPU load; higher values sharpen details.',
+    'Lower values ease GPU load; higher values sharpen detail.',
   );
   const resolutionValue = createValueLabel('');
   const resolutionSlider = document.createElement('input');
@@ -134,8 +133,8 @@ export function initSystemControls(
   resolutionRow.append(resolutionSlider, resolutionValue);
 
   const pixelRatioRow = panel.addSection(
-    'Max pixel ratio',
-    'Caps the effective DPI to balance clarity and thermal load.',
+    'Pixel ratio cap',
+    'Caps effective DPI to balance clarity and thermal load.',
   );
   const pixelRatioValue = createValueLabel('');
   const pixelRatioSlider = document.createElement('input');
@@ -163,7 +162,7 @@ export function initSystemControls(
   const resetButton = document.createElement('button');
   resetButton.type = 'button';
   resetButton.className = 'cta-button ghost';
-  resetButton.textContent = 'Reset overrides to preset';
+  resetButton.textContent = 'Reset to preset';
   resetButton.addEventListener('click', () => {
     clearRenderOverrides();
     const preset = getActiveQualityPreset({

--- a/index.html
+++ b/index.html
@@ -85,13 +85,21 @@
           </p>
           <h1>Stim library.</h1>
           <p class="section-description">
-            A curated gallery of light and motion synced to sound, touch, and
-            movement.
+            A carefully edited library of light and motion, tuned for sound,
+            touch, and momentum.
           </p>
           <p class="intro-tagline">
-            Shape your focus with soft gradients, steady rhythm, and tactile
-            controls tuned for flow.
+            Stay in flow with calm gradients, steady rhythm, and tactile controls
+            that respond without friction.
           </p>
+          <div class="editorial-panel" aria-label="Editor’s cue">
+            <p class="editorial-panel__eyebrow">Editor’s cue</p>
+            <p class="editorial-panel__title">Start with Halo Flow.</p>
+            <p class="editorial-panel__copy">
+              A soft, circular study that listens to your mic or demo audio and
+              responds with slow, luminous motion.
+            </p>
+          </div>
           <a
             href="#system-check"
             class="text-link details-toggle"
@@ -102,21 +110,6 @@
             <span data-details-label="open">Learn more</span>
             <span data-details-label="close">Hide details</span>
           </a>
-        </div>
-        <div class="launch-panel" aria-label="Launch sequence status">
-          <div class="launch-panel__header">
-            <p class="launch-panel__eyebrow">Quick start status</p>
-            <p class="launch-panel__status">Ready • Live checks running</p>
-          </div>
-          <div class="launch-meter" role="presentation">
-            <span class="launch-meter__bar" aria-hidden="true"></span>
-            <span class="launch-meter__pulse" aria-hidden="true"></span>
-          </div>
-          <div class="launch-badges">
-            <span class="launch-badge">Mic optional</span>
-            <span class="launch-badge">Visuals active</span>
-            <span class="launch-badge">Controls available</span>
-          </div>
         </div>
         <div class="cta-row hero-cta-row">
           <a
@@ -134,7 +127,7 @@
           >
             Use demo audio
           </a>
-          <a href="#toy-list" class="cta-button ghost">Library</a>
+          <a href="#toy-list" class="cta-button ghost">Browse library</a>
           <a
             href="https://github.com/zz-plant/stims"
             target="_blank"
@@ -155,38 +148,21 @@
             Adjust performance
           </a>
         </div>
-        <div class="hero-highlights" aria-label="Creative highlights">
-          <div class="highlight-chip">
-            <span>Immersive palettes</span>
-          </div>
-          <div class="highlight-chip">
-            <span>Gesture-first play</span>
-          </div>
-          <div class="highlight-chip">
-            <span>Calm by design</span>
-          </div>
-        </div>
-        <dl class="hero-metrics">
-          <div class="hero-metric">
-            <dt>Responsive light</dt>
-            <dd>Breathes with live input or curated demo sound.</dd>
-          </div>
-          <div class="hero-metric">
-            <dt>Touch + motion</dt>
-            <dd>Gesture-driven controls for hands-on, embodied play.</dd>
-          </div>
-          <div class="hero-metric">
-            <dt>Open-source</dt>
-            <dd>Crafted in public with gentle, inviting defaults.</dd>
-          </div>
-        </dl>
+        <ul class="editorial-notes" aria-label="Editorial notes">
+          <li>
+            Responsive visuals that breathe with live input or curated demo
+            sound.
+          </li>
+          <li>Gesture-first controls that stay clear and steady.</li>
+          <li>Open-source work crafted in public, with inviting defaults.</li>
+        </ul>
         <div class="intro-details details-panel" data-details-panel id="intro-details">
           <p class="section-description">
-            A curated set of responsive visuals built for flow state, clarity, and
-            calm. Audio input options and performance controls live in the toy panel.
+            A condensed collection of responsive visuals tuned for clarity and calm.
+            Audio inputs and performance controls live inside each toy.
           </p>
           <p class="cta-helper">
-            No account required. Mic access enables live audio.
+            No account required. Mic access unlocks live audio response.
           </p>
         </div>
       </section>

--- a/toy.html
+++ b/toy.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta
       name="description"
-      content="Play a responsive, audio-reactive visual toy. Tune visuals, audio inputs, and performance settings in one immersive canvas."
+      content="Launch a responsive visual toy with curated audio options and focused performance controls."
     />
     <meta name="theme-color" content="#0b0f1a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <title>Web Toy</title>
+    <title>Stim Webtoy</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
@@ -165,7 +165,7 @@
       };
 
       attachCapabilityPreflight({
-        heading: 'Capability check',
+        heading: 'Quick check',
         backHref: 'index.html',
         onComplete: (result) => {
           if (result.canProceed) {


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the library hero by replacing decorative launch widgets with a compact editorial cue and readable notes so users have a clearer entry point. 
- Make audio and performance control labels more direct and calmer so toy pages read as focused launching surfaces for live or demo audio. 

### Description
- Reworked library hero: replaced the previous launch panel with an `editorial-panel` and added an `editorial-notes` list, revised hero copy, and changed the CTA to `Browse library` (updated `index.html` and `assets/css/index.css`).
- Simplified and restyled CSS to support the new `editorial-panel` and `editorial-notes`, removed several decorative launch elements/animations, and adjusted responsive spacing (updated `assets/css/index.css`).
- Refined toy audio UI copy and affordances: updated labels and buttons for microphone, demo, tab, and YouTube capture (e.g. `Live mic` / `Start mic`, `Curated demo` / `Play demo`, `Tab capture`, `YouTube capture`), shortened placeholders/buttons, and tuned helper text (updated `assets/js/ui/audio-controls.ts`).
- Clarified system/performance controls copy and labels including the panel title, toggles, section labels, and reset button text (updated `assets/js/ui/system-controls.ts`).
- Updated toy page metadata and preflight heading for clearer launch language (updated `toy.html`).

### Testing
- Ran `bun run check` which runs `biome check`, TypeScript (`tsc`), and the test suite; all automated checks passed with 78 tests passing, 2 skipped, and 0 failures.
- `biome lint assets scripts tests` completed successfully as part of pre-commit hooks.
- `biome format --write assets scripts tests` ran and confirmed formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979bbf403f08332a99aca433a78c09e)