### PR TITLE
Remove hero readiness prompt to reduce landing friction

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -12,7 +12,6 @@ import { initAudioControls } from './ui/audio-controls.ts';
 import { initNavigation as initTopNav } from './ui/nav.ts';
 import { initSystemControls } from './ui/system-controls.ts';
 import { initGamepadNavigation } from './utils/gamepad-navigation.ts';
-import { initHeroReadinessSummary } from './utils/init-hero-readiness.ts';
 import { initLibraryView } from './utils/init-library.ts';
 import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
 import { initQuickstartCta } from './utils/init-quickstart.ts';
@@ -101,7 +100,6 @@ const startApp = async () => {
     });
 
     runInit('quickstart CTA', () => initQuickstartCta({ loadToy }));
-    runInit('hero readiness summary', initHeroReadinessSummary);
     runInit('nav scroll effects', initNavScrollEffects);
     runInit('system check', initSystemCheck);
   }

--- a/index.html
+++ b/index.html
@@ -156,18 +156,6 @@
             <p class="intro-card__body">Works on phone, tablet, and desktop.</p>
           </div>
         </div>
-        <div class="hero-readiness" data-hero-readiness-summary>
-          <p class="hero-readiness__text" data-hero-readiness-text aria-live="polite">
-            Checking device…
-          </p>
-          <button
-            type="button"
-            class="cta-button ghost hero-readiness__action"
-            data-open-preflight
-          >
-            Tune device
-          </button>
-        </div>
       </section>
 
       <section class="quick-starts" id="quick-starts">


### PR DESCRIPTION
### Motivation
- Simplify the library landing experience by removing a device readiness prompt that added friction to quick starts.

### Description
- Deleted the hero readiness UI block in `index.html` and removed the corresponding `initHeroReadinessSummary` initialization call from `assets/js/app.ts`.

### Testing
- Ran `bun run check` (which runs `biome check`, `tsc --noEmit`, and `bun test`) and all checks/tests succeeded: 78 passed, 2 skipped, 0 failed; docs touched: none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984293ab4e48332a2b3ed3d39fb28bc)