### PR TITLE
Revamp responsive CSS behavior across breakpoints

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2626,14 +2626,26 @@ footer {
 }
 
 @media (max-width: 900px) {
+  :root {
+    --radius-lg: 18px;
+    --radius-md: 12px;
+  }
+
   .top-nav {
     flex-wrap: wrap;
     gap: 0.75rem;
+    align-items: flex-start;
   }
 
   .nav-actions {
+    width: 100%;
     flex-wrap: wrap;
-    justify-content: flex-start;
+    justify-content: space-between;
+    gap: 0.65rem;
+  }
+
+  .nav-section {
+    flex: 1 1 240px;
   }
 
   .hero-visual {
@@ -2653,9 +2665,21 @@ footer {
   .hero-callouts {
     width: 100%;
   }
+
+  .hero-cta-row {
+    width: 100%;
+  }
+
+  .hero-cta-row .cta-button {
+    flex: 1 1 220px;
+  }
 }
 
 @media (max-width: 680px) {
+  body {
+    font-size: 0.97rem;
+  }
+
   section.intro {
     padding: 1.4rem 1.2rem;
     border-radius: 18px;
@@ -2721,6 +2745,10 @@ footer {
     grid-template-columns: 1fr;
   }
 
+  .search-row > * {
+    min-width: 0;
+  }
+
   .search-field {
     flex-wrap: wrap;
     padding: 0.5rem 0.75rem;
@@ -2752,6 +2780,12 @@ footer {
   .sort-control {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .chip-row {
+    overflow-x: auto;
+    padding-bottom: 0.2rem;
+    scrollbar-width: thin;
   }
 
   .preview-controls {
@@ -2800,9 +2834,17 @@ footer {
   .preview-track {
     min-height: 240px;
   }
+
+  .preview-card {
+    padding: 1rem;
+  }
 }
 
 @media (max-width: 768px) {
+  h2 {
+    font-size: clamp(1.4rem, 4vw, 1.8rem);
+  }
+
   h1 {
     font-size: 1.9rem;
   }
@@ -2835,6 +2877,10 @@ footer {
 }
 
 @media (max-width: 520px) {
+  h1 {
+    font-size: clamp(1.6rem, 7vw, 1.8rem);
+  }
+
   .content {
     --content-padding: clamp(1rem, 4vw, 1.4rem);
     gap: 1.25rem;
@@ -2905,6 +2951,10 @@ footer {
     justify-content: flex-start;
   }
 
+  .theme-toggle__label {
+    flex: 1;
+  }
+
   .cta-row {
     flex-direction: column;
     align-items: stretch;
@@ -2952,6 +3002,7 @@ footer {
   .search-field input {
     font-size: 0.9rem;
     padding-right: 2.8rem;
+    min-width: 0;
   }
 
   .search-clear {


### PR DESCRIPTION
### Motivation
- Improve layout resilience and readability on mid and small viewports by tightening nav wrapping, CTA sizing, and preventing overflow in search/filter rows.
- Make component spacing and typography more consistent across the 900px, 680px, 768px and 520px breakpoints to reduce clipping and crowded UI elements.

### Description
- Adjusted responsive rules in `assets/css/index.css` to add root radius tweaks, make `.top-nav` align to `flex-start`, and give `.nav-section` a flexible basis at the `900px` breakpoint.
- Made hero CTA area fluid by sizing `.hero-cta-row` and its `.cta-button` (`flex: 1 1 220px`) so CTAs scale across mid-width viewports.
- Hardened small-screen behavior at the `680px` breakpoint by adding a subtle global font-size tweak, preventing child overflow inside `.search-row`, enabling horizontal scroll for `.chip-row`, and tightening preview card padding.
- Toned heading scaling and compact controls at `768px` and `520px` breakpoints by introducing responsive `h1`/`h2` clamps, making the theme toggle label flexible, and ensuring search inputs have `min-width: 0` to avoid layout breaks.

### Testing
- Ran the project quality check with `bun run check`, which runs `biome` lint/format, `tsc`, and the test suite; lint/format and typecheck completed but the test suite failed due to an existing import error (`Export named 'PerspectiveCamera' not found` in `tests/mobile-ripples.test.ts` and `tests/pocket-pulse.test.ts`).
- Started the dev server with `bun run dev --host` and validated the UI visually via an automated Playwright script that navigated to the local site and produced a full-page screenshot (artifact generated successfully).
- Pre-commit lint/format hooks were executed as part of the commit and completed without changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69865329bb888332a8cb7192cbc64678)