### PR TITLE
Trim homepage microcopy in library search and empty states

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
           <p class="eyebrow">Library</p>
           <h2>Browse all stims</h2>
           <p class="section-description">
-            Tap a card to launch or open details.
+            Tap a card to launch.
           </p>
           <search class="library-search">
             <div class="search-heading">
@@ -317,7 +317,7 @@
                   Clear
                 </button>
                 <span id="toy-search-hint" class="search-field__hint">
-                  Enter a name, tag, or capability
+                  Name, tag, or capability
                 </span>
                 <datalist id="toy-search-suggestions"></datalist>
               </form>
@@ -949,13 +949,13 @@
           const parts = [`${count} ${descriptor}`];
           const trimmedQuery = query.trim();
           if (trimmedQuery) {
-            parts.push(`Search: “${trimmedQuery}”`);
+            parts.push(`“${trimmedQuery}”`);
           }
           const filterLabels = getActiveFilterLabels();
           if (filterLabels.length > 0) {
-            parts.push(`Filters: ${filterLabels.join(', ')}`);
+            parts.push(filterLabels.join(', '));
           }
-          parts.push(`Sort: ${getSortLabel()}`);
+          parts.push(getSortLabel());
           searchResults.textContent = parts.join(' • ');
         };
 
@@ -964,13 +964,12 @@
           empty.className = 'empty-state';
           const message = document.createElement('p');
           message.className = 'empty-state__message';
-          message.textContent =
-            'No stims match your search or filters. Try clearing your search or removing filters.';
+          message.textContent = 'No matching stims.';
 
           const reset = document.createElement('button');
           reset.type = 'button';
           reset.className = 'cta-button ghost';
-          reset.textContent = 'Reset search and filters';
+          reset.textContent = 'Reset';
           reset.addEventListener('click', () => {
             if (search instanceof HTMLInputElement) {
               search.value = '';


### PR DESCRIPTION
### Motivation
- Reduce verbose library microcopy to improve scanability and keep the search/status UI compact.

### Description
- Shortened the library section description from "Tap a card to launch or open details." to "Tap a card to launch." in `index.html`.
- Reworded the inline search hint from "Enter a name, tag, or capability" to "Name, tag, or capability" in `index.html`.
- Simplified the search-results metadata by removing the explicit `Search:`, `Filters:`, and `Sort:` prefixes and presenting the same information more compactly in `updateResultsMeta` in `index.html`.
- Replaced the verbose empty-state message with `No matching stims.` and shortened the reset button label to `Reset` in the fallback renderer in `index.html`.

### Testing
- Ran `bun run check` (Biome lint/format, TypeScript typecheck, and the test suite), which completed successfully with 82 tests passing and 2 skipped.
- No documentation files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986538a1aac833297782cdab3ea5559)