### PR TITLE
Clarify library hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,15 +102,15 @@
 
       <section class="intro" id="intro">
         <div class="section-heading">
-          <p class="eyebrow">Audio-reactive visuals • Ready fast</p>
+          <p class="eyebrow">Audio-reactive visuals • Instant play</p>
           <h1>Stim library</h1>
-          <p class="section-description">Visuals tuned for sound, touch, and focus.</p>
+          <p class="section-description">Start a visual toy tuned for sound, touch, and focus.</p>
           <ul class="intro-pills" aria-label="Quick highlights">
             <li class="intro-pill">✨ Featured: Halo Flow</li>
             <li class="intro-pill">🎧 Mic not required</li>
             <li class="intro-pill">🔊 Built-in audio</li>
             <li class="intro-pill">🖐️ Touch-friendly</li>
-            <li class="intro-pill">🔁 Flow mode auto-switches</li>
+            <li class="intro-pill">🔁 Auto-switch flow mode</li>
           </ul>
         </div>
         <div class="cta-row hero-cta-row">
@@ -129,7 +129,7 @@
             data-quickstart-audio="demo"
             data-quickstart-flow="true"
           >
-            Flow mode
+            Start flow mode
           </a>
           <a
             href="toy.html?toy=spiral-burst"
@@ -140,20 +140,20 @@
           >
             Surprise me
           </a>
-          <a href="#toy-list" class="cta-button ghost">Browse library</a>
+          <a href="#toy-list" class="cta-button ghost">Browse all stims</a>
         </div>
         <div class="intro-grid" aria-label="Fast facts">
           <div class="intro-card">
-            <p class="intro-card__title">Pick a vibe</p>
-            <p class="intro-card__body">Calm, energetic, or immersive. Jump straight into a mood.</p>
+            <p class="intro-card__title">Choose a vibe</p>
+            <p class="intro-card__body">Pick calm, energetic, or immersive to jump in.</p>
           </div>
           <div class="intro-card">
             <p class="intro-card__title">Start in seconds</p>
-            <p class="intro-card__body">No setup. Open a toy and you are moving with audio.</p>
+            <p class="intro-card__body">No setup—open a toy and react to audio.</p>
           </div>
           <div class="intro-card">
             <p class="intro-card__title">Built for touch</p>
-            <p class="intro-card__body">Responsive on mobile, tablet, and desktop.</p>
+            <p class="intro-card__body">Works on phone, tablet, and desktop.</p>
           </div>
         </div>
         <div class="hero-readiness" data-hero-readiness-summary>
@@ -173,16 +173,16 @@
       <section class="quick-starts" id="quick-starts">
         <div class="section-heading">
           <p class="eyebrow">Quick start</p>
-          <h2>Launch a favorite fast</h2>
+          <h2>Start playing fast</h2>
           <p class="section-description">
-            Three curated starts if you want motion without scrolling.
+            Pick a quick start without scrolling.
           </p>
         </div>
         <div class="quick-start-grid">
           <article class="quick-card">
             <p class="quick-card__eyebrow">Featured</p>
             <h3>Halo Flow</h3>
-            <p>Soft nebula arcs that respond to audio and touch.</p>
+            <p>Soft nebula arcs that react to audio and touch.</p>
             <div class="quick-card__actions">
               <a
                 href="toy.html?toy=holy"
@@ -191,13 +191,13 @@
               >
                 Open Halo Flow
               </a>
-              <a href="#toy-list" class="text-link">See similar</a>
+              <a href="#toy-list" class="text-link">See similar toys</a>
             </div>
           </article>
           <article class="quick-card">
             <p class="quick-card__eyebrow">Flow mode</p>
-            <h3>Auto-switch session</h3>
-            <p>Let the library cycle through favorites on its own.</p>
+            <h3>Auto-switch playlist</h3>
+            <p>Let the library cycle through featured toys.</p>
             <div class="quick-card__actions">
               <a
                 href="toy.html?toy=spiral-burst"
@@ -209,13 +209,13 @@
               >
                 Start flow mode
               </a>
-              <a href="#library" class="text-link">Pick a list</a>
+              <a href="#library" class="text-link">Choose a pool</a>
             </div>
           </article>
           <article class="quick-card">
             <p class="quick-card__eyebrow">Surprise</p>
-            <h3>Random featured</h3>
-            <p>Jump into a curated toy you might not have seen yet.</p>
+            <h3>Random featured toy</h3>
+            <p>Jump into a featured toy you might not have seen.</p>
             <div class="quick-card__actions">
               <a
                 href="toy.html?toy=spiral-burst"
@@ -235,14 +235,14 @@
       <section class="library" id="library">
         <div class="section-heading">
           <p class="eyebrow">Library</p>
-          <h2>Browse every stim</h2>
+          <h2>Browse all stims</h2>
           <p class="section-description">
-            Tap a card to launch.
+            Tap a card to launch or open details.
           </p>
           <search class="library-search">
             <div class="search-heading">
               <h3>Find a stim</h3>
-              <p>Filter by mood or capability.</p>
+              <p>Search by name, mood, or capability.</p>
             </div>
             <div class="search-row">
               <label class="sr-only" for="toy-search">Search the library</label>


### PR DESCRIPTION
### Motivation

- Make the library landing copy more direct and discoverable by tightening hero, quick-start, and library messaging. 
- Reduce verbosity and improve action cues so users can start playing or find toys faster. 
- Keep wording consistent across CTAs, pills, and search hints for clearer affordances.

### Description

- Updated copy in `index.html` across the hero, quick-start, and library sections including the eyebrow, section descriptions, intro pills, CTA labels, quick-card titles/bodies, and search hint. 
- Reworded CTAs and links to be more action-oriented (for example `Flow mode` → `Start flow mode`, `Browse library` → `Browse all stims`). 
- Adjusted small UI copy bits for clarity such as `Pick a vibe` → `Choose a vibe` and `Start in seconds` → `Start in seconds` (concise phrasing). 
- Change set is limited to `index.html` (21 insertions, 21 deletions).

### Testing

- Ran `biome lint assets scripts tests` and it completed successfully. 
- Ran `biome format --write assets scripts tests` and it completed successfully. 
- No typechecks or full `bun run check` were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698381aaeedc8332bfdde68761a80ba8)