### PR TITLE
Refine toy settings panel helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,16 +178,12 @@ If you add a new toy, place the implementation in `assets/js/toys/`, register it
 - **Audio permission clarity**: Audio controls surface demo audio alongside the microphone CTA by default, plus immediate “starting” feedback and fallback guidance when mic access fails.
 - **Touch + gesture consistency**: Shared input helpers normalize multi-touch gestures and enforce touch-action defaults while keeping control targets sized for reliable taps.
 - **Library discovery**: Search supports tags/capabilities, empty-state guidance, and capability badges (mic/motion/demo audio) on toy cards.
+- **Shared runtime helpers**: Unified audio start wrappers, audio-permission flow helpers, control panel recipes, and toy runtime scaffolding reduce per-toy wiring.
 
 ### Next priorities
 
 - **Toy onboarding quick wins**: Add lightweight presets or first-time hints for toys with multiple controls so the “wow” moment is immediate.
 - **Touch polish**: Add clearer gesture hints and input affordances on the toy page.
-- **Control panel recipes**: Extract shared settings-panel patterns (button-group/select recipes, slider/toggle builders) so toys can declare controls instead of hand-wiring DOM elements.
-- **Unified audio start wrappers**: Standardize the common `runtime.startAudio` wrapper used for mic errors and silent fallbacks into a reusable helper.
-- **Audio permission UI flow helper**: Wrap `createAudioFlowController` + visibility/reduced-motion handling into a higher-level utility to reduce per-toy wiring.
-- **Quality + performance panel helper**: Provide a single setup API for toys that opt into both quality presets and the performance panel.
-- **Toy runtime scaffolding**: Create a higher-level audio-toy bootstrap that composes runtime creation, plugin lifecycle, and optional settings/performance panels.
 
 ---
 

--- a/assets/js/toys/neon-wave.ts
+++ b/assets/js/toys/neon-wave.ts
@@ -20,7 +20,6 @@ import {
 } from 'three';
 import {
   getActivePerformanceSettings,
-  getPerformancePanel,
   type PerformanceSettings,
 } from '../core/performance-panel';
 import {
@@ -36,7 +35,7 @@ import { createPerformanceSettingsHandler } from '../utils/performance-settings'
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import {
-  buildToySettingsPanel,
+  buildToySettingsPanelWithPerformance,
   createToyQualityControls,
 } from '../utils/toy-settings';
 
@@ -451,11 +450,15 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
 
   function setupSettingsPanel() {
     const themes: NeonTheme[] = ['synthwave', 'cyberpunk', 'arctic', 'sunset'];
-    buildToySettingsPanel({
+    buildToySettingsPanelWithPerformance({
       title: 'Neon Wave',
       description: 'Retro-wave visualizer with bloom effects. Pick a theme!',
       panel: settingsPanel,
       quality,
+      performance: {
+        title: 'Performance',
+        description: 'Balance visual fidelity and frame rate.',
+      },
       sections: [
         {
           title: 'Theme',
@@ -488,13 +491,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
           ],
         },
       ],
-    });
-  }
-
-  function setupPerformancePanel() {
-    getPerformancePanel({
-      title: 'Performance',
-      description: 'Balance visual fidelity and frame rate.',
     });
   }
 
@@ -622,7 +618,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
           toy.scene.add(horizonGroup);
 
           setupSettingsPanel();
-          setupPerformancePanel();
           createWaveMesh();
           createGrid();
           createParticles();

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import {
   getActivePerformanceSettings,
-  getPerformancePanel,
   type PerformanceSettings,
 } from '../core/performance-panel';
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
@@ -9,7 +8,7 @@ import { getWeightedAverageFrequency } from '../utils/audio-handler';
 import { applyAudioColor } from '../utils/color-audio';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
-import { createToyQualityControls } from '../utils/toy-settings';
+import { createToyQualityControlsWithPerformance } from '../utils/toy-settings';
 import type { UnifiedInputState } from '../utils/unified-input';
 
 type StarFieldBuffers = {
@@ -30,7 +29,7 @@ type StarfieldPalette = {
 };
 
 export function start({ container }: { container?: HTMLElement | null } = {}) {
-  const { quality, configurePanel } = createToyQualityControls({
+  const { quality, configurePanel } = createToyQualityControlsWithPerformance({
     title: 'Star field',
     description:
       'Tune render resolution and particle density for your GPU. Pinch to intensify the drift and rotate to swap nebula moods.',
@@ -42,6 +41,10 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     onChange: () => {
       disposeStarField();
       starField = createStarField();
+    },
+    performance: {
+      title: 'Performance',
+      description: 'Cap DPI or scale particle budgets to match your device.',
     },
   });
   let performanceSettings: PerformanceSettings = getActivePerformanceSettings();
@@ -261,13 +264,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     configurePanel();
   }
 
-  function setupPerformancePanel() {
-    getPerformancePanel({
-      title: 'Performance',
-      description: 'Cap DPI or scale particle budgets to match your device.',
-    });
-  }
-
   function animate(data: Uint8Array, time: number) {
     if (!starField) return;
     const avg = getWeightedAverageFrequency(data);
@@ -405,7 +401,6 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
         name: 'star-field',
         setup: () => {
           setupSettingsPanel();
-          setupPerformancePanel();
           starField = createStarField();
           createNebula();
           applyPalette(activePaletteIndex);

--- a/assets/js/utils/toy-settings.ts
+++ b/assets/js/utils/toy-settings.ts
@@ -138,6 +138,27 @@ export function createToyQualityControls({
   return { quality, configurePanel };
 }
 
+type ToyQualityControlsWithPerformanceOptions = ToyQualityControlsOptions & {
+  performance?: PerformancePanelOptions;
+};
+
+export function createToyQualityControlsWithPerformance({
+  performance,
+  ...options
+}: ToyQualityControlsWithPerformanceOptions) {
+  const { quality, configurePanel } = createToyQualityControls(options);
+
+  const configurePanelWithPerformance = () => {
+    const panel = configurePanel();
+    if (performance) {
+      getPerformancePanel(performance);
+    }
+    return panel;
+  };
+
+  return { quality, configurePanel: configurePanelWithPerformance };
+}
+
 type ToySettingsPanelOptions = {
   title: string;
   description?: string;


### PR DESCRIPTION
### Motivation

- Reduce per-toy wiring for quality + performance UI by providing a single helper that composes quality presets with the performance panel.
- Replace duplicated performance panel setup code in toys with the shared helpers to make settings wiring consistent.
- Reflect the delivered helper work in the roadmap so docs match the code changes.

### Description

- Add `createToyQualityControlsWithPerformance` in `assets/js/utils/toy-settings.ts` which composes existing quality controls with optional `getPerformancePanel` setup.
- Switch `Neon Wave` to use `buildToySettingsPanelWithPerformance` and provide the performance section via the panel options, removing a separate `getPerformancePanel` call and its helper function.
- Switch `Star Field` to use `createToyQualityControlsWithPerformance` and remove the separate `getPerformancePanel` call.
- Update `README.md` roadmap to mark shared runtime helpers (control panel recipes, audio start wrappers, runtime scaffolding) as delivered foundations.

### Testing

- Ran `bun run check` (Biome lint/format, TypeScript typecheck, and test suite). The command completed successfully.
- Test summary: 78 passed, 2 skipped, 0 failed across the test suite.
- Docs touched: `README.md`; Code touched: `assets/js/utils/toy-settings.ts`, `assets/js/toys/neon-wave.ts`, `assets/js/toys/star-field.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698026fa0ee48332bac1e51a9a017922)