### PR TITLE
Improve homepage SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,21 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="Audio-reactive visual toys for sensory stimulation and creative play. Open-source, no accounts required." />
+    <meta
+      name="description"
+      content="Audio-reactive visual toys and WebGL stims for sensory play. Instant, open-source, no signups."
+    />
+    <meta
+      name="keywords"
+      content="audio-reactive, webgl, three.js, visual toys, sensory play, stimming, interactive art"
+    />
+    <meta name="application-name" content="Stim Webtoys Library" />
     <meta name="robots" content="index,follow" />
     <meta name="theme-color" content="#0b0f1a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="canonical" href="https://no.toil.fyi/" />
+    <link rel="alternate" href="https://no.toil.fyi/" hreflang="en" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
@@ -16,18 +25,26 @@
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <title>Stim Webtoys Library</title>
-    <meta property="og:title" content="Stim Webtoys Library" />
-    <meta property="og:description" content="Audio-reactive visual toys for sensory stimulation and creative play. Open-source, no accounts required." />
+    <title>Stim Webtoys Library | Audio-reactive visual toys</title>
+    <meta property="og:title" content="Stim Webtoys Library | Audio-reactive visual toys" />
+    <meta
+      property="og:description"
+      content="Audio-reactive visual toys and WebGL stims for sensory play. Instant, open-source, no signups."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Stim Webtoys Library" />
-    <meta name="twitter:description" content="Audio-reactive visual toys for sensory stimulation and creative play. Open-source, no accounts required." />
+    <meta name="twitter:title" content="Stim Webtoys Library | Audio-reactive visual toys" />
+    <meta
+      name="twitter:description"
+      content="Audio-reactive visual toys and WebGL stims for sensory play. Instant, open-source, no signups."
+    />
     <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
     <link
@@ -60,7 +77,12 @@
             "name": "Stim Webtoys Library",
             "publisher": { "@id": "https://no.toil.fyi/#organization" },
             "inLanguage": "en",
-            "description": "Audio-reactive visual toys for sensory stimulation and creative play.",
+            "description": "Audio-reactive visual toys and WebGL stims for sensory play.",
+            "potentialAction": {
+              "@type": "SearchAction",
+              "target": "https://no.toil.fyi/?q={search_term_string}",
+              "query-input": "required name=search_term_string"
+            },
             "image": {
               "@type": "ImageObject",
               "url": "https://no.toil.fyi/icons/icon-512.png",


### PR DESCRIPTION
### Motivation
- Improve search discoverability and clarity by refining homepage metadata and keywords.
- Enable richer search behavior for engines by adding structured data `SearchAction` to the site JSON-LD.
- Improve social sharing previews by clarifying titles/descriptions and adding image sizing and app/language hints.

### Description
- Update `index.html` to replace the generic `meta[name=description]` with a clearer, SEO-friendly description string.
- Add `meta[name=keywords]` and `meta[name=application-name]`, and add a `link rel="alternate" hreflang="en"` tag for language signaling.
- Update the `<title>` and Open Graph/Twitter `title` and `description` fields for clearer social previews and branding.
- Add `og:image:width` and `og:image:height`, and extend the JSON-LD `WebSite` object with a `potentialAction` `SearchAction` entry.

### Testing
- Ran `biome lint assets scripts tests` and the lint completed successfully.
- Ran `biome format --write assets scripts tests` and formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698572bd0ff48332b75f518530e989af)