### PR TITLE
Improve mobile flow nudges

### DIFF
--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -1,3 +1,4 @@
+import { isMobileDevice } from '../utils/device-detect.ts';
 import {
   exitToyPictureInPicture,
   getToyPictureInPictureVideo,
@@ -151,12 +152,15 @@ function renderToyNav(
 ) {
   const safeTitle = escapeHtml(options.title ?? 'Web toy');
   const safeSlug = options.slug ? escapeHtml(options.slug) : '';
+  const hintText = isMobileDevice()
+    ? 'Tap Flow mode to auto-switch every 45s. Use Back to return to the library.'
+    : 'Press Esc or use Back to return to the library.';
   container.className = 'active-toy-nav';
   container.innerHTML = `
     <div class="active-toy-nav__content">
       <p class="active-toy-nav__eyebrow">Now playing</p>
       <p class="active-toy-nav__title">${safeTitle}</p>
-      <p class="active-toy-nav__hint">Press Esc or use Back to return to the library.</p>
+      <p class="active-toy-nav__hint">${hintText}</p>
       ${safeSlug ? `<span class="active-toy-nav__pill">${safeSlug}</span>` : ''}
     </div>
     <div class="active-toy-nav__actions">

--- a/assets/js/utils/init-quickstart.ts
+++ b/assets/js/utils/init-quickstart.ts
@@ -1,5 +1,6 @@
 import toysData from '../toys-data.js';
 import { DATA_SELECTORS, DATASET_KEYS } from './data-attributes.ts';
+import { isMobileDevice } from './device-detect.ts';
 
 type InitQuickstartOptions = {
   loadToy: typeof import('../loader.ts').loadToy;
@@ -15,6 +16,7 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
   if (!quickstarts.length) return;
 
   const quickstartToys = toysData as QuickstartToy[];
+  const isMobile = isMobileDevice();
 
   quickstarts.forEach((quickstart) => {
     if (!(quickstart instanceof HTMLElement)) return;
@@ -30,6 +32,12 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
       if (quickstartFlow === '' || quickstartFlow === 'true') return true;
       if (quickstartFlow === 'false') return false;
       return quickstartFlow === '1';
+    };
+
+    const resolveMobileFlowFallback = () => {
+      if (quickstartFlow !== undefined) return resolveFlowState();
+      if (isMobile && quickstartMode === 'random') return true;
+      return undefined;
     };
 
     const resolveRandomSlug = () => {
@@ -67,7 +75,7 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         pushState: true,
         preferDemoAudio:
           quickstartMode === 'demo' || quickstartAudio === 'demo',
-        startFlow: resolveFlowState(),
+        startFlow: resolveMobileFlowFallback(),
       });
     });
   });


### PR DESCRIPTION
### Motivation
- Encourage mobile users to stay engaged by nudging Flow mode and auto-starting Flow for mobile-random quickstarts so toys cycle automatically on touch devices.

### Description
- Default mobile "random" quickstarts to start Flow by returning `startFlow: true` when the device is mobile via a new `resolveMobileFlowFallback` in `assets/js/utils/init-quickstart.ts` and import `isMobileDevice`.
- Add a mobile-specific hint to the toy navigation that promotes tapping Flow mode and import `isMobileDevice` into `assets/js/ui/nav.ts`, and tidy imports to satisfy linting.

### Testing
- Ran `bun run check` (Biome lint/format + TypeScript check + tests); the command completed successfully and the test run finished with 80 tests executed, 78 passed, and 2 skipped; Docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982612a846c8332a0a6f4ed855baf91)