### PR TITLE
Add starter packs and onboarding tips to the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Head to [no.toil.fyi](https://no.toil.fyi) and jump right in. The toys respond t
 - **Guided toy start**: the shared toy shell runs a capability preflight before loading a toy, then offers microphone, demo audio, and YouTube tab-capture audio flows with status messaging.
 - **Consistent performance controls**: quality presets and pixel-ratio caps persist between toys, while pooled renderer/audio services keep toy switching fast without re-prompting for microphone access.
 
+### Accessibility & comfort notes
+
+- **Motion comfort**: the system check and performance panel surface reduced-motion guidance and quality presets so you can dial in lower-intensity visuals.
+- **Input flexibility**: toys support microphone, demo audio, and tab/YouTube audio to reduce friction when permissions are blocked.
+- **Touch-first affordances**: shared input helpers and touch-action defaults keep gestures predictable across devices.
+
 ## Repository Layout
 
 This project is organized so you can find the visuals, core utilities, and shared assets quickly:

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -767,6 +767,86 @@ header.hero {
   pointer-events: none;
 }
 
+.starter-packs {
+  position: relative;
+  padding: clamp(2.5rem, 6vw, 5rem) 0;
+  margin-top: clamp(2rem, 5vw, 4rem);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent-color) 12%, transparent),
+    transparent 65%
+  );
+}
+
+.starter-packs .section-heading {
+  margin-bottom: 2.5rem;
+}
+
+.pack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.pack-card {
+  padding: 1.75rem;
+  border-radius: calc(var(--radius-lg) + 4px);
+  background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pack-card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.pack-card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.pack-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.pack-card ul a {
+  color: inherit;
+}
+
+.pack-card .text-link {
+  margin-top: auto;
+  align-self: flex-start;
+}
+
+.library-first-run {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
+  border: 1px solid var(--surface-border);
+  color: var(--text-default);
+}
+
+.library-first-run__title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.library-first-run ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
 .system-grid {
   display: grid;
   gap: 1.4rem;

--- a/docs/QA_PLAN.md
+++ b/docs/QA_PLAN.md
@@ -15,6 +15,15 @@ This guide captures the highest-impact flows to validate and how we keep them co
   - What to verify: microphone setup resolves permissions, falls back to demo audio when blocked, and emits state changes that toys can react to.
   - Automation: `tests/microphone-flow.test.ts` validates the state machine around permission requests, error handling, and fallback triggers.
 
+## Quick manual checklist (UI smoke pass)
+
+When you touch the landing page or toy shell UI, run this short manual pass:
+
+1. **Landing page**: Starter packs render, and their links open the expected toys.
+2. **Library search**: Search input filters cards and clearing filters restores all results.
+3. **Toy launch**: Open a toy from the library, start demo audio, and confirm visuals respond.
+4. **Performance panel**: Open system check, toggle a quality preset, and verify the selection persists when switching toys.
+
 ## How to run the QA automation
 
 Use Bun to match the repository tooling:

--- a/index.html
+++ b/index.html
@@ -268,6 +268,61 @@
         </div>
       </section>
 
+      <section class="starter-packs" id="starter-packs">
+        <div class="section-heading">
+          <p class="eyebrow">Starter packs</p>
+          <h2>Pick a mood, then hit play</h2>
+          <p class="section-description">
+            Curated runs that get you into flow fast, with toys grouped by vibe.
+          </p>
+        </div>
+        <div class="pack-grid">
+          <article class="pack-card" aria-label="Calm reset starter pack">
+            <h3>Calm reset</h3>
+            <p>
+              Slow, luminous visuals with steady movement for quiet focus and
+              gentle breathing space.
+            </p>
+            <ul>
+              <li><a href="toy.html?toy=holy">Halo Flow</a></li>
+              <li><a href="toy.html?toy=aurora-painter">Aurora Painter</a></li>
+              <li><a href="toy.html?toy=star-field">Star Field</a></li>
+            </ul>
+            <a class="text-link" href="toy.html?toy=holy">Open the pack</a>
+          </article>
+          <article class="pack-card" aria-label="Energy lift starter pack">
+            <h3>Energy lift</h3>
+            <p>
+              Punchier bursts, bright palettes, and responsive motion when you
+              want a little extra spark.
+            </p>
+            <ul>
+              <li><a href="toy.html?toy=spiral-burst">Spiral Burst</a></li>
+              <li><a href="toy.html?toy=lights">Audio Light Show</a></li>
+              <li><a href="toy.html?toy=rainbow-tunnel">Rainbow Tunnel</a></li>
+            </ul>
+            <a class="text-link" href="toy.html?toy=spiral-burst">
+              Open the pack
+            </a>
+          </article>
+          <article class="pack-card" aria-label="Touch-first starter pack">
+            <h3>Touch-first</h3>
+            <p>
+              Gesture-led toys built for phones and tablets, with satisfying
+              feedback and easy controls.
+            </p>
+            <ul>
+              <li><a href="toy.html?toy=pocket-pulse">Pocket Pulse</a></li>
+              <li><a href="toy.html?toy=mobile-ripples">Mobile Ripples</a></li>
+              <li><a href="toy.html?toy=tactile-sand-table">Tactile Sand Table</a></li>
+            </ul>
+            <a class="text-link" href="toy.html?toy=pocket-pulse">
+              Open the pack
+            </a>
+          </article>
+        </div>
+      </section>
+
       <section class="library" id="library">
         <div class="section-heading">
           <p class="eyebrow">Library</p>
@@ -275,6 +330,14 @@
           <p class="section-description">
             Tap a card to launch. Everything is accessible and ready to play.
           </p>
+          <div class="library-first-run" aria-label="First time tips">
+            <p class="library-first-run__title">First time here?</p>
+            <ul>
+              <li>Start with demo audio if microphone access isn’t ready.</li>
+              <li>Pinch or scroll to adjust intensity on most toys.</li>
+              <li>Use the performance panel for smoother motion on older devices.</li>
+            </ul>
+          </div>
           <search class="library-search">
             <div class="search-heading">
               <h3>Find a stim fast</h3>


### PR DESCRIPTION
### Motivation

- Make the landing page more approachable by surfacing curated "starter packs" so users can pick a mood and launch a small set of toys quickly.
- Improve first-time onboarding with lightweight tips and surface accessibility/comfort guidance for motion, input, and touch affordances.

### Description

- Add a new `starter-packs` section to `index.html` with three example packs and links to relevant toys. 
- Add a compact `library-first-run` block to `index.html` containing first-time tips for audio, gestures, and performance controls. 
- Add styling for the new UI blocks in `assets/css/index.css` (grid, card styling, and first-run panel). 
- Update `README.md` with an "Accessibility & comfort notes" section and append a quick manual UI smoke checklist to `docs/QA_PLAN.md`.

### Testing

- Ran the pre-commit formatting/linting hooks which executed `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both completed successfully. 
- Started the dev server with `bun run dev` (Vite reported ready and served at the local host), and confirmed the page renders. 
- Captured a headless smoke screenshot with Playwright to verify the new starter packs and onboarding UI rendered; the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8bfd5d548332a3d9fa35f3e52092)