### PR TITLE
Fix WebGPU texture usage stub type regression for PR #617

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
+  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,


### PR DESCRIPTION
### Motivation

- Reintroduce the missing `TRANSIENT_ATTACHMENT` field on the WebGPU texture usage test stub so the `globalThis.GPUTextureUsage` object structurally satisfies the `GPUTextureUsage` shape and prevents `tsc --noEmit` / `bun run check` type errors (TS2741) in `tests/setup.ts`.

### Description

- Restored `TRANSIENT_ATTACHMENT: 32` in `tests/setup.ts` by updating the `globalThis.GPUTextureUsage` stub to include the required property.

### Testing

- Ran `bun run check` (Biome + `tsc --noEmit` + `bun test`) and it completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986495bb5e48332be0c786c1aafc678)