### PR TITLE
Update README toy list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,21 +105,18 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [3D Toy](./toy.html?toy=3dtoy)                            | A twisting 3D tunnel that responds to sound.                                          |
 | [Aurora Painter](./toy.html?toy=aurora-painter)           | Paint flowing aurora ribbons that react to your microphone in layered waves.          |
-| [Star Guitar Visualizer](./toy.html?toy=brand)            | Visuals inspired by an iconic music video, synced to your music.                      |
 | [Pottery Wheel Sculptor](./toy.html?toy=clay)             | Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.          |
-| [Defrag Visualizer](./toy.html?toy=defrag)                | A nostalgic, sound-reactive visualizer evoking old defragmentation screens.           |
 | [Evolutionary Weirdcore](./toy.html?toy=evol)             | Watch surreal landscapes evolve with fractals and glitches that react to music.       |
-| [Geometry Visualizer](./toy.html?toy=geom)                | Push shifting geometric forms directly from live mic input with responsive controls.  |
+| [Microphone Geometry Visualizer](./toy.html?toy=geom)     | Push shifting geometric forms directly from live mic input with responsive controls.  |
 | [Halo Visualizer](./toy.html?toy=holy)                    | Layered halos, particles, and shapes that respond to your music.                      |
 | [Multi-Capability Visualizer](./toy.html?toy=multi)       | Shapes and lights move with both sound and device motion. (Requires WebGPU.)          |
 | [Synesthetic Visualizer](./toy.html?toy=seary)            | Blend audio and visuals into linked patterns.                                         |
-| [Pattern Recognition Visualizer](./toy.html?toy=sgpat)    | See patterns form dynamically in response to sound.                                   |
 | [Terminal Word Grid](./toy.html?toy=legible)              | A retro green text grid that pulses to audio and surfaces fresh words as you play.    |
-| [SVG + Three.js Visualizer](./toy.html?toy=svgtest)       | A hybrid visualizer blending 2D and 3D elements, reacting in real time.               |
 | [Spectrograph](./toy.html?toy=symph)                     | A spectrograph that moves gently with your audio.                                     |
-| [Interactive Word Cloud](./toy.html?toy=words)            | Speak and watch the word cloud react and shift with your voice.                       |
 | [Grid Visualizer](./toy.html?toy=cube-wave)               | Swap between cube waves and bouncing spheres without stopping the music.              |
 | [Bubble Harmonics](./toy.html?toy=bubble-harmonics)       | Translucent, audio-inflated bubbles that split into harmonics on high frequencies.    |
+| [Pocket Pulse](./toy.html?toy=pocket-pulse)               | A mobile-optimized pulse field that responds to audio and touch gestures.             |
+| [Mobile Ripples](./toy.html?toy=mobile-ripples)           | Low-power neon ripples tuned for touch-first screens and pocket GPUs.                 |
 | [Cosmic Particles](./toy.html?toy=cosmic-particles)       | Jump between orbiting swirls and nebula fly-throughs with a single toggle.            |
 | [Audio Light Show](./toy.html?toy=lights)                 | Swap shader styles and color palettes while lights ripple with your microphone input. |
 | [Spiral Burst](./toy.html?toy=spiral-burst)               | Colorful spirals rotate and expand with every beat.                                   |
@@ -128,6 +125,8 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 | [Fractal Kite Garden](./toy.html?toy=fractal-kite-garden) | Grow branching kite fractals that sway with mids and shimmer with crisp highs.        |
 | [Tactile Sand Table](./toy.html?toy=tactile-sand-table)   | Heightfield sand ripples that respond to bass, mids, and device tilt.                 |
 | [Bioluminescent Tidepools](./toy.html?toy=bioluminescent-tidepools) | Sketch glowing currents that bloom with high-frequency sparkle from your music. |
+| [Neon Wave](./toy.html?toy=neon-wave)                     | Retro-wave visualizer with bloom effects, custom shaders, and four color themes.      |
+| [MilkDrop Proto](./toy.html?toy=milkdrop)                 | A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system.   |
 
 ---
 


### PR DESCRIPTION
### Motivation
- Keep the public README in sync with the current toy lineup and metadata in the codebase so contributors and readers see an accurate catalog.
- Surface newer mobile- and prototype-focused toys and remove stale or unlisted entries to reduce confusion during discovery.

### Description
- Updated the `Toys in the Collection` table in `README.md` to reflect the current library lineup and ordering. 
- Added mobile/prototype entries: `Pocket Pulse`, `Mobile Ripples`, `Neon Wave`, and `MilkDrop Proto`, and renamed `Geometry Visualizer` to `Microphone Geometry Visualizer` to match `assets/js/toys-data.js`.
- Removed outdated/unpublished entries from the list (several legacy items were omitted) and adjusted descriptions to match current toy titles.

### Testing
- Ran `biome lint assets scripts tests`, which completed with no lint errors.
- Ran `biome format --write assets scripts tests`, which formatted files as needed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c71b45c88332b12fe5eeb92bb061)