### PR TITLE
Expand literature feature mapping

### DIFF
--- a/docs/LITERATURE.md
+++ b/docs/LITERATURE.md
@@ -1,0 +1,64 @@
+# Scientific literature reference map
+
+This guide collects published scientific literature that can serve as grounding references for the **Stim Webtoys Library** positioning: interactive, audio-reactive visuals for playful sensory stimulation and exploration, with particular relevance to neurodiverse audiences. Use these references when documenting the rationale for audio-visual mappings, multisensory experiences, or sensory processing considerations. It also links literature themes to product features so citations are specific rather than generic.
+
+## How to use this list
+
+- **Cite by claim**: pick references that directly support the user-facing statement you are making (e.g., audio-visual binding, crossmodal correspondences, sensory processing differences).
+- **Avoid medical claims**: unless there is a direct study matching the exact claim, keep language descriptive (e.g., "audio-reactive visuals" or "sensory exploration") rather than therapeutic.
+- **Prefer review papers** when summarizing broader phenomena; use primary studies for specific phenomena.
+- **Connect to a feature**: each citation should point to a concrete UI or toy behavior (see the mapping below).
+
+## Feature-to-literature map
+
+Use the following table to tie literature to specific features so citations are meaningful and traceable.
+
+| Feature or behavior | UI surface | Recommended literature focus |
+| --- | --- | --- |
+| Audio-reactive visuals (frequency to motion/color mapping) | Toy descriptions, audio onboarding copy | Multisensory integration & audio-visual binding; crossmodal correspondences |
+| “Synesthetic” or linked audio-visual patterns | Toy description for synesthetic-themed visuals | Crossmodal correspondences & synesthesia-related perception |
+| Sensory exploration language (non-therapeutic) | Library landing copy, toy overview cards | Sensory processing differences in neurodiversity (framed as diversity, not treatment) |
+| Music-driven engagement/affect | Demo audio option, descriptions referencing musical response | Music, rhythm, and affective engagement |
+
+## UI citation/footnote guidance
+
+If the UI references scientific grounding, use lightweight footnotes so users can inspect sources without cluttering the interface.
+
+- **Footnote trigger**: Only add citations when a claim implies scientific backing (e.g., “audio-visual binding,” “crossmodal mapping,” or “sensory processing diversity”). Avoid citations for purely aesthetic language.
+- **Placement**: Prefer a footnote marker in the toy description block, settings tooltip, or info panel. If a toy has a “Learn more” link, put citations there instead of inline.
+- **Format**: Use numeric footnotes with a short bibliography in the same UI panel or a linked “Sources” drawer. Keep them readable on mobile.
+- **Linking**: Use DOI links when available; otherwise link to the publisher or journal landing page.
+
+## Multisensory integration & audio-visual binding
+
+These sources describe how auditory and visual stimuli are combined, perceived, and bound in human perception—useful for explaining audio-reactive visuals.
+
+- Stein, B. E., & Meredith, M. A. (1993). *The Merging of the Senses*. MIT Press.
+- Shams, L., Kamitani, Y., & Shimojo, S. (2000). What you see is what you hear. *Nature*, 408(6814), 788.
+- Spence, C. (2011). Crossmodal correspondences: A tutorial review. *Attention, Perception, & Psychophysics*, 73(4), 971–995.
+
+## Crossmodal correspondences & synesthesia-related perception
+
+Relevant when describing systematic mappings between audio properties (pitch, timbre, rhythm) and visual properties (color, motion, spatial position).
+
+- Marks, L. E. (1978). *The Unity of the Senses*. Academic Press.
+- Ward, J. (2008). *The Frog Who Croaked Blue: Synesthesia and the Mixing of the Senses*. Routledge.
+
+## Sensory processing differences in neurodiversity
+
+These references cover sensory modulation and processing differences commonly discussed in neurodiversity research. Use when talking about sensory experience diversity or accessibility.
+
+- Ben-Sasson, A., et al. (2009). A meta-analysis of sensory modulation symptoms in individuals with autism spectrum disorders. *Journal of Autism and Developmental Disorders*, 39, 1–11.
+- Baranek, G. T. (2002). Efficacy of sensory and motor interventions for children with autism. *Journal of Autism and Developmental Disorders*, 32(5), 397–422.
+
+## Music, rhythm, and affective engagement
+
+If describing how rhythmic or musical inputs shape engagement or emotional response, these sources provide grounding.
+
+- Thaut, M. H. (2005). *Rhythm, Music, and the Brain*. Routledge.
+- Juslin, P. N., & Västfjäll, D. (2008). Emotional responses to music: The need to consider underlying mechanisms. *Behavioral and Brain Sciences*, 31(5), 559–621.
+
+## Notes on scope
+
+- This list is not exhaustive; it is a starter set aligned with the current positioning of the library.
+- Add new references as new claims or toy mechanics emerge (e.g., motion coupling, haptic feedback, or attention effects).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains resources for contributors who are building or maintaining 
 - [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): map from each toy/visualizer to the JS/TS entry points it uses.
 - [`stim-assessment.md`](./stim-assessment.md): Assessment findings and remediation plans.
 - [`stim-user-critiques.md`](./stim-user-critiques.md): user-standpoint critiques for each toy to guide UX polish and onboarding.
+- [`LITERATURE.md`](./LITERATURE.md): published scientific literature that can ground audio-visual and sensory experience claims.
 - [`QA_PLAN.md`](./QA_PLAN.md): coverage for the highest-impact flows and the automation that protects them.
 - [`toys.md`](./toys.md): per-toy notes, presets, and other focused references.
 - [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md): page-level specifications for the library landing and toy shell, including data, layout, and accessibility expectations.


### PR DESCRIPTION
### Motivation

- Provide more actionable connections between the literature and concrete product features so citations are specific and traceable.
- Surface lightweight UI guidance for when and where to show scientific citations without cluttering the interface.

### Description

- Add a feature-to-literature mapping table and a "Connect to a feature" note in `docs/LITERATURE.md` linking features to UI surfaces and recommended literature focus.
- Add a new "UI citation/footnote guidance" section in `docs/LITERATURE.md` describing when to show footnotes, placement, format, and linking preferences.
- Update `docs/README.md` to include `LITERATURE.md` in the docs index.

### Testing

- Ran `biome lint assets scripts tests`, which completed with no errors.
- Ran `biome format --write assets scripts tests`, which applied no changes and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c4bc62148332907d07b7944412fa)