### PR TITLE
Centralize toy quality controls

### DIFF
--- a/assets/js/toys/aurora-painter.ts
+++ b/assets/js/toys/aurora-painter.ts
@@ -4,10 +4,7 @@ import { getBandAverage } from '../utils/audio-bands';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { disposeGeometry, disposeMesh } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 import type { UnifiedInputState } from '../utils/unified-input';
 
 type AuroraPalette = {
@@ -21,7 +18,10 @@ type AuroraPalette = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Aurora painter',
+    description:
+      'Control render scale and ribbon density without restarting audio. Pinch to swell the ribbons and rotate to switch moods.',
     getRuntime: () => runtime,
     onChange: () => {
       rebuildRibbons();
@@ -238,12 +238,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Aurora painter',
-      description:
-        'Control render scale and ribbon density without restarting audio. Pinch to swell the ribbons and rotate to switch moods.',
-      quality,
-    });
+    configurePanel();
   }
 
   function applyPalette(index: number) {

--- a/assets/js/toys/bioluminescent-tidepools.ts
+++ b/assets/js/toys/bioluminescent-tidepools.ts
@@ -4,10 +4,7 @@ import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import type { ToyAudioRequest } from '../utils/audio-start';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 import type { UnifiedInputState, UnifiedPointer } from '../utils/unified-input';
 
 type TideBlob = {
@@ -32,7 +29,10 @@ const MAX_BLOBS = 28;
 const BASE_SPARK_COUNT = 200;
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Bioluminescent tidepools',
+    description:
+      'Quality presets update DPI caps, blob limits, and spark counts without reloading. Pinch to shape the currents, rotate to swap moods, and nudge with arrow keys.',
     getRuntime: () => runtime,
     onChange: () => {
       activeSparkCount = getSparkCount();
@@ -497,12 +497,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Bioluminescent tidepools',
-      description:
-        'Quality presets update DPI caps, blob limits, and spark counts without reloading. Pinch to shape the currents, rotate to swap moods, and nudge with arrow keys.',
-      quality,
-    });
+    configurePanel();
   }
 
   function computeHighBandEnergy(data: Uint8Array) {

--- a/assets/js/toys/bubble-harmonics.ts
+++ b/assets/js/toys/bubble-harmonics.ts
@@ -8,10 +8,7 @@ import {
   disposeMesh,
 } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 type Bubble = {
   mesh: THREE.Mesh<THREE.SphereGeometry, THREE.ShaderMaterial>;
@@ -28,7 +25,9 @@ type HarmonicBubble = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Bubble harmonics',
+    description: 'Presets adjust DPI caps plus bubble and harmonic counts.',
     getRuntime: () => runtime,
     onChange: () => {
       bubbleDetail = getBubbleDetail();
@@ -293,11 +292,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Bubble harmonics',
-      description: 'Presets adjust DPI caps plus bubble and harmonic counts.',
-      quality,
-    });
+    configurePanel();
   }
 
   const startRuntime = createToyRuntimeStarter({

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -11,9 +11,8 @@ import { applyAudioColor } from '../utils/color-audio';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  configureToySettingsPanel,
   createControlPanelButtonGroup,
-  createRendererQualityManager,
+  createToyQualityControls,
 } from '../utils/toy-settings';
 
 type PresetKey = 'orbit' | 'nebula';
@@ -24,7 +23,10 @@ type PresetInstance = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Cosmic controls',
+    description:
+      'Quality changes persist between toys so you can cap DPI or ramp visuals.',
     defaultPresetId: 'balanced',
     getRuntime: () => runtime,
     getRendererSettings: (preset) => ({
@@ -308,12 +310,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    const panel = configureToySettingsPanel({
-      title: 'Cosmic controls',
-      description:
-        'Quality changes persist between toys so you can cap DPI or ramp visuals.',
-      quality,
-    });
+    const panel = configurePanel();
 
     const presetRow = panel.addSection(
       'Cosmic preset',

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -4,10 +4,7 @@ import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { type AudioColorParams, applyAudioColor } from '../utils/color-audio';
 import { disposeObject3D } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 type ShapeMode = 'cubes' | 'spheres';
 
@@ -61,7 +58,10 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   const gridGroup = new THREE.Group();
   const gridItems: GridItem[] = [];
 
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Grid visualizer',
+    description:
+      'Adjust render resolution caps and switch primitives without restarting audio.',
     defaultPresetId: 'balanced',
     getRuntime: () => runtime,
     onChange: () => {
@@ -229,12 +229,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    const panel = configureToySettingsPanel({
-      title: 'Grid visualizer',
-      description:
-        'Adjust render resolution caps and switch primitives without restarting audio.',
-      quality,
-    });
+    const panel = configurePanel();
 
     const shapeRow = panel.addSection(
       'Shape',

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -4,9 +4,8 @@ import { getBandAverage } from '../utils/audio-bands';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  configureToySettingsPanel,
   createControlPanelButtonGroup,
-  createRendererQualityManager,
+  createToyQualityControls,
 } from '../utils/toy-settings';
 
 type PaletteKey = 'aurora' | 'sunset' | 'midnight';
@@ -22,7 +21,10 @@ type KiteInstance = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Fractal Kite Garden',
+    description:
+      'Quality presets persist across toys so you can balance DPI and branching density.',
     getRuntime: () => runtime,
     onChange: () => {
       buildGarden();
@@ -32,7 +34,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     },
   });
   let runtime: ToyRuntimeInstance;
-  let settingsPanel: ReturnType<typeof configureToySettingsPanel>;
+  let settingsPanel: ReturnType<typeof configurePanel>;
   let paletteButtons: ReturnType<typeof createControlPanelButtonGroup> | null =
     null;
 
@@ -258,12 +260,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    settingsPanel = configureToySettingsPanel({
-      title: 'Fractal Kite Garden',
-      description:
-        'Quality presets persist across toys so you can balance DPI and branching density.',
-      quality,
-    });
+    settingsPanel = configurePanel();
   }
 
   function init() {

--- a/assets/js/toys/milkdrop-toy.ts
+++ b/assets/js/toys/milkdrop-toy.ts
@@ -2,10 +2,7 @@ import * as THREE from 'three';
 import FeedbackManager from '../utils/feedback-manager';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 import WarpShader from '../utils/warp-shader';
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
@@ -143,16 +140,14 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   const runtime = startRuntime({ container });
 
-  const quality = createRendererQualityManager({
+  const { configurePanel } = createToyQualityControls({
+    title: 'MilkDrop Proto',
+    description: 'A prototype of MilkDrop-style feedback engine.',
     defaultPresetId: 'medium',
     getRuntime: () => runtime,
     getRendererSettings: (preset) => ({ renderScale: preset.renderScale }),
   });
-  configureToySettingsPanel({
-    title: 'MilkDrop Proto',
-    description: 'A prototype of MilkDrop-style feedback engine.',
-    quality,
-  });
+  configurePanel();
 
   return runtime;
 }

--- a/assets/js/toys/mobile-ripples.ts
+++ b/assets/js/toys/mobile-ripples.ts
@@ -8,10 +8,7 @@ import { getBandAverage } from '../utils/audio-bands';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 const MOBILE_QUALITY_PRESET: QualityPreset = {
   id: 'mobile',
@@ -42,7 +39,9 @@ type RingState = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Mobile Ripples',
+    description: 'Low-power neon ripples tuned for touch-first screens.',
     presets: QUALITY_PRESETS,
     defaultPresetId: isCompactDevice() ? 'mobile' : 'balanced',
     storageKey: 'stims:mobile-ripples:quality',
@@ -151,11 +150,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Mobile Ripples',
-      description: 'Low-power neon ripples tuned for touch-first screens.',
-      quality,
-    });
+    configurePanel();
   }
 
   const startRuntime = createToyRuntimeStarter({

--- a/assets/js/toys/neon-wave.ts
+++ b/assets/js/toys/neon-wave.ts
@@ -35,9 +35,8 @@ import type { FrequencyAnalyser } from '../utils/audio-handler';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  configureToySettingsPanel,
   createControlPanelButtonGroup,
-  createRendererQualityManager,
+  createToyQualityControls,
 } from '../utils/toy-settings';
 
 type NeonTheme = 'synthwave' | 'cyberpunk' | 'arctic' | 'sunset';
@@ -83,7 +82,9 @@ const THEMES: Record<NeonTheme, ThemePalette> = {
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
   const settingsPanel = new PersistentSettingsPanel(container || undefined);
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Neon Wave',
+    description: 'Retro-wave visualizer with bloom effects. Pick a theme!',
     panel: settingsPanel,
     getRuntime: () => runtime,
     getRendererSettings: (preset) => ({
@@ -457,19 +458,12 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Neon Wave',
-      description: 'Retro-wave visualizer with bloom effects. Pick a theme!',
-      panel: settingsPanel,
-      quality,
-    });
-
-    const panel = container?.querySelector('.control-panel');
-    if (!(panel instanceof HTMLElement)) return;
+    const panel = configurePanel();
+    const panelElement = panel.getElement();
 
     const themes: NeonTheme[] = ['synthwave', 'cyberpunk', 'arctic', 'sunset'];
     themeButtons = createControlPanelButtonGroup({
-      panel,
+      panel: panelElement,
       options: themes.map((theme) => ({
         id: theme,
         label: theme.charAt(0).toUpperCase() + theme.slice(1),

--- a/assets/js/toys/pocket-pulse.ts
+++ b/assets/js/toys/pocket-pulse.ts
@@ -8,10 +8,7 @@ import { getBandAverage } from '../utils/audio-bands';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 const MOBILE_QUALITY_PRESET: QualityPreset = {
   id: 'mobile',
@@ -36,7 +33,9 @@ const isCompactDevice = () => {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Pocket Pulse',
+    description: 'Mobile-tuned pulses that drift with touch and audio.',
     presets: QUALITY_PRESETS,
     defaultPresetId: isCompactDevice() ? 'mobile' : 'balanced',
     storageKey: 'stims:pocket-pulse:quality',
@@ -160,11 +159,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Pocket Pulse',
-      description: 'Mobile-tuned pulses that drift with touch and audio.',
-      quality,
-    });
+    configurePanel();
   }
 
   const startRuntime = createToyRuntimeStarter({

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -7,10 +7,7 @@ import {
   disposeMesh,
 } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 interface RingData {
   outer: THREE.Mesh;
@@ -20,7 +17,9 @@ interface RingData {
 }
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Rainbow tunnel',
+    description: 'Preset tweaks update DPI and ring density together.',
     getRuntime: () => runtime,
     onChange: () => {
       rebuildScene();
@@ -224,11 +223,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Rainbow tunnel',
-      description: 'Preset tweaks update DPI and ring density together.',
-      quality,
-    });
+    configurePanel();
   }
 
   const startRuntime = createToyRuntimeStarter({

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -13,9 +13,8 @@ import { applyAudioColor } from '../utils/color-audio';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  configureToySettingsPanel,
   createControlPanelButtonGroup,
-  createRendererQualityManager,
+  createToyQualityControls,
 } from '../utils/toy-settings';
 import type { UnifiedInputState } from '../utils/unified-input';
 
@@ -47,7 +46,10 @@ type ParticleField = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Spiral Burst',
+    description:
+      'Explosive spirals that pulse with your music. Try different modes, pinch to amplify, and rotate to swap moods!',
     getRuntime: () => runtime,
     getRendererSettings: (preset) => ({
       maxPixelRatio: performanceSettings.maxPixelRatio,
@@ -319,16 +321,8 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Spiral Burst',
-      description:
-        'Explosive spirals that pulse with your music. Try different modes, pinch to amplify, and rotate to swap moods!',
-      quality,
-    });
-
-    // Add mode buttons
-    const panelElement = container?.querySelector('.control-panel');
-    if (!(panelElement instanceof HTMLElement)) return;
+    const panel = configurePanel();
+    const panelElement = panel.getElement();
 
     modeRow?.remove();
     const modes: SpiralMode[] = ['burst', 'bloom', 'vortex', 'heartbeat'];

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -9,10 +9,7 @@ import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor } from '../utils/color-audio';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 import type { UnifiedInputState } from '../utils/unified-input';
 
 type StarFieldBuffers = {
@@ -33,7 +30,10 @@ type StarfieldPalette = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Star field',
+    description:
+      'Tune render resolution and particle density for your GPU. Pinch to intensify the drift and rotate to swap nebula moods.',
     getRuntime: () => runtime,
     getRendererSettings: (preset) => ({
       maxPixelRatio: performanceSettings.maxPixelRatio,
@@ -258,12 +258,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: 'Star field',
-      description:
-        'Tune render resolution and particle density for your GPU. Pinch to intensify the drift and rotate to swap nebula moods.',
-      quality,
-    });
+    configurePanel();
   }
 
   function setupPerformancePanel() {

--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -8,10 +8,7 @@ import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 type GravityState = {
   vector: THREE.Vector3;
@@ -158,7 +155,10 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   const clock = new THREE.Clock();
   let damping = 0.984;
   let grainScale = 1.2;
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: 'Tactile sand table',
+    description:
+      'Ripple the grains with bass and mids. Tilt your device to nudge gravity, or lock it when playing on desktop.',
     defaultPresetId: 'balanced',
     getRuntime: () => runtime,
     onChange: (preset) => {
@@ -182,12 +182,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   ) as MotionAccessState;
   gravity.locked = motionAccess !== 'granted';
 
-  const panel = configureToySettingsPanel({
-    title: 'Tactile sand table',
-    description:
-      'Ripple the grains with bass and mids. Tilt your device to nudge gravity, or lock it when playing on desktop.',
-    quality,
-  });
+  const panel = configurePanel();
 
   const grainRow = panel.addSection(
     'Grain size',

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -16,14 +16,13 @@ import {
 import { createIdleDetector } from '../utils/idle-detector';
 import { disposeGeometry, disposeMesh } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import {
-  configureToySettingsPanel,
-  createRendererQualityManager,
-} from '../utils/toy-settings';
+import { createToyQualityControls } from '../utils/toy-settings';
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
   let errorElement: HTMLElement | null = null;
-  const quality = createRendererQualityManager({
+  const { quality, configurePanel } = createToyQualityControls({
+    title: '3D soundscape',
+    description: 'Resolution and particle density follow the preset you pick.',
     getRuntime: () => runtime,
     onChange: () => {
       rebuildSceneContents();
@@ -349,12 +348,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    configureToySettingsPanel({
-      title: '3D soundscape',
-      description:
-        'Resolution and particle density follow the preset you pick.',
-      quality,
-    });
+    configurePanel();
   }
 
   async function startAudio(request: ToyAudioRequest = false) {

--- a/assets/js/utils/toy-settings.ts
+++ b/assets/js/utils/toy-settings.ts
@@ -45,6 +45,12 @@ type RendererQualityManagerOptions = QualityPresetManagerOptions & {
   onChange?: (preset: QualityPreset) => void;
 };
 
+export type ToyQualityControlsOptions = RendererQualityManagerOptions & {
+  title: string;
+  description?: string;
+  panel?: PersistentSettingsPanel;
+};
+
 export function createQualityPresetManager(
   options: QualityPresetManagerOptions = {},
 ): QualityPresetManager {
@@ -107,6 +113,25 @@ export function createRendererQualityManager(
       onChange?.(preset);
     },
   });
+}
+
+export function createToyQualityControls({
+  title,
+  description,
+  panel,
+  ...qualityOptions
+}: ToyQualityControlsOptions) {
+  const quality = createRendererQualityManager(qualityOptions);
+
+  const configurePanel = () =>
+    configureToySettingsPanel({
+      title,
+      description,
+      panel,
+      quality,
+    });
+
+  return { quality, configurePanel };
 }
 
 type ToySettingsPanelOptions = {


### PR DESCRIPTION
### Motivation

- Reduce repeated boilerplate across toy modules for creating quality presets and wiring the settings panel by centralizing that logic in a small helper.

### Description

- Add `createToyQualityControls` to `assets/js/utils/toy-settings.ts` which returns `{ quality, configurePanel }` to encapsulate `createRendererQualityManager` + `configureToySettingsPanel` wiring.
- Update toy modules to use the new helper and simplify panel configuration, replacing ad-hoc calls to `createRendererQualityManager` and `configureToySettingsPanel` in the following files: `aurora-painter.ts`, `bioluminescent-tidepools.ts`, `bubble-harmonics.ts`, `cosmic-particles.ts`, `cube-wave.ts`, `fractal-kite-garden.ts`, `milkdrop-toy.ts`, `mobile-ripples.ts`, `neon-wave.ts`, `pocket-pulse.ts`, `rainbow-tunnel.ts`, `spiral-burst.ts`, `star-field.ts`, `tactile-sand-table.ts`, and `three-d-toy.ts`.
- Adjust a few toys to accept the configured panel (exposing the panel element when needed) and remove a now-unused variable in `milkdrop-toy.ts` as part of the refactor.

### Testing

- Ran `bun run check` (Biome checks + TypeScript typecheck + test suite) and the checks completed successfully with the test run showing all tests passing (78 passed, 2 skipped). 
- Ran `biome lint` and `biome format` as part of the commit workflow, and formatting/linting were applied/verified successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d65595de88332980daf136df79fe6)