### PR TITLE
Expand stim metadata improvements to featured toys too

### DIFF
--- a/assets/data/toys.json
+++ b/assets/data/toys.json
@@ -11,7 +11,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["energetic", "immersive"],
+    "tags": ["tunnel", "3d", "legacy"],
+    "controls": [
+      "Tunnel twist amount",
+      "Color pulse intensity",
+      "Reactivity sensitivity"
+    ]
   },
   {
     "slug": "aurora-painter",
@@ -47,7 +54,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["focus", "tactile"],
+    "tags": ["sculpting", "pottery", "3d"],
+    "controls": ["Smoothing tool", "Carving tool", "Pinching tool"]
   },
   {
     "slug": "evol",
@@ -61,7 +71,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["psychedelic", "cosmic"],
+    "tags": ["fractal", "glitch", "evolutionary"],
+    "controls": ["Reactivity boost", "Mutation speed", "Palette shift"]
   },
   {
     "slug": "geom",
@@ -75,7 +88,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": [
+      "Frequency band modes",
+      "Geometry complexity slider",
+      "Sensitivity boost toggle"
+    ],
+    "tags": ["geometry", "microphone", "reactive"],
+    "moods": ["energetic", "immersive"]
   },
   {
     "slug": "holy",
@@ -89,7 +109,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["serene", "ethereal"],
+    "tags": ["halos", "particles", "ambient"],
+    "controls": ["Halo intensity", "Particle density", "Palette cycle"]
   },
   {
     "slug": "multi",
@@ -104,7 +127,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": true
-    }
+    },
+    "controls": [
+      "Motion input toggle",
+      "Audio gain slider",
+      "WebGL fallback notice"
+    ],
+    "tags": ["motion", "hybrid", "immersive"],
+    "moods": ["energetic", "cosmic"]
   },
   {
     "slug": "seary",
@@ -118,7 +148,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": [
+      "Frequency mapping overlay",
+      "Palette mode switch",
+      "Pattern speed slider"
+    ],
+    "tags": ["synesthetic", "patterns", "audio-mapped"],
+    "moods": ["dreamy", "immersive"]
   },
   {
     "slug": "legible",
@@ -132,7 +169,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": [
+      "Word cadence slider",
+      "Character glow level",
+      "Vocabulary refresh"
+    ],
+    "tags": ["text", "retro", "grid"],
+    "moods": ["focus", "minimal"]
   },
   {
     "slug": "symph",
@@ -146,7 +190,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": ["Sensitivity slider", "Smoothing toggle", "Color intensity"],
+    "tags": ["spectrograph", "ambient", "calming"],
+    "moods": ["calming", "serene"]
   },
   {
     "slug": "cube-wave",
@@ -160,7 +207,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": [
+      "Wave/sphere mode toggle",
+      "Beat response amount",
+      "Camera drift speed"
+    ],
+    "tags": ["grid", "waves", "mode-switch"],
+    "moods": ["pulsing", "energetic"]
   },
   {
     "slug": "bubble-harmonics",
@@ -175,7 +229,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["playful", "uplifting"],
+    "tags": ["bubbles", "harmonics", "reactive"],
+    "controls": ["Split sensitivity", "Bubble growth rate", "Trail persistence"]
   },
   {
     "slug": "pocket-pulse",
@@ -224,7 +281,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["cosmic", "immersive"],
+    "tags": ["particles", "nebula", "swirl"],
+    "controls": ["Mode toggle", "Orbit speed", "Particle density"]
   },
   {
     "slug": "lights",
@@ -238,7 +298,10 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": ["Shader style switch", "Palette shuffle", "Bloom intensity"],
+    "tags": ["lights", "shader", "palette"],
+    "moods": ["energetic", "luminous"]
   },
   {
     "slug": "spiral-burst",
@@ -274,7 +337,14 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "controls": [
+      "Tunnel speed slider",
+      "Camera drift toggle",
+      "Color pulse depth"
+    ],
+    "tags": ["tunnel", "rainbow", "immersive"],
+    "moods": ["cosmic", "drifting"]
   },
   {
     "slug": "star-field",
@@ -306,7 +376,9 @@
       "microphone": true,
       "demoAudio": true,
       "motion": false
-    }
+    },
+    "moods": ["dreamy", "serene"],
+    "tags": ["fractal", "kite", "generative"]
   },
   {
     "slug": "tactile-sand-table",
@@ -322,7 +394,9 @@
       "microphone": true,
       "demoAudio": true,
       "motion": true
-    }
+    },
+    "moods": ["calming", "grounded"],
+    "tags": ["sand", "tilt", "haptics"]
   },
   {
     "slug": "bioluminescent-tidepools",

--- a/assets/js/data/toy-manifest.ts
+++ b/assets/js/data/toy-manifest.ts
@@ -10,6 +10,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['energetic', 'immersive'],
+    tags: ['tunnel', '3d', 'legacy'],
+    controls: [
+      'Tunnel twist amount',
+      'Color pulse intensity',
+      'Reactivity sensitivity',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -48,6 +55,9 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['focus', 'tactile'],
+    tags: ['sculpting', 'pottery', '3d'],
+    controls: ['Smoothing tool', 'Carving tool', 'Pinching tool'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -63,6 +73,9 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['psychedelic', 'cosmic'],
+    tags: ['fractal', 'glitch', 'evolutionary'],
+    controls: ['Reactivity boost', 'Mutation speed', 'Palette shift'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -78,6 +91,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['energetic', 'immersive'],
+    tags: ['geometry', 'microphone', 'reactive'],
+    controls: [
+      'Frequency band modes',
+      'Geometry complexity slider',
+      'Sensitivity boost toggle',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -93,6 +113,9 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['serene', 'ethereal'],
+    tags: ['halos', 'particles', 'ambient'],
+    controls: ['Halo intensity', 'Particle density', 'Palette cycle'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -108,6 +131,13 @@ export const toyManifest: ToyManifest = [
     requiresWebGPU: true,
     allowWebGLFallback: true,
     lifecycleStage: 'archived',
+    moods: ['energetic', 'cosmic'],
+    tags: ['motion', 'hybrid', 'immersive'],
+    controls: [
+      'Motion input toggle',
+      'Audio gain slider',
+      'WebGL fallback notice',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -122,6 +152,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['dreamy', 'immersive'],
+    tags: ['synesthetic', 'patterns', 'audio-mapped'],
+    controls: [
+      'Frequency mapping overlay',
+      'Palette mode switch',
+      'Pattern speed slider',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -137,6 +174,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['focus', 'minimal'],
+    tags: ['text', 'retro', 'grid'],
+    controls: [
+      'Word cadence slider',
+      'Character glow level',
+      'Vocabulary refresh',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -151,6 +195,9 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['calming', 'serene'],
+    tags: ['spectrograph', 'ambient', 'calming'],
+    controls: ['Sensitivity slider', 'Smoothing toggle', 'Color intensity'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -166,6 +213,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['pulsing', 'energetic'],
+    tags: ['grid', 'waves', 'mode-switch'],
+    controls: [
+      'Wave/sphere mode toggle',
+      'Beat response amount',
+      'Camera drift speed',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -182,6 +236,9 @@ export const toyManifest: ToyManifest = [
     requiresWebGPU: false,
     lifecycleStage: 'featured',
     featuredRank: 7,
+    moods: ['playful', 'uplifting'],
+    tags: ['bubbles', 'harmonics', 'reactive'],
+    controls: ['Split sensitivity', 'Bubble growth rate', 'Trail persistence'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -234,6 +291,9 @@ export const toyManifest: ToyManifest = [
     requiresWebGPU: false,
     lifecycleStage: 'featured',
     featuredRank: 5,
+    moods: ['cosmic', 'immersive'],
+    tags: ['particles', 'nebula', 'swirl'],
+    controls: ['Mode toggle', 'Orbit speed', 'Particle density'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -249,6 +309,9 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['energetic', 'luminous'],
+    tags: ['lights', 'shader', 'palette'],
+    controls: ['Shader style switch', 'Palette shuffle', 'Bloom intensity'],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -281,6 +344,13 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['cosmic', 'drifting'],
+    tags: ['tunnel', 'rainbow', 'immersive'],
+    controls: [
+      'Tunnel speed slider',
+      'Camera drift toggle',
+      'Color pulse depth',
+    ],
     capabilities: {
       microphone: true,
       demoAudio: true,
@@ -313,6 +383,8 @@ export const toyManifest: ToyManifest = [
     type: 'module',
     requiresWebGPU: false,
     lifecycleStage: 'archived',
+    moods: ['dreamy', 'serene'],
+    tags: ['fractal', 'kite', 'generative'],
     controls: ['Pattern density slider', 'Palette switches'],
     capabilities: {
       microphone: true,
@@ -330,6 +402,8 @@ export const toyManifest: ToyManifest = [
     requiresWebGPU: false,
     lifecycleStage: 'featured',
     featuredRank: 3,
+    moods: ['calming', 'grounded'],
+    tags: ['sand', 'tilt', 'haptics'],
     controls: ['Grain size slider', 'Damping slider', 'Gravity lock toggle'],
     capabilities: {
       microphone: true,

--- a/public/toys.json
+++ b/public/toys.json
@@ -7,6 +7,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "energetic",
+      "immersive"
+    ],
+    "tags": [
+      "tunnel",
+      "3d",
+      "legacy"
+    ],
+    "controls": [
+      "Tunnel twist amount",
+      "Color pulse intensity",
+      "Reactivity sensitivity"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -51,6 +65,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "focus",
+      "tactile"
+    ],
+    "tags": [
+      "sculpting",
+      "pottery",
+      "3d"
+    ],
+    "controls": [
+      "Smoothing tool",
+      "Carving tool",
+      "Pinching tool"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -65,6 +93,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "psychedelic",
+      "cosmic"
+    ],
+    "tags": [
+      "fractal",
+      "glitch",
+      "evolutionary"
+    ],
+    "controls": [
+      "Reactivity boost",
+      "Mutation speed",
+      "Palette shift"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -79,6 +121,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "energetic",
+      "immersive"
+    ],
+    "tags": [
+      "geometry",
+      "microphone",
+      "reactive"
+    ],
+    "controls": [
+      "Frequency band modes",
+      "Geometry complexity slider",
+      "Sensitivity boost toggle"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -93,6 +149,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "serene",
+      "ethereal"
+    ],
+    "tags": [
+      "halos",
+      "particles",
+      "ambient"
+    ],
+    "controls": [
+      "Halo intensity",
+      "Particle density",
+      "Palette cycle"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -108,6 +178,20 @@
     "requiresWebGPU": true,
     "allowWebGLFallback": true,
     "lifecycleStage": "archived",
+    "moods": [
+      "energetic",
+      "cosmic"
+    ],
+    "tags": [
+      "motion",
+      "hybrid",
+      "immersive"
+    ],
+    "controls": [
+      "Motion input toggle",
+      "Audio gain slider",
+      "WebGL fallback notice"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -122,6 +206,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "dreamy",
+      "immersive"
+    ],
+    "tags": [
+      "synesthetic",
+      "patterns",
+      "audio-mapped"
+    ],
+    "controls": [
+      "Frequency mapping overlay",
+      "Palette mode switch",
+      "Pattern speed slider"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -136,6 +234,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "focus",
+      "minimal"
+    ],
+    "tags": [
+      "text",
+      "retro",
+      "grid"
+    ],
+    "controls": [
+      "Word cadence slider",
+      "Character glow level",
+      "Vocabulary refresh"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -150,6 +262,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "calming",
+      "serene"
+    ],
+    "tags": [
+      "spectrograph",
+      "ambient",
+      "calming"
+    ],
+    "controls": [
+      "Sensitivity slider",
+      "Smoothing toggle",
+      "Color intensity"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -164,6 +290,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "pulsing",
+      "energetic"
+    ],
+    "tags": [
+      "grid",
+      "waves",
+      "mode-switch"
+    ],
+    "controls": [
+      "Wave/sphere mode toggle",
+      "Beat response amount",
+      "Camera drift speed"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -179,6 +319,20 @@
     "requiresWebGPU": false,
     "lifecycleStage": "featured",
     "featuredRank": 7,
+    "moods": [
+      "playful",
+      "uplifting"
+    ],
+    "tags": [
+      "bubbles",
+      "harmonics",
+      "reactive"
+    ],
+    "controls": [
+      "Split sensitivity",
+      "Bubble growth rate",
+      "Trail persistence"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -250,6 +404,20 @@
     "requiresWebGPU": false,
     "lifecycleStage": "featured",
     "featuredRank": 5,
+    "moods": [
+      "cosmic",
+      "immersive"
+    ],
+    "tags": [
+      "particles",
+      "nebula",
+      "swirl"
+    ],
+    "controls": [
+      "Mode toggle",
+      "Orbit speed",
+      "Particle density"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -264,6 +432,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "energetic",
+      "luminous"
+    ],
+    "tags": [
+      "lights",
+      "shader",
+      "palette"
+    ],
+    "controls": [
+      "Shader style switch",
+      "Palette shuffle",
+      "Bloom intensity"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -308,6 +490,20 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "cosmic",
+      "drifting"
+    ],
+    "tags": [
+      "tunnel",
+      "rainbow",
+      "immersive"
+    ],
+    "controls": [
+      "Tunnel speed slider",
+      "Camera drift toggle",
+      "Color pulse depth"
+    ],
     "capabilities": {
       "microphone": true,
       "demoAudio": true,
@@ -350,6 +546,15 @@
     "type": "module",
     "requiresWebGPU": false,
     "lifecycleStage": "archived",
+    "moods": [
+      "dreamy",
+      "serene"
+    ],
+    "tags": [
+      "fractal",
+      "kite",
+      "generative"
+    ],
     "controls": [
       "Pattern density slider",
       "Palette switches"
@@ -369,6 +574,15 @@
     "requiresWebGPU": false,
     "lifecycleStage": "featured",
     "featuredRank": 3,
+    "moods": [
+      "calming",
+      "grounded"
+    ],
+    "tags": [
+      "sand",
+      "tilt",
+      "haptics"
+    ],
     "controls": [
       "Grain size slider",
       "Damping slider",


### PR DESCRIPTION
### Motivation
- Improve discoverability and UI affordances by ensuring every toy has consistent `moods`, `tags`, and `controls` metadata so search and runtime surfaces can surface useful filters and hints.
- Extend earlier metadata work (which targeted archived toys) to cover featured and other toys that were still missing fields so runtime and import consumers receive consistent manifests.

### Description
- Filled missing `moods`, `tags`, and/or `controls` for additional toys including `3dtoy`, `clay`, `evol`, `holy`, `bubble-harmonics`, `cosmic-particles`, `fractal-kite-garden`, and `tactile-sand-table` by updating `assets/data/toys.json`.
- Regenerated typed and public manifests so the app and fetch-based consumers stay in sync by updating `assets/js/data/toy-manifest.ts` and `public/toys.json` via the manifest generator.
- Applied project formatting to ensure stable JSON/TS layout across changed files.
- Files modified: `assets/data/toys.json`, `assets/js/data/toy-manifest.ts`, and `public/toys.json`.

### Testing
- Ran `bun run format` which completed successfully.
- Ran the manifest generator with `bun run scripts/generate-toy-manifest.ts` and updated the runtime manifest successfully.
- Ran full checks with `bun run check` (includes lint, typecheck, and tests) which passed.
- Unit test summary from the run: `84 passed`, `2 skipped`, `0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e8adea7c833299c2f3ac95aa7b99)