### PR TITLE
Limit mobile control panel height and tighten mobile HUD spacing

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -283,15 +283,15 @@ body {
 
 .active-toy-nav {
   position: fixed;
-  top: 12px;
+  top: 8px;
   left: 50%;
   transform: translateX(-50%);
-  width: min(1080px, calc(100% - 24px));
+  width: min(980px, calc(100% - 20px));
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
+  gap: 10px;
+  padding: 8px 12px;
   background: linear-gradient(
     135deg,
     rgba(7, 11, 22, 0.92),
@@ -310,20 +310,20 @@ body {
 
 .active-toy-nav__content {
   display: grid;
-  gap: 4px;
+  gap: 2px;
 }
 
 .active-toy-nav__eyebrow {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   color: rgba(233, 251, 255, 0.88);
 }
 
 .active-toy-nav__title {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: 1.05rem;
   font-weight: 700;
   letter-spacing: 0.015em;
   color: #e9fbff;
@@ -332,7 +332,7 @@ body {
 .active-toy-nav__hint {
   margin: 0;
   color: rgba(233, 251, 255, 0.9);
-  font-size: 1rem;
+  font-size: 0.92rem;
 }
 
 .active-toy-nav__pill {
@@ -359,7 +359,7 @@ body {
 .active-toy-nav__actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
@@ -808,11 +808,11 @@ body {
 
 .control-panel {
   position: fixed;
-  bottom: max(16px, env(safe-area-inset-bottom));
-  left: max(16px, env(safe-area-inset-left));
-  width: min(320px, 90vw);
+  bottom: max(12px, env(safe-area-inset-bottom));
+  left: max(12px, env(safe-area-inset-left));
+  width: min(280px, 88vw);
   color: #e9fbff;
-  padding: 16px;
+  padding: 12px;
   background: rgba(4, 6, 14, 0.85);
   border: 1px solid rgba(148, 165, 180, 0.65);
   clip-path: polygon(8% 0, 100% 0, 100% 78%, 92% 100%, 0 100%, 0 22%);
@@ -828,13 +828,13 @@ body {
 .control-panel--floating {
   bottom: auto;
   left: auto;
-  top: max(12px, env(safe-area-inset-top));
-  right: max(12px, env(safe-area-inset-right));
-  width: min(360px, 92vw);
+  top: max(10px, env(safe-area-inset-top));
+  right: max(10px, env(safe-area-inset-right));
+  width: min(320px, 90vw);
   max-height: min(
     calc(
       100dvh -
-      24px -
+      20px -
       env(safe-area-inset-top) -
       env(safe-area-inset-bottom)
     ),
@@ -897,8 +897,8 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin: 10px 0;
-  padding: 12px 0;
+  margin: 8px 0;
+  padding: 8px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
@@ -1393,8 +1393,8 @@ body {
   .active-toy-nav {
     flex-direction: column;
     align-items: flex-start;
-    gap: 8px;
-    padding: 10px 12px;
+    gap: 4px;
+    padding: 6px 8px;
   }
 
   .active-toy-nav__actions {
@@ -1422,17 +1422,20 @@ body {
   }
 
   .control-panel {
-    left: max(12px, env(safe-area-inset-left));
-    right: max(12px, env(safe-area-inset-right));
+    left: max(6px, env(safe-area-inset-left));
+    right: max(6px, env(safe-area-inset-right));
     width: auto;
-    padding: 12px;
+    padding: 8px;
     clip-path: none;
     border-radius: 18px;
-    max-height: calc(
-      100dvh -
-      24px -
-      env(safe-area-inset-top) -
-      env(safe-area-inset-bottom)
+    max-height: min(
+      45svh,
+      calc(
+        100dvh -
+        12px -
+        env(safe-area-inset-top) -
+        env(safe-area-inset-bottom)
+      )
     );
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
@@ -1445,8 +1448,13 @@ body {
   .control-panel__row {
     flex-wrap: wrap;
     align-items: flex-start;
-    gap: 8px;
-    padding: 6px 0;
+    gap: 6px;
+    padding: 4px 0;
+  }
+
+  .control-panel__description {
+    font-size: 0.78rem;
+    margin-bottom: 6px;
   }
 
   .control-panel__value {
@@ -1468,18 +1476,22 @@ body {
   }
 
   .active-toy-nav {
-    top: calc(env(safe-area-inset-top) + 8px);
-    width: calc(100% - 20px);
-    padding: 8px 10px;
+    top: calc(env(safe-area-inset-top) + 4px);
+    width: calc(100% - 12px);
+    padding: 4px 6px;
     border-radius: 14px;
   }
 
   .active-toy-nav__eyebrow {
-    font-size: 0.7rem;
+    font-size: 0.65rem;
   }
 
   .active-toy-nav__title {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
+  }
+
+  .active-toy-nav__hint {
+    font-size: 0.85rem;
   }
 
   .renderer-status {
@@ -1491,7 +1503,16 @@ body {
   }
 
   .control-panel {
-    padding: 10px;
+    padding: 6px;
+    max-height: min(
+      40svh,
+      calc(
+        100dvh -
+        10px -
+        env(safe-area-inset-top) -
+        env(safe-area-inset-bottom)
+      )
+    );
   }
 
   .control-panel__actions--inline {


### PR DESCRIPTION
### Motivation
- Reclaim playable canvas on small screens because the settings panel and HUD were occupying too much space and making the toy difficult to use. 

### Description
- Cap the control panel height on small screens using `min()`/`svh` and `calc()` so the panel becomes scrollable and never overwhelms the viewport. 
- Reduce paddings, gaps, and typographic sizes for the mobile HUD (`.active-toy-nav`) and control panel to shrink visual footprint while preserving existing visual treatments and scroll behavior. 
- Add a compact rule for `.control-panel__description` to reduce vertical spacing in mobile layouts. 
- Adjust floating panel offsets and widths for tighter placement on small viewports while keeping `overflow-y: auto` and touch scrolling enabled.

### Testing
- Ran `biome lint assets scripts tests` and it completed successfully. 
- Ran `biome format --write assets scripts tests` and it completed successfully. 
- Launched the dev server with `bun run dev -- --host 0.0.0.0 --port 4173` (Vite ready) and captured a Playwright mobile viewport screenshot saved to `artifacts/toy-layout-mobile-more-space.png` to validate the compact layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698448cb8a8c8332a5cdc85ce04862a1)