### PR TITLE
Improve compatibility for older browsers

### DIFF
--- a/assets/js/utils/canvas-resize.ts
+++ b/assets/js/utils/canvas-resize.ts
@@ -69,15 +69,26 @@ export function setupCanvasResize(
   };
 
   resize();
-  const observer = new ResizeObserver(() => resize());
-  observer.observe(canvas.parentElement ?? canvas);
+  let resizeObserver: ResizeObserver | null = null;
+  const handleWindowResize = () => resize();
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => resize());
+    resizeObserver.observe(canvas.parentElement ?? canvas);
+  } else {
+    window.addEventListener('resize', handleWindowResize);
+    window.addEventListener('orientationchange', handleWindowResize);
+  }
 
   const visualViewport = window.visualViewport;
   visualViewport?.addEventListener('resize', resize);
   visualViewport?.addEventListener('scroll', resize);
 
   return () => {
-    observer.disconnect();
+    resizeObserver?.disconnect();
+    if (!resizeObserver) {
+      window.removeEventListener('resize', handleWindowResize);
+      window.removeEventListener('orientationchange', handleWindowResize);
+    }
     visualViewport?.removeEventListener('resize', resize);
     visualViewport?.removeEventListener('scroll', resize);
   };

--- a/assets/js/utils/init-preview-reels.ts
+++ b/assets/js/utils/init-preview-reels.ts
@@ -112,7 +112,7 @@ export const initPreviewReels = () => {
     setActive(activeIndex);
     updateToggleState();
 
-    prefersReducedMotion.addEventListener('change', () => {
+    const handleReducedMotionChange = () => {
       stopTimer();
       if (prefersReducedMotion.matches) {
         isAutoPlay = false;
@@ -120,7 +120,18 @@ export const initPreviewReels = () => {
         return;
       }
       if (isAutoPlay) startTimer();
-    });
+    };
+    const legacyMediaQueryList = prefersReducedMotion as MediaQueryList & {
+      addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+    };
+    if ('addEventListener' in prefersReducedMotion) {
+      prefersReducedMotion.addEventListener(
+        'change',
+        handleReducedMotionChange,
+      );
+    } else if (legacyMediaQueryList.addListener) {
+      legacyMediaQueryList.addListener(handleReducedMotionChange);
+    }
 
     if (prevButton) {
       prevButton.addEventListener('click', () => {

--- a/assets/js/utils/unified-input.ts
+++ b/assets/js/utils/unified-input.ts
@@ -151,10 +151,17 @@ export function createUnifiedInput({
     bounds = boundsSource.getBoundingClientRect();
   };
 
-  const resizeObserver = new ResizeObserver(() => {
-    updateBounds();
-  });
-  resizeObserver.observe(boundsSource);
+  let resizeObserver: ResizeObserver | null = null;
+  const handleWindowResize = () => updateBounds();
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      updateBounds();
+    });
+    resizeObserver.observe(boundsSource);
+  } else {
+    window.addEventListener('resize', handleWindowResize);
+    window.addEventListener('orientationchange', handleWindowResize);
+  }
 
   const updatePointerFromEvent = (event: PointerEvent) => {
     const normalized = normalizePoint(event.clientX, event.clientY, bounds);
@@ -545,7 +552,11 @@ export function createUnifiedInput({
     if (gamepadFrameId != null) {
       cancelAnimationFrame(gamepadFrameId);
     }
-    resizeObserver.disconnect();
+    resizeObserver?.disconnect();
+    if (!resizeObserver) {
+      window.removeEventListener('resize', handleWindowResize);
+      window.removeEventListener('orientationchange', handleWindowResize);
+    }
     target.removeEventListener('pointerdown', handlePointerDown);
     target.removeEventListener('pointermove', handlePointerMove);
     target.removeEventListener('pointerup', handlePointerUp);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "node",
     "strict": true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    target: 'es2020',
     // Emit the standard .vite/manifest.json so docs and tooling resolve assets
     // without custom paths.
     manifest: true,


### PR DESCRIPTION
### Motivation
- Provide runtime fallbacks for older browsers that lack modern web APIs like `ResizeObserver` and newer `MediaQueryList` event helpers.
- Keep reduced-motion and resize behaviors working on devices from ~2021 by using legacy-friendly listeners when needed.
- Produce broader build output compatibility by lowering the TypeScript and Vite targets to ES2020.

### Description
- Add a conditional `ResizeObserver` fallback that installs `window` `resize` and `orientationchange` handlers when `ResizeObserver` is unavailable in `assets/js/utils/unified-input.ts`.
- Add the same `ResizeObserver` fallback and cleanup to `assets/js/utils/canvas-resize.ts` so canvas sizing still responds on legacy browsers.
- Add a `MediaQueryList` legacy path in `assets/js/utils/init-preview-reels.ts` to call `addListener` when `addEventListener` isn't present, with a narrow type assertion to avoid TS errors.
- Lower compilation/output targets to `ES2020` by updating `tsconfig.json` (`target`) and `vite.config.js` (`build.target`) for broader 2021-era browser compatibility.

### Testing
- Ran `bun run check` (which runs Biome checks/formatting, `tsc --noEmit`, and the test suite) and it completed successfully with no errors.
- Type checking (`tsc --noEmit`) succeeded as part of `bun run check`.
- Unit tests via `bun test` completed with `78` passed, `2` skipped, and `0` failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c157202e48332a426606f435f4588)