### PR TITLE
Refresh library UI copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,16 +80,14 @@
 
       <section class="intro" id="intro">
         <div class="section-heading">
-          <p class="eyebrow">Audio-reactive visuals • No setup</p>
+          <p class="eyebrow">Audio-reactive visuals • Ready fast</p>
           <h1>Stim library</h1>
-          <p class="section-description">
-            Light and motion tuned for sound, touch, and calm focus.
-          </p>
+          <p class="section-description">Visuals tuned for sound, touch, and focus.</p>
           <div class="intro-pills" aria-label="Quick highlights">
             <span class="intro-pill">✨ Featured: Halo Flow</span>
-            <span class="intro-pill">🎧 Mic optional</span>
-            <span class="intro-pill">🔊 Demo audio</span>
-            <span class="intro-pill">🖐️ Touch ready</span>
+            <span class="intro-pill">🎧 Mic not required</span>
+            <span class="intro-pill">🔊 Built-in audio</span>
+            <span class="intro-pill">🖐️ Touch-friendly</span>
           </div>
         </div>
         <div class="cta-row hero-cta-row">
@@ -104,14 +102,14 @@
         </div>
         <div class="hero-readiness" data-hero-readiness-summary>
           <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
-            Ready • Checking compatibility…
+            Checking device…
           </p>
           <a
             href="#system-check"
             class="cta-button ghost hero-readiness__action"
             data-open-preflight
           >
-            Adjust performance
+            Tune device
           </a>
         </div>
       </section>
@@ -119,16 +117,14 @@
       <section class="system-check" id="system-check">
         <div class="section-heading">
           <p class="eyebrow">System check</p>
-          <h2>Confirm your device</h2>
-          <p class="section-description">
-            Live readiness updates as we check your device.
-          </p>
+          <h2>Check your device</h2>
+          <p class="section-description">Live status while we scan.</p>
           <p
             class="section-description details-panel"
             data-details-panel
             id="system-check-details"
           >
-            Graphics, mic, motion, and comfort at a glance.
+            Graphics, mic, motion, comfort.
           </p>
           <a
             href="#system-check"


### PR DESCRIPTION
### Motivation
- Make the library and system-check UI copy clearer and less verbose so users can scan status and controls quickly.
- Reduce microcopy friction by replacing longer phrases with concise, explicit alternatives in the hero and system sections.

### Description
- Performed 10 copy edits in `index.html` to simplify the library hero and system-check language.
- Shortened the hero eyebrow and section description to be more direct (`Audio-reactive visuals • Ready fast`, `Visuals tuned for sound, touch, and focus.`).
- Updated intro highlight pills to clearer labels (`🎧 Mic not required`, `🔊 Built-in audio`, `🖐️ Touch-friendly`).
- Replaced readiness messaging and action copy with `Checking device…` and `Tune device` for quicker scanning.
- Simplified the system-check heading and details panel to compact status copy (`Check your device`, `Live status while we scan.`, and `Graphics, mic, motion, comfort.`).

### Testing
- Ran `biome lint assets scripts tests` which completed successfully.
- Ran `biome format --write assets scripts tests` which completed successfully.
- Launched the dev server (`bun run dev` / `vite`) and captured a page screenshot via Playwright to confirm the updated UI rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eaf73098c8332a6ed90c051d96ea5)