### PR TITLE
Add surprise me quickstart

### DIFF
--- a/assets/js/utils/data-attributes.ts
+++ b/assets/js/utils/data-attributes.ts
@@ -1,10 +1,12 @@
 export const DATASET_KEYS = {
   quickstartSlug: 'quickstartSlug',
   quickstartMode: 'quickstartMode',
+  quickstartPool: 'quickstartPool',
+  quickstartAudio: 'quickstartAudio',
 };
 
 export const DATA_SELECTORS = {
-  quickstart: '[data-quickstart-slug]',
+  quickstart: '[data-quickstart-slug], [data-quickstart-mode]',
   topNav: '[data-top-nav]',
   previewReel: '[data-preview-reel]',
   previewCard: '[data-preview-card]',

--- a/index.html
+++ b/index.html
@@ -95,6 +95,15 @@
           >
             Open Halo Flow
           </a>
+          <a
+            href="toy.html?toy=spiral-burst"
+            class="cta-button cta-button--accent"
+            data-quickstart-mode="random"
+            data-quickstart-pool="featured"
+            data-quickstart-audio="demo"
+          >
+            Surprise me
+          </a>
           <a href="#toy-list" class="cta-button ghost">Browse library</a>
         </div>
         <div class="hero-readiness" data-hero-readiness-summary>


### PR DESCRIPTION
### Motivation
- Provide a more engaging hero entry point by adding a “Surprise me” CTA that quickly launches a random featured toy with demo audio to improve discoverability and retention.

### Description
- Add `quickstartPool` and `quickstartAudio` keys and expand the quickstart selector in `assets/js/utils/data-attributes.ts` to support new data attributes.
- Implement random quickstart resolution in `assets/js/utils/init-quickstart.ts`, including pool selection (supports `featured`) and a `data-quickstart-audio` override for demo audio, and add a small `QuickstartToy` type for safety.
- Wire the new CTA into the UI by adding a `Surprise me` button in `index.html` with `data-quickstart-mode="random"`, `data-quickstart-pool="featured"`, and `data-quickstart-audio="demo"`.

### Testing
- Ran `bun run check` (Biome lint + `tsc --noEmit` + test suite) and addressed initial typecheck errors; final `bun run check` completed successfully.
- Test summary: Ran 80 tests across 24 files with 78 passed, 2 skipped, and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980dc3d9c8483328bd4dd2ee829c3f2)