### PR TITLE
Preserve user activation for PiP requests

### DIFF
--- a/assets/js/utils/picture-in-picture.ts
+++ b/assets/js/utils/picture-in-picture.ts
@@ -68,7 +68,12 @@ export async function requestToyPictureInPicture(doc: Document) {
   const stream = updateStream(canvas);
   video.srcObject = stream;
 
-  await video.play();
+  const playPromise = video.play();
+  if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+    await playPromise;
+  } else {
+    void playPromise.catch(() => undefined);
+  }
 
   return video.requestPictureInPicture();
 }


### PR DESCRIPTION
### Motivation
- Avoid breaking browsers that require a user gesture for Picture-in-Picture by preventing an unnecessary async boundary before calling `requestPictureInPicture()` which could cause `NotAllowedError` when the video is already ready.

### Description
- Update `requestToyPictureInPicture` in `assets/js/utils/picture-in-picture.ts` to call `video.play()` and only `await` the returned promise when `video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA`; otherwise handle the play promise asynchronously and proceed to `video.requestPictureInPicture()` synchronously.

### Testing
- Ran `bun run check` (Biome checks, TypeScript typecheck, and tests); test run result: `78 pass`, `2 skip`, `0 fail` across 80 tests, and format/lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810f94cfcc8332b444f8c87c70a1e4)