### PR TITLE
Refine mobile nav layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2603,15 +2603,19 @@ footer {
     justify-content: flex-start;
   }
 
+  .nav-section--jump,
   .nav-section--utilities {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 0.6rem;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.45rem;
+    padding: 0.45rem;
+    border-radius: var(--radius-md);
   }
 
   .nav-section__label {
     width: 100%;
-    padding: 0 0.5rem;
+    padding: 0 0.35rem;
   }
 
   .top-nav {
@@ -2634,7 +2638,7 @@ footer {
 
   .theme-toggle {
     width: 100%;
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   .cta-row {


### PR DESCRIPTION
### Motivation
- Improve the mobile navigation appearance on narrow viewports by preventing oversized pill controls and improving scanability of the Jump and Utilities groups.

### Description
- Update `assets/css/index.css` to stack `.nav-section--jump` and `.nav-section--utilities` into a vertical layout on small screens and add spacing, padding, and rounded corners to each section.
- Remove the grid layout for the utilities section and adjust `.nav-section__label` padding to better align with stacked content.
- Make the `.theme-toggle` align to the start on mobile so its label aligns with other nav items.

### Testing
- Ran `biome lint assets scripts tests` which passed after the fix (no outstanding warnings).
- Ran `biome format --write assets scripts tests` which completed successfully.
- Generated a visual smoke check via Playwright that produced a mobile screenshot (`artifacts/nav-mobile.png`) for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811098c968833299dcd0ede998f74b)