### PR TITLE
Extract audio start/UI and control-panel helpers; refactor toys to use them

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 
 - **Toy onboarding quick wins**: Add lightweight presets or first-time hints for toys with multiple controls so the “wow” moment is immediate.
 - **Touch polish**: Add clearer gesture hints and input affordances on the toy page.
+- **Control panel recipes**: Extract shared settings-panel patterns (button-group/select recipes, slider/toggle builders) so toys can declare controls instead of hand-wiring DOM elements.
+- **Unified audio start wrappers**: Standardize the common `runtime.startAudio` wrapper used for mic errors and silent fallbacks into a reusable helper.
+- **Audio permission UI flow helper**: Wrap `createAudioFlowController` + visibility/reduced-motion handling into a higher-level utility to reduce per-toy wiring.
+- **Quality + performance panel helper**: Provide a single setup API for toys that opt into both quality presets and the performance panel.
+- **Toy runtime scaffolding**: Create a higher-level audio-toy bootstrap that composes runtime creation, plugin lifecycle, and optional settings/performance panels.
 
 ---
 

--- a/assets/js/toys/bioluminescent-tidepools.ts
+++ b/assets/js/toys/bioluminescent-tidepools.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { registerToyGlobals } from '../core/toy-globals';
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
-import type { ToyAudioRequest } from '../utils/audio-start';
+import { createRuntimeAudioStarter } from '../utils/audio-start-helpers';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import { createToyQualityControls } from '../utils/toy-settings';
@@ -626,18 +626,17 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   runtime = startRuntime({ container });
 
-  async function startAudio(request: ToyAudioRequest = false) {
-    try {
-      return await runtime.startAudio(request);
-    } catch (error) {
+  const startAudio = createRuntimeAudioStarter({
+    runtime,
+    onFallback: async (error) => {
       console.warn('Falling back to silent animation', error);
       if (runtime.toy.rendererReady) {
         await runtime.toy.rendererReady;
       }
       runtime.toy.renderer?.setAnimationLoop(() => animate(new Uint8Array()));
       return null;
-    }
-  }
+    },
+  });
 
   const unregisterGlobals = registerToyGlobals(container, startAudio);
 

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import {
   getActivePerformanceSettings,
-  getPerformancePanel,
   type PerformanceSettings,
 } from '../core/performance-panel';
 import type { QualityPreset } from '../core/settings-panel';
@@ -10,9 +9,9 @@ import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor } from '../utils/color-audio';
 import { createPerformanceSettingsHandler } from '../utils/performance-settings';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
-import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
+import { createAudioToyStarter } from '../utils/toy-runtime-starter';
 import {
-  buildToySettingsPanel,
+  buildToySettingsPanelWithPerformance,
   createToyQualityControls,
 } from '../utils/toy-settings';
 
@@ -307,11 +306,16 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    buildToySettingsPanel({
+    buildToySettingsPanelWithPerformance({
       title: 'Cosmic controls',
       description:
         'Quality changes persist between toys so you can cap DPI or ramp visuals.',
       quality,
+      performance: {
+        title: 'Performance',
+        description:
+          'Cap DPI, trim particle budgets, or lower shader detail for smoother play.',
+      },
       sections: [
         {
           title: 'Cosmic preset',
@@ -337,20 +341,12 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     });
   }
 
-  function setupPerformancePanel() {
-    getPerformancePanel({
-      title: 'Performance',
-      description:
-        'Cap DPI, trim particle budgets, or lower shader detail for smoother play.',
-    });
-  }
-
   function animate(data: Uint8Array, time: number) {
     activePreset?.animate(data, time);
   }
 
   setupSettingsPanel();
-  const startRuntime = createToyRuntimeStarter({
+  const startRuntime = createAudioToyStarter({
     toyOptions: {
       cameraOptions: { position: { x: 0, y: 0, z: 80 } },
       ambientLightOptions: { intensity: 0.35 },
@@ -364,7 +360,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
         name: 'cosmic-particles',
         setup: () => {
           setupSettingsPanel();
-          setupPerformancePanel();
           setActivePreset(activePresetKey);
         },
         update: ({ frequencyData, time }) => {

--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -5,7 +5,7 @@ import { type AudioColorParams, applyAudioColor } from '../utils/color-audio';
 import { disposeObject3D } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  buildToySettingsPanel,
+  buildSingleSelectPanel,
   createToyQualityControls,
 } from '../utils/toy-settings';
 
@@ -232,28 +232,24 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   }
 
   function setupSettingsPanel() {
-    buildToySettingsPanel({
+    buildSingleSelectPanel({
       title: 'Grid visualizer',
       description:
         'Adjust render resolution caps and switch primitives without restarting audio.',
       quality,
-      sections: [
-        {
-          title: 'Shape',
-          description: 'Change the primitive without restarting audio.',
-          controls: [
-            {
-              type: 'select',
-              options: Object.entries(presets).map(([key, preset]) => ({
-                value: key,
-                label: preset.label,
-              })),
-              getValue: () => activeMode,
-              onChange: (value) => rebuildGrid(value as ShapeMode),
-            },
-          ],
-        },
-      ],
+      section: {
+        title: 'Shape',
+        description: 'Change the primitive without restarting audio.',
+      },
+      select: {
+        type: 'select',
+        options: Object.entries(presets).map(([key, preset]) => ({
+          value: key,
+          label: preset.label,
+        })),
+        getValue: () => activeMode,
+        onChange: (value) => rebuildGrid(value as ShapeMode),
+      },
     });
   }
 

--- a/assets/js/toys/lights/audio.ts
+++ b/assets/js/toys/lights/audio.ts
@@ -6,8 +6,8 @@ import {
   applyAudioRotation,
   applyAudioScale,
 } from '../../utils/animation-utils.ts';
-import { createAudioFlowController } from '../../utils/audio-flow-controller';
 import { getWeightedAverageFrequency } from '../../utils/audio-handler.ts';
+import { createManagedAudioFlow } from '../../utils/audio-ui-flow';
 import PatternRecognizer from '../../utils/patternRecognition.ts';
 
 type AudioControllerOptions = {
@@ -26,12 +26,9 @@ type AudioControllerOptions = {
 
 export type AudioController = {
   setupMicrophoneFlow: ReturnType<
-    typeof createAudioFlowController
+    typeof createManagedAudioFlow
   >['setupMicrophoneFlow'];
-  handleVisibilityChange: () => Promise<void>;
-  handleReducedMotionChange: (event: MediaQueryListEvent) => void;
-  handlePageHide: () => void;
-  cleanupAudio: () => void;
+  cleanup: () => void;
 };
 
 export const createAudioController = ({
@@ -76,7 +73,7 @@ export const createAudioController = ({
     renderOnce();
   };
 
-  const audioFlow = createAudioFlowController({
+  const audioFlow = createManagedAudioFlow({
     doc,
     toy,
     prefersReducedMotion,
@@ -94,9 +91,9 @@ export const createAudioController = ({
   });
 
   return {
-    ...audioFlow,
-    cleanupAudio: () => {
-      audioFlow.cleanupAudio();
+    setupMicrophoneFlow: audioFlow.setupMicrophoneFlow,
+    cleanup: () => {
+      audioFlow.cleanup();
       patternRecognizer = null;
     },
   };

--- a/assets/js/toys/lights/index.ts
+++ b/assets/js/toys/lights/index.ts
@@ -19,10 +19,6 @@ export const startLightsExperience = ({
   let audioController: ReturnType<typeof createAudioController> | null = null;
   let microphoneFlow: { dispose?: () => void } | null = null;
   let removeLightChangeListener: (() => void) | undefined;
-  let handleReducedMotionChange: ((event: MediaQueryListEvent) => void) | null =
-    null;
-  let handleVisibilityChange: (() => void) | null = null;
-  let handlePageHide: (() => void) | null = null;
 
   const renderOnce = () => {
     scene?.toy.render();
@@ -77,37 +73,14 @@ export const startLightsExperience = ({
       applyLighting(scene.lightingGroup, lightType);
       renderOnce();
     });
-
-    handleReducedMotionChange = audioController.handleReducedMotionChange;
-    handleVisibilityChange = audioController.handleVisibilityChange;
-    handlePageHide = audioController.handlePageHide;
-
-    prefersReducedMotion?.addEventListener('change', handleReducedMotionChange);
-    doc.addEventListener('visibilitychange', handleVisibilityChange);
-    win.addEventListener('pagehide', handlePageHide);
   };
 
   const dispose = () => {
     microphoneFlow?.dispose?.();
     microphoneFlow = null;
-    audioController?.cleanupAudio();
+    audioController?.cleanup();
     removeLightChangeListener?.();
     removeLightChangeListener = undefined;
-    if (handleReducedMotionChange) {
-      prefersReducedMotion?.removeEventListener(
-        'change',
-        handleReducedMotionChange,
-      );
-    }
-    if (handleVisibilityChange) {
-      doc?.removeEventListener('visibilitychange', handleVisibilityChange);
-    }
-    if (handlePageHide) {
-      win?.removeEventListener('pagehide', handlePageHide);
-    }
-    handleReducedMotionChange = null;
-    handleVisibilityChange = null;
-    handlePageHide = null;
     scene?.toy.dispose();
     scene = null;
     audioController = null;

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import {
   getActivePerformanceSettings,
-  getPerformancePanel,
   type PerformanceSettings,
 } from '../core/performance-panel';
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
@@ -12,9 +11,9 @@ import { mapFrequencyToItems } from '../utils/audio-mapper';
 import { applyAudioColor } from '../utils/color-audio';
 import { createPerformanceSettingsHandler } from '../utils/performance-settings';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
-import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
+import { createAudioToyStarter } from '../utils/toy-runtime-starter';
 import {
-  buildToySettingsPanel,
+  buildToySettingsPanelWithPerformance,
   createToyQualityControls,
 } from '../utils/toy-settings';
 import type { UnifiedInputState } from '../utils/unified-input';
@@ -314,11 +313,15 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function setupSettingsPanel() {
     const modes: SpiralMode[] = ['burst', 'bloom', 'vortex', 'heartbeat'];
-    buildToySettingsPanel({
+    buildToySettingsPanelWithPerformance({
       title: 'Spiral Burst',
       description:
         'Explosive spirals that pulse with your music. Try different modes, pinch to amplify, and rotate to swap moods!',
       quality,
+      performance: {
+        title: 'Performance',
+        description: 'Adjust particle density and render quality.',
+      },
       sections: [
         {
           title: 'Mode',
@@ -341,13 +344,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
           ],
         },
       ],
-    });
-  }
-
-  function setupPerformancePanel() {
-    getPerformancePanel({
-      title: 'Performance',
-      description: 'Adjust particle density and render quality.',
     });
   }
 
@@ -651,7 +647,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     }
   }
 
-  const startRuntime = createToyRuntimeStarter({
+  const startRuntime = createAudioToyStarter({
     toyOptions: {
       cameraOptions: { position: { x: 0, y: 0, z: 120 } },
       lightingOptions: { type: 'HemisphereLight', intensity: 0.6 },
@@ -671,7 +667,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
         setup: ({ toy }) => {
           toy.scene.add(spiralContainer);
           setupSettingsPanel();
-          setupPerformancePanel();
           buildSpiralArms();
           particleField = createParticleField();
           createBloomMesh();

--- a/assets/js/toys/tactile-sand-table.ts
+++ b/assets/js/toys/tactile-sand-table.ts
@@ -6,6 +6,11 @@ import {
 } from '../core/motion-preferences';
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
+import {
+  createControlPanelCheckbox,
+  createControlPanelNote,
+  createControlPanelSlider,
+} from '../utils/control-panel-elements';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import { createToyQualityControls } from '../utils/toy-settings';
@@ -188,18 +193,16 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     'Grain size',
     'Scale the displacement height for taller or flatter dunes.',
   );
-  const grainSlider = document.createElement('input');
-  grainSlider.type = 'range';
-  grainSlider.min = '0.6';
-  grainSlider.max = '2.4';
-  grainSlider.step = '0.02';
-  grainSlider.value = grainScale.toString();
-  grainSlider.setAttribute('aria-label', 'Grain size');
-  grainSlider.className = 'control-panel__slider';
-  grainSlider.addEventListener('input', (event) => {
-    const value = Number((event.target as HTMLInputElement).value);
-    grainScale = value;
-    sandMaterial.displacementScale = value;
+  const grainSlider = createControlPanelSlider({
+    min: 0.6,
+    max: 2.4,
+    step: 0.02,
+    value: grainScale,
+    ariaLabel: 'Grain size',
+    onInput: (value) => {
+      grainScale = value;
+      sandMaterial.displacementScale = value;
+    },
   });
   grainRow.appendChild(grainSlider);
 
@@ -207,16 +210,15 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     'Damping',
     'Higher damping calms ripples faster; lower values keep waves lively.',
   );
-  const dampingSlider = document.createElement('input');
-  dampingSlider.type = 'range';
-  dampingSlider.min = '0.94';
-  dampingSlider.max = '0.995';
-  dampingSlider.step = '0.001';
-  dampingSlider.value = damping.toFixed(3);
-  dampingSlider.setAttribute('aria-label', 'Ripple damping');
-  dampingSlider.className = 'control-panel__slider';
-  dampingSlider.addEventListener('input', (event) => {
-    damping = Number((event.target as HTMLInputElement).value);
+  const dampingSlider = createControlPanelSlider({
+    min: 0.94,
+    max: 0.995,
+    step: 0.001,
+    value: Number(damping.toFixed(3)),
+    ariaLabel: 'Ripple damping',
+    onInput: (value) => {
+      damping = value;
+    },
   });
   dampingRow.appendChild(dampingSlider);
 
@@ -229,22 +231,18 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     'Gravity',
     'Lock to the default downward pull on desktop, or let device tilt steer the sand.',
   );
-  const gravityLock = document.createElement('input');
-  gravityLock.type = 'checkbox';
-  gravityLock.id = 'tactile-gravity-lock';
-  const gravityToggle = document.createElement('label');
-  gravityToggle.className = 'control-panel__checkbox-inline';
-  gravityToggle.htmlFor = gravityLock.id;
-  gravityToggle.textContent = 'Lock gravity';
-
-  gravityLock.checked = gravity.locked;
-
-  gravityLock.addEventListener('change', () => {
-    gravity.locked = gravityLock.checked;
-    if (gravity.locked) {
-      gravity.target.copy(DEFAULT_GRAVITY);
-    }
-  });
+  const { input: gravityLock, toggle: gravityToggle } =
+    createControlPanelCheckbox({
+      id: 'tactile-gravity-lock',
+      label: 'Lock gravity',
+      checked: gravity.locked,
+      onChange: (checked) => {
+        gravity.locked = checked;
+        if (gravity.locked) {
+          gravity.target.copy(DEFAULT_GRAVITY);
+        }
+      },
+    });
 
   const recenter = document.createElement('button');
   recenter.type = 'button';
@@ -257,16 +255,15 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     gravity.locked = true;
   });
 
-  gravityToggle.prepend(gravityLock);
   gravityRow.append(gravityToggle, recenter);
 
-  const motionStatus = document.createElement('p');
-  motionStatus.className = 'control-panel__note';
-  motionStatus.textContent = motionSupported
-    ? 'Enable device motion to steer the sand with tilt.'
-    : deviceMotionSupported
-      ? 'Motion input is off. Enable it in the global settings to steer the sand.'
-      : 'Device motion is unavailable; gravity will stay locked.';
+  const motionStatus = createControlPanelNote({
+    text: motionSupported
+      ? 'Enable device motion to steer the sand with tilt.'
+      : deviceMotionSupported
+        ? 'Motion input is off. Enable it in the global settings to steer the sand.'
+        : 'Device motion is unavailable; gravity will stay locked.',
+  });
 
   const motionButton = document.createElement('button');
   motionButton.type = 'button';

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -8,7 +8,7 @@ import type { RendererBackend } from '../core/renderer-capabilities';
 import { registerToyGlobals } from '../core/toy-globals';
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
-import type { ToyAudioRequest } from '../utils/audio-start';
+import { createRuntimeAudioStarter } from '../utils/audio-start-helpers';
 import {
   type ControlPanelState,
   createControlPanel,
@@ -351,19 +351,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     configurePanel();
   }
 
-  async function startAudio(request: ToyAudioRequest = false) {
-    try {
-      await runtime.startAudio(request);
-      hideError();
-      return true;
-    } catch (e) {
-      showError(
-        'Microphone access was denied. Please allow access and reload.',
-      );
-      throw e;
-    }
-  }
-
   const startRuntime = createToyRuntimeStarter({
     toyOptions: {
       cameraOptions: { position: { x: 0, y: 0, z: 80 } },
@@ -410,6 +397,18 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   });
 
   runtime = startRuntime({ container });
+
+  const startAudio = createRuntimeAudioStarter({
+    runtime,
+    onSuccess: () => {
+      hideError();
+    },
+    onError: () => {
+      showError(
+        'Microphone access was denied. Please allow access and reload.',
+      );
+    },
+  });
 
   const unregisterGlobals = registerToyGlobals(container, startAudio);
 

--- a/assets/js/utils/audio-start-helpers.ts
+++ b/assets/js/utils/audio-start-helpers.ts
@@ -1,0 +1,30 @@
+import type { ToyRuntimeInstance } from '../core/toy-runtime';
+import type { ToyAudioRequest } from './audio-start';
+
+type RuntimeAudioHandlerOptions = {
+  runtime: ToyRuntimeInstance;
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+  onFallback?: (error: unknown) => Promise<unknown> | unknown;
+};
+
+export function createRuntimeAudioStarter({
+  runtime,
+  onSuccess,
+  onError,
+  onFallback,
+}: RuntimeAudioHandlerOptions) {
+  return async (request: ToyAudioRequest = false) => {
+    try {
+      const result = await runtime.startAudio(request);
+      onSuccess?.();
+      return result;
+    } catch (error) {
+      onError?.(error);
+      if (onFallback) {
+        return await onFallback(error);
+      }
+      throw error;
+    }
+  };
+}

--- a/assets/js/utils/audio-ui-flow.ts
+++ b/assets/js/utils/audio-ui-flow.ts
@@ -1,0 +1,74 @@
+import type { AudioFlowController } from './audio-flow-controller';
+import { createAudioFlowController } from './audio-flow-controller';
+
+type ManagedAudioFlowOptions = Parameters<
+  typeof createAudioFlowController
+>[0] & {
+  windowRef?: Window | null;
+};
+
+type ManagedAudioFlowHandle = {
+  setupMicrophoneFlow: AudioFlowController['setupMicrophoneFlow'];
+  cleanup: () => void;
+};
+
+export function createManagedAudioFlow({
+  windowRef = typeof window !== 'undefined' ? window : null,
+  ...options
+}: ManagedAudioFlowOptions): ManagedAudioFlowHandle {
+  const controller = createAudioFlowController(options);
+  let microphoneFlow: ReturnType<
+    AudioFlowController['setupMicrophoneFlow']
+  > | null = null;
+  let handleReducedMotionChange: ((event: MediaQueryListEvent) => void) | null =
+    null;
+  let handleVisibilityChange: (() => void) | null = null;
+  let handlePageHide: (() => void) | null = null;
+
+  const setupMicrophoneFlow = () => {
+    microphoneFlow?.dispose?.();
+    microphoneFlow = controller.setupMicrophoneFlow();
+
+    handleReducedMotionChange = controller.handleReducedMotionChange;
+    handleVisibilityChange = controller.handleVisibilityChange;
+    handlePageHide = controller.handlePageHide;
+
+    options.prefersReducedMotion?.addEventListener(
+      'change',
+      handleReducedMotionChange,
+    );
+    options.doc.addEventListener('visibilitychange', handleVisibilityChange);
+    windowRef?.addEventListener('pagehide', handlePageHide);
+
+    return microphoneFlow;
+  };
+
+  const cleanup = () => {
+    microphoneFlow?.dispose?.();
+    microphoneFlow = null;
+    controller.cleanupAudio();
+    if (handleReducedMotionChange) {
+      options.prefersReducedMotion?.removeEventListener(
+        'change',
+        handleReducedMotionChange,
+      );
+    }
+    if (handleVisibilityChange) {
+      options.doc.removeEventListener(
+        'visibilitychange',
+        handleVisibilityChange,
+      );
+    }
+    if (handlePageHide) {
+      windowRef?.removeEventListener('pagehide', handlePageHide);
+    }
+    handleReducedMotionChange = null;
+    handleVisibilityChange = null;
+    handlePageHide = null;
+  };
+
+  return {
+    setupMicrophoneFlow,
+    cleanup,
+  };
+}

--- a/assets/js/utils/control-panel-elements.ts
+++ b/assets/js/utils/control-panel-elements.ts
@@ -1,0 +1,79 @@
+type SliderOptions = {
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  ariaLabel: string;
+  className?: string;
+  onInput: (value: number) => void;
+};
+
+type CheckboxOptions = {
+  id: string;
+  label: string;
+  checked: boolean;
+  className?: string;
+  onChange: (checked: boolean) => void;
+};
+
+type NoteOptions = {
+  text: string;
+  className?: string;
+};
+
+export function createControlPanelSlider({
+  min,
+  max,
+  step,
+  value,
+  ariaLabel,
+  className = 'control-panel__slider',
+  onInput,
+}: SliderOptions) {
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = min.toString();
+  slider.max = max.toString();
+  slider.step = step.toString();
+  slider.value = value.toString();
+  slider.setAttribute('aria-label', ariaLabel);
+  slider.className = className;
+  slider.addEventListener('input', (event) => {
+    const target = event.target as HTMLInputElement;
+    onInput(Number(target.value));
+  });
+  return slider;
+}
+
+export function createControlPanelCheckbox({
+  id,
+  label,
+  checked,
+  className = 'control-panel__checkbox-inline',
+  onChange,
+}: CheckboxOptions) {
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.id = id;
+  input.checked = checked;
+
+  const toggle = document.createElement('label');
+  toggle.className = className;
+  toggle.htmlFor = id;
+  toggle.textContent = label;
+  toggle.prepend(input);
+
+  input.addEventListener('change', () => onChange(input.checked));
+
+  return { input, toggle };
+}
+
+export function createControlPanelNote({
+  text,
+  className = 'control-panel__note',
+}: NoteOptions) {
+  const note = document.createElement('p');
+  note.className = className;
+  note.textContent = text;
+  return note;
+}

--- a/assets/js/utils/toy-runtime-starter.ts
+++ b/assets/js/utils/toy-runtime-starter.ts
@@ -1,4 +1,12 @@
-import { createToyRuntime, type ToyRuntimeOptions } from '../core/toy-runtime';
+import {
+  getPerformancePanel,
+  type PerformancePanelOptions,
+} from '../core/performance-panel';
+import {
+  createToyRuntime,
+  type ToyRuntimeOptions,
+  type ToyRuntimePlugin,
+} from '../core/toy-runtime';
 import {
   configureToySettingsPanel,
   type QualityPresetManager,
@@ -17,6 +25,14 @@ export type ToyRuntimeStarterOptions = Omit<
   canvasSelector?: string;
   boundsSelector?: string;
   settingsPanel?: ToyRuntimeStarterSettings;
+};
+
+export type AudioToyStarterOptions = Omit<
+  ToyRuntimeStarterOptions,
+  'plugins'
+> & {
+  plugins?: ToyRuntimePlugin[];
+  performancePanel?: PerformancePanelOptions;
 };
 
 export function createToyRuntimeStarter({
@@ -55,5 +71,28 @@ export function createToyRuntimeStarter({
     }
 
     return runtime;
+  };
+}
+
+export function createAudioToyStarter({
+  plugins = [],
+  performancePanel,
+  ...options
+}: AudioToyStarterOptions) {
+  const startRuntime = createToyRuntimeStarter({
+    ...options,
+    plugins,
+  });
+
+  return function start({
+    container,
+  }: {
+    container?: HTMLElement | null;
+  } = {}) {
+    if (performancePanel) {
+      getPerformancePanel(performancePanel);
+    }
+
+    return startRuntime({ container });
   };
 }

--- a/assets/js/utils/toy-settings.ts
+++ b/assets/js/utils/toy-settings.ts
@@ -1,4 +1,8 @@
 import {
+  getPerformancePanel,
+  type PerformancePanelOptions,
+} from '../core/performance-panel';
+import {
   DEFAULT_QUALITY_PRESETS,
   getActiveQualityPreset,
   getSettingsPanel,
@@ -285,6 +289,27 @@ type BuildToySettingsPanelOptions = ToySettingsPanelOptions & {
   sections: ToySettingsSection[];
 };
 
+export type SingleSelectPanelOptions = ToySettingsPanelOptions & {
+  section: {
+    title: string;
+    description?: string;
+  };
+  select: SelectControl;
+};
+
+export type SingleButtonGroupPanelOptions = ToySettingsPanelOptions & {
+  section: {
+    title: string;
+    description?: string;
+  };
+  buttonGroup: ButtonGroupControl;
+};
+
+type BuildToySettingsPanelWithPerformanceOptions =
+  BuildToySettingsPanelOptions & {
+    performance?: PerformancePanelOptions;
+  };
+
 export function buildToySettingsPanel({
   sections,
   ...panelOptions
@@ -325,4 +350,72 @@ export function buildToySettingsPanel({
   });
 
   return panel;
+}
+
+export function buildToySettingsPanelWithPerformance({
+  performance,
+  ...options
+}: BuildToySettingsPanelWithPerformanceOptions): PersistentSettingsPanel {
+  const panel = buildToySettingsPanel(options);
+  if (performance) {
+    getPerformancePanel(performance);
+  }
+  return panel;
+}
+
+export function buildSingleSelectPanel({
+  section,
+  select,
+  ...panelOptions
+}: SingleSelectPanelOptions): PersistentSettingsPanel {
+  return buildToySettingsPanel({
+    ...panelOptions,
+    sections: [
+      {
+        title: section.title,
+        description: section.description,
+        controls: [
+          {
+            type: 'select',
+            options: select.options,
+            getValue: select.getValue,
+            onChange: select.onChange,
+            selectClassName: select.selectClassName,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+export function buildSingleButtonGroupPanel({
+  section,
+  buttonGroup,
+  ...panelOptions
+}: SingleButtonGroupPanelOptions): PersistentSettingsPanel {
+  return buildToySettingsPanel({
+    ...panelOptions,
+    sections: [
+      {
+        title: section.title,
+        description: section.description,
+        controls: [
+          {
+            type: 'button-group',
+            options: buttonGroup.options,
+            getActiveId: buttonGroup.getActiveId,
+            onChange: buttonGroup.onChange,
+            rowClassName: buttonGroup.rowClassName,
+            rowStyle: buttonGroup.rowStyle,
+            buttonClassName: buttonGroup.buttonClassName,
+            buttonStyle: buttonGroup.buttonStyle,
+            activeClassName: buttonGroup.activeClassName,
+            setDisabledOnActive: buttonGroup.setDisabledOnActive,
+            setAriaPressed: buttonGroup.setAriaPressed,
+            dataAttribute: buttonGroup.dataAttribute,
+          },
+        ],
+      },
+    ],
+  });
 }


### PR DESCRIPTION
### Motivation
- Reduce duplication by extracting common audio start/error/fallback handling, a managed audio UI flow, and reusable control-panel element builders so toys can declare behavior instead of hand-wiring it. 
- Provide convenience recipes for settings panels and an audio-focused runtime starter that wire quality + performance panels consistently across audio toys. 

### Description
- Added new helper modules: `assets/js/utils/audio-start-helpers.ts`, `assets/js/utils/audio-ui-flow.ts`, and `assets/js/utils/control-panel-elements.ts` to centralize audio start logic, managed audio UI flow, and DOM control builders. 
- Extended settings utilities in `assets/js/utils/toy-settings.ts` with `buildToySettingsPanelWithPerformance`, `buildSingleSelectPanel`, and `buildSingleButtonGroupPanel` and added `createAudioToyStarter` in `assets/js/utils/toy-runtime-starter.ts` to compose performance wiring and runtime bootstrapping. 
- Refactored toys to use the new helpers: `cube-wave`, `tactile-sand-table`, `lights` (audio and index), `cosmic-particles`, `spiral-burst`, `three-d-toy`, and `bioluminescent-tidepools` now use the runtime audio starter, managed audio flow, settings recipes, or control-panel element builders. 

### Testing
- Ran `bun run check` (includes `tsc --noEmit`) which completed successfully. 
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests` which completed successfully. 
- Ran the test suite with `bun test` which completed with the test summary: 80 tests run, 78 passed and 2 skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d795499388332a082614eb213be0e)