### PR TITLE
Add flow mode auto-advance to toy navigation

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -361,7 +361,8 @@ body {
 
 .toy-nav__share-wrapper,
 .toy-nav__pip-wrapper,
-.toy-nav__next-wrapper {
+.toy-nav__next-wrapper,
+.toy-nav__flow-wrapper {
   display: grid;
   gap: 4px;
   justify-items: flex-end;
@@ -369,7 +370,8 @@ body {
 
 .toy-nav__share,
 .toy-nav__pip,
-.toy-nav__next {
+.toy-nav__next,
+.toy-nav__flow {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -397,7 +399,8 @@ body {
 
 .toy-nav__share:hover,
 .toy-nav__pip:hover,
-.toy-nav__next:hover {
+.toy-nav__next:hover,
+.toy-nav__flow:hover {
   transform: translateY(-1px);
   border-color: rgba(255, 0, 153, 0.8);
   box-shadow:
@@ -412,7 +415,8 @@ body {
 
 .toy-nav__share:focus-visible,
 .toy-nav__pip:focus-visible,
-.toy-nav__next:focus-visible {
+.toy-nav__next:focus-visible,
+.toy-nav__flow:focus-visible {
   outline: 2px solid rgba(111, 247, 255, 0.9);
   outline-offset: 3px;
   box-shadow:
@@ -422,13 +426,15 @@ body {
 
 .toy-nav__share:active,
 .toy-nav__pip:active,
-.toy-nav__next:active {
+.toy-nav__next:active,
+.toy-nav__flow:active {
   transform: translateY(0);
 }
 
 .toy-nav__share-status,
 .toy-nav__pip-status,
-.toy-nav__next-status {
+.toy-nav__next-status,
+.toy-nav__flow-status {
   min-height: 16px;
   font-size: 0.75rem;
   color: rgba(233, 251, 255, 0.75);
@@ -1384,14 +1390,16 @@ body {
 
   .toy-nav__share-wrapper,
   .toy-nav__pip-wrapper,
-  .toy-nav__next-wrapper {
+  .toy-nav__next-wrapper,
+  .toy-nav__flow-wrapper {
     width: 100%;
     justify-items: stretch;
   }
 
   .toy-nav__share,
   .toy-nav__pip,
-  .toy-nav__next {
+  .toy-nav__next,
+  .toy-nav__flow {
     width: 100%;
   }
 

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -78,6 +78,8 @@ type ViewState = {
   mode: 'library' | 'toy';
   backHandler?: () => void;
   onNextToy?: () => void;
+  onToggleFlow?: (active: boolean) => void;
+  flowActive?: boolean;
   rendererStatus: RendererStatusState | null;
   activeToyMeta?: Toy;
   status: StatusConfig | null;
@@ -215,12 +217,16 @@ function buildToyNav({
   onBack,
   rendererStatus,
   onNextToy,
+  onToggleFlow,
+  flowActive,
 }: {
   container: HTMLElement | null;
   toy?: Toy;
   onBack?: () => void;
   rendererStatus: RendererStatusState | null;
   onNextToy?: () => void;
+  onToggleFlow?: (active: boolean) => void;
+  flowActive?: boolean;
 }) {
   if (!container) return null;
   let navContainer = container.querySelector<HTMLElement>('[data-toy-nav]');
@@ -237,6 +243,8 @@ function buildToyNav({
     slug: toy?.slug,
     onBack,
     onNextToy,
+    onToggleFlow,
+    flowActive,
     rendererStatus,
   });
   return container;
@@ -356,6 +364,8 @@ export function createToyView({
       toy: state.activeToyMeta,
       onBack: state.backHandler,
       onNextToy: state.onNextToy,
+      onToggleFlow: state.onToggleFlow,
+      flowActive: state.flowActive,
       rendererStatus: state.rendererStatus,
     });
 
@@ -376,6 +386,8 @@ export function createToyView({
     state.mode = 'library';
     state.backHandler = undefined;
     state.onNextToy = undefined;
+    state.onToggleFlow = undefined;
+    state.flowActive = false;
     state.rendererStatus = null;
     state.activeToyMeta = undefined;
     state.status = null;
@@ -386,11 +398,21 @@ export function createToyView({
   const showActiveToyView = (
     onBack?: () => void,
     toy?: Toy,
-    { onNextToy }: { onNextToy?: () => void } = {},
+    {
+      onNextToy,
+      onToggleFlow,
+      flowActive,
+    }: {
+      onNextToy?: () => void;
+      onToggleFlow?: (active: boolean) => void;
+      flowActive?: boolean;
+    } = {},
   ) => {
     state.mode = 'toy';
     state.backHandler = onBack ?? state.backHandler;
     state.onNextToy = onNextToy ?? state.onNextToy;
+    state.onToggleFlow = onToggleFlow ?? state.onToggleFlow;
+    state.flowActive = flowActive ?? state.flowActive;
     state.activeToyMeta = toy ?? state.activeToyMeta;
     const { container } = runViewTransition(() => render());
     return container;
@@ -521,6 +543,11 @@ export function createToyView({
     render();
   };
 
+  const setFlowState = (active: boolean) => {
+    state.flowActive = active;
+    render();
+  };
+
   return {
     showLibraryView,
     showActiveToyView,
@@ -532,6 +559,7 @@ export function createToyView({
       clearContainerContent(findActiveToyContainer()),
     ensureActiveToyContainer,
     setRendererStatus,
+    setFlowState,
     showUnavailableToy,
     showAudioPrompt: (
       active: boolean = true,


### PR DESCRIPTION
### Motivation
- Provide an optional "Flow" mode so the toy experience can auto-advance between stims to keep sessions continuous and more engaging.
- Expose a simple toggle in the active toy UI and ensure the loader coordinates timed transitions safely without overlapping navigations.

### Description
- Add a Flow toggle and status UI to the toy navigation (`assets/js/ui/nav.ts`) with `onToggleFlow`/`flowActive` options and status messages.  
- Wire view state to surface the Flow control and expose `setFlowState` (`assets/js/toy-view.ts`).  
- Implement loader-side scheduling and control in `assets/js/loader.ts` including `FLOW_INTERVAL_MS` (45s), timer management, `setFlowActive`, tracking `activeToySlug`, and a guarded `handleNextToy` to avoid concurrent loads.  
- Add matching styles for the control and responsive behavior in `assets/css/base.css`.  
- Docs: None.

### Testing
- Ran the standard quality gate with `bun run check` (Biome lint, `tsc --noEmit`, and tests), which completed successfully with all automated tests passing (`78` pass, `2` skip, `0` fail).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e065396c833286d0630cf2903c73)