### PR TITLE
Add agent skill definitions

### DIFF
--- a/.agent/skills/create-toy/SKILL.md
+++ b/.agent/skills/create-toy/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: create-toy
+description: "Scaffold and register new toys in the Stim Webtoys Library. Use when asked to create a new toy module, add a toy entry, or set up a toy's files and registration."
+---
+
+# Create a new toy
+
+## Quick scaffold
+
+Use the scaffold script for the standard module layout:
+
+```bash
+bun run scripts/scaffold-toy.ts --slug <slug> --title "<Title>" --type module --with-test
+```
+
+## Register the toy
+
+Add the toy metadata entry in `assets/data/toys.json` and point `module` to the new TypeScript file.
+
+## Verify
+
+```bash
+bun run check:toys
+```
+
+## Manual creation (when scaffolding is not enough)
+
+1. Create `assets/js/toys/<slug>.ts` and export `start({ container })`.
+2. Add cleanup logic (remove canvas, cancel animation frame).
+3. Register audio handlers with `registerToyGlobals`.
+4. Add the toy entry in `assets/data/toys.json`.
+
+## Local validation
+
+```bash
+bun run dev
+```
+
+Open `http://localhost:5173/toy.html?toy=<slug>` and confirm the toy loads.

--- a/.agent/skills/play-toy/SKILL.md
+++ b/.agent/skills/play-toy/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: play-toy
+description: "Run and interact with toys in the Stim Webtoys Library. Use when asked to launch the dev server, open a toy in the browser, or validate toy behavior manually."
+---
+
+# Play a toy locally
+
+## Start the dev server
+
+```bash
+bun run dev
+```
+
+## Open a toy
+
+Navigate to:
+
+```
+http://localhost:5173/toy.html?toy=<slug>
+```
+
+## Quick manual checks
+
+- Confirm the canvas renders without errors.
+- Use demo audio if microphone access is blocked.
+- Verify the toy responds to audio if applicable.

--- a/.agent/skills/test-toy/SKILL.md
+++ b/.agent/skills/test-toy/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: test-toy
+description: "Validate toys in the Stim Webtoys Library. Use when asked to run toy-related tests, run the full quality gate, or verify toy registrations and type checks."
+---
+
+# Test toys
+
+## Full quality gate
+
+```bash
+bun run check
+```
+
+## Focused commands
+
+```bash
+bun run check:toys
+bun run typecheck
+bun test
+```

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -17,6 +17,7 @@ Start with the root [AGENTS.md](../../AGENTS.md) for the essentials, then use th
 - `toys/` - Standalone HTML toy pages.
 - `tests/` - Automated tests.
 - `docs/` - Documentation and architecture references.
+- `.agent/skills/` - Agent skill definitions for common workflows.
 
 - [Tooling & quality checks](./tooling-and-quality.md)
 - [Metadata & documentation expectations](./metadata-and-docs.md)


### PR DESCRIPTION
### Motivation
- Provide reusable agent skills for common toy workflows so agents have concise, discoverable procedures for creating, running, and testing toys.

### Description
- Add three skill definitions at `.agent/skills/` — `create-toy`, `play-toy`, and `test-toy` — each with YAML frontmatter and short workflows, and document the new directory in `docs/agents/README.md`.

### Testing
- Ran `biome lint assets scripts tests` and `biome format --write assets scripts tests`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698579aab3d88332a3b3244ddeb0a1a4)