### PR TITLE
Improve audio sensitivity for gentle input

### DIFF
--- a/assets/js/toys/neon-wave.ts
+++ b/assets/js/toys/neon-wave.ts
@@ -124,7 +124,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   let smoothedHighs = 0;
   let beatIntensity = 0;
   const beatTracker = createBeatTracker({
-    threshold: 0.55,
+    threshold: 0.45,
     minIntervalMs: 150,
     smoothing: { bass: 0.85, mid: 0.9, treble: 0.92 },
     beatDecay: 0.92,

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -127,7 +127,7 @@ export function start({ container }: { container?: HTMLElement | null } = {}) {
   let beatFlash = 0;
   let beatStreak = 0;
   const beatTracker = createBeatTracker({
-    threshold: 0.55,
+    threshold: 0.45,
     minIntervalMs: 120,
     smoothing: { bass: 0.85, mid: 0.9, treble: 0.92 },
     beatDecay: 0.92,

--- a/assets/js/utils/audio-beat.ts
+++ b/assets/js/utils/audio-beat.ts
@@ -29,7 +29,7 @@ const DEFAULT_SMOOTHING = {
 
 export function createBeatTracker(options: BeatTrackerOptions = {}) {
   const {
-    threshold = 0.55,
+    threshold = 0.45,
     minIntervalMs = 150,
     smoothing = DEFAULT_SMOOTHING,
     beatDecay = 0.92,

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -611,7 +611,7 @@ export function getWeightedAverageFrequency(data: Uint8Array): number {
   const trebleAvg = trebleSum / Math.max(1, len - midEnd) / 255;
 
   const weighted = bassAvg * 0.6 + midAvg * 0.25 + trebleAvg * 0.15;
-  const boosted = Math.min(1, weighted ** 0.78 * 1.05);
+  const boosted = Math.min(1, weighted ** 0.65 * 1.2);
 
   return boosted * 255;
 }

--- a/assets/js/utils/audio-reactivity.ts
+++ b/assets/js/utils/audio-reactivity.ts
@@ -57,7 +57,7 @@ export function getWeightedEnergy(
 export function updateEnergyPeak(
   currentPeak: number,
   weightedEnergy: number,
-  { decay = 0.96, floor = 0.05 }: { decay?: number; floor?: number } = {},
+  { decay = 0.96, floor = 0.02 }: { decay?: number; floor?: number } = {},
 ): number {
   return Math.max(currentPeak * decay, weightedEnergy, floor);
 }

--- a/assets/js/utils/peak-detector.ts
+++ b/assets/js/utils/peak-detector.ts
@@ -51,7 +51,7 @@ function resolveDataSource({
   return null;
 }
 
-const DEFAULT_SENSITIVITY = 0.35;
+const DEFAULT_SENSITIVITY = 0.25;
 const DEFAULT_DECAY = 0.9;
 const DEFAULT_COOLDOWN_MS = 150;
 

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -140,10 +140,10 @@
       <input
         id="sensitivity"
         type="range"
-        min="0.1"
+        min="0.05"
         max="1"
         step="0.05"
-        value="0.3"
+        value="0.2"
       />
       <label for="color-scheme">Color Scheme:</label>
       <select id="color-scheme">

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -248,7 +248,7 @@
         </label>
         <label>
           Peak sensitivity
-          <input class="fun-slider fun-sensitivity" type="range" min="0.1" max="1" step="0.05" value="0.35" aria-label="Peak sensitivity" />
+          <input class="fun-slider fun-sensitivity" type="range" min="0.05" max="1" step="0.05" value="0.2" aria-label="Peak sensitivity" />
         </label>
         <label>
           Particle size <span class="fun-particle-size-value">0.6</span>
@@ -385,7 +385,7 @@
       let burstValue = 0;
       let burstTarget = 0;
       let lastFrequencyData = new Uint8Array(0);
-      let peakSensitivity = 0.35;
+      let peakSensitivity = 0.2;
 
       const handlePeak = (level, threshold) => {
         const strength = Math.min(1.25, (level - threshold) * 3);

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -91,7 +91,7 @@
       let viewHeight = window.innerHeight;
       let sparklesEnabled = true;
       let burstsEnabled = true;
-      let peakSensitivity = 0.35;
+      let peakSensitivity = 0.2;
       let lastRenderTime = 0;
       let renderElapsed = 0;
 

--- a/toys/symph.html
+++ b/toys/symph.html
@@ -275,7 +275,7 @@
       let peakLevel = 0.12;
       let bassPulse = 0;
       let trebleShimmer = 0;
-      const defaultSensitivity = 0.7;
+      const defaultSensitivity = 0.85;
       let transientSensitivity = defaultSensitivity;
       let sparklesEnabled = true;
       let burstsEnabled = true;
@@ -321,7 +321,7 @@
         </div>
         <label class="fun-row">
           <span>Sensitivity</span>
-          <input class="fun-slider fun-sensitivity" type="range" min="0.3" max="1" step="0.01" value="${defaultSensitivity}" aria-valuemin="0.3" aria-valuemax="1" aria-valuenow="${defaultSensitivity}" aria-label="Transient sensitivity" />
+          <input class="fun-slider fun-sensitivity" type="range" min="0.4" max="1" step="0.01" value="${defaultSensitivity}" aria-valuemin="0.4" aria-valuemax="1" aria-valuenow="${defaultSensitivity}" aria-label="Transient sensitivity" />
         </label>
       `;
       funControls.appendControl(extraControls);


### PR DESCRIPTION
### Motivation

- Make audio-reactive toys trigger more reliably from soft sounds (e.g. gentle humming) by increasing low-level audio weighting and lowering activation floors.  
- Relax peak/beat thresholds and default slider values so users can more easily elicit reactions without loud input.  

### Description

- Tweak frequency-to-value mapping in `getWeightedAverageFrequency` to boost quieter energy by changing the exponent and multiplier.  
- Lower the energy floor in `updateEnergyPeak` from `0.05` to `0.02` to keep visuals alive at low levels.  
- Reduce default peak sensitivity in `createPeakDetector` from `0.35` to `0.25`.  
- Lower default beat threshold in `createBeatTracker` from `0.55` to `0.45` and apply that change to `spiral-burst` and `neon-wave`.  
- Adjust UI defaults and slider ranges in HTML toys for easier triggering: `toys/multi.html`, `toys/seary.html`, and `toys/legible.html` use gentler peak defaults (`0.2`) and expanded minimums, and `toys/symph.html` increases transient default sensitivity and minimum slider to better reflect the tuning.  

### Testing

- Ran `bun run check`, which executes `biome check`, `tsc --noEmit`, and the test suite.  
- Test run result: `bun test` executed as part of the check with `80` tests across `24` files, `78` passed, `2` skipped, and `0` failed, and `bun run check` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a583c62083328f27ef4e21e41cc0)