### PR TITLE
Tighten landing and README messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ See the [Deployment Guide](./docs/DEPLOYMENT.md) for build, preview, static host
 ### Why people use Stim Webtoys
 
 - **Self-regulation moments**: settle into a repeatable rhythm of sound + visuals without claiming a specific outcome.
-- **Instant sensory input**: open a toy and play—no gear or setup required beyond a browser.
+- **Instant sensory input**: open a toy and play—no signup, no install, just a browser.
 - **Clear control surfaces**: adjust intensity with the shared settings panel and its [performance/quality presets](./docs/DEVELOPMENT.md#performance-tips).
 - **Fallback audio**: switch to demo audio when mic access is hard or you just want to listen.
 - **Short, contained sessions**: jump in for a few minutes and return whenever you want.
+- **Sensory-first exploration**: controls support different comfort and input needs.
 
 ### What You’ll Need
 

--- a/index.html
+++ b/index.html
@@ -142,12 +142,15 @@
         <div class="section-heading">
           <p class="eyebrow">Audio-reactive visuals • Instant play</p>
           <h1>Stim library</h1>
-          <p class="section-description">Start a visual toy tuned for sound, touch, and focus.</p>
+          <p class="section-description">
+            Open a visual in seconds—no signup, just sound, touch, and flow.
+          </p>
           <ul class="intro-pills" aria-label="Quick highlights">
             <li class="intro-pill">✨ Featured: Halo Flow</li>
-            <li class="intro-pill">🎧 Mic not required</li>
-            <li class="intro-pill">🔊 Built-in audio</li>
+            <li class="intro-pill">🎧 Mic optional</li>
+            <li class="intro-pill">🔊 Demo audio ready</li>
             <li class="intro-pill">🖐️ Touch-friendly</li>
+            <li class="intro-pill">🌈 Sensory-first</li>
             <li class="intro-pill">🔁 Auto-switch flow mode</li>
           </ul>
         </div>
@@ -183,15 +186,15 @@
         <div class="intro-grid" aria-label="Fast facts">
           <div class="intro-card">
             <p class="intro-card__title">Choose a vibe</p>
-            <p class="intro-card__body">Pick calm, energetic, or immersive to jump in.</p>
+            <p class="intro-card__body">Pick calm, energetic, or immersive for your mood.</p>
           </div>
           <div class="intro-card">
             <p class="intro-card__title">Start in seconds</p>
-            <p class="intro-card__body">No setup—open a toy and react to audio.</p>
+            <p class="intro-card__body">No signup or setup—open a toy and start.</p>
           </div>
           <div class="intro-card">
-            <p class="intro-card__title">Built for touch</p>
-            <p class="intro-card__body">Works on phone, tablet, and desktop.</p>
+            <p class="intro-card__title">Built for every screen</p>
+            <p class="intro-card__body">Phone, tablet, and desktop with mic or demo audio.</p>
           </div>
         </div>
       </section>
@@ -200,9 +203,7 @@
         <div class="section-heading">
           <p class="eyebrow">Quick start</p>
           <h2>Start playing fast</h2>
-          <p class="section-description">
-            Pick a quick start without scrolling.
-          </p>
+          <p class="section-description">Pick a path: favorite, flow mode, or surprise me.</p>
         </div>
         <div class="quick-start-grid">
           <article class="quick-card">


### PR DESCRIPTION
### Motivation
- Reduce wordiness on the landing hero and intro areas so visitors can scan the core promise quickly while preserving key cues (instant start, mic optional, demo audio, touch, flow mode).

### Description
- Shortened hero copy and refined intro pills in `index.html` to `Open a visual in seconds—no signup, just sound, touch, and flow` and updated pills to `🎧 Mic optional`, `🔊 Demo audio ready`, and `🌈 Sensory-first`.
- Condensed the intro cards and quick-start blurb in `index.html` to be more concise and mobile-friendly (e.g. `No signup or setup—open a toy and start.` and `Phone, tablet, and desktop with mic or demo audio`).
- Tightened two README bullets in `README.md` to more direct phrasing (`open a toy and play—no signup, no install, just a browser.` and `Sensory-first exploration: controls support different comfort and input needs.`).

### Testing
- Ran `bun run check`, which completed successfully with `82 pass`, `2 skip`, and `0 fail`.
- Automatic lint/format checks (`biome`) ran during the change and reported no issues or fixes applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698639d4cb808332a96d00ed200b9b44)