### PR TITLE
Improve mobile library layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2638,6 +2638,58 @@ footer {
     gap: 0.5rem;
   }
 
+  .intro-pills {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding: 0 0.5rem 0.25rem;
+    margin: 0.75rem -0.5rem 0;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .intro-pill {
+    white-space: nowrap;
+    scroll-snap-align: start;
+    padding: 0.4rem 0.85rem;
+    font-size: 0.85rem;
+  }
+
+  .intro-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .quick-start-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quick-card {
+    padding: 1.1rem;
+  }
+
+  .quick-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .quick-card__actions .cta-button,
+  .quick-card__actions .text-link {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .system-legend {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .system-legend__item {
+    white-space: nowrap;
+  }
+
   .search-row {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
### Motivation
- Improve the mobile browsing experience for the library by reducing horizontal clutter and making quick actions easier to tap on small devices.
- Ensure key UI rows (intro pills, quick starts, system legend) behave well on narrow viewports and support touch-friendly scrolling.

### Description
- Add mobile-specific CSS under `@media (max-width: 680px)` in `assets/css/index.css` to make `.intro-pills` horizontally scrollable with `scroll-snap-type` and touch-friendly scrolling behavior.
- Force single-column layouts for `.intro-grid` and `.quick-start-grid`, reduce `.quick-card` padding, and stack `.quick-card__actions` so CTAs and text links become full-width tappable controls.
- Make `.system-legend` horizontally scrollable and prevent wrapping on legend items via `white-space: nowrap` to avoid cramped layouts on small screens.

### Testing
- Ran `biome lint assets scripts tests` which completed successfully.
- Ran `biome format --write assets scripts tests` which completed successfully.
- Started the dev server with `bun run dev -- --host 0.0.0.0 --port 4173` and captured a mobile viewport screenshot via a Playwright script, which ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698426784a2083328934184a3dff40f0)