### PR TITLE
Improve repo discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil
 - 📘 **Docs hub**: [`docs/README.md`](./docs/README.md)
 - 🧰 **Contribute**: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 
+**Discover & share**
+- ⭐ **Star the repo** if the toys help you focus, unwind, or explore sound-reactive visuals.
+- 🔗 **Share the live site** in newsletters, playlists, or “cool web experiments” lists: https://no.toil.fyi
+- 🏷️ **Suggested topics/keywords** for GitHub lists and search: `threejs`, `webgl`, `audio-reactive`, `web-audio`, `creative-coding`, `interactive-art`, `visualizer`, `browser-toys`, `neurodiversity`, `accessibility`.
+
 For setup, testing, and contribution details, see [CONTRIBUTING.md](./CONTRIBUTING.md). If you're building or updating toys, the developer docs in [`docs/`](./docs) cover common workflows and patterns. If you’re using the Model Context Protocol server in [`scripts/mcp-server.ts`](./scripts/mcp-server.ts), see the dedicated guide in [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md).
 
 Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what’s new, what changed, and what’s coming next.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,19 @@
   "version": "1.0.0",
   "type": "module",
   "packageManager": "bun@1.2.14",
+  "keywords": [
+    "threejs",
+    "webgl",
+    "audio-reactive",
+    "web-audio",
+    "creative-coding",
+    "interactive-art",
+    "visualizer",
+    "browser-toys",
+    "generative",
+    "accessibility",
+    "neurodiversity"
+  ],
   "scripts": {
     "test": "bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json",
     "test:watch": "bun test --watch --preload=./tests/setup.ts --importmap=./tests/importmap.json",


### PR DESCRIPTION
### Motivation
- Encourage more users to find, star, and share the project by surfacing sharing guidance and search-friendly keywords.

### Description
- Add a new “Discover & share” section to `README.md` with a star/share call-to-action and suggested topics/keywords for GitHub lists and social sharing.
- Add a `keywords` array to `package.json` containing terms like `threejs`, `webgl`, `audio-reactive`, `web-audio`, `creative-coding`, `interactive-art`, `visualizer`, `accessibility`, and `neurodiversity` to improve repository search signals.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully with no issues.
- Ran `biome format --write assets scripts tests` which completed successfully and applied no changes.
- Files touched: `README.md` and `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979db415fd083328698950d93c21226)