### PR TITLE
Redesign library search panel

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1894,7 +1894,7 @@ html.light .experience-card {
 
 .search-meta {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.3rem;
   align-content: center;
   padding: 0.75rem 0.95rem;
   border-radius: var(--radius-md);
@@ -1925,6 +1925,16 @@ html.light .search-meta__note {
   color: var(--text-color);
 }
 
+html.light .search-meta__tokens li {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 24%,
+    var(--surface-border)
+  );
+  color: var(--text-color);
+  background: color-mix(in srgb, var(--card-bg) 92%, var(--accent-color));
+}
+
 .search-meta__results {
   margin: 0;
   font-size: 0.95rem;
@@ -1936,8 +1946,31 @@ html.light .search-meta__note {
 
 .search-meta__note {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.search-meta__tokens {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.search-meta__tokens li {
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 18%, var(--surface-border));
+  border-radius: var(--radius-pill);
+  padding: 0.15rem 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--card-bg) 80%, transparent);
 }
 
 .active-filters {
@@ -2059,10 +2092,10 @@ html.light .active-filters__label {
 }
 
 .search-field {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.55rem;
   background: rgba(10, 18, 32, 0.92);
   border: 1px solid
     color-mix(in srgb, var(--accent-color) 22%, var(--surface-border));
@@ -2092,12 +2125,12 @@ html.light .active-filters__label {
 }
 
 .search-field input {
-  flex: 1;
+  width: 100%;
   background: transparent;
   border: none;
   color: var(--text-color);
   font-size: 1rem;
-  padding: 0.55rem 3.5rem 0.55rem 0.15rem;
+  padding: 0.55rem 0.15rem;
   min-height: 44px;
   touch-action: manipulation;
 }
@@ -2107,10 +2140,10 @@ html.light .active-filters__label {
 }
 
 .search-field__hint {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: var(--text-muted);
-  flex-basis: 100%;
-  padding-left: 0.35rem;
+  grid-column: 1 / -1;
+  padding-left: 0.2rem;
 }
 
 .search-clear {
@@ -2123,10 +2156,6 @@ html.light .active-filters__label {
   min-height: 44px;
   min-width: 44px;
   touch-action: manipulation;
-  position: absolute;
-  right: 0.5rem;
-  top: 50%;
-  transform: translateY(-50%);
   transition:
     opacity 0.2s ease,
     background 0.2s ease,
@@ -2886,8 +2915,13 @@ footer {
   }
 
   .search-field {
-    flex-wrap: wrap;
+    grid-template-columns: auto minmax(0, 1fr);
     padding: 0.5rem 0.75rem;
+  }
+
+  .search-clear {
+    grid-column: 1 / -1;
+    justify-self: flex-end;
   }
 
   .search-field__hint {

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
         <search class="library-search">
           <div class="search-heading">
             <h3>Find a stim</h3>
-            <p>Search by name, mood, or capability.</p>
+            <p>Search by name, mood, tags, and capabilities.</p>
           </div>
           <div class="search-row">
             <label class="sr-only" for="toy-search">Search the library</label>
@@ -203,7 +203,7 @@
                 id="toy-search"
                 type="search"
                 name="toy-search"
-                placeholder="Search stims by name, tag, or capability…"
+                placeholder="Try calm, spiral, microphone, or webgpu"
                 autocomplete="off"
                 aria-describedby="toy-search-hint"
                 inputmode="search"
@@ -218,7 +218,7 @@
                 Clear
               </button>
               <span id="toy-search-hint" class="search-field__hint">
-                / focus • ↵ open match
+                / focus • esc clear • ↵ open top match
               </span>
               <datalist id="toy-search-suggestions"></datalist>
             </form>
@@ -231,6 +231,13 @@
               >
                 Loading library…
               </p>
+              <p class="search-meta__note">Search scope</p>
+              <ul class="search-meta__tokens" aria-hidden="true">
+                <li>Name</li>
+                <li>Mood</li>
+                <li>Tags</li>
+                <li>Capabilities</li>
+              </ul>
             </div>
           </div>
           <div class="active-filters" data-active-filters hidden>


### PR DESCRIPTION
### Motivation
- Clarify what the library search covers and improve keyboard guidance so users better understand discovery behavior.
- Surface the indexed fields (name, mood, tags, capabilities) visually to reduce confusion about matches.
- Improve layout so the icon/input/clear controls align consistently across desktop and mobile breakpoints.

### Description
- Updated `index.html` to change the search heading copy, replace the input `placeholder`, improve the keyboard hint text, and add a `Search scope` token list (`Name`, `Mood`, `Tags`, `Capabilities`).
- Modified `assets/css/index.css` to add token chip styles (`.search-meta__tokens` / `.search-meta__tokens li`), convert `.search-field` to a grid layout for improved alignment, adjust hint and clear-button placement, and make small spacing/typography tweaks.
- No JavaScript search logic was changed in this patch; the work is visual/UX and markup-only.

### Testing
- Ran `bun run check` (which runs `biome check`, `bun run typecheck`, and the test suite) and it completed successfully with `87` tests passing and `2` skipped.
- Ran `bunx biome format --write assets/css/index.css` to fix formatter suggestions and started a local dev server with `bun run dev` to smoke-test the UI; a Playwright screenshot of the redesigned panel was captured as a visual check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883fcad4908332ba1e2d4ddd762eb9)