### PR TITLE
Refresh homepage layout for quick starts

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -448,6 +448,33 @@ section.intro > * {
   z-index: 1;
 }
 
+.intro-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1.4rem;
+}
+
+.intro-card {
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface-gradient);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.intro-card__title {
+  margin: 0 0 0.35rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.intro-card__body {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
 header.hero {
   min-height: 55vh;
   padding: clamp(2.4rem, 2vw + 1.4rem, 3.2rem);
@@ -620,6 +647,56 @@ header.hero {
   margin: 0;
   color: var(--text-muted);
   line-height: 1.4;
+}
+
+.quick-starts {
+  display: grid;
+  gap: 1.5rem;
+  padding: clamp(1.4rem, 2vw, 2rem);
+  border-radius: calc(var(--radius-lg) + 6px);
+  background: var(--panel-gradient);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.quick-start-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.1rem;
+}
+
+.quick-card {
+  padding: 1.2rem 1.3rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface-gradient);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.quick-card__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.quick-card h3 {
+  margin: 0;
+}
+
+.quick-card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.quick-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
 }
 
 .system-check {

--- a/index.html
+++ b/index.html
@@ -142,6 +142,20 @@
           </a>
           <a href="#toy-list" class="cta-button ghost">Browse library</a>
         </div>
+        <div class="intro-grid" aria-label="Fast facts">
+          <div class="intro-card">
+            <p class="intro-card__title">Pick a vibe</p>
+            <p class="intro-card__body">Calm, energetic, or immersive. Jump straight into a mood.</p>
+          </div>
+          <div class="intro-card">
+            <p class="intro-card__title">Start in seconds</p>
+            <p class="intro-card__body">No setup. Open a toy and you are moving with audio.</p>
+          </div>
+          <div class="intro-card">
+            <p class="intro-card__title">Built for touch</p>
+            <p class="intro-card__body">Responsive on mobile, tablet, and desktop.</p>
+          </div>
+        </div>
         <div class="hero-readiness" data-hero-readiness-summary>
           <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
             Checking device…
@@ -156,105 +170,65 @@
         </div>
       </section>
 
-      <section class="system-check" id="system-check">
+      <section class="quick-starts" id="quick-starts">
         <div class="section-heading">
-          <p class="eyebrow">System check</p>
-          <h2>Check your device</h2>
-          <p class="section-description">Live status while we scan.</p>
-          <p
-            class="section-description details-panel"
-            data-details-panel
-            id="system-check-details"
-          >
-            Graphics, mic, motion, comfort.
+          <p class="eyebrow">Quick start</p>
+          <h2>Launch a favorite fast</h2>
+          <p class="section-description">
+            Three curated starts if you want motion without scrolling.
           </p>
-          <button
-            type="button"
-            class="text-link details-toggle"
-            data-details-toggle
-            aria-expanded="false"
-            aria-controls="system-check-details"
-          >
-            <span data-details-label="open">Details</span>
-            <span data-details-label="close">Hide details</span>
-          </button>
         </div>
-        <ul class="system-legend" aria-label="System signals">
-          <li class="system-legend__item">🖥️ Graphics</li>
-          <li class="system-legend__item">🎙️ Mic</li>
-          <li class="system-legend__item">🧭 Motion</li>
-          <li class="system-legend__item">🫧 Comfort</li>
-        </ul>
-        <div class="system-grid">
-          <div class="readiness-panel" data-readiness-panel>
-            <div class="readiness-header">
-              <h3 class="readiness-title">Live readiness</h3>
-              <p class="readiness-subtitle" data-details-panel>
-                We’ll keep these signals updated so you know what’s available.
-              </p>
+        <div class="quick-start-grid">
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Featured</p>
+            <h3>Halo Flow</h3>
+            <p>Soft nebula arcs that respond to audio and touch.</p>
+            <div class="quick-card__actions">
+              <a
+                href="toy.html?toy=holy"
+                class="cta-button primary"
+                data-quickstart-slug="holy"
+              >
+                Open Halo Flow
+              </a>
+              <a href="#toy-list" class="text-link">See similar</a>
             </div>
-            <ul class="readiness-list">
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="render"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Graphics acceleration</span>
-                </div>
-                <p class="readiness-note" data-status-note="render">
-                  Checking graphics…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="mic"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Microphone</span>
-                </div>
-                <p class="readiness-note" data-status-note="mic">
-                  Checking mic…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="motion"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion input</span>
-                </div>
-                <p class="readiness-note" data-status-note="motion">
-                  Checking motion…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="reduced"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion comfort</span>
-                </div>
-                <p class="readiness-note" data-status-note="reduced">
-                  Reading comfort…
-                </p>
-              </li>
-            </ul>
-          </div>
-          <div class="system-controls" data-system-controls></div>
-        </div>
-        <div class="cta-row system-actions">
-          <button type="button" class="cta-button primary" data-open-preflight>
-            Open system check
-          </button>
-          <a href="#toy-list" class="text-link">Skip to library</a>
+          </article>
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Flow mode</p>
+            <h3>Auto-switch session</h3>
+            <p>Let the library cycle through favorites on its own.</p>
+            <div class="quick-card__actions">
+              <a
+                href="toy.html?toy=spiral-burst"
+                class="cta-button cta-button--muted"
+                data-quickstart-mode="random"
+                data-quickstart-pool="featured"
+                data-quickstart-audio="demo"
+                data-quickstart-flow="true"
+              >
+                Start flow mode
+              </a>
+              <a href="#library" class="text-link">Pick a list</a>
+            </div>
+          </article>
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Surprise</p>
+            <h3>Random featured</h3>
+            <p>Jump into a curated toy you might not have seen yet.</p>
+            <div class="quick-card__actions">
+              <a
+                href="toy.html?toy=spiral-burst"
+                class="cta-button cta-button--accent"
+                data-quickstart-mode="random"
+                data-quickstart-pool="featured"
+                data-quickstart-audio="demo"
+              >
+                Surprise me
+              </a>
+              <a href="#toy-list" class="text-link">Browse all</a>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -396,6 +370,108 @@
         <main id="toy-list" class="webtoy-container"></main>
       </section>
 
+      <section class="system-check" id="system-check">
+        <div class="section-heading">
+          <p class="eyebrow">System check</p>
+          <h2>Check your device</h2>
+          <p class="section-description">Live status while we scan.</p>
+          <p
+            class="section-description details-panel"
+            data-details-panel
+            id="system-check-details"
+          >
+            Graphics, mic, motion, comfort.
+          </p>
+          <button
+            type="button"
+            class="text-link details-toggle"
+            data-details-toggle
+            aria-expanded="false"
+            aria-controls="system-check-details"
+          >
+            <span data-details-label="open">Details</span>
+            <span data-details-label="close">Hide details</span>
+          </button>
+        </div>
+        <ul class="system-legend" aria-label="System signals">
+          <li class="system-legend__item">🖥️ Graphics</li>
+          <li class="system-legend__item">🎙️ Mic</li>
+          <li class="system-legend__item">🧭 Motion</li>
+          <li class="system-legend__item">🫧 Comfort</li>
+        </ul>
+        <div class="system-grid">
+          <div class="readiness-panel" data-readiness-panel>
+            <div class="readiness-header">
+              <h3 class="readiness-title">Live readiness</h3>
+              <p class="readiness-subtitle" data-details-panel>
+                We’ll keep these signals updated so you know what’s available.
+              </p>
+            </div>
+            <ul class="readiness-list">
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="render"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Graphics acceleration</span>
+                </div>
+                <p class="readiness-note" data-status-note="render">
+                  Checking graphics…
+                </p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="mic"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Microphone</span>
+                </div>
+                <p class="readiness-note" data-status-note="mic">
+                  Checking mic…
+                </p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="motion"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Motion input</span>
+                </div>
+                <p class="readiness-note" data-status-note="motion">
+                  Checking motion…
+                </p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="reduced"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Motion comfort</span>
+                </div>
+                <p class="readiness-note" data-status-note="reduced">
+                  Reading comfort…
+                </p>
+              </li>
+            </ul>
+          </div>
+          <div class="system-controls" data-system-controls></div>
+        </div>
+        <div class="cta-row system-actions">
+          <button type="button" class="cta-button primary" data-open-preflight>
+            Open system check
+          </button>
+          <a href="#toy-list" class="text-link">Skip to library</a>
+        </div>
+      </section>
+
       <footer id="site-footer">
         <div class="footer-actions">
           <p>
@@ -411,6 +487,8 @@
           </p>
           <p class="footer-nav">
             <a href="#intro" class="text-link">Intro</a>
+            <span aria-hidden="true">·</span>
+            <a href="#quick-starts" class="text-link">Quick start</a>
             <span aria-hidden="true">·</span>
             <a href="#system-check" class="text-link">System check</a>
             <span aria-hidden="true">·</span>


### PR DESCRIPTION
### Motivation
- Users were not scrolling far enough and bounce rate from the home page was high, so launch options need to be surfaced earlier. 
- Provide low-friction entry points that work well on mobile and desktop so visitors can start a toy without deep scrolling or configuration. 
- Deprioritize the diagnostic system check visually so discovery and immediate engagement are emphasized.

### Description
- Add an inline fast-facts grid under the hero by introducing `.intro-grid` and `.intro-card` elements in `index.html` to call out quick benefits. 
- Add a new `quick-starts` section with three curated quick-start cards and actions (`Open Halo Flow`, `Start flow mode`, `Surprise me`) and move the system-check block below the library listing in `index.html`. 
- Update footer navigation to include a `#quick-starts` link and wire each quick card to existing quickstart query params so they launch existing toys. 
- Add CSS for `.intro-grid`, `.intro-card`, `.quick-starts`, `.quick-start-grid`, `.quick-card`, and related utility rules in `assets/css/index.css` to match panel treatments and responsive grid behavior.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully. 
- Ran `biome format --write assets scripts tests` which completed successfully. 
- Started the dev server and captured an automated Playwright screenshot of the updated homepage to verify layout rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837dc419688332839c1d2b775030d9)