### PR TITLE
Centralize breakpoint utilities

### DIFF
--- a/assets/js/toys/mobile-ripples.ts
+++ b/assets/js/toys/mobile-ripples.ts
@@ -6,6 +6,12 @@ import {
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import { getBandAverage } from '../utils/audio-bands';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
+import {
+  BREAKPOINTS,
+  MEDIA_QUERIES,
+  matchesMediaQuery,
+  maxWidthQuery,
+} from '../utils/breakpoints.ts';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import { createToyQualityControls } from '../utils/toy-settings';
@@ -25,10 +31,9 @@ const QUALITY_PRESETS: QualityPreset[] = [
 ];
 
 const isCompactDevice = () => {
-  if (typeof window === 'undefined' || !window.matchMedia) return false;
   return (
-    window.matchMedia('(max-width: 720px)').matches ||
-    window.matchMedia('(pointer: coarse)').matches
+    matchesMediaQuery(maxWidthQuery(BREAKPOINTS.md)) ||
+    matchesMediaQuery(MEDIA_QUERIES.coarsePointer)
   );
 };
 

--- a/assets/js/toys/pocket-pulse.ts
+++ b/assets/js/toys/pocket-pulse.ts
@@ -6,6 +6,12 @@ import {
 import type { ToyRuntimeInstance } from '../core/toy-runtime';
 import { getBandAverage } from '../utils/audio-bands';
 import { getWeightedAverageFrequency } from '../utils/audio-handler';
+import {
+  BREAKPOINTS,
+  MEDIA_QUERIES,
+  matchesMediaQuery,
+  maxWidthQuery,
+} from '../utils/breakpoints.ts';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import { createToyQualityControls } from '../utils/toy-settings';
@@ -25,10 +31,9 @@ const QUALITY_PRESETS: QualityPreset[] = [
 ];
 
 const isCompactDevice = () => {
-  if (typeof window === 'undefined' || !window.matchMedia) return false;
   return (
-    window.matchMedia('(max-width: 720px)').matches ||
-    window.matchMedia('(pointer: coarse)').matches
+    matchesMediaQuery(maxWidthQuery(BREAKPOINTS.md)) ||
+    matchesMediaQuery(MEDIA_QUERIES.coarsePointer)
   );
 };
 

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -1,3 +1,9 @@
+import {
+  BREAKPOINTS,
+  getMediaQueryList,
+  isBelowBreakpoint,
+  maxWidthQuery,
+} from '../utils/breakpoints.ts';
 import { isMobileDevice } from '../utils/device-detect.ts';
 import {
   exitToyPictureInPicture,
@@ -101,8 +107,8 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
   const icon = container.querySelector(
     '[data-nav-toggle-icon]',
   ) as HTMLSpanElement | null;
-  const mediaQuery = window.matchMedia('(max-width: 520px)');
-  let isExpanded = !mediaQuery.matches;
+  const mediaQuery = getMediaQueryList(maxWidthQuery(BREAKPOINTS.xs));
+  let isExpanded = !isBelowBreakpoint(BREAKPOINTS.xs);
 
   const applyState = (expanded: boolean) => {
     if (!nav || !toggle) return;
@@ -117,7 +123,7 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
   };
 
   const syncWithViewport = () => {
-    if (mediaQuery.matches) {
+    if (isBelowBreakpoint(BREAKPOINTS.xs)) {
       isExpanded = false;
     } else {
       isExpanded = true;
@@ -132,13 +138,17 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
     applyState(isExpanded);
   });
 
-  mediaQuery.addEventListener('change', syncWithViewport);
+  if (mediaQuery) {
+    mediaQuery.addEventListener('change', syncWithViewport);
+  } else {
+    window.addEventListener('resize', syncWithViewport);
+  }
 
   container
     .querySelectorAll('.nav-link, .nav-link--section, .theme-toggle')
     .forEach((link) => {
       link.addEventListener('click', () => {
-        if (!mediaQuery.matches) return;
+        if (!isBelowBreakpoint(BREAKPOINTS.xs)) return;
         isExpanded = false;
         applyState(isExpanded);
       });

--- a/assets/js/utils/breakpoints.ts
+++ b/assets/js/utils/breakpoints.ts
@@ -1,0 +1,32 @@
+export const BREAKPOINTS = {
+  xs: 520,
+  sm: 640,
+  md: 720,
+  lg: 768,
+  xl: 900,
+  xxl: 1024,
+} as const;
+
+export const MEDIA_QUERIES = {
+  coarsePointer: '(pointer: coarse)',
+};
+
+export const maxWidthQuery = (px: number) => `(max-width: ${px}px)`;
+export const minWidthQuery = (px: number) => `(min-width: ${px}px)`;
+
+const supportsMatchMedia = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
+export const getMediaQueryList = (query: string) =>
+  supportsMatchMedia() ? window.matchMedia(query) : null;
+
+export const matchesMediaQuery = (query: string) =>
+  supportsMatchMedia() ? window.matchMedia(query).matches : false;
+
+export const isBelowBreakpoint = (px: number) => {
+  if (supportsMatchMedia()) {
+    return window.matchMedia(maxWidthQuery(px)).matches;
+  }
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth <= px;
+};

--- a/assets/js/utils/init-nav-scroll.ts
+++ b/assets/js/utils/init-nav-scroll.ts
@@ -1,3 +1,4 @@
+import { BREAKPOINTS, isBelowBreakpoint } from './breakpoints.ts';
 import { DATA_SELECTORS } from './data-attributes.ts';
 
 export const initNavScrollEffects = () => {
@@ -28,7 +29,8 @@ export const initNavScrollEffects = () => {
   const updateActiveSection = () => {
     if (sectionLinks.length === 0) return;
     const offset =
-      nav.getBoundingClientRect().height + (window.innerWidth <= 768 ? 40 : 56);
+      nav.getBoundingClientRect().height +
+      (isBelowBreakpoint(BREAKPOINTS.lg) ? 40 : 56);
     const scrollPosition = window.scrollY + offset;
     let activeId = sectionLinks[0].id;
     sectionLinks.forEach(({ section, id }) => {

--- a/assets/ui/fun-controls.ts
+++ b/assets/ui/fun-controls.ts
@@ -1,3 +1,5 @@
+import { BREAKPOINTS, maxWidthQuery } from '../js/utils/breakpoints.ts';
+
 export type PaletteOption = 'bright' | 'pastel' | 'neon';
 
 export interface FunControlsCallbacks {
@@ -211,7 +213,7 @@ function ensureStyles() {
         opacity: 0.7;
         margin: 0;
       }
-      @media (max-width: 640px) {
+      @media ${maxWidthQuery(BREAKPOINTS.sm)} {
         .fun-controls {
           left: 0.5rem;
           right: 0.5rem;


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for breakpoint values and media-query helpers to avoid duplicated matchMedia checks across the codebase.
- Make responsive detection more resilient when `window.matchMedia` is missing by providing fallbacks and safer helpers.

### Description
- Add `assets/js/utils/breakpoints.ts` exporting `BREAKPOINTS`, `MEDIA_QUERIES`, `getMediaQueryList`, `matchesMediaQuery`, `isBelowBreakpoint`, and helper query builders.
- Update navigation (`assets/js/ui/nav.ts`) to use the breakpoint helpers and to fall back to a `resize` listener when `matchMedia` is unavailable.
- Use `isBelowBreakpoint` in `assets/js/utils/init-nav-scroll.ts` to compute nav offset consistently across viewports.
- Replace ad-hoc matchMedia checks in mobile toys (`assets/js/toys/mobile-ripples.ts` and `assets/js/toys/pocket-pulse.ts`) with `matchesMediaQuery` and the shared `MEDIA_QUERIES.coarsePointer` constant.
- Wire breakpoint helpers into inline styles for the controls UI (`assets/ui/fun-controls.ts`) using `maxWidthQuery(BREAKPOINTS.sm)` so CSS media rules share the same values as JS.

### Testing
- Ran `bun run check` which executes `biome check`, TypeScript `tsc --noEmit`, and the test suite, and it completed successfully. 
- Automated tests: `bun test` ran 80 tests with 78 passed, 2 skipped, and 0 failed. 
- Lint/format checks from the `check` task completed with no remaining errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b70d5a6483328b13fc4ae1d28596)