### PR TITLE
Refine CTA and system panel styling

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -864,16 +864,16 @@ body {
 .control-panel__description {
   margin: 0 0 10px;
   font-size: 0.85rem;
-  color: rgba(245, 245, 245, 0.78);
+  color: rgba(245, 245, 245, 0.88);
 }
 
 .control-panel__row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin: 6px 0;
-  padding: 8px 0;
+  gap: 14px;
+  margin: 8px 0;
+  padding: 10px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
@@ -1021,7 +1021,7 @@ body {
 
 .control-panel__info-text {
   font-size: 0.85rem;
-  color: rgba(233, 251, 255, 0.75);
+  color: rgba(233, 251, 255, 0.85);
   opacity: 0;
   max-height: 0;
   overflow: hidden;
@@ -1039,7 +1039,7 @@ body {
 .control-panel__note {
   margin: 6px 0 0;
   font-size: 0.95rem;
-  color: rgba(233, 251, 255, 0.88);
+  color: rgba(233, 251, 255, 0.93);
 }
 
 .control-panel__value {
@@ -1113,15 +1113,17 @@ body {
 }
 
 .control-panel small {
-  color: rgba(245, 245, 245, 0.7);
+  color: rgba(245, 245, 245, 0.82);
   line-height: 1.3;
 }
 
 .control-panel input[type="checkbox"] {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   accent-color: #70f0ff;
   filter: drop-shadow(0 0 6px rgba(111, 247, 255, 0.5));
+  border: 1px solid rgba(111, 247, 255, 0.55);
+  border-radius: 6px;
   cursor: pointer;
 }
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -783,6 +783,7 @@ header.hero {
   clip-path: none;
   overflow: visible;
   border-radius: calc(var(--radius-lg) + 2px);
+  padding: 1.15rem 1.35rem;
 }
 
 .system-controls .control-panel__heading {
@@ -1190,13 +1191,24 @@ header.hero {
   color: var(--text-muted);
   padding: 0.35rem 0.75rem;
   border-radius: var(--radius-pill);
-  border: 1px solid var(--surface-border);
-  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 30%, var(--surface-border));
+  background: color-mix(in srgb, var(--card-bg) 82%, transparent);
+  box-shadow: var(--shadow-soft);
 }
 
 .hero-readiness__action {
   font-size: 0.95rem;
   padding: 0.55rem 1.1rem;
+}
+
+html.light .hero-readiness__text {
+  background: color-mix(in srgb, #ffffff 92%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 25%,
+    var(--surface-border)
+  );
 }
 
 .editorial-notes {
@@ -1336,6 +1348,22 @@ body[data-details-open] .readiness-note {
   box-shadow: var(--shadow-soft), var(--surface-emboss);
 }
 
+.cta-button--accent {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 45%,
+    var(--surface-border)
+  );
+  background: color-mix(in srgb, var(--accent-color) 14%, var(--card-bg));
+  color: var(--text-color);
+}
+
+.cta-button--muted {
+  border-color: color-mix(in srgb, var(--surface-border) 75%, transparent);
+  background: color-mix(in srgb, var(--card-bg) 75%, transparent);
+  color: color-mix(in srgb, var(--text-muted) 90%, var(--text-color));
+}
+
 .hero-cta-row .cta-button.primary {
   padding: 0.85rem 1.6rem;
   font-size: 1.05rem;
@@ -1368,8 +1396,23 @@ body[data-details-open] .readiness-note {
 
 .cta-button:hover {
   filter: none;
-  box-shadow: var(--shadow-strong);
+  transform: translateY(-2px);
+  box-shadow:
+    var(--shadow-strong),
+    0 0 0 1px rgba(255, 255, 255, 0.12);
   color: var(--text-color);
+}
+
+.cta-button.primary:hover {
+  color: #0b0f1a;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.3),
+    0 18px 32px rgba(15, 23, 42, 0.55),
+    0 0 26px var(--glow-color);
+}
+
+.hero-cta-row .cta-button.primary:hover {
+  transform: translateY(-2px) scale(1.01);
 }
 
 .cta-button:focus-visible {
@@ -1996,6 +2039,14 @@ html.light .experience-card {
   isolation: isolate;
 }
 
+html:not(.light) .webtoy-card {
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    var(--shadow-soft),
+    var(--surface-emboss);
+}
+
 .webtoy-card__link {
   color: inherit;
   text-decoration: none;
@@ -2178,6 +2229,22 @@ footer {
 .footer-cta-row {
   margin: 0.5rem 0 0;
   justify-content: center;
+}
+
+.footer-cta-row .cta-button {
+  box-shadow:
+    var(--shadow-soft),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.footer-cta-row .cta-button.ghost {
+  background:
+    var(--surface-texture), color-mix(in srgb, var(--card-bg) 88%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 25%,
+    var(--surface-border)
+  );
 }
 
 .footer-helper {

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           </a>
           <a
             href="toy.html?toy=holy"
-            class="cta-button ghost"
+            class="cta-button ghost cta-button--accent"
             data-quickstart-slug="holy"
             data-quickstart-mode="demo"
           >
@@ -132,7 +132,7 @@
             href="https://github.com/zz-plant/stims"
             target="_blank"
             rel="noopener noreferrer"
-            class="cta-button ghost"
+            class="cta-button ghost cta-button--muted"
             >View source</a
           >
         </div>


### PR DESCRIPTION
### Motivation
- Improve hero CTA hierarchy and visual feedback so primary and secondary actions read more clearly. 
- Make the hero readiness pill more legible and consistent across light/dark themes. 
- Increase contrast, spacing, and target sizes in the system controls panel for better readability and interaction. 
- Strengthen library card and footer CTA presentation to improve visual grouping and hover feedback.

### Description
- Updated markup in `index.html` to add `cta-button--accent` to the demo audio CTA and `cta-button--muted` to the "View source" link to enable new styling variants. 
- Modified `assets/css/index.css` to restyle the hero readiness chip, add `.cta-button--accent` and `.cta-button--muted` variants, improve CTA hover/active shadows and transforms, add light-mode readiness overrides, add footer CTA emphasis, and strengthen dark-mode library card borders. 
- Adjusted `assets/css/index.css` to add padding to `.system-controls .control-panel` for consistent spacing when rendered inline. 
- Tuned `assets/css/base.css` to increase control-panel contrast and spacing, raise informational text contrast, enlarge and visually improve checkbox toggles, and refine chip/info text colors for improved legibility.

### Testing
- Ran `biome lint assets scripts tests` and it completed successfully. 
- Ran `biome format --write assets scripts tests` and it completed successfully. 
- Started the dev server and captured visual verification screenshots of the homepage, hero section, system panel, library cards, CTA hover, and dark-mode states using an automated Playwright script; screenshots were generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf080753c8332bc411fe5f20db1c8)