### PR TITLE
Extract shared toy control helpers

### DIFF
--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -4,7 +4,10 @@ import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { type AudioColorParams, applyAudioColor } from '../utils/color-audio';
 import { disposeObject3D } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import { createToyQualityControls } from '../utils/toy-settings';
+import {
+  buildToySettingsPanel,
+  createToyQualityControls,
+} from '../utils/toy-settings';
 
 type ShapeMode = 'cubes' | 'spheres';
 
@@ -58,7 +61,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   const gridGroup = new THREE.Group();
   const gridItems: GridItem[] = [];
 
-  const { quality, configurePanel } = createToyQualityControls({
+  const { quality } = createToyQualityControls({
     title: 'Grid visualizer',
     description:
       'Adjust render resolution caps and switch primitives without restarting audio.',
@@ -229,29 +232,29 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    const panel = configurePanel();
-
-    const shapeRow = panel.addSection(
-      'Shape',
-      'Change the primitive without restarting audio.',
-    );
-
-    const select = document.createElement('select');
-    select.className = 'control-panel__select';
-    Object.entries(presets).forEach(([key, preset]) => {
-      const option = document.createElement('option');
-      option.value = key;
-      option.textContent = preset.label;
-      select.appendChild(option);
+    buildToySettingsPanel({
+      title: 'Grid visualizer',
+      description:
+        'Adjust render resolution caps and switch primitives without restarting audio.',
+      quality,
+      sections: [
+        {
+          title: 'Shape',
+          description: 'Change the primitive without restarting audio.',
+          controls: [
+            {
+              type: 'select',
+              options: Object.entries(presets).map(([key, preset]) => ({
+                value: key,
+                label: preset.label,
+              })),
+              getValue: () => activeMode,
+              onChange: (value) => rebuildGrid(value as ShapeMode),
+            },
+          ],
+        },
+      ],
     });
-
-    select.value = activeMode;
-    select.addEventListener('change', () => {
-      const nextMode = select.value as ShapeMode;
-      rebuildGrid(nextMode);
-    });
-
-    shapeRow.appendChild(select);
   }
 
   function updateTransforms(

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -4,7 +4,7 @@ import { getBandAverage } from '../utils/audio-bands';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  createControlPanelButtonGroup,
+  buildToySettingsPanel,
   createToyQualityControls,
 } from '../utils/toy-settings';
 
@@ -21,7 +21,7 @@ type KiteInstance = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const { quality, configurePanel } = createToyQualityControls({
+  const { quality } = createToyQualityControls({
     title: 'Fractal Kite Garden',
     description:
       'Quality presets persist across toys so you can balance DPI and branching density.',
@@ -34,9 +34,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     },
   });
   let runtime: ToyRuntimeInstance;
-  let settingsPanel: ReturnType<typeof configurePanel>;
-  let paletteButtons: ReturnType<typeof createControlPanelButtonGroup> | null =
-    null;
+  let settingsPanel: ReturnType<typeof buildToySettingsPanel>;
 
   const palettes: Record<PaletteKey, number[]> = {
     aurora: [0x83e6ff, 0x6ad0f7, 0xd3afff, 0xa8f7dd],
@@ -234,33 +232,42 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     });
     panelDensityInput = densityInput;
     densityRow.appendChild(densityInput);
-
-    const paletteRow = settingsPanel.addSection(
-      'Color palette',
-      'Switch gradients without resetting audio.',
-    );
-
-    paletteButtons = createControlPanelButtonGroup({
-      panel: paletteRow,
-      options: (Object.keys(palettes) as PaletteKey[]).map((paletteKey) => ({
-        id: paletteKey,
-        label: paletteKey.charAt(0).toUpperCase() + paletteKey.slice(1),
-      })),
-      getActiveId: () => settings.palette,
-      onSelect: (paletteKey) => {
-        settings.palette = paletteKey as PaletteKey;
-        paletteButtons?.setActive(settings.palette);
-        buildGarden();
-      },
-      buttonClassName: 'cta-button',
-      activeClassName: 'active',
-      setDisabledOnActive: true,
-      setAriaPressed: false,
-    });
   }
 
   function setupSettingsPanel() {
-    settingsPanel = configurePanel();
+    settingsPanel = buildToySettingsPanel({
+      title: 'Fractal Kite Garden',
+      description:
+        'Quality presets persist across toys so you can balance DPI and branching density.',
+      quality,
+      sections: [
+        {
+          title: 'Color palette',
+          description: 'Switch gradients without resetting audio.',
+          controls: [
+            {
+              type: 'button-group',
+              options: (Object.keys(palettes) as PaletteKey[]).map(
+                (paletteKey) => ({
+                  id: paletteKey,
+                  label:
+                    paletteKey.charAt(0).toUpperCase() + paletteKey.slice(1),
+                }),
+              ),
+              getActiveId: () => settings.palette,
+              onChange: (paletteKey) => {
+                settings.palette = paletteKey as PaletteKey;
+                buildGarden();
+              },
+              buttonClassName: 'cta-button',
+              activeClassName: 'active',
+              setDisabledOnActive: true,
+              setAriaPressed: false,
+            },
+          ],
+        },
+      ],
+    });
   }
 
   function init() {

--- a/assets/js/toys/lights/audio.ts
+++ b/assets/js/toys/lights/audio.ts
@@ -1,17 +1,14 @@
 import type { Mesh } from 'three';
 import type { AnimationContext } from '../../core/animation-loop';
 import { getContextFrequencyData } from '../../core/animation-loop';
-import { setupMicrophonePermissionFlow } from '../../core/microphone-flow.ts';
 import type WebToy from '../../core/web-toy';
 import {
   applyAudioRotation,
   applyAudioScale,
 } from '../../utils/animation-utils.ts';
+import { createAudioFlowController } from '../../utils/audio-flow-controller';
 import { getWeightedAverageFrequency } from '../../utils/audio-handler.ts';
 import PatternRecognizer from '../../utils/patternRecognition.ts';
-import { startToyAudio } from '../../utils/start-audio.ts';
-
-export type AudioMode = 'microphone' | 'sample';
 
 type AudioControllerOptions = {
   doc: Document;
@@ -28,7 +25,9 @@ type AudioControllerOptions = {
 };
 
 export type AudioController = {
-  setupMicrophoneFlow: () => ReturnType<typeof setupMicrophonePermissionFlow>;
+  setupMicrophoneFlow: ReturnType<
+    typeof createAudioFlowController
+  >['setupMicrophoneFlow'];
   handleVisibilityChange: () => Promise<void>;
   handleReducedMotionChange: (event: MediaQueryListEvent) => void;
   handlePageHide: () => void;
@@ -44,26 +43,10 @@ export const createAudioController = ({
   renderOnce,
   elements,
 }: AudioControllerOptions): AudioController => {
-  let isReducedMotionPreferred = prefersReducedMotion?.matches ?? false;
-  let shouldAnimate = true;
-  let animationContext: AnimationContext | null = null;
   let patternRecognizer: PatternRecognizer | null = null;
-  let audioMode: AudioMode | null = null;
 
-  const clearAnimationLoop = () => {
-    if (toy.renderer?.setAnimationLoop) {
-      toy.renderer.setAnimationLoop(null);
-    }
-  };
-
-  const animate = (ctx: AnimationContext) => {
+  const renderFrame = (ctx: AnimationContext) => {
     if (!cube) return;
-
-    if (!shouldAnimate) {
-      renderOnce();
-      clearAnimationLoop();
-      return;
-    }
 
     const audioData = getContextFrequencyData(ctx);
     const avg = getWeightedAverageFrequency(audioData);
@@ -71,6 +54,9 @@ export const createAudioController = ({
     applyAudioRotation(cube, audioData, 0.05 + intensity * 0.08);
     applyAudioScale(cube, audioData, 50 - intensity * 20);
 
+    if (!patternRecognizer && ctx.analyser) {
+      patternRecognizer = new PatternRecognizer(ctx.analyser);
+    }
     patternRecognizer?.updatePatternBuffer();
     const detectedPattern = patternRecognizer?.detectPattern();
 
@@ -90,145 +76,28 @@ export const createAudioController = ({
     renderOnce();
   };
 
-  const restartAnimationLoop = () => {
-    if (!toy.renderer || !animationContext || !shouldAnimate) return;
-    const context = animationContext;
-    toy.renderer.setAnimationLoop(() => animate(context));
-  };
-
-  const cleanupAudio = () => {
-    clearAnimationLoop();
-    toy?.audioCleanup?.();
-    toy.analyser = null;
-    toy.audioListener = null;
-    toy.audio = null;
-    toy.audioStream = null;
-    toy.audioCleanup = null;
-    animationContext = null;
-    patternRecognizer = null;
-  };
-
-  const startAudio = async (mode: AudioMode) => {
-    if (!toy) {
-      setStatus('Renderer is not ready yet. Please retry.', 'error');
-      return;
-    }
-
-    shouldAnimate = !isReducedMotionPreferred;
-    audioMode = mode;
-
-    try {
-      animationContext = await startToyAudio(toy, animate, {
-        fallbackToSynthetic: mode === 'microphone',
-        preferSynthetic: mode === 'sample',
-      });
-
-      if (animationContext.analyser) {
-        patternRecognizer = new PatternRecognizer(animationContext.analyser);
-      }
-
-      if (isReducedMotionPreferred) {
-        renderOnce();
-      }
-    } catch (error) {
-      audioMode = null;
-      clearAnimationLoop();
-      throw error;
-    }
-  };
-
-  const handleVisibilityChange = async () => {
-    if (!doc) return;
-
-    if (doc.visibilityState === 'hidden') {
-      clearAnimationLoop();
-      if (toy.audioListener?.context?.state === 'running') {
-        try {
-          await toy.audioListener.context.suspend();
-        } catch (error) {
-          console.error('Error suspending audio context:', error);
-        }
-      } else {
-        cleanupAudio();
-      }
-      return;
-    }
-
-    if (doc.visibilityState === 'visible') {
-      if (toy.audioListener?.context?.state === 'suspended') {
-        try {
-          await toy.audioListener.context.resume();
-        } catch (error) {
-          console.error('Error resuming audio context:', error);
-        }
-      } else if (audioMode && !animationContext) {
-        try {
-          await startAudio(audioMode);
-        } catch (error) {
-          setStatus(
-            'Microphone or demo audio is required for the visualization to work. Please try again.',
-            'error',
-          );
-          console.error(
-            'Unable to restart audio after visibility change',
-            error,
-          );
-        }
-      }
-
-      if (animationContext) {
-        restartAnimationLoop();
-      }
-    }
-  };
-
-  const handleReducedMotionChange = (event: MediaQueryListEvent) => {
-    isReducedMotionPreferred = event.matches;
-    shouldAnimate = !isReducedMotionPreferred;
-
-    if (isReducedMotionPreferred) {
-      clearAnimationLoop();
-      renderOnce();
-    } else {
-      restartAnimationLoop();
-    }
-  };
-
-  const handlePageHide = () => {
-    cleanupAudio();
-    clearAnimationLoop();
-  };
-
-  const setupMicrophoneFlow = () =>
-    setupMicrophonePermissionFlow({
-      startButton: elements.startButton,
-      fallbackButton: elements.fallbackButton,
-      statusElement: elements.statusElement,
-      requestMicrophone: () => startAudio('microphone'),
-      requestSampleAudio: () => startAudio('sample'),
-      analytics: {
-        log: (event, detail) =>
-          console.info(`[audio-flow] ${event}`, detail ?? {}),
-      },
-      onSuccess: (mode) => {
-        if (elements.startButton instanceof HTMLButtonElement) {
-          elements.startButton.style.display = 'none';
-        }
-
-        if (
-          mode === 'microphone' &&
-          elements.fallbackButton instanceof HTMLButtonElement
-        ) {
-          elements.fallbackButton.hidden = true;
-        }
-      },
-    });
+  const audioFlow = createAudioFlowController({
+    doc,
+    toy,
+    prefersReducedMotion,
+    renderFrame,
+    renderOnce,
+    setStatus,
+    elements,
+    analytics: {
+      log: (event, detail) =>
+        console.info(`[audio-flow] ${event}`, detail ?? {}),
+    },
+    onSuccess: () => {
+      patternRecognizer = null;
+    },
+  });
 
   return {
-    setupMicrophoneFlow,
-    handleVisibilityChange,
-    handleReducedMotionChange,
-    handlePageHide,
-    cleanupAudio,
+    ...audioFlow,
+    cleanupAudio: () => {
+      audioFlow.cleanupAudio();
+      patternRecognizer = null;
+    },
   };
 };

--- a/assets/js/utils/audio-flow-controller.ts
+++ b/assets/js/utils/audio-flow-controller.ts
@@ -1,0 +1,199 @@
+import type { AnimationContext } from '../core/animation-loop';
+import { setupMicrophonePermissionFlow } from '../core/microphone-flow';
+import type WebToy from '../core/web-toy';
+import { startToyAudio } from './start-audio';
+
+export type AudioFlowMode = 'microphone' | 'sample';
+
+type AudioFlowElements = {
+  startButton: HTMLButtonElement | null;
+  fallbackButton: HTMLButtonElement | null;
+  statusElement: HTMLElement | null;
+};
+
+type AudioFlowControllerOptions = {
+  doc: Document;
+  toy: WebToy;
+  prefersReducedMotion: MediaQueryList | null;
+  renderFrame: (ctx: AnimationContext) => void;
+  renderOnce: () => void;
+  setStatus: (message: string, variant?: 'info' | 'error') => void;
+  elements: AudioFlowElements;
+  analytics?: {
+    log?: (message: string, detail?: unknown) => void;
+  };
+  onSuccess?: (mode: AudioFlowMode) => void;
+};
+
+export type AudioFlowController = {
+  setupMicrophoneFlow: () => ReturnType<typeof setupMicrophonePermissionFlow>;
+  handleVisibilityChange: () => Promise<void>;
+  handleReducedMotionChange: (event: MediaQueryListEvent) => void;
+  handlePageHide: () => void;
+  cleanupAudio: () => void;
+};
+
+export function createAudioFlowController({
+  doc,
+  toy,
+  prefersReducedMotion,
+  renderFrame,
+  renderOnce,
+  setStatus,
+  elements,
+  analytics,
+  onSuccess,
+}: AudioFlowControllerOptions): AudioFlowController {
+  let isReducedMotionPreferred = prefersReducedMotion?.matches ?? false;
+  let shouldAnimate = true;
+  let animationContext: AnimationContext | null = null;
+  let audioMode: AudioFlowMode | null = null;
+
+  const clearAnimationLoop = () => {
+    if (toy.renderer?.setAnimationLoop) {
+      toy.renderer.setAnimationLoop(null);
+    }
+  };
+
+  const startAnimationLoop = (ctx: AnimationContext) => {
+    if (!toy.renderer) return;
+    if (!shouldAnimate) {
+      renderOnce();
+      clearAnimationLoop();
+      return;
+    }
+    toy.renderer.setAnimationLoop(() => renderFrame(ctx));
+  };
+
+  const cleanupAudio = () => {
+    clearAnimationLoop();
+    toy?.audioCleanup?.();
+    toy.analyser = null;
+    toy.audioListener = null;
+    toy.audio = null;
+    toy.audioStream = null;
+    toy.audioCleanup = null;
+    animationContext = null;
+  };
+
+  const startAudio = async (mode: AudioFlowMode) => {
+    if (!toy) {
+      setStatus('Renderer is not ready yet. Please retry.', 'error');
+      return;
+    }
+
+    shouldAnimate = !isReducedMotionPreferred;
+    audioMode = mode;
+
+    try {
+      animationContext = await startToyAudio(toy, renderFrame, {
+        fallbackToSynthetic: mode === 'microphone',
+        preferSynthetic: mode === 'sample',
+      });
+
+      if (isReducedMotionPreferred) {
+        renderOnce();
+      } else if (animationContext) {
+        startAnimationLoop(animationContext);
+      }
+    } catch (error) {
+      audioMode = null;
+      clearAnimationLoop();
+      throw error;
+    }
+  };
+
+  const handleVisibilityChange = async () => {
+    if (!doc) return;
+
+    if (doc.visibilityState === 'hidden') {
+      clearAnimationLoop();
+      if (toy.audioListener?.context?.state === 'running') {
+        try {
+          await toy.audioListener.context.suspend();
+        } catch (error) {
+          console.error('Error suspending audio context:', error);
+        }
+      } else {
+        cleanupAudio();
+      }
+      return;
+    }
+
+    if (doc.visibilityState === 'visible') {
+      if (toy.audioListener?.context?.state === 'suspended') {
+        try {
+          await toy.audioListener.context.resume();
+        } catch (error) {
+          console.error('Error resuming audio context:', error);
+        }
+      } else if (audioMode && !animationContext) {
+        try {
+          await startAudio(audioMode);
+        } catch (error) {
+          setStatus(
+            'Microphone or demo audio is required for the visualization to work. Please try again.',
+            'error',
+          );
+          console.error(
+            'Unable to restart audio after visibility change',
+            error,
+          );
+        }
+      }
+
+      if (animationContext) {
+        startAnimationLoop(animationContext);
+      }
+    }
+  };
+
+  const handleReducedMotionChange = (event: MediaQueryListEvent) => {
+    isReducedMotionPreferred = event.matches;
+    shouldAnimate = !isReducedMotionPreferred;
+
+    if (isReducedMotionPreferred) {
+      clearAnimationLoop();
+      renderOnce();
+    } else if (animationContext) {
+      startAnimationLoop(animationContext);
+    }
+  };
+
+  const handlePageHide = () => {
+    cleanupAudio();
+    clearAnimationLoop();
+  };
+
+  const setupMicrophoneFlow = () =>
+    setupMicrophonePermissionFlow({
+      startButton: elements.startButton,
+      fallbackButton: elements.fallbackButton,
+      statusElement: elements.statusElement,
+      requestMicrophone: () => startAudio('microphone'),
+      requestSampleAudio: () => startAudio('sample'),
+      analytics,
+      onSuccess: (mode) => {
+        if (elements.startButton instanceof HTMLButtonElement) {
+          elements.startButton.style.display = 'none';
+        }
+
+        if (
+          mode === 'microphone' &&
+          elements.fallbackButton instanceof HTMLButtonElement
+        ) {
+          elements.fallbackButton.hidden = true;
+        }
+
+        onSuccess?.(mode);
+      },
+    });
+
+  return {
+    setupMicrophoneFlow,
+    handleVisibilityChange,
+    handleReducedMotionChange,
+    handlePageHide,
+    cleanupAudio,
+  };
+}

--- a/assets/js/utils/performance-settings.ts
+++ b/assets/js/utils/performance-settings.ts
@@ -1,0 +1,43 @@
+import {
+  getActivePerformanceSettings,
+  type PerformanceSettings,
+  subscribeToPerformanceSettings,
+} from '../core/performance-panel';
+
+export type PerformanceSettingsHandler = {
+  getSettings: () => PerformanceSettings;
+  dispose: () => void;
+};
+
+type PerformanceSettingsHandlerOptions = {
+  onChange?: (settings: PerformanceSettings) => void;
+  applyRendererSettings?: (settings: PerformanceSettings) => void;
+  enabled?: boolean;
+};
+
+export function createPerformanceSettingsHandler({
+  onChange,
+  applyRendererSettings,
+  enabled = true,
+}: PerformanceSettingsHandlerOptions): PerformanceSettingsHandler {
+  let settings = getActivePerformanceSettings();
+
+  const applySettings = (next: PerformanceSettings) => {
+    settings = next;
+    applyRendererSettings?.(next);
+    onChange?.(next);
+  };
+
+  applyRendererSettings?.(settings);
+
+  const unsubscribe = enabled
+    ? subscribeToPerformanceSettings(applySettings)
+    : null;
+
+  return {
+    getSettings: () => settings,
+    dispose: () => {
+      unsubscribe?.();
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated control-panel wiring by providing a composable panel builder for common controls (button groups + select fields). 
- Centralize performance settings handling so renderer updates and “rebuild visuals” callbacks are applied consistently across toys. 
- Consolidate audio startup, mic-permission flow, and lifecycle handling into a reusable audio flow controller and provide a small stateful button-group helper to keep buttons in sync.

### Description
- Add `assets/js/utils/toy-settings.ts` enhancements: `createStatefulControlPanelButtonGroup` and `buildToySettingsPanel` to build sections with button groups and select controls from a declarative config. 
- Add `assets/js/utils/performance-settings.ts` with `createPerformanceSettingsHandler` that exposes `getSettings` and `dispose` and wires `applyRendererSettings` + subscription to performance changes. 
- Add `assets/js/utils/audio-flow-controller.ts` implementing `createAudioFlowController` to manage mic/sample startup, animation loop lifecycle, visibility/reduced-motion handling, and cleanup. 
- Update multiple toys (`neon-wave`, `spiral-burst`, `cosmic-particles`, `cube-wave`, `fractal-kite-garden`) to consume `buildToySettingsPanel` and `createPerformanceSettingsHandler` and remove duplicated per-toy control plumbing and renderer-setting code. 
- Refactor `assets/js/toys/lights/audio.ts` to delegate microphone permission flow and animation loop lifecycle to `createAudioFlowController` and keep a local `PatternRecognizer` only for pattern logic. 
- Ensure toys dispose performance handlers on runtime `dispose` to clean up subscriptions and keep behavior consistent across toys.

### Testing
- Ran `bun run check` (Biome formatting/lint, `tsc` typecheck and tests) and it completed successfully. 
- Test suite executed as part of checks: `bun test` ran 80 tests with 78 passed and 2 skipped and 0 failed. 

Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d6ba7281c83329d88003e4c20dd26)