### PR TITLE
Add agent vibe mode for nonhuman play sessions

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1785,3 +1785,26 @@ body {
   color: rgba(148, 165, 180, 0.96);
   font-weight: 700;
 }
+
+:root[data-agent-vibe-mode="true"] {
+  --agent-vibe-intensity: 1;
+}
+
+:root[data-agent-vibe-mode="true"] .active-toy-container {
+  animation: agentVibePulse 620ms ease-in-out infinite;
+}
+
+:root[data-agent-vibe-mode="true"] .toy-canvas {
+  filter: saturate(calc(1 + (0.2 * var(--agent-vibe-intensity, 1))))
+    contrast(calc(1 + (0.08 * var(--agent-vibe-intensity, 1))));
+}
+
+@keyframes agentVibePulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(calc(1 + (0.004 * var(--agent-vibe-intensity, 1))));
+  }
+}

--- a/tests/agent-api.test.ts
+++ b/tests/agent-api.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test';
+import {
+  initAgentAPI,
+  setAudioActive,
+  setCurrentToy,
+} from '../assets/js/core/agent-api.ts';
+
+test('activateVibeMode toggles state and root dataset', async () => {
+  const api = initAgentAPI();
+  const activatePromise = api.activateVibeMode(600);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(api.getState().vibeMode).toBe(true);
+  expect(document.documentElement.dataset.agentVibeMode).toBe('true');
+  expect(
+    document.documentElement.style.getPropertyValue('--agent-vibe-intensity'),
+  ).toBeTruthy();
+
+  await activatePromise;
+
+  expect(api.getState().vibeMode).toBe(false);
+  expect(document.documentElement.dataset.agentVibeMode).toBeUndefined();
+  expect(
+    document.documentElement.style.getPropertyValue('--agent-vibe-intensity'),
+  ).toBe('');
+});
+
+test('api state includes vibe mode alongside toy and audio state', () => {
+  const api = initAgentAPI();
+  setCurrentToy('holy');
+  setAudioActive(true, 'demo');
+
+  expect(api.getState()).toMatchObject({
+    currentToy: 'holy',
+    toyLoaded: true,
+    audioActive: true,
+    audioSource: 'demo',
+    vibeMode: false,
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight, agent-facing way to “make it more fun” for nonhuman/automation players by temporarily boosting visuals without modifying individual toy modules.

### Description
- Add a `vibeMode` flag to the agent state and a new `activateVibeMode(durationMs?)` method on the Stim API that toggles a root dataset and CSS variable for the requested duration and then cleans up automatically (`assets/js/core/agent-api.ts`).
- Add CSS hooks (`data-agent-vibe-mode` and `--agent-vibe-intensity`) to pulse the active toy container and increase canvas saturation/contrast while vibe mode is active (`assets/css/base.css`).
- Wire the Playwright runner to attempt activating vibe mode in agent sessions and report whether it was triggered via `vibeModeActivated` in the returned result (`scripts/play-toy.ts`).
- Add unit tests that verify vibe mode lifecycle, DOM dataset/styling toggles, and compatibility of API state with existing toy/audio fields (`tests/agent-api.test.ts`).

### Testing
- Ran `bun run check` (Biome formatting/lint, TypeScript, and tests) and it completed successfully with the new tests included.
- Ran the test suite (`bun test`) which passed the added `agent-api` tests and left two existing integration tests skipped; overall tests passed.
- Launched the dev server and executed a Playwright script to visually validate and capture a screenshot of vibe mode activation, which produced the expected artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862c5575e4833297f4c235ad24e502)