### PR TITLE
Fix demo audio primary emphasis in audio controls

### DIFF
--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -211,7 +211,7 @@ export function initAudioControls(
 
   const emphasizeDemoAudio = () => {
     setPrimaryRow(demoRow, true);
-    setPrimaryRow(micRow, true);
+    setPrimaryRow(micRow, false);
   };
 
   const buildMicrophoneErrorMessage = (message: string) => {
@@ -236,10 +236,10 @@ export function initAudioControls(
 
   if (preferDemoAudio && demoBtn instanceof HTMLButtonElement) {
     setPrimaryRow(demoRow, true);
-    setPrimaryRow(micRow, true);
+    setPrimaryRow(micRow, false);
   } else {
     setPrimaryRow(micRow, true);
-    setPrimaryRow(demoRow, true);
+    setPrimaryRow(demoRow, false);
   }
 
   if (options.initialStatus) {

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { initAudioControls } from '../assets/js/ui/audio-controls.ts';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('audio controls primary emphasis', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+    const bootstrapScript = document.createElement('script');
+    document.body.appendChild(bootstrapScript);
+    globalThis.HTMLButtonElement =
+      window.HTMLButtonElement as unknown as typeof HTMLButtonElement;
+  });
+
+  test('highlights demo row when preferDemoAudio is true', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      preferDemoAudio: true,
+    });
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+  });
+
+  test('keeps microphone row primary by default', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+  });
+
+  test('switches emphasis to demo row after microphone failure', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {
+        throw new Error('Mic denied');
+      },
+      onRequestDemoAudio: async () => {},
+    });
+
+    const micButton = container.querySelector(
+      '#start-audio-btn',
+    ) as HTMLButtonElement;
+    micButton.click();
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- A bug caused both the microphone and demo audio rows to be marked primary when `preferDemoAudio` was set, which made the UI fail to steer users away from the unavailable mic path.
- The change restores clear guidance for users who cannot grant mic access by ensuring only the preferred option is emphasized.

### Description

- Update `initAudioControls` so `emphasizeDemoAudio` sets the mic row to non-primary and the initial `preferDemoAudio` branch marks demo primary and mic non-primary, while the default branch marks mic primary and demo non-primary (`assets/js/ui/audio-controls.ts`).
- Adjust microphone error handling to call the updated `emphasizeDemoAudio` behavior so the fallback path highlights only demo audio.
- Add focused unit tests in `tests/audio-controls.test.ts` that cover preferred-demo initialization, default microphone initialization, and switching emphasis to demo after a microphone failure, and include a small test setup tweak to expose `HTMLButtonElement` to the test environment.

### Testing

- Ran the full project check with `bun run check` which runs linting, typecheck, and the test suite, and the run succeeded.
- The new `tests/audio-controls.test.ts` executed and passed as part of the test suite run.
- Overall test run summary: `87 pass`, `2 skip`, `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986fbd7d27083329a45422e79324d5b)