### PR TITLE
Streamline homepage highlights and system check

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -583,6 +583,27 @@ header.hero {
   content: none;
 }
 
+.system-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.system-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-bg) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+}
+
 .system-grid {
   display: grid;
   gap: 1.4rem;
@@ -1049,6 +1070,26 @@ html.light .hero-readiness__text {
   margin: 0.35rem 0 0;
   color: var(--text-muted);
   font-size: 0.9rem;
+}
+
+.intro-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.intro-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-bg) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
 }
 
 .details-panel {

--- a/index.html
+++ b/index.html
@@ -83,11 +83,14 @@
           <p class="eyebrow">Audio-reactive visuals • No setup</p>
           <h1>Stim library</h1>
           <p class="section-description">
-            A minimal library of light and motion, tuned for sound, touch, and
-            calm focus.
+            Light and motion tuned for sound, touch, and calm focus.
           </p>
-          <p class="intro-focus">Featured: Halo Flow.</p>
-          <p class="intro-meta">Mic optional • Demo audio in every toy.</p>
+          <div class="intro-pills" aria-label="Quick highlights">
+            <span class="intro-pill">✨ Featured: Halo Flow</span>
+            <span class="intro-pill">🎧 Mic optional</span>
+            <span class="intro-pill">🔊 Demo audio</span>
+            <span class="intro-pill">🖐️ Touch ready</span>
+          </div>
         </div>
         <div class="cta-row hero-cta-row">
           <a
@@ -118,15 +121,14 @@
           <p class="eyebrow">System check</p>
           <h2>Confirm your device</h2>
           <p class="section-description">
-            Live readiness stays in sync with your device.
+            Live readiness stays in sync.
           </p>
           <p
             class="section-description details-panel"
             data-details-panel
             id="system-check-details"
           >
-            Open the system check for graphics, microphone, and performance
-            presets before launching a stim.
+            Graphics, mic, motion, and comfort at a glance.
           </p>
           <a
             href="#system-check"
@@ -139,6 +141,12 @@
             <span data-details-label="close">Hide details</span>
           </a>
         </div>
+        <ul class="system-legend" aria-label="System signals">
+          <li class="system-legend__item">🖥️ Graphics</li>
+          <li class="system-legend__item">🎙️ Mic</li>
+          <li class="system-legend__item">🧭 Motion</li>
+          <li class="system-legend__item">🫧 Comfort</li>
+        </ul>
         <div class="system-grid">
           <div class="readiness-panel" data-readiness-panel>
             <div class="readiness-header">
@@ -158,7 +166,7 @@
                   <span class="readiness-name">Graphics acceleration</span>
                 </div>
                 <p class="readiness-note" data-status-note="render">
-                  Checking WebGL and WebGPU support…
+                  Checking graphics…
                 </p>
               </li>
               <li class="readiness-item">
@@ -171,7 +179,7 @@
                   <span class="readiness-name">Microphone</span>
                 </div>
                 <p class="readiness-note" data-status-note="mic">
-                  Checking microphone permissions…
+                  Checking mic…
                 </p>
               </li>
               <li class="readiness-item">
@@ -184,7 +192,7 @@
                   <span class="readiness-name">Motion input</span>
                 </div>
                 <p class="readiness-note" data-status-note="motion">
-                  Checking device motion support…
+                  Checking motion…
                 </p>
               </li>
               <li class="readiness-item">
@@ -197,7 +205,7 @@
                   <span class="readiness-name">Motion comfort</span>
                 </div>
                 <p class="readiness-note" data-status-note="reduced">
-                  Reading motion comfort settings…
+                  Reading comfort…
                 </p>
               </li>
             </ul>


### PR DESCRIPTION
### Motivation
- Reduce on-page verbosity so key information is scannable without extra clicks or explanation. 
- Surface important signals (featured toy, mic/demo audio, motion readiness) as visual, self-explanatory elements to improve quick comprehension. 

### Description
- Tighten the intro copy and replace multi-line descriptive paragraphs with compact highlight pills by adding an `intro-pills` block and `intro-pill` items in `index.html`. 
- Add a concise system-check legend (`system-legend` / `system-legend__item`) above the readiness panel and shorten readiness notes to single-word cues in `index.html`. 
- Include styling for the new pills and legend in `assets/css/index.css` (`.intro-pills`, `.intro-pill`, `.system-legend`, `.system-legend__item`). 
- Files changed: `index.html`, `assets/css/index.css`. 

### Testing
- Ran `biome lint assets scripts tests` which completed with no errors. 
- Ran `biome format --write assets scripts tests` which completed successfully. 
- Docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e79d516508332b29d296fe15ba9fa)