### PR TITLE
Refine navigation look and feel

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -167,6 +167,11 @@ h6 {
   text-wrap: balance;
 }
 
+section,
+footer {
+  scroll-margin-top: 6rem;
+}
+
 .content {
   position: relative;
   z-index: 1;
@@ -283,7 +288,62 @@ h6 {
 .nav-actions {
   display: flex;
   align-items: center;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.nav-section {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.nav-section__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding: 0 0.35rem;
+}
+
+.nav-section--jump {
+  padding: 0.2rem 0.35rem;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface-highlight) 70%, transparent);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--surface-emboss);
+}
+
+.nav-section--utilities {
+  display: flex;
+  align-items: center;
   gap: 0.65rem;
+  flex-wrap: wrap;
+  padding: 0.2rem 0.35rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--surface-highlight) 35%, transparent);
+}
+
+.nav-link--section {
+  font-size: 0.85rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--surface-highlight) 35%, transparent);
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.nav-link--section.is-active,
+.nav-link--section[aria-current="location"] {
+  border-color: color-mix(in srgb, var(--accent-color) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 18%, var(--card-bg));
+  box-shadow: 0 0 16px color-mix(in srgb, var(--accent-color) 25%, transparent);
 }
 
 .nav-link {
@@ -2105,6 +2165,16 @@ footer {
   justify-items: center;
 }
 
+.footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  margin: 0.1rem 0 0.35rem;
+}
+
 .footer-cta-row {
   margin: 0.5rem 0 0;
   justify-content: center;
@@ -2417,9 +2487,26 @@ footer {
 
   .nav-actions {
     width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     gap: 0.6rem;
+  }
+
+  .nav-section {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .nav-section--utilities {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.6rem;
+  }
+
+  .nav-section__label {
+    width: 100%;
+    padding: 0 0.5rem;
   }
 
   .top-nav {
@@ -2430,6 +2517,10 @@ footer {
   .nav-link {
     justify-content: flex-start;
     padding: 0.65rem 0.85rem;
+  }
+
+  .nav-link--section {
+    justify-content: flex-start;
   }
 
   .nav-link {

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -63,12 +63,22 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
         </div>
       </div>
       <div class="nav-actions">
-        <a class="nav-link" href="#toy-list">Library</a>
-        <a class="nav-link" href="https://github.com/zz-plant/stims" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" aria-label="Switch to dark mode">
-          <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
-          <span class="theme-toggle__label" data-theme-label>Dark mode</span>
-        </button>
+        <div class="nav-section nav-section--jump" aria-label="Jump to">
+          <span class="nav-section__label">Jump</span>
+          <a class="nav-link nav-link--section" data-section-link href="#intro">Intro</a>
+          <a class="nav-link nav-link--section" data-section-link href="#system-check">System check</a>
+          <a class="nav-link nav-link--section" data-section-link href="#library">Library</a>
+          <a class="nav-link nav-link--section" data-section-link href="#site-footer">Connect</a>
+        </div>
+        <div class="nav-section nav-section--utilities" aria-label="Utilities">
+          <span class="nav-section__label">Utilities</span>
+          <a class="nav-link" href="#toy-list">Browse</a>
+          <a class="nav-link" href="https://github.com/zz-plant/stims" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" aria-label="Switch to dark mode">
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+            <span class="theme-toggle__label" data-theme-label>Dark mode</span>
+          </button>
+        </div>
       </div>
     </nav>
   `;

--- a/assets/js/utils/init-nav-scroll.ts
+++ b/assets/js/utils/init-nav-scroll.ts
@@ -3,12 +3,55 @@ import { DATA_SELECTORS } from './data-attributes.ts';
 export const initNavScrollEffects = () => {
   const nav = document.querySelector(DATA_SELECTORS.topNav);
   if (!nav) return;
+  const sectionLinks = Array.from(
+    nav.querySelectorAll<HTMLAnchorElement>('[data-section-link]'),
+  )
+    .map((link) => {
+      const href = link.getAttribute('href') ?? '';
+      const targetId = href.startsWith('#') ? href.slice(1) : '';
+      if (!targetId) return null;
+      const section = document.getElementById(targetId);
+      if (!section) return null;
+      return { link, section, id: targetId };
+    })
+    .filter(
+      (
+        entry,
+      ): entry is {
+        link: HTMLAnchorElement;
+        section: HTMLElement;
+        id: string;
+      } => Boolean(entry),
+    );
 
   let ticking = false;
+  const updateActiveSection = () => {
+    if (sectionLinks.length === 0) return;
+    const offset =
+      nav.getBoundingClientRect().height + (window.innerWidth <= 768 ? 40 : 56);
+    const scrollPosition = window.scrollY + offset;
+    let activeId = sectionLinks[0].id;
+    sectionLinks.forEach(({ section, id }) => {
+      if (section.offsetTop <= scrollPosition) {
+        activeId = id;
+      }
+    });
+    sectionLinks.forEach(({ link, id }) => {
+      const isActive = id === activeId;
+      link.classList.toggle('is-active', isActive);
+      if (isActive) {
+        link.setAttribute('aria-current', 'location');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  };
+
   const applyNavState = () => {
     ticking = false;
     const isScrolled = window.scrollY > 24;
     nav.classList.toggle('top-nav--scrolled', isScrolled);
+    updateActiveSection();
   };
 
   applyNavState();
@@ -22,4 +65,6 @@ export const initNavScrollEffects = () => {
     },
     { passive: true },
   );
+
+  window.addEventListener('resize', applyNavState);
 };

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <div class="content">
       <div data-top-nav-container></div>
 
-      <section class="intro">
+      <section class="intro" id="intro">
         <div class="section-heading">
           <p class="eyebrow">
             Sensory library • Audio-reactive visuals • Design-forward play
@@ -268,7 +268,7 @@
         </div>
       </section>
 
-      <section class="library">
+      <section class="library" id="library">
         <div class="section-heading">
           <p class="eyebrow">Library</p>
           <h2>Browse every stim</h2>
@@ -392,7 +392,7 @@
         <main id="toy-list" class="webtoy-container"></main>
       </section>
 
-      <footer>
+      <footer id="site-footer">
         <div class="footer-actions">
           <p>
             Curious about how these work?
@@ -404,6 +404,13 @@
             >
               Check out our open-source project.
             </a>
+          </p>
+          <p class="footer-nav">
+            <a href="#intro" class="text-link">Intro</a>
+            <span aria-hidden="true">·</span>
+            <a href="#system-check" class="text-link">System check</a>
+            <span aria-hidden="true">·</span>
+            <a href="#library" class="text-link">Library</a>
           </p>
           <div class="cta-row footer-cta-row">
             <a


### PR DESCRIPTION
### Motivation
- Improve wayfinding and visual cohesion in the top navigation so library sections are easier to scan and reach while keeping mobile layouts tidy.
- Surface quick footer links so users can easily navigate back to key page anchors.

### Description
- Add labeled nav groups to the library top bar by updating `renderLibraryNav` in `assets/js/ui/nav.ts` to include a `Jump` section and a `Utilities` section with explicit anchors and controls.
- Implement scroll-aware section highlighting by enhancing `assets/js/utils/init-nav-scroll.ts` to compute offsets, toggle `is-active`/`aria-current`, and respond to resize events.
- Polish navigation visuals and mobile layout in `assets/css/index.css` by adding `.nav-section`, `.nav-section__label`, improved chip backgrounds, hover/focus transitions, and responsive grid/flex rules for mobile.
- Add anchor IDs to important page sections and a footer quick-links row in `index.html` for reliable jump targets (`#intro`, `#library`, `#site-footer`).

### Testing
- Ran `bun run check` (which runs `biome` checks, `tsc`, and the test suite) and the test run completed successfully with `78 passed, 2 skipped, 0 failed`.
- Executed `bun test` as part of the check and observed the same test summary (`78 pass, 2 skip, 0 fail`).
- Started the dev server with `bun run dev` and captured a Playwright screenshot of the updated navigation as an automated smoke capture which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa9c0c29083329d9709e795294428)