### PR TITLE
Refine landing layout and streamline audio controls

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -871,10 +871,23 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
-  margin: 8px 0;
-  padding: 10px 0;
+  gap: 16px;
+  margin: 10px 0;
+  padding: 12px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.control-panel__row--primary {
+  border-radius: 12px;
+  padding: 14px 12px;
+  background: linear-gradient(
+    120deg,
+    rgba(17, 216, 255, 0.14),
+    rgba(255, 255, 255, 0.02)
+  );
+  border: 1px solid rgba(17, 216, 255, 0.28);
+  border-top: none;
+  box-shadow: 0 12px 30px rgba(6, 12, 24, 0.35);
 }
 
 .control-panel__row--toggle {
@@ -940,14 +953,87 @@ body {
   gap: 2px;
 }
 
+.control-panel__subtext {
+  font-size: 0.85rem;
+  color: rgba(233, 251, 255, 0.82);
+}
+
+.control-panel__advanced {
+  display: grid;
+  gap: 8px;
+  padding: 4px 0 8px;
+}
+
+.control-panel__row--advanced-toggle {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.control-panel__advanced-toggle {
+  width: 100%;
+  text-align: left;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  padding: 10px 12px;
+  display: grid;
+  gap: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.control-panel__advanced-title {
+  font-weight: 600;
+}
+
+.control-panel__advanced-hint {
+  font-size: 0.8rem;
+  color: rgba(233, 251, 255, 0.7);
+}
+
+.control-panel__advanced-toggle:hover {
+  border-color: rgba(111, 247, 255, 0.5);
+  box-shadow: 0 10px 24px rgba(6, 12, 24, 0.35);
+  transform: translateY(-1px);
+}
+
+.control-panel__advanced-toggle:focus-visible {
+  outline: 2px solid rgba(111, 247, 255, 0.85);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
 .control-panel__status {
   margin-top: 8px;
   font-size: 0.9rem;
   line-height: 1.4;
-  padding: 10px 12px;
+  padding: 12px 14px 12px 38px;
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(111, 247, 255, 0.35);
+  background:
+    linear-gradient(120deg, rgba(17, 216, 255, 0.1), rgba(255, 255, 255, 0)),
+    rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(111, 247, 255, 0.4);
+  position: relative;
+  box-shadow: 0 10px 22px rgba(6, 12, 24, 0.35);
+}
+
+.control-panel__status::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  transform: translateY(-50%);
+  background: rgba(111, 247, 255, 0.9);
+  box-shadow: 0 0 0 4px rgba(111, 247, 255, 0.15);
 }
 
 .control-panel__status[data-variant="error"] {
@@ -958,12 +1044,22 @@ body {
     rgba(0, 0, 0, 0.45);
 }
 
+.control-panel__status[data-variant="error"]::before {
+  background: rgba(255, 82, 130, 0.9);
+  box-shadow: 0 0 0 4px rgba(255, 82, 130, 0.18);
+}
+
 .control-panel__status[data-variant="success"] {
   border-color: rgba(17, 216, 255, 0.8);
   color: #e9fbff;
   background:
     linear-gradient(120deg, rgba(17, 216, 255, 0.12), rgba(255, 255, 255, 0)),
     rgba(0, 0, 0, 0.38);
+}
+
+.control-panel__status[data-variant="success"]::before {
+  background: rgba(17, 216, 255, 0.95);
+  box-shadow: 0 0 0 4px rgba(17, 216, 255, 0.18);
 }
 
 .control-panel__actions {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -378,7 +378,7 @@ header {
 
 section.intro {
   position: relative;
-  padding: clamp(2.2rem, 2.5vw + 1.4rem, 3.2rem);
+  padding: clamp(2.4rem, 2.8vw + 1.6rem, 3.6rem);
   border-radius: calc(var(--radius-lg) + 6px);
   background:
     radial-gradient(
@@ -398,8 +398,8 @@ section.intro {
       rgba(10, 16, 30, 0.88) 100%
     );
   border: 1px solid
-    color-mix(in srgb, var(--accent-color) 20%, var(--surface-border));
-  box-shadow: var(--shadow-surface);
+    color-mix(in srgb, var(--accent-color) 26%, var(--surface-border));
+  box-shadow: 0 24px 60px rgba(5, 10, 24, 0.45);
   overflow: hidden;
 }
 
@@ -1140,6 +1140,16 @@ header.hero {
   text-shadow: none;
 }
 
+.intro .section-heading h1 {
+  font-size: clamp(2.8rem, 1.6rem + 3.4vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: 0.02em;
+}
+
+.intro .section-heading .section-description {
+  font-size: 1.05rem;
+}
+
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -1707,8 +1717,8 @@ html.light .experience-card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-top: 1rem;
-  padding: clamp(1.1rem, 2vw, 1.5rem);
+  margin-top: 1.2rem;
+  padding: clamp(1.2rem, 2.2vw, 1.7rem);
   border-radius: calc(var(--radius-lg) + 6px);
   border: 1px solid
     color-mix(in srgb, var(--accent-color) 18%, var(--surface-border));
@@ -1721,6 +1731,23 @@ html.light .experience-card {
     ),
     var(--surface-gradient);
   box-shadow: var(--shadow-strong);
+}
+
+.search-heading {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 0.4rem;
+}
+
+.search-heading h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.search-heading p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
 }
 
 .search-row {
@@ -2170,6 +2197,30 @@ html:not(.light) .webtoy-card {
   gap: 0.35rem;
   cursor: pointer;
   touch-action: manipulation;
+}
+
+.capability-badge--primary {
+  border-color: rgba(17, 216, 255, 0.45);
+  background: rgba(17, 216, 255, 0.12);
+  color: #e9fbff;
+}
+
+.capability-badge--soft {
+  border-color: rgba(129, 140, 248, 0.4);
+  background: rgba(129, 140, 248, 0.12);
+  color: #eef2ff;
+}
+
+.capability-badge--motion {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.12);
+  color: #ecfdf5;
+}
+
+.capability-badge--webgpu {
+  border-color: rgba(251, 191, 36, 0.45);
+  background: rgba(251, 191, 36, 0.12);
+  color: #fef3c7;
 }
 
 .capability-badge--warning {

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1603,6 +1603,7 @@ export function createLibraryView({
         ariaLabel,
         warning = false,
         role = null,
+        tone = null,
       }) => {
         const badge = document.createElement('span');
         badge.className = 'capability-badge';
@@ -1615,6 +1616,9 @@ export function createLibraryView({
         }
         if (role) {
           badge.setAttribute('role', role);
+        }
+        if (tone) {
+          badge.classList.add(`capability-badge--${tone}`);
         }
         if (warning) {
           badge.classList.add('capability-badge--warning');
@@ -1634,6 +1638,7 @@ export function createLibraryView({
             ariaLabel: 'Requires WebGPU',
             role: 'status',
             warning: !hasWebGPU,
+            tone: 'webgpu',
           }),
         );
 
@@ -1652,6 +1657,7 @@ export function createLibraryView({
             label: 'Mic',
             title: 'Uses live microphone input.',
             ariaLabel: 'Requires microphone input',
+            tone: 'primary',
           }),
         );
       }
@@ -1662,6 +1668,7 @@ export function createLibraryView({
             label: 'Demo audio',
             title: 'Includes a demo track if you skip the mic.',
             ariaLabel: 'Demo audio available',
+            tone: 'soft',
           }),
         );
       }
@@ -1672,6 +1679,7 @@ export function createLibraryView({
             label: 'Motion',
             title: 'Responds to device motion or tilt.',
             ariaLabel: 'Requires device motion',
+            tone: 'motion',
           }),
         );
       }

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -33,109 +33,145 @@ export function initAudioControls(
   };
 
   container.className = 'control-panel';
+  const hasAdvancedOptions =
+    Boolean(options.onRequestTabAudio) ||
+    Boolean(options.onRequestYouTubeAudio);
   container.innerHTML = `
     <p class="control-panel__description">
       Choose how this toy listens.
     </p>
-    <div class="control-panel__row">
+    <div class="control-panel__row" data-audio-row="mic">
       <div class="control-panel__text">
         <span class="control-panel__label">Live mic</span>
+        <span class="control-panel__subtext">Best for real-time sound.</span>
       </div>
       <button id="start-audio-btn" class="cta-button primary" type="button">
         Start mic
       </button>
     </div>
-    <div class="control-panel__row">
+    <div class="control-panel__row" data-audio-row="demo">
       <div class="control-panel__text">
         <span class="control-panel__label">Curated demo</span>
+        <span class="control-panel__subtext">Instant start with built-in audio.</span>
       </div>
       <button id="use-demo-audio" class="cta-button" type="button">Play demo</button>
     </div>
 
     ${
-      options.onRequestTabAudio
+      hasAdvancedOptions
         ? `
-    <div class="control-panel__row">
-      <div class="control-panel__text">
-        <span class="control-panel__label">Tab capture</span>
-        <span class="control-panel__info-wrap">
-          <button
-            class="control-panel__info"
-            type="button"
-            aria-describedby="tab-audio-info"
-          >
-            More info
-          </button>
-          <span id="tab-audio-info" class="control-panel__info-text">
-            Capture sound from the current tab. In the picker, choose “This tab” and enable
-            Share audio.
+    <div class="control-panel__row control-panel__row--advanced-toggle">
+      <button
+        type="button"
+        class="control-panel__advanced-toggle"
+        aria-expanded="false"
+        data-advanced-toggle
+      >
+        <span class="control-panel__advanced-title">Advanced audio options</span>
+        <span class="control-panel__advanced-hint">Tab or YouTube capture</span>
+      </button>
+    </div>
+    <div class="control-panel__advanced" data-advanced-panel hidden>
+      ${
+        options.onRequestTabAudio
+          ? `
+      <div class="control-panel__row">
+        <div class="control-panel__text">
+          <span class="control-panel__label">Tab capture</span>
+          <span class="control-panel__info-wrap">
+            <button
+              class="control-panel__info"
+              type="button"
+              aria-describedby="tab-audio-info"
+            >
+              More info
+            </button>
+            <span id="tab-audio-info" class="control-panel__info-text">
+              Capture sound from the current tab. In the picker, choose “This tab” and enable
+              Share audio.
+            </span>
           </span>
-        </span>
+        </div>
+        <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
       </div>
-      <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
+      `
+          : ''
+      }
+      ${
+        options.onRequestYouTubeAudio
+          ? `
+      <div class="control-panel__row control-panel__row--stacked">
+        <div class="control-panel__text">
+          <span class="control-panel__label">YouTube capture</span>
+          <span class="control-panel__info-wrap">
+            <button
+              class="control-panel__info"
+              type="button"
+              aria-describedby="youtube-audio-info"
+            >
+              More info
+            </button>
+            <span id="youtube-audio-info" class="control-panel__info-text">
+              Paste a link, load it, then capture. In the picker, choose “This tab” and enable
+              Share audio.
+            </span>
+          </span>
+        </div>
+        <div class="control-panel__field">
+          <label class="sr-only" for="youtube-url">YouTube URL</label>
+          <input
+            id="youtube-url"
+            class="control-panel__input"
+            type="url"
+            placeholder="https://youtube.com/watch?v=..."
+            autocomplete="off"
+            inputmode="url"
+          />
+          <button id="load-youtube" class="cta-button" type="button">Load</button>
+        </div>
+        <div id="recent-youtube" class="control-panel__recent" hidden>
+          <span class="control-panel__label small">Recent</span>
+          <div id="recent-list" class="control-panel__chip-list"></div>
+        </div>
+        <div class="control-panel__actions control-panel__actions--inline">
+          <button id="use-youtube-audio" class="cta-button" type="button">
+            Capture YouTube
+          </button>
+        </div>
+        <div id="youtube-player-container" class="control-panel__embed" hidden>
+          <div id="youtube-player"></div>
+        </div>
+      </div>
+      `
+          : ''
+      }
     </div>
     `
         : ''
     }
-    
-    ${
-      options.onRequestYouTubeAudio
-        ? `
-    <div class="control-panel__row control-panel__row--stacked">
-      <div class="control-panel__text">
-        <span class="control-panel__label">YouTube capture</span>
-        <span class="control-panel__info-wrap">
-          <button
-            class="control-panel__info"
-            type="button"
-            aria-describedby="youtube-audio-info"
-          >
-            More info
-          </button>
-          <span id="youtube-audio-info" class="control-panel__info-text">
-            Paste a link, load it, then capture. In the picker, choose “This tab” and enable
-            Share audio.
-          </span>
-        </span>
-      </div>
-      <div class="control-panel__field">
-        <label class="sr-only" for="youtube-url">YouTube URL</label>
-        <input
-          id="youtube-url"
-          class="control-panel__input"
-          type="url"
-          placeholder="https://youtube.com/watch?v=..."
-          autocomplete="off"
-          inputmode="url"
-        />
-        <button id="load-youtube" class="cta-button" type="button">Load</button>
-      </div>
-      <div id="recent-youtube" class="control-panel__recent" hidden>
-        <span class="control-panel__label small">Recent</span>
-        <div id="recent-list" class="control-panel__chip-list"></div>
-      </div>
-      <div class="control-panel__actions control-panel__actions--inline">
-        <button id="use-youtube-audio" class="cta-button" type="button">
-          Capture YouTube
-        </button>
-      </div>
-      <div id="youtube-player-container" class="control-panel__embed" hidden>
-        <div id="youtube-player"></div>
-      </div>
-    </div>
-    `
-        : ''
-    }
-    
+
     <div id="audio-status" class="control-panel__status" role="status" aria-live="polite" hidden></div>
   `;
 
   const micBtn = container.querySelector('#start-audio-btn');
   const demoBtn = container.querySelector('#use-demo-audio');
   const tabBtn = container.querySelector('#use-tab-audio');
+  const micRow = container.querySelector('[data-audio-row="mic"]');
+  const demoRow = container.querySelector('[data-audio-row="demo"]');
   const statusEl = (options.statusElement ||
     container.querySelector('#audio-status')) as HTMLElement;
   const requestTabAudio = options.onRequestTabAudio;
+  const advancedToggle = container.querySelector(
+    '[data-advanced-toggle]',
+  ) as HTMLButtonElement | null;
+  const advancedPanel = container.querySelector(
+    '[data-advanced-panel]',
+  ) as HTMLElement | null;
+  const ADVANCED_KEY = 'stims-audio-advanced-open';
+
+  const setPrimaryRow = (row: Element | null, isPrimary: boolean): void => {
+    row?.classList.toggle('control-panel__row--primary', isPrimary);
+  };
 
   const setPending = (button: Element | null, pending: boolean) => {
     if (!(button instanceof HTMLElement)) return;
@@ -164,6 +200,8 @@ export function initAudioControls(
     if (micBtn instanceof HTMLButtonElement) {
       micBtn.classList.remove('primary');
     }
+    setPrimaryRow(demoRow, true);
+    setPrimaryRow(micRow, false);
   };
 
   const buildMicrophoneErrorMessage = (message: string) => {
@@ -191,6 +229,11 @@ export function initAudioControls(
     if (micBtn instanceof HTMLButtonElement) {
       micBtn.classList.remove('primary');
     }
+    setPrimaryRow(demoRow, true);
+    setPrimaryRow(micRow, false);
+  } else {
+    setPrimaryRow(micRow, true);
+    setPrimaryRow(demoRow, false);
   }
 
   if (options.initialStatus) {
@@ -198,6 +241,27 @@ export function initAudioControls(
       options.initialStatus.message,
       options.initialStatus.variant ?? 'error',
     );
+  }
+
+  if (advancedToggle && advancedPanel) {
+    let isOpen = false;
+    try {
+      isOpen = window.sessionStorage.getItem(ADVANCED_KEY) === 'true';
+    } catch (_error) {
+      isOpen = false;
+    }
+    advancedPanel.hidden = !isOpen;
+    advancedToggle.setAttribute('aria-expanded', String(isOpen));
+    advancedToggle.addEventListener('click', () => {
+      const nextState = advancedPanel.hidden;
+      advancedPanel.hidden = !nextState;
+      advancedToggle.setAttribute('aria-expanded', String(nextState));
+      try {
+        window.sessionStorage.setItem(ADVANCED_KEY, String(nextState));
+      } catch (_error) {
+        // Ignore storage errors.
+      }
+    });
   }
 
   const handleRequest = async (

--- a/index.html
+++ b/index.html
@@ -276,6 +276,10 @@
             Tap a card to launch. Everything is accessible and ready to play.
           </p>
           <search class="library-search">
+            <div class="search-heading">
+              <h3>Find a stim fast</h3>
+              <p>Filter by mood, capability, or keyword.</p>
+            </div>
             <div class="search-row">
               <label class="sr-only" for="toy-search">Search the library</label>
               <form class="search-field" role="search" data-search-form>


### PR DESCRIPTION
### Motivation
- Improve the library landing hierarchy so the hero and search entry are clearer and more inviting.  
- Make audio controls easier to understand by highlighting the primary action (mic vs demo) and hiding advanced capture options behind a toggle.  
- Surface capability distinctions more clearly by introducing tonal variants for capability badges (WebGPU, Mic, Demo audio, Motion).

### Description
- Add an inline search heading and tweak landing hero spacing and elevation to increase visual hierarchy (`index.html`, `assets/css/index.css`).  
- Introduce an advanced audio options toggle and primary-row emphasis in the audio control UI, persist the advanced panel state to session storage, and add row-level primary styling and subtext (`assets/js/ui/audio-controls.ts`, `assets/css/base.css`).  
- Add a `tone` option to capability badge creation and apply visual tone classes for WebGPU, Mic, Demo audio, and Motion, plus matching CSS variants (`assets/js/library-view.js`, `assets/css/index.css`).  
- Adjust control-panel status styling, spacing, and affordances for better readability and accessibility (`assets/css/base.css`).

### Testing
- Ran `bun run check` (Biome checks + TypeScript typecheck + test suite) and it completed successfully.  
- Test run summary: the test suite executed 80 tests with `78 passed`, `2 skipped`, and `0 failed`.  
- Performed a dev-server smoke render by running the site locally and capturing screenshots with a Playwright script to verify visual changes (artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d29c701ec83329f96b9f9579e234c)