### PR TITLE
Refine feature card grid layouts

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2131,17 +2131,34 @@ footer {
   margin-top: 1rem;
 }
 
+.feature-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
 .feature-card {
   background: var(--surface-gradient);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
   padding: 1rem;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.85rem;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  align-items: flex-start;
   box-shadow: var(--shadow-soft);
   backdrop-filter: none;
+}
+
+.feature-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
 }
 
 .feature-icon {
@@ -2232,10 +2249,6 @@ footer {
 
   .preview-track {
     min-height: 320px;
-  }
-
-  .feature-card {
-    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Fix visual layout and accessibility issues where mood/tag/toy detail lists rendered with inconsistent column flow and default list bullets, producing cramped or awkward feature cards.

### Description
- Add a new `.feature-card-grid` rule to normalize the feature collections into a consistent responsive grid with `minmax(220px, 1fr)` columns.
- Convert `.feature-card` from a two-column grid into a vertical card (`display: flex; flex-direction: column`) to improve spacing and readability.
- Reset list styles inside cards with `.feature-card ul { list-style: none; padding: 0; margin: 0; }` to remove bullets and tidy internal lists.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully.
- Ran `biome format --write assets scripts tests` which completed successfully.
- Started the dev server and captured a visual snapshot with Playwright (artifact: `artifacts/moods-grid.png`) to verify the mood/tag grid rendering visually.
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa19f304c83328abe89b5c3a6e75a)