### PR TITLE
Remove redundant dns-prefetch hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
-    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/toy.html
+++ b/toy.html
@@ -13,8 +13,6 @@
     <title>Stim Webtoy</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />


### PR DESCRIPTION
### Motivation
- Remove superfluous `dns-prefetch` resource hints that duplicate existing `preconnect` entries and simplify the head of the library and toy pages.

### Description
- Deleted duplicate `<link rel="dns-prefetch" ...>` entries for Google Fonts and CDN from `index.html` and `toy.html` to rely on `preconnect` and reduce redundancy.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both succeeded; docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed771b660833299a7f9fb647e4eb7)