### PR TITLE
Refine global shadow tokens

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -29,9 +29,12 @@
     color-mix(in srgb, var(--card-bg) 96%, transparent),
     var(--card-bg)
   );
-  --shadow-strong: 0 8px 18px rgba(0, 0, 0, 0.2);
-  --shadow-soft: 0 4px 10px rgba(0, 0, 0, 0.16);
-  --shadow-surface: 0 6px 16px rgba(0, 0, 0, 0.2);
+  --shadow-strong:
+    0 12px 28px rgba(0, 0, 0, 0.32), 0 2px 10px rgba(106, 124, 143, 0.18);
+  --shadow-soft:
+    0 6px 16px rgba(0, 0, 0, 0.22), 0 1px 6px rgba(106, 124, 143, 0.12);
+  --shadow-surface:
+    0 10px 24px rgba(0, 0, 0, 0.28), 0 1px 8px rgba(106, 124, 143, 0.16);
   --radius-lg: 20px;
   --radius-md: 14px;
   --radius-pill: 999px;
@@ -75,6 +78,12 @@ html.light {
     rgba(91, 110, 130, 0.65),
     rgba(111, 115, 128, 0.5)
   );
+  --shadow-strong:
+    0 12px 28px rgba(15, 23, 42, 0.18), 0 2px 8px rgba(91, 110, 130, 0.2);
+  --shadow-soft:
+    0 6px 14px rgba(15, 23, 42, 0.12), 0 1px 4px rgba(91, 110, 130, 0.18);
+  --shadow-surface:
+    0 10px 22px rgba(15, 23, 42, 0.16), 0 1px 6px rgba(91, 110, 130, 0.16);
   color-scheme: light;
 }
 


### PR DESCRIPTION
### Motivation
- Improve shadow appearance and depth across the site by introducing layered, theme-aware shadow tokens for both dark and light modes.

### Description
- Replace single-value shadow variables in `assets/css/index.css` with multi-layered `--shadow-strong`, `--shadow-soft`, and `--shadow-surface` variants for dark and `html.light` themes to provide richer, more consistent depth.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both of which completed successfully, and generated a visual snapshot via Playwright to verify the updated shadow rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b3c9bad88332a9141fec1bfcc9b9)