### PR TITLE
Refactor WebGL renderer creation

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -2,6 +2,7 @@
 import { ACESFilmicToneMapping, SRGBColorSpace, WebGLRenderer } from 'three';
 import { isMobileDevice } from '../utils/device-detect.ts';
 import { ensureWebGL } from '../utils/webgl-check.ts';
+import { createWebGLRenderer } from '../utils/webgl-renderer.ts';
 import {
   getRendererCapabilities,
   type RendererBackend,
@@ -148,7 +149,7 @@ export async function initRenderer(
     rememberRendererFallback(reason, { shouldRetryWebGPU, triedWebGPU });
 
     // Mobile-optimized WebGL context attributes
-    const renderer = new WebGLRenderer({
+    const renderer = createWebGLRenderer({
       canvas,
       antialias,
       alpha,

--- a/assets/js/toys/clay-toy.ts
+++ b/assets/js/toys/clay-toy.ts
@@ -11,10 +11,10 @@ import {
   Scene,
   SpotLight,
   Vector2,
-  WebGLRenderer,
 } from 'three';
 import { createUnifiedInput } from '../utils/unified-input';
 import { ensureWebGL } from '../utils/webgl-check';
+import { createWebGLRenderer } from '../utils/webgl-renderer';
 
 type ClayStartOptions = {
   container?: HTMLElement | null;
@@ -37,7 +37,7 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
   camera.position.set(0, 8, 10);
   camera.lookAt(0, 5, 0);
 
-  const renderer = new WebGLRenderer({
+  const renderer = createWebGLRenderer({
     antialias: true,
     powerPreference: 'default', // Better battery life on mobile
     failIfMajorPerformanceCaveat: false, // Don't fail on mobile GPU limitations

--- a/assets/js/utils/webgl-renderer.ts
+++ b/assets/js/utils/webgl-renderer.ts
@@ -1,0 +1,31 @@
+import { WebGLRenderer } from 'three';
+
+export type WebGLRendererConfig = {
+  canvas?: HTMLCanvasElement;
+  antialias?: boolean;
+  alpha?: boolean;
+  powerPreference?: WebGLPowerPreference;
+  failIfMajorPerformanceCaveat?: boolean;
+  stencil?: boolean;
+  preserveDrawingBuffer?: boolean;
+};
+
+export function createWebGLRenderer({
+  canvas,
+  antialias = true,
+  alpha = false,
+  powerPreference = 'default',
+  failIfMajorPerformanceCaveat = false,
+  stencil = true,
+  preserveDrawingBuffer = false,
+}: WebGLRendererConfig = {}) {
+  return new WebGLRenderer({
+    canvas,
+    antialias,
+    alpha,
+    powerPreference,
+    failIfMajorPerformanceCaveat,
+    stencil,
+    preserveDrawingBuffer,
+  });
+}


### PR DESCRIPTION
### Motivation
- Consolidate WebGLRenderer construction to a single helper to reduce duplicated configuration and make future renderer tweaks easier to apply across the codebase.

### Description
- Add `assets/js/utils/webgl-renderer.ts` which exports `createWebGLRenderer` and a `WebGLRendererConfig` type to centralize renderer options.
- Replace direct `new WebGLRenderer(...)` usage in `assets/js/core/renderer-setup.ts` with `createWebGLRenderer` for the WebGL fallback path.
- Replace direct `new WebGLRenderer(...)` usage in `assets/js/toys/clay-toy.ts` with `createWebGLRenderer` and adjust imports accordingly.

### Testing
- Ran `bun run check` (runs Biome checks, TypeScript typecheck, and the test suite) and it completed successfully with tests: 78 passed, 2 skipped, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982799d516c83329441737e05f02d29)