### PR TITLE
Add Why people use section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ See the [Deployment Guide](./docs/DEPLOYMENT.md) for build, preview, static host
 
 ## Getting Started
 
+### Why people use Stim Webtoys
+
+- **Self-regulation moments**: settle into a repeatable rhythm of sound + visuals without claiming a specific outcome.
+- **Instant sensory input**: open a toy and play—no gear or setup required beyond a browser.
+- **Clear control surfaces**: adjust intensity with the shared settings panel and its [performance/quality presets](./docs/DEVELOPMENT.md#performance-tips).
+- **Fallback audio**: switch to demo audio when mic access is hard or you just want to listen.
+- **Short, contained sessions**: jump in for a few minutes and return whenever you want.
+
 ### What You’ll Need
 
 - **A Modern Web Browser**: Any browser with WebGL should work (think Chrome, Firefox, Edge).


### PR DESCRIPTION
### Motivation
- Surface a short, low-friction explanation near Getting Started that highlights AuDHD-relevant, non-medical outcomes like self-regulation, instant sensory input, clear controls, fallback demo audio, and short sessions.

### Description
- Add a new `Why people use Stim Webtoys` subsection under `Getting Started` in `README.md` containing five concise bullets and a link to the shared performance/quality presets at `./docs/DEVELOPMENT.md#performance-tips`.

### Testing
- Run `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c48d146883328866e46ba30645c8)