### PR TITLE
Add Next stim navigation

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -360,14 +360,16 @@ body {
 }
 
 .toy-nav__share-wrapper,
-.toy-nav__pip-wrapper {
+.toy-nav__pip-wrapper,
+.toy-nav__next-wrapper {
   display: grid;
   gap: 4px;
   justify-items: flex-end;
 }
 
 .toy-nav__share,
-.toy-nav__pip {
+.toy-nav__pip,
+.toy-nav__next {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -394,7 +396,8 @@ body {
 }
 
 .toy-nav__share:hover,
-.toy-nav__pip:hover {
+.toy-nav__pip:hover,
+.toy-nav__next:hover {
   transform: translateY(-1px);
   border-color: rgba(255, 0, 153, 0.8);
   box-shadow:
@@ -408,7 +411,8 @@ body {
 }
 
 .toy-nav__share:focus-visible,
-.toy-nav__pip:focus-visible {
+.toy-nav__pip:focus-visible,
+.toy-nav__next:focus-visible {
   outline: 2px solid rgba(111, 247, 255, 0.9);
   outline-offset: 3px;
   box-shadow:
@@ -417,12 +421,14 @@ body {
 }
 
 .toy-nav__share:active,
-.toy-nav__pip:active {
+.toy-nav__pip:active,
+.toy-nav__next:active {
   transform: translateY(0);
 }
 
 .toy-nav__share-status,
-.toy-nav__pip-status {
+.toy-nav__pip-status,
+.toy-nav__next-status {
   min-height: 16px;
   font-size: 0.75rem;
   color: rgba(233, 251, 255, 0.75);
@@ -1377,13 +1383,15 @@ body {
   }
 
   .toy-nav__share-wrapper,
-  .toy-nav__pip-wrapper {
+  .toy-nav__pip-wrapper,
+  .toy-nav__next-wrapper {
     width: 100%;
     justify-items: stretch;
   }
 
   .toy-nav__share,
-  .toy-nav__pip {
+  .toy-nav__pip,
+  .toy-nav__next {
     width: 100%;
   }
 

--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -85,6 +85,37 @@ export function createLoader({
   let navigationInitialized = false;
   const lifecycle = toyLifecycle ?? defaultToyLifecycle;
   lifecycle.reset();
+  const recentToySlugs: string[] = [];
+
+  const rememberToy = (slug: string) => {
+    if (!slug) return;
+    const existingIndex = recentToySlugs.indexOf(slug);
+    if (existingIndex === 0) return;
+    if (existingIndex > -1) {
+      recentToySlugs.splice(existingIndex, 1);
+    }
+    recentToySlugs.unshift(slug);
+    if (recentToySlugs.length > 4) {
+      recentToySlugs.pop();
+    }
+  };
+
+  const pickNextToySlug = (currentSlug?: string | null) => {
+    const available = toys.filter((toy) => toy.type === 'module');
+    if (!available.length) return null;
+
+    const avoid = new Set(recentToySlugs);
+    if (currentSlug) {
+      avoid.add(currentSlug);
+    }
+    const fresh = available.filter((toy) => !avoid.has(toy.slug));
+    const fallback = available.filter((toy) => toy.slug !== currentSlug);
+    const pool = fresh.length ? fresh : fallback.length ? fallback : available;
+    if (!pool.length) return null;
+
+    const choice = pool[Math.floor(Math.random() * pool.length)];
+    return choice?.slug ?? null;
+  };
   const updateRendererStatus = (
     capabilities: Awaited<ReturnType<typeof rendererCapabilities>> | null,
     onRetry?: () => void,
@@ -162,7 +193,15 @@ export function createLoader({
     disposeActiveToy();
     removeEscapeHandler();
 
-    const container = view.showActiveToyView(backToLibrary, toy);
+    const handleNextToy = () => {
+      const nextSlug = pickNextToySlug(toy.slug);
+      if (!nextSlug) return;
+      void loadToy(nextSlug, { pushState: true, preferDemoAudio });
+    };
+
+    const container = view.showActiveToyView(backToLibrary, toy, {
+      onNextToy: handleNextToy,
+    });
     if (!container) return;
     updateRendererStatus(
       capabilities,
@@ -228,6 +267,7 @@ export function createLoader({
 
       // Track toy load for agents
       setCurrentToy(toy.slug);
+      rememberToy(toy.slug);
 
       // Setup audio prompt if startAudio globals are registered by the toy.
       const win = (container?.ownerDocument.defaultView ??

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -77,6 +77,7 @@ type AudioPromptCallbacks = {
 type ViewState = {
   mode: 'library' | 'toy';
   backHandler?: () => void;
+  onNextToy?: () => void;
   rendererStatus: RendererStatusState | null;
   activeToyMeta?: Toy;
   status: StatusConfig | null;
@@ -213,11 +214,13 @@ function buildToyNav({
   toy,
   onBack,
   rendererStatus,
+  onNextToy,
 }: {
   container: HTMLElement | null;
   toy?: Toy;
   onBack?: () => void;
   rendererStatus: RendererStatusState | null;
+  onNextToy?: () => void;
 }) {
   if (!container) return null;
   let navContainer = container.querySelector<HTMLElement>('[data-toy-nav]');
@@ -233,6 +236,7 @@ function buildToyNav({
     title: toy?.title,
     slug: toy?.slug,
     onBack,
+    onNextToy,
     rendererStatus,
   });
   return container;
@@ -351,6 +355,7 @@ export function createToyView({
       container,
       toy: state.activeToyMeta,
       onBack: state.backHandler,
+      onNextToy: state.onNextToy,
       rendererStatus: state.rendererStatus,
     });
 
@@ -370,6 +375,7 @@ export function createToyView({
   const showLibraryView = () => {
     state.mode = 'library';
     state.backHandler = undefined;
+    state.onNextToy = undefined;
     state.rendererStatus = null;
     state.activeToyMeta = undefined;
     state.status = null;
@@ -377,9 +383,14 @@ export function createToyView({
     runViewTransition(() => render({ clearContainer: true }));
   };
 
-  const showActiveToyView = (onBack?: () => void, toy?: Toy) => {
+  const showActiveToyView = (
+    onBack?: () => void,
+    toy?: Toy,
+    { onNextToy }: { onNextToy?: () => void } = {},
+  ) => {
     state.mode = 'toy';
     state.backHandler = onBack ?? state.backHandler;
+    state.onNextToy = onNextToy ?? state.onNextToy;
     state.activeToyMeta = toy ?? state.activeToyMeta;
     const { container } = runViewTransition(() => render());
     return container;


### PR DESCRIPTION
### Motivation

- Encourage quicker exploration by letting users jump to a fresh toy from the active toy navbar.

### Description

- Add a `Next stim` button and status UI to the active toy navigation and wire an `onNextToy` callback in `assets/js/ui/nav.ts`.
- Extend the toy view to accept and surface an `onNextToy` handler via `assets/js/toy-view.ts` and preserve it across view transitions.
- Implement recent-toy tracking and a `pickNextToySlug` algorithm in `assets/js/loader.ts` to avoid immediate repeats and load a randomized next module toy.
- Add CSS rules in `assets/css/base.css` to style the new control and ensure responsive behavior alongside existing nav actions.

### Testing

- Ran `bun run check`, which executes `biome check`, `tsc --noEmit`, and the test suite, and it completed successfully with `78 passed`, `2 skipped`, and `0 failed`.
- `biome check` and `tsc` both returned without errors during the `bun run check` run.

Docs:
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980dc3d9c8483328bd4dd2ee829c3f2)