### PR TITLE
Improve accessibility semantics on library hero and system check

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1115,7 +1115,9 @@ html.light .hero-readiness__text {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 0.75rem;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
 }
 
 .intro-pill {
@@ -1170,6 +1172,14 @@ body[data-details-open] .readiness-note {
   margin: -0.25rem 0;
   border-radius: 8px;
   touch-action: manipulation;
+}
+
+button.text-link {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 
 .text-link:focus-visible {

--- a/index.html
+++ b/index.html
@@ -80,13 +80,13 @@
           <p class="eyebrow">Audio-reactive visuals • Ready fast</p>
           <h1>Stim library</h1>
           <p class="section-description">Visuals tuned for sound, touch, and focus.</p>
-          <div class="intro-pills" aria-label="Quick highlights">
-            <span class="intro-pill">✨ Featured: Halo Flow</span>
-            <span class="intro-pill">🎧 Mic not required</span>
-            <span class="intro-pill">🔊 Built-in audio</span>
-            <span class="intro-pill">🖐️ Touch-friendly</span>
-            <span class="intro-pill">🔁 Flow mode auto-switches</span>
-          </div>
+          <ul class="intro-pills" aria-label="Quick highlights">
+            <li class="intro-pill">✨ Featured: Halo Flow</li>
+            <li class="intro-pill">🎧 Mic not required</li>
+            <li class="intro-pill">🔊 Built-in audio</li>
+            <li class="intro-pill">🖐️ Touch-friendly</li>
+            <li class="intro-pill">🔁 Flow mode auto-switches</li>
+          </ul>
         </div>
         <div class="cta-row hero-cta-row">
           <a
@@ -121,13 +121,13 @@
           <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
             Checking device…
           </p>
-          <a
-            href="#system-check"
+          <button
+            type="button"
             class="cta-button ghost hero-readiness__action"
             data-open-preflight
           >
             Tune device
-          </a>
+          </button>
         </div>
       </section>
 
@@ -143,8 +143,8 @@
           >
             Graphics, mic, motion, comfort.
           </p>
-          <a
-            href="#system-check"
+          <button
+            type="button"
             class="text-link details-toggle"
             data-details-toggle
             aria-expanded="false"
@@ -152,7 +152,7 @@
           >
             <span data-details-label="open">Details</span>
             <span data-details-label="close">Hide details</span>
-          </a>
+          </button>
         </div>
         <ul class="system-legend" aria-label="System signals">
           <li class="system-legend__item">🖥️ Graphics</li>


### PR DESCRIPTION
### Motivation
- Improve Lighthouse and a11y scores by using correct semantic elements and safer interactive controls in the library hero and system-check areas.
- Replace presentation-only markup and anchor-based toggles with proper list and button semantics so assistive tech and keyboard users get accurate affordances.

### Description
- Convert the quick highlight pills from a `div` of `span`s to a semantic `<ul class="intro-pills">` with `<li class="intro-pill">` items in `index.html` to expose list semantics to screen readers.
- Replace anchor toggles that open the system preflight/check (hero “Tune device” and the details toggle) with `button` elements to provide correct interactive semantics and prevent misleading link behavior.
- Reset list visuals and add a button-safe reset for `.text-link` by updating `assets/css/index.css` to add `margin`, `padding`, `list-style: none` for `.intro-pills` and a `button.text-link` rule to preserve styling and focus behavior.
- Updated associated focus/visibility behavior remains unchanged; no functional library behavior was modified.

### Testing
- Ran `biome lint assets scripts tests`, which completed with no issues (passed).
- Ran `biome format --write assets scripts tests`, which completed successfully (passed).
- Captured a headless UI snapshot via Playwright against the dev server to validate the updated hero and system-check controls, and the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698192609d688332b47ce536a62c73ba)