### PR TITLE
Respect editable targets for Ctrl/Cmd+K search shortcut

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -2136,7 +2136,7 @@ export function createLibraryView({
         event.key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey;
       const isEscapeShortcut = event.key === 'Escape';
 
-      if (isMetaShortcut) {
+      if (isMetaShortcut && !isEditableTarget(target)) {
         event.preventDefault();
         focusSearch();
         return;


### PR DESCRIPTION
### Motivation
- The global `Ctrl/Cmd+K` handler always called `preventDefault()` and focused the search input even when the active element was editable, which suppressed native editing behavior in inputs, textareas, and contenteditable elements and contradicts the existing intent for `/` and `Escape` shortcuts.

### Description
- Add the same `!isEditableTarget(target)` guard to the meta shortcut in `assets/js/library-view.js` so `Ctrl/Cmd+K` only intercepts keys when the event target is not editable.

### Testing
- Ran `bun run check` (runs Biome checks, typecheck, and the test suite) and it completed successfully with the test summary showing 84 passed, 2 skipped, and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e0912dc88332ae1fdc91401554d5)