### PR TITLE
Refactor runtime audio starter typing and test helpers

### DIFF
--- a/tests/toy-test-helpers.ts
+++ b/tests/toy-test-helpers.ts
@@ -8,7 +8,7 @@ export class FakeAnalyserNode {
     this.frequencyBinCount = frequencyBinCount;
   }
 
-  connect() {
+  connect(_destination?: unknown) {
     this.connected = true;
   }
 
@@ -24,10 +24,16 @@ export class FakeAnalyserNode {
 export class FakeAudioContext {
   closed = false;
   analyzersCreated = 0;
+  private readonly buildAnalyser: () => FakeAnalyserNode;
+
+  constructor(options: { analyserFactory?: () => FakeAnalyserNode } = {}) {
+    this.buildAnalyser =
+      options.analyserFactory ?? (() => new FakeAnalyserNode());
+  }
 
   createAnalyser() {
     this.analyzersCreated += 1;
-    return new FakeAnalyserNode();
+    return this.buildAnalyser();
   }
 
   async close() {
@@ -42,7 +48,6 @@ export function createToyContainer(id = 'toy-container') {
 
   const dispose = () => {
     container.remove();
-    document.body.innerHTML = '';
   };
 
   return { container, dispose };


### PR DESCRIPTION
### Motivation
- Improve type safety and fallback handling for runtime audio startup flows so callers can provide typed fallbacks.
- Make test helpers more configurable and safer for test runs by allowing custom analyser factories and avoiding destructive DOM cleanup.

### Description
- Add `RuntimeAudioStartResult`, `RuntimeAudioStartFallbackResult`, and `RuntimeAudioStarter` types and normalize the `onFallback` signature in `assets/js/utils/audio-start-helpers.ts`, and centralize fallback logic in a `runFallback` helper.
- Update `createRuntimeAudioStarter` to return the new `RuntimeAudioStarter` type and allow fallback handlers to return `null` as a valid fallback result.
- Enhance `tests/toy-test-helpers.ts` by making `FakeAudioContext` accept an `analyserFactory` option and use it in `createAnalyser`, change `FakeAnalyserNode.connect` to accept an optional destination argument, and stop clearing `document.body.innerHTML` in `createToyContainer.dispose` to avoid wiping unrelated test DOM.
- Apply minor formatting adjustments to satisfy the project's linter/formatter.

### Testing
- Ran `bun run check` (runs `biome check`, TypeScript typecheck, and the test suite) and the suite completed successfully with all tests passing; reported `78 pass`, `2 skip`, `0 fail`.
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c058fcd48332a5d0d323bf3f3700)