### PR TITLE
Improve architecture documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,16 @@
 
 This document summarizes how the Stim Webtoys app is assembled, from the entry HTML shells through module loading, rendering, audio, and quality controls. It is meant as a quick map for contributors adding new toys or extending the core runtime.
 
+## Architecture at a Glance
+
+- **Entry shells** (`toy.html`, `holy.html`) are thin HTML pages that bootstrap the runtime and pass a `toy=<slug>` query param.
+- **Loader orchestration** (`assets/js/loader.ts`, `assets/js/router.ts`) owns navigation, lifecycle boundaries, and loader state.
+- **View state** (`assets/js/toy-view.ts`, `assets/js/library-view.js`) renders the library, toy container, and status banners.
+- **Runtime core** (`assets/js/core/*`) encapsulates rendering, audio, settings, and per-frame loop wiring.
+- **Toy modules** (`assets/js/toys/*.ts`) provide toy-specific scenes and a cleanup hook (`dispose`) that the loader can call safely.
+
+Use this section as a quick compass: if you need to change how a toy starts or stops, look at the loader and core runtime; if you need to change UI state or status messaging, look at the views; if you need to change toy behavior, look at the toy modules and `WebToy` helpers.
+
 ## Runtime Layers
 
 - **HTML entry points** (`toy.html`, `holy.html`, etc.) load the bundled shell and pass query params like `?toy=<slug>`.
@@ -11,6 +21,18 @@ This document summarizes how the Stim Webtoys app is assembled, from the entry H
 - **Core runtime** (`assets/js/core/*`) initializes the scene, camera, renderer (WebGPU or WebGL), audio pipeline, quality controls, and handles linting/formatting via **Biome**. Helpers such as `animation-loop.ts`, `settings-panel.ts`, and `iframe-quality-sync.ts` manage per-frame work and preset propagation.
 - **Shared services** (`assets/js/core/services/*`) pool renderers and microphone streams so toys can hand off resources without re-allocating (and re-prompting for mic access).
 - **Toys** (`assets/js/toys/*.ts`) compose the core primitives, export a `start` entry, and provide a cleanup hook (commonly via `dispose`).
+
+## Source Map (Where Things Live)
+
+| Concern | Primary files | Notes |
+| --- | --- | --- |
+| Entry points | `toy.html`, `holy.html`, `index.html` | HTML shells are intentionally slim; logic starts in loader/router. |
+| Loader + routing | `assets/js/loader.ts`, `assets/js/router.ts` | Navigation, lifecycle, and dynamic imports live here. |
+| Views | `assets/js/toy-view.ts`, `assets/js/library-view.js` | UI for the library grid, toy container, loading, and error states. |
+| Core runtime | `assets/js/core/web-toy.ts` + `assets/js/core/*` | Rendering, audio, settings, and the animation loop. |
+| Pools/services | `assets/js/core/services/*` | Renderer and microphone pooling. |
+| Toy registry | `assets/js/toys-data.js` | Toy metadata and slug registration. |
+| Toy implementations | `assets/js/toys/*.ts` | Per-toy scenes, materials, and audio mappings. |
 
 ## App Shell and Loader Flow
 
@@ -45,6 +67,16 @@ flowchart TD
 4. **Import module**: resolve a Vite-friendly URL via the manifest client and `import()` it.
 5. **Start toy**: call the module’s `start` or default export; normalize the returned reference so `dispose` can be called on navigation.
 6. **Cleanup**: on Escape/back, dispose the active toy, clear the container, and reset renderer status in the view.
+
+### Lifecycle responsibilities
+
+| Phase | Owner | Notes |
+| --- | --- | --- |
+| Navigation | `router.ts` | Syncs query params and back/forward navigation. |
+| UI scaffolding | `toy-view.ts` | Shows loader, active toy shell, and status badges. |
+| Module load | `loader.ts` + `manifest-client.ts` | Resolves module URLs for both dev and build. |
+| Runtime init | `web-toy.ts` | Builds scene, camera, renderer, and audio loop wiring. |
+| Cleanup | `web-toy.ts` + toy `dispose` | Releases pooled resources and removes canvas/audio refs. |
 
 ## Rendering and Capability Detection
 
@@ -89,6 +121,13 @@ graph LR
 - **Resize safety**: `web-toy.ts` hooks window resize to update aspect ratio and renderer size via the pooled handle.
 - **Lifecycle cleanup**: disposal tears down animation loops, disposes geometries/materials, releases audio/renderer handles back to their pools, and clears the DOM container.
 
+## Runtime State and Data Flow
+
+- **Active toy state**: the loader owns the active toy reference and is responsible for calling `dispose`. The toy should only manage its own scene resources (geometries, materials, textures).
+- **Renderer state**: pooled renderers are configured by `renderer-settings.ts`; toys can layer overrides via `handle.applySettings` but should not mutate shared renderer state permanently.
+- **Audio state**: the audio service owns the shared `MediaStream`, while each toy owns its `AudioAnalyser` instance. Release the handle so the pool can reuse the stream.
+- **Settings propagation**: `settings-panel.ts` updates propagate to `web-toy.ts` through `iframe-quality-sync.ts`, keeping both the shell UI and toy renderer in sync.
+
 ## Audio Path
 
 - `services/audio-service.ts` reuses a single `MediaStream` to avoid repeat prompts; each acquisition gets a fresh `THREE.AudioListener`/`THREE.Audio`/`AudioAnalyser` while sharing the mic stream. Release the handle to stop the analyser and return the stream to the pool.
@@ -114,3 +153,9 @@ graph LR
 - **WebGPU unavailable**: `renderer-capabilities.ts` writes a fallback reason and toggles `shouldRetryWebGPU`; the view surfaces a retry button that re-probes with `forceRetry`.
 - **Import failures**: the loader’s `view.showImportError` shows the module URL and offers a back link.
 - **Performance**: lower `maxPixelRatio`/`renderScale` via the settings panel; heavy scenes should debounce allocations in animation loops.
+
+## Common Extension Points
+
+- **New toy modules**: register the slug in `assets/js/toys-data.js`, create the module in `assets/js/toys/*.ts`, and return a `dispose` to clean up.
+- **New runtime services**: add to `assets/js/core/services/*` and thread through `web-toy.ts` so toys can request handles consistently.
+- **New settings controls**: extend `settings-panel.ts` and `renderer-settings.ts`, then ensure `iframe-quality-sync.ts` forwards updates to running toys.


### PR DESCRIPTION
### Motivation

- Make the architecture guide easier to scan by adding a concise overview and clear navigation cues for contributors. 
- Surface where source files live and who owns lifecycle responsibilities so contributors can quickly find the right place to change runtime, views, or toy code. 
- Clarify runtime state, data flow, and common extension points to reduce onboarding friction and maintenance errors.

### Description

- Expanded `docs/ARCHITECTURE.md` with an `Architecture at a Glance` overview to summarize the primary responsibilities of entry shells, loader, views, runtime core, and toy modules. 
- Added a `Source Map (Where Things Live)` table that lists primary files for each concern and a `Lifecycle responsibilities` table that maps phases to owning modules. 
- Added `Runtime State and Data Flow` and `Common Extension Points` sections documenting pooled renderer/audio ownership, settings propagation, and how to add toys or services. 
- Only documentation was changed in `docs/ARCHITECTURE.md`.

### Testing

- Ran `biome lint assets scripts tests` which completed successfully with no fixes applied. 
- Ran `biome format --write assets scripts tests` which completed successfully with no changes required. 
- This is a docs-only change so no additional runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ff69a154c833288966a25cc68e057)