### PR TITLE
Restore TRANSIENT_ATTACHMENT in WebGPU texture usage test stub

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
+  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,


### PR DESCRIPTION
### Motivation
- Restore the `TRANSIENT_ATTACHMENT` field on the `globalThis.GPUTextureUsage` test stub so the stub structurally matches the expected WebGPU texture usage shape and avoids TypeScript TS2741 errors introduced by a previous change.

### Description
- Add `TRANSIENT_ATTACHMENT: 32` to `globalThis.GPUTextureUsage` in `tests/setup.ts` to restore the missing flag.

### Testing
- Ran `bun run check` (Biome lint/format, `tsc` typecheck, and tests) and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698649f7e1dc8332bb7bf2b4dd44a620)