### PR TITLE
Fix manifest resolution for Vite output

### DIFF
--- a/tests/manifest-client.test.js
+++ b/tests/manifest-client.test.js
@@ -27,7 +27,7 @@ describe('manifest client', () => {
     });
     const modulePath = await client.resolveModulePath(moduleEntry);
 
-    expect(fetchImpl).toHaveBeenCalledWith('/app/manifest.json');
+    expect(fetchImpl).toHaveBeenCalledWith('/app/.vite/manifest.json');
     expect(modulePath).toBe('/app/assets/js/toys/example.123.js');
   });
 
@@ -79,7 +79,7 @@ describe('manifest client', () => {
     const modulePath = await client.resolveModulePath(moduleEntry);
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://cdn.example.com/app/manifest.json',
+      'https://cdn.example.com/app/.vite/manifest.json',
     );
     expect(modulePath).toBe(
       'https://cdn.example.com/app/assets/js/toys/example.123.js',
@@ -127,7 +127,7 @@ describe('manifest client', () => {
 
     const modulePath = await client.resolveModulePath(moduleEntry);
 
-    expect(fetchImpl).toHaveBeenCalledWith('/manifest.json');
+    expect(fetchImpl).toHaveBeenCalledWith('/.vite/manifest.json');
     expect(modulePath).toBe('/assets/js/toys/example.123.js');
   });
 });


### PR DESCRIPTION
### Motivation
- Production builds were resolving the public web manifest (`/manifest.json`) as the module manifest, but that file contains app metadata (not compiled module entries), causing module toys to fail to load in production.
- The manifest client needs to prefer the Vite-generated manifest and correctly resolve compiled asset paths when `.vite/manifest.json` is present.

### Description
- Reordered manifest lookup to prefer `./.vite/manifest.json` before `./manifest.json` and added `isViteManifest` to skip non-Vite manifests in the search. 
- Adjusted manifest base resolution so `.vite/manifest.json` entries resolve from the correct parent path (`new URL('../', manifestUrl)`) instead of producing `/.vite/...` prefixes. 
- Updated unit tests in `tests/manifest-client.test.js` to expect `.vite/manifest.json` lookups and the corrected resolved module URLs. 
- Modified files: `assets/js/utils/manifest-client.ts` and `tests/manifest-client.test.js`.

### Testing
- Ran the full project check with `bun run check` (Biome + typecheck + tests), which initially surfaced failing manifest tests, then after fixes completed with all tests passing. 
- Test run summary: `bun run check` executed the test suite and resulted in 78 passed, 2 skipped, 0 failed. 
- No docs were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839bc062b883329305f93438e1fbcb)