### PR TITLE
Update mobile nav toggle labeling and behavior

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -283,6 +283,38 @@ footer {
   flex-wrap: wrap;
 }
 
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  border: 1px solid var(--surface-border);
+  background: var(--card-bg);
+  color: inherit;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.nav-toggle:hover {
+  border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
+  box-shadow: var(--shadow-soft);
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 3px;
+}
+
+.nav-toggle__icon {
+  font-size: 1.1rem;
+}
+
 .nav-section {
   display: flex;
   align-items: center;
@@ -2583,12 +2615,21 @@ footer {
     justify-content: flex-start;
   }
 
+  .nav-toggle {
+    display: flex;
+    width: 100%;
+  }
+
   .nav-actions {
     width: 100%;
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: 0.6rem;
+  }
+
+  .top-nav[data-nav-expanded="false"] .nav-actions {
+    display: none;
   }
 
   .nav-section {

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -57,7 +57,7 @@ export function initNavigation(container: HTMLElement, options: NavOptions) {
 
 function renderLibraryNav(container: HTMLElement, _doc: Document) {
   container.innerHTML = `
-    <nav class="top-nav" data-top-nav aria-label="Primary">
+    <nav class="top-nav" data-top-nav aria-label="Primary" data-nav-expanded="true">
       <div class="brand">
         <span class="brand-mark"></span>
         <div class="brand-copy">
@@ -65,7 +65,11 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
           <p class="brand-title">Webtoy Library ✦</p>
         </div>
       </div>
-      <div class="nav-actions">
+      <button class="nav-toggle" type="button" aria-expanded="true" aria-controls="nav-actions">
+        <span data-nav-toggle-label>Menu</span>
+        <span class="nav-toggle__icon" data-nav-toggle-icon aria-hidden="true">☰</span>
+      </button>
+      <div class="nav-actions" id="nav-actions">
         <div class="nav-section nav-section--jump" aria-label="Jump to">
           <span class="nav-section__label">Jump</span>
           <a class="nav-link nav-link--section" data-section-link href="#intro">Intro</a>
@@ -85,6 +89,59 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
       </div>
     </nav>
   `;
+
+  const nav = container.querySelector('.top-nav') as HTMLElement | null;
+  const toggle = container.querySelector(
+    '.nav-toggle',
+  ) as HTMLButtonElement | null;
+  const label = container.querySelector(
+    '[data-nav-toggle-label]',
+  ) as HTMLSpanElement | null;
+  const icon = container.querySelector(
+    '[data-nav-toggle-icon]',
+  ) as HTMLSpanElement | null;
+  const mediaQuery = window.matchMedia('(max-width: 520px)');
+  let isExpanded = !mediaQuery.matches;
+
+  const applyState = (expanded: boolean) => {
+    if (!nav || !toggle) return;
+    nav.dataset.navExpanded = expanded ? 'true' : 'false';
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    if (label) {
+      label.textContent = expanded ? 'Close menu' : 'Menu';
+    }
+    if (icon) {
+      icon.textContent = expanded ? '✕' : '☰';
+    }
+  };
+
+  const syncWithViewport = () => {
+    if (mediaQuery.matches) {
+      isExpanded = false;
+    } else {
+      isExpanded = true;
+    }
+    applyState(isExpanded);
+  };
+
+  syncWithViewport();
+
+  toggle?.addEventListener('click', () => {
+    isExpanded = !isExpanded;
+    applyState(isExpanded);
+  });
+
+  mediaQuery.addEventListener('change', syncWithViewport);
+
+  container
+    .querySelectorAll('.nav-link, .nav-link--section, .theme-toggle')
+    .forEach((link) => {
+      link.addEventListener('click', () => {
+        if (!mediaQuery.matches) return;
+        isExpanded = false;
+        applyState(isExpanded);
+      });
+    });
 }
 
 function renderToyNav(


### PR DESCRIPTION
### Motivation
- Fix the mobile navigation toggle so the visible label and icon update when the menu is expanded or collapsed and the ARIA state stays in sync.
- Ensure the nav is collapsed by default on narrow viewports and auto-closes after a link selection to preserve primary content on small screens.

### Description
- Add `data-nav-toggle-label` and `data-nav-toggle-icon` spans to the library nav markup and query them in `assets/js/ui/nav.ts` so the script can update the visible copy and icon.
- Update `assets/js/ui/nav.ts` to set `data-nav-expanded`, toggle `aria-expanded`, swap the label (`Menu` ↔ `Close menu`) and swap the icon (`☰` ↔ `✕`), and wire a viewport-aware `matchMedia` sync plus click handlers that auto-close on link selection.
- Add responsive styles in `assets/css/index.css` for `.nav-toggle` and a rule that hides `.nav-actions` when `data-nav-expanded="false"` so the menu collapses cleanly on small screens.

### Testing
- Ran `bun run check` (Biome lint/format + `tsc` + tests) which completed successfully. 
- Ran `bun test` and the suite reported `78 pass`, `2 skip`, and `0 fail` across the tests. 
- Executed the Playwright screenshot script to validate mobile toggle behavior but the headless Chromium instance crashed (SIGSEGV / `TargetClosedError`), so screenshots could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824949e2fc83329e2a114a06174636)