### PR TITLE
Refactor pointer input listeners

### DIFF
--- a/assets/js/utils/pointer-input.ts
+++ b/assets/js/utils/pointer-input.ts
@@ -250,75 +250,61 @@ export function createPointerInput({
     updateAndNotify();
   };
 
+  const pointerEvents: Array<
+    [keyof GlobalEventHandlersEventMap, (event: PointerEvent) => void]
+  > = [
+    ['pointermove', handlePointerMove],
+    ['pointerdown', handlePointerDown],
+    ['pointerup', handlePointerEnd],
+    ['pointercancel', handlePointerEnd],
+    ['pointerout', handlePointerEnd],
+    ['pointerleave', handlePointerEnd],
+    ['lostpointercapture', handlePointerLost],
+  ];
+
+  const touchEvents: Array<
+    [keyof GlobalEventHandlersEventMap, (event: Event) => void]
+  > = [
+    ['touchstart', handleTouchEvent],
+    ['touchmove', handleTouchEvent],
+    ['touchend', handleTouchEvent],
+    ['touchcancel', handleTouchEvent],
+  ];
+
+  const mouseEvents: Array<
+    [keyof GlobalEventHandlersEventMap, (event: Event) => void]
+  > = [
+    ['mousemove', handleMouseEvent],
+    ['mousedown', handleMouseEvent],
+    ['mouseup', handleMouseEnd],
+    ['mouseleave', handleMouseEnd],
+  ];
+
   if (supportsPointerEvents) {
-    addPointerListener('pointermove', handlePointerMove);
-    addPointerListener('pointerdown', handlePointerDown);
-    addPointerListener('pointerup', handlePointerEnd);
-    addPointerListener('pointercancel', handlePointerEnd);
-    addPointerListener('pointerout', handlePointerEnd);
-    addPointerListener('pointerleave', handlePointerEnd);
-    addPointerListener('lostpointercapture', handlePointerLost);
+    pointerEvents.forEach(([type, handler]) => {
+      addPointerListener(type, handler);
+    });
   } else {
-    listenerTarget.addEventListener(
-      'touchstart',
-      handleTouchEvent,
-      touchListenerOptions,
-    );
-    listenerTarget.addEventListener(
-      'touchmove',
-      handleTouchEvent,
-      touchListenerOptions,
-    );
-    listenerTarget.addEventListener(
-      'touchend',
-      handleTouchEvent,
-      touchListenerOptions,
-    );
-    listenerTarget.addEventListener(
-      'touchcancel',
-      handleTouchEvent,
-      touchListenerOptions,
-    );
-    listenerTarget.addEventListener('mousemove', handleMouseEvent);
-    listenerTarget.addEventListener('mousedown', handleMouseEvent);
-    listenerTarget.addEventListener('mouseup', handleMouseEnd);
-    listenerTarget.addEventListener('mouseleave', handleMouseEnd);
+    touchEvents.forEach(([type, handler]) => {
+      listenerTarget.addEventListener(type, handler, touchListenerOptions);
+    });
+    mouseEvents.forEach(([type, handler]) => {
+      listenerTarget.addEventListener(type, handler);
+    });
   }
 
   function dispose() {
     if (supportsPointerEvents) {
-      removePointerListener('pointermove', handlePointerMove);
-      removePointerListener('pointerdown', handlePointerDown);
-      removePointerListener('pointerup', handlePointerEnd);
-      removePointerListener('pointercancel', handlePointerEnd);
-      removePointerListener('pointerout', handlePointerEnd);
-      removePointerListener('pointerleave', handlePointerEnd);
-      removePointerListener('lostpointercapture', handlePointerLost);
+      pointerEvents.forEach(([type, handler]) => {
+        removePointerListener(type, handler);
+      });
     } else {
-      listenerTarget.removeEventListener(
-        'touchstart',
-        handleTouchEvent,
-        touchListenerOptions,
-      );
-      listenerTarget.removeEventListener(
-        'touchmove',
-        handleTouchEvent,
-        touchListenerOptions,
-      );
-      listenerTarget.removeEventListener(
-        'touchend',
-        handleTouchEvent,
-        touchListenerOptions,
-      );
-      listenerTarget.removeEventListener(
-        'touchcancel',
-        handleTouchEvent,
-        touchListenerOptions,
-      );
-      listenerTarget.removeEventListener('mousemove', handleMouseEvent);
-      listenerTarget.removeEventListener('mousedown', handleMouseEvent);
-      listenerTarget.removeEventListener('mouseup', handleMouseEnd);
-      listenerTarget.removeEventListener('mouseleave', handleMouseEnd);
+      touchEvents.forEach(([type, handler]) => {
+        listenerTarget.removeEventListener(type, handler, touchListenerOptions);
+      });
+      mouseEvents.forEach(([type, handler]) => {
+        listenerTarget.removeEventListener(type, handler);
+      });
     }
     activePointers.clear();
     gestureAnchor = null;


### PR DESCRIPTION
### Motivation
- Reduce duplication in pointer/touch/mouse event registration and teardown by centralizing event lists and iteration.
- Improve maintainability of `pointer-input` utilities while keeping existing behavior and compatibility.

### Description
- Consolidated individual `addEventListener`/`removeEventListener` calls into shared `pointerEvents`, `touchEvents`, and `mouseEvents` arrays and iterate to register/unregister them in `assets/js/utils/pointer-input.ts`.
- Preserved existing semantics for pointer, touch, and mouse fallbacks and kept `touchListenerOptions` for touch passive/prevent behavior.
- Adjusted TypeScript event tuple types to satisfy the typechecker and formatting rules.

### Testing
- Ran `bun run check` (which runs Biome formatting/lint, `tsc` typecheck, and the test suite) and it completed successfully.
- Test results: `82` tests run with `80` passed and `2` skipped, and `0` failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984474cc9688332a71d8c3994279672)