### PR TITLE
Improve hint rendering readability

### DIFF
--- a/assets/ui/hints.ts
+++ b/assets/ui/hints.ts
@@ -16,6 +16,7 @@ export interface HintOptions {
 const STYLE_ID = 'stims-hints-style';
 const STORAGE_PREFIX = 'stims.hints.dismissed.';
 const DEFAULT_IDLE_DELAY_MS = 1200;
+const DISMISS_LABEL = "Don't show again";
 
 function injectHintStyles() {
   if (document.getElementById(STYLE_ID)) return;
@@ -175,6 +176,31 @@ export function initHints({
     manualButtonElement = null;
   };
 
+  const createButton = (
+    className: string,
+    label: string,
+    onClick: () => void,
+  ) => {
+    const button = doc.createElement('button');
+    button.className = className;
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    return button;
+  };
+
+  const createTipsList = () => {
+    const list = doc.createElement('ul');
+    list.className = 'stims-hint__list';
+    tips.forEach((tip) => {
+      const item = doc.createElement('li');
+      item.className = 'stims-hint__item';
+      item.textContent = tip;
+      list.appendChild(item);
+    });
+    return list;
+  };
+
   const renderHint = () => {
     if (hintElement || hasDismissed(id)) return;
 
@@ -189,33 +215,17 @@ export function initHints({
     heading.textContent = title;
     wrapper.appendChild(heading);
 
-    const list = doc.createElement('ul');
-    list.className = 'stims-hint__list';
-    tips.forEach((tip) => {
-      const item = doc.createElement('li');
-      item.className = 'stims-hint__item';
-      item.textContent = tip;
-      list.appendChild(item);
-    });
-    wrapper.appendChild(list);
+    wrapper.appendChild(createTipsList());
 
     const actions = doc.createElement('div');
     actions.className = 'stims-hint__actions';
 
-    const confirm = doc.createElement('button');
-    confirm.className = 'stims-hint__button';
-    confirm.type = 'button';
-    confirm.textContent = ctaLabel;
-    confirm.addEventListener('click', () => {
+    const confirm = createButton('stims-hint__button', ctaLabel, () => {
       wrapper.remove();
       hintElement = null;
     });
 
-    const dismiss = doc.createElement('button');
-    dismiss.className = 'stims-hint__dismiss';
-    dismiss.type = 'button';
-    dismiss.textContent = "Don't show again";
-    dismiss.addEventListener('click', () => {
+    const dismiss = createButton('stims-hint__dismiss', DISMISS_LABEL, () => {
       setDismissed(id);
       wrapper.remove();
       hintElement = null;


### PR DESCRIPTION
### Motivation
- Reduce duplicated DOM construction in the hint UI and make the rendering logic clearer and easier to maintain.

### Description
- Extracted a shared `createButton` helper to centralize button creation and event wiring.
- Extracted a `createTipsList` helper to encapsulate list rendering for tip items.
- Added a `DISMISS_LABEL` constant and replaced inline markup with the new helpers in `initHints` to improve readability and reuse.
- Kept public API and behavior unchanged while simplifying internal structure in `assets/ui/hints.ts`.

### Testing
- Ran the project checks with `bun run check`, which completed successfully.
- Ran the test suite with `bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json`, resulting in 78 passed, 2 skipped, and 0 failed tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8aa6064c8332a6cae461fe5c4cab)