### PR TITLE
Add MCP doc search tool

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -24,6 +24,9 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
 - **`read_doc_section`**
   - **Input:** required `file` enum (e.g., `README.md`, `docs/MCP_SERVER.md`) and optional `heading` string.
   - **Output:** `text` response containing the full markdown file when no heading is provided, or the matching section beginning at the requested heading. Returns a friendly error when the file or heading cannot be found.
+- **`search_docs`**
+  - **Input:** required `query` string plus optional `file` enum to limit search scope and optional `limit` (1-20) for result count.
+  - **Output:** `text` response with each matching section’s file, heading, line range, and a short excerpt containing the query. Returns a friendly message when no matches are found.
 - **`describe_loader`**
   - **Input:** none.
   - **Output:** `text` summary of how the toy loader resolves entries and errors, including manifest resolution (`/.vite/manifest.json`), URL/history handling, WebGPU gating, and the recovery states shown when imports fail.

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { getDocSectionContent, normalizeToys } from '../scripts/mcp-server.ts';
+import {
+  getDocSectionContent,
+  normalizeToys,
+  searchMarkdownSources,
+} from '../scripts/mcp-server.ts';
 
 describe('normalizeToys', () => {
   test('preserves optional metadata fields when provided', () => {
@@ -61,5 +65,24 @@ describe('getDocSectionContent', () => {
     if (!result.ok) {
       expect(result.message).toContain('was not found');
     }
+  });
+});
+
+describe('searchMarkdownSources', () => {
+  test('finds matches across markdown files', async () => {
+    const results = await searchMarkdownSources('Registered tools', {
+      file: 'docs/MCP_SERVER.md',
+      limit: 5,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.file).toBe('docs/MCP_SERVER.md');
+    expect(results[0]?.heading).toContain('Registered tools');
+  });
+
+  test('returns empty results when no matches exist', async () => {
+    const results = await searchMarkdownSources('this should not match');
+
+    expect(results).toHaveLength(0);
   });
 });


### PR DESCRIPTION
### Motivation
- Provide an MCP tool to let clients search repository markdown (README.md and docs/*.md) and receive matching sections with line ranges and short excerpts for easier discovery.
- Surface searchable documentation programmatically so MCP clients don't need to scrape or load full documents to find relevant guidance.

### Description
- Add a `search_docs` MCP tool that accepts `query`, optional `file`, and optional `limit` and returns matching sections with file, heading, L[start]-L[end] ranges, and excerpts.
- Implement `searchMarkdownSources`, `getMarkdownSections`, and associated `DocSearchResult` types in `scripts/mcp-shared.ts`, and export them for testing and reuse.
- Update MCP server registration to include the new `search_docs` tool and export `getMarkdownSections` and `searchMarkdownSources` from the module.
- Document the new tool in `docs/MCP_SERVER.md` and add tests in `tests/mcp-server.test.ts` covering positive and empty-result cases.

### Testing
- Ran the repository quality gate with `bun run check` (Biome lint/format, TypeScript typecheck, and tests), which completed successfully.
- Unit tests executed (`bun test`) and all automated tests passed (80 passed, 2 skipped), including the new `searchMarkdownSources` tests in `tests/mcp-server.test.ts`.
- Docs updated: `docs/MCP_SERVER.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843f7b57dc8332b9acfaf99df948a3)