### PR TITLE
Add flow mode quickstart CTA

### DIFF
--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -405,8 +405,17 @@ export function createLoader({
     {
       pushState = false,
       preferDemoAudio = false,
-    }: { pushState?: boolean; preferDemoAudio?: boolean } = {},
+      startFlow,
+    }: {
+      pushState?: boolean;
+      preferDemoAudio?: boolean;
+      startFlow?: boolean;
+    } = {},
   ) => {
+    if (typeof startFlow === 'boolean') {
+      setFlowActive(startFlow);
+    }
+
     const toy = toys.find((t) => t.slug === slug);
     if (!toy) {
       console.error(`Toy not found: ${slug}`);

--- a/assets/js/utils/data-attributes.ts
+++ b/assets/js/utils/data-attributes.ts
@@ -3,6 +3,7 @@ export const DATASET_KEYS = {
   quickstartMode: 'quickstartMode',
   quickstartPool: 'quickstartPool',
   quickstartAudio: 'quickstartAudio',
+  quickstartFlow: 'quickstartFlow',
 };
 
 export const DATA_SELECTORS = {

--- a/assets/js/utils/init-quickstart.ts
+++ b/assets/js/utils/init-quickstart.ts
@@ -23,6 +23,14 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
     const quickstartMode = quickstart.dataset[DATASET_KEYS.quickstartMode];
     const quickstartPool = quickstart.dataset[DATASET_KEYS.quickstartPool];
     const quickstartAudio = quickstart.dataset[DATASET_KEYS.quickstartAudio];
+    const quickstartFlow = quickstart.dataset[DATASET_KEYS.quickstartFlow];
+
+    const resolveFlowState = () => {
+      if (quickstartFlow === undefined) return undefined;
+      if (quickstartFlow === '' || quickstartFlow === 'true') return true;
+      if (quickstartFlow === 'false') return false;
+      return quickstartFlow === '1';
+    };
 
     const resolveRandomSlug = () => {
       const normalizedPool = quickstartPool?.toLowerCase();
@@ -59,6 +67,7 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         pushState: true,
         preferDemoAudio:
           quickstartMode === 'demo' || quickstartAudio === 'demo',
+        startFlow: resolveFlowState(),
       });
     });
   });

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
             <span class="intro-pill">🎧 Mic not required</span>
             <span class="intro-pill">🔊 Built-in audio</span>
             <span class="intro-pill">🖐️ Touch-friendly</span>
+            <span class="intro-pill">🔁 Flow mode auto-switches</span>
           </div>
         </div>
         <div class="cta-row hero-cta-row">
@@ -94,6 +95,16 @@
             data-quickstart-slug="holy"
           >
             Open Halo Flow
+          </a>
+          <a
+            href="toy.html?toy=spiral-burst"
+            class="cta-button cta-button--muted"
+            data-quickstart-mode="random"
+            data-quickstart-pool="featured"
+            data-quickstart-audio="demo"
+            data-quickstart-flow="true"
+          >
+            Flow mode
           </a>
           <a
             href="toy.html?toy=spiral-burst"


### PR DESCRIPTION
### Motivation
- Provide a low-friction entry that enables automatic stim switching (Flow mode) from the library hero to keep sessions continuous. 
- Surface Flow mode as a quickstart so users can launch a toy and immediately opt into periodic automatic switching for a more engaging experience.

### Description
- Add a new dataset key `quickstartFlow` in `assets/js/utils/data-attributes.ts` for wiring quickstart flow intent. 
- Parse and normalize the `data-quickstart-flow` attribute in `assets/js/utils/init-quickstart.ts` and pass a `startFlow` flag through the `loadToy` call. 
- Update `assets/js/loader.ts` to accept an optional `startFlow` parameter and call `setFlowActive(true|false)` when present, and add the new param type to the `loadToy` signature. 
- Add a hero CTA and intro pill in `index.html` for the new Flow mode quickstart using `data-quickstart-flow="true"`.

### Testing
- Ran `bun run check` (Biome + typecheck) and it completed successfully. 
- Ran the test suite with `bun test` and automated tests passed (78 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ea2ead4483329832d596ca107feb)