### PR TITLE
Clarify using `bun run test` in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ bun run dev
   Always invoke the script so the pinned `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags apply, loading happy-dom globals and a Three.js stub needed for headless specs.
 - Run the Bun test runner with filters (for example, targeting specific files):
   ```bash
-  bun test tests/path/to/spec.test.js
+  bun run test tests/path/to/spec.test.js
   ```
 - Lint the project:
   ```bash
@@ -66,7 +66,7 @@ bun run dev
 - Register toy metadata (labels, slugs, and settings) in `assets/data/toys.json` so the loader can find your new toy.
 - Toy entry points are served through `toy.html` using a `?toy=` query string (for example, `toy.html?toy=cube-wave`). Ensure your toy slug matches the metadata entry.
 - Shared styling and assets live under `assets/css/` and `assets/data/`. Add new static assets there when needed.
-- Update or add tests under `tests/` to cover new behaviors. You can run targeted checks by passing the spec path to `bun test`.
+- Update or add tests under `tests/` to cover new behaviors. You can run targeted checks by passing the spec path to `bun run test`.
 - Use `bun run scripts/scaffold-toy.ts` to scaffold a new toy: it prompts for slug/title/type, writes a starter module using the playbook template, updates `assets/data/toys.json` and `docs/TOY_SCRIPT_INDEX.md`, and can generate a minimal Bun spec that asserts `start` is exported.
 
 Happy building!

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,7 +29,7 @@ If you’re spinning up the project for the first time, confirm the basics befor
 
   If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install`.
   - Keep `bun.lock` authoritative. Use `bun install --frozen-lockfile` in CI and prefer Bun locally to keep dependency resolution consistent.
-- The project uses **TypeScript**, **Vite**, **Three.js**, **Biome**, and the Bun test runner. No extra ESM flags are required when running `bun test`.
+- The project uses **TypeScript**, **Vite**, **Three.js**, **Biome**, and the Bun test runner. Use `bun run test` so the repo’s preload/import map flags are always applied.
 - Run the dev server locally with Bun:
 
   ```bash
@@ -72,7 +72,7 @@ Notes:
 When debugging a single test file, run:
 
 ```bash
-bun test tests/filename.test.js
+bun run test tests/filename.test.js
 ```
 
 ### Editor Tooling

--- a/docs/agents/toy-workflows.md
+++ b/docs/agents/toy-workflows.md
@@ -20,7 +20,7 @@ bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --w
 bun run check:toys
 
 # Run all tests
-bun test
+bun run test
 
 # Start dev server for interactive testing
 bun run dev


### PR DESCRIPTION
### Motivation

- Ensure contributors use the repository test script so the repo’s `--preload` and `--importmap` flags are always applied when running tests.
- Prevent confusing or failing local runs that omit headless DOM and Three.js stubs required by the specs.
- Keep docs consistent with the project’s Bun-first tooling and CI expectations.

### Description

- Replaced instances of `bun test` with `bun run test` in `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, and `docs/agents/toy-workflows.md` to recommend the scripted test invocation.
- Updated the single-file debugging example to `bun run test tests/filename.test.js` so the preload/importmap flags are applied.
- Left all other Bun script references unchanged and limited edits to documentation only.

### Testing

- Ran `biome lint assets scripts tests` and it completed successfully with no errors.
- Ran `biome format --write assets scripts tests` and it completed successfully with no formatting changes needed.
- No code or runtime tests were modified as this change only updates documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f6e820c8332b4710abae9324455)