### PR TITLE
Fix view transition fallback

### DIFF
--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -302,11 +302,28 @@ export function createToyView({
       return action();
     }
 
-    let result: T;
-    doc.startViewTransition(() => {
+    let result: T | undefined;
+    let ran = false;
+    const runOnce = () => {
+      if (ran) return result;
+      ran = true;
       result = action();
-    });
-    // biome-ignore lint/style/noNonNullAssertion: callback runs synchronously
+      return result;
+    };
+
+    try {
+      doc.startViewTransition(() => {
+        runOnce();
+      });
+    } catch (_error) {
+      return action();
+    }
+
+    if (!ran) {
+      runOnce();
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: action always runs
     return result!;
   };
 


### PR DESCRIPTION
### Motivation
- Prevent a production crash where `startViewTransition` may not invoke its callback synchronously, causing `render()` to return undefined `container`/`status` and failing toy startup.

### Description
- Harden `runViewTransition` in `assets/js/toy-view.ts` so the provided `action` always runs once and its result is returned by adding a `runOnce` guard, wrapping `doc.startViewTransition` in a `try/catch`, and falling back to calling `action()` directly when necessary.
- This removes the dependency on synchronous execution of the transition callback and eliminates the race that produced runtime errors like "Cannot destructure property 'container' ... as it is undefined.".

### Testing
- Ran `bun run check` (includes lint, `tsc` typecheck, and the test suite); automated tests completed with `78 pass`, `2 skip`, and `0 fail`.
- Docs touched: none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839bc062b883329305f93438e1fbcb)