### PR TITLE
Consume input release once per update

### DIFF
--- a/assets/js/toys/pocket-pulse.ts
+++ b/assets/js/toys/pocket-pulse.ts
@@ -56,6 +56,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   let interactionEnergy = 0;
   let touchPulse = 0;
   let lastCentroid = { x: 0, y: 0 };
+  let lastInputTime = 0;
 
   const palette = {
     background: new THREE.Color('#050611'),
@@ -125,6 +126,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     input: {
       normalizedCentroid: { x: number; y: number };
       deltaMs: number;
+      time: number;
       isPressed: boolean;
       justPressed: boolean;
       justReleased: boolean;
@@ -146,11 +148,17 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
     );
     lastCentroid = { ...normalizedCentroid };
 
-    if (input?.justPressed) {
-      touchPulse = Math.max(touchPulse, 1.4);
-    }
-    if (input?.justReleased) {
-      touchPulse = Math.max(touchPulse, 0.9);
+    const inputTime = input?.time ?? 0;
+    const hasNewInput = inputTime !== 0 && inputTime !== lastInputTime;
+
+    if (hasNewInput) {
+      if (input?.justPressed) {
+        touchPulse = Math.max(touchPulse, 1.4);
+      }
+      if (input?.justReleased) {
+        touchPulse = Math.max(touchPulse, 0.9);
+      }
+      lastInputTime = inputTime;
     }
     touchPulse = Math.max(0, touchPulse - deltaSeconds * 1.4);
 


### PR DESCRIPTION
### Motivation
- The touch pulse in Pocket Pulse was being re-triggered repeatedly because the last `UnifiedInputState` (with `justReleased=true`) could be reused across animation ticks when there are no active pointers or keys, preventing the touch decay from resuming.

### Description
- Track the last input timestamp with a new `lastInputTime` variable and only apply `justPressed`/`justReleased` boosts when `input.time` differs from `lastInputTime` so release pulses are consumed once per new input frame.
- Add the `time` field to the `animate` input type and update the pulse gating logic inside `assets/js/toys/pocket-pulse.ts` accordingly.

### Testing
- Ran `bun run check` (runs `biome check`, TypeScript typecheck, and the test suite) and the run completed successfully with the test summary `78 pass, 2 skip, 0 fail` and no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980eac9b07c8332b230736cafec2fea)