### PR TITLE
Improve SVG attribute helpers

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1,5 +1,13 @@
 const ns = 'http://www.w3.org/2000/svg';
 
+function applyAttributes(element, attributes = {}) {
+  Object.entries(attributes).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      element.setAttribute(key, String(value));
+    }
+  });
+}
+
 function createSvgContext(_slug, label) {
   const svg = document.createElementNS(ns, 'svg');
   svg.setAttribute('viewBox', '0 0 120 120');
@@ -16,16 +24,15 @@ function createSvgContext(_slug, label) {
 
   const createGradient = (type, id, stops, attrs = {}) => {
     const gradient = document.createElementNS(ns, `${type}Gradient`);
-    gradient.setAttribute('id', id);
-    Object.entries(attrs).forEach(([key, value]) => {
-      gradient.setAttribute(key, value);
-    });
+    applyAttributes(gradient, { id, ...attrs });
 
     stops.forEach(({ offset, color, opacity }) => {
       const stop = document.createElementNS(ns, 'stop');
-      stop.setAttribute('offset', offset);
-      stop.setAttribute('stop-color', color);
-      if (opacity !== undefined) stop.setAttribute('stop-opacity', opacity);
+      applyAttributes(stop, {
+        offset,
+        'stop-color': color,
+        'stop-opacity': opacity,
+      });
       gradient.appendChild(stop);
     });
 
@@ -35,11 +42,7 @@ function createSvgContext(_slug, label) {
 
   const createNode = (tag, attributes = {}, children = []) => {
     const el = document.createElementNS(ns, tag);
-    Object.entries(attributes).forEach(([key, value]) => {
-      if (value !== undefined && value !== null) {
-        el.setAttribute(key, String(value));
-      }
-    });
+    applyAttributes(el, attributes);
     children.forEach((child) => el.appendChild(child));
     return el;
   };
@@ -50,14 +53,12 @@ function createSvgContext(_slug, label) {
     children = [],
   ) => {
     const pattern = document.createElementNS(ns, 'pattern');
-    pattern.setAttribute('id', id);
-    pattern.setAttribute('width', String(width));
-    pattern.setAttribute('height', String(height));
-    pattern.setAttribute('patternUnits', units ?? 'userSpaceOnUse');
-    Object.entries(attrs).forEach(([key, value]) => {
-      if (value !== undefined && value !== null) {
-        pattern.setAttribute(key, String(value));
-      }
+    applyAttributes(pattern, {
+      id,
+      width,
+      height,
+      patternUnits: units ?? 'userSpaceOnUse',
+      ...attrs,
     });
     children.forEach((child) => pattern.appendChild(child));
     defs.appendChild(pattern);


### PR DESCRIPTION
### Motivation
- Reduce repetitive `setAttribute` calls and improve readability in the SVG icon rendering utilities by centralizing attribute application.

### Description
- Add `applyAttributes(element, attributes = {})` to safely apply attributes to SVG elements.
- Replace manual `setAttribute` loops in `createGradient`, `createNode`, and `createPattern` with `applyAttributes` in `assets/js/library-view.js`.
- Update `stop` element creation to use `applyAttributes` for `offset`, `stop-color`, and `stop-opacity` values.

### Testing
- Ran `bun run check` (which runs `biome`, `tsc`, and the test suite) and it completed successfully with no errors.
- The test run reported the suite result as `78 pass, 2 skip, 0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8aa6064c8332a6cae461fe5c4cab)