### PR TITLE
Improve type safety in audio loop helpers

### DIFF
--- a/assets/js/core/animation-loop.ts
+++ b/assets/js/core/animation-loop.ts
@@ -4,14 +4,20 @@ import type {
 } from '../utils/audio-handler';
 import { getAverageFrequency, getFrequencyData } from '../utils/audio-handler';
 
-// biome-ignore lint/suspicious/noExplicitAny: generic toy instance
-type WebToyInstance = any;
+export interface AudioLoopToy {
+  rendererReady?: Promise<unknown>;
+  initAudio: (options?: AudioInitOptions) => Promise<unknown>;
+  analyser: FrequencyAnalyser | null;
+  renderer: {
+    setAnimationLoop: ((callback: () => void) => void) | null;
+  } | null;
+}
 
 /**
  * Context passed to animation callbacks.
  */
 export interface AnimationContext {
-  toy: WebToyInstance;
+  toy: AudioLoopToy;
   analyser: FrequencyAnalyser | null;
   time: number;
 }
@@ -60,7 +66,7 @@ function fillSyntheticFrequencyData(
  * @returns The animation context
  */
 export async function startAudioLoop(
-  toy: WebToyInstance,
+  toy: AudioLoopToy,
   animate: (ctx: AnimationContext) => void,
   audioOptions: AudioInitOptions = {},
 ): Promise<AnimationContext> {

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -118,8 +118,9 @@ export class FrequencyAnalyser {
 
   getFrequencyData() {
     if (this.analyserNode) {
-      // biome-ignore lint/suspicious/noExplicitAny: ArrayBuffer mismatch
-      this.analyserNode.getByteFrequencyData(this.frequencyData as any);
+      this.analyserNode.getByteFrequencyData(
+        this.frequencyData as Uint8Array<ArrayBuffer>,
+      );
     }
 
     return this.frequencyData;

--- a/assets/js/utils/start-audio.ts
+++ b/assets/js/utils/start-audio.ts
@@ -1,5 +1,8 @@
-import { type AnimationContext, startAudioLoop } from '../core/animation-loop';
-import type WebToy from '../core/web-toy';
+import {
+  type AnimationContext,
+  type AudioLoopToy,
+  startAudioLoop,
+} from '../core/animation-loop';
 import type { AudioInitOptions } from './audio-handler';
 import { AudioAccessError, getCachedDemoAudioStream } from './audio-handler';
 
@@ -23,7 +26,7 @@ function normalizeOptions(options: StartAudioOptions): AudioInitOptions & {
 }
 
 export async function startToyAudio(
-  toy: WebToy,
+  toy: AudioLoopToy,
   animate: (ctx: AnimationContext) => void,
   options?: StartAudioOptions,
 ): Promise<AnimationContext> {

--- a/assets/js/utils/toy-audio-bootstrap.ts
+++ b/assets/js/utils/toy-audio-bootstrap.ts
@@ -15,8 +15,15 @@ interface ToyAudioStartHandlers {
   onError?: ToyAudioErrorHandler;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: flexible toy instances in HTML modules
-type ToyWithAudio = any;
+type ToyWithAudio = {
+  rendererReady?: Promise<unknown>;
+  renderer: {
+    setAnimationLoop: ((callback: () => void) => void) | null;
+  } | null;
+  analyser: Awaited<ReturnType<typeof initAudio>>['analyser'] | null;
+  audioCleanup: Awaited<ReturnType<typeof initAudio>>['cleanup'] | null;
+  initAudio: (audioOptions?: AudioInitOptions) => Promise<unknown>;
+};
 
 export function createToyAudioBootstrap(
   toy: ToyWithAudio,


### PR DESCRIPTION
### Motivation
- Replace untyped `any` usage in shared audio/animation helpers with a focused contract to catch misuse at compile time.
- Tighten the toy/audio bootstrap typing so audio utilities express required fields (`initAudio`, `analyser`, `audioCleanup`, renderer loop) rather than relying on broad types.

### Description
- Introduce `AudioLoopToy` interface and update `AnimationContext` and `startAudioLoop` to accept the narrower contract (`assets/js/core/animation-loop.ts`).
- Update `startToyAudio` to use `AudioLoopToy` so the start helper depends on behavior instead of the concrete `WebToy` type (`assets/js/utils/start-audio.ts`).
- Replace the `any` bootstrap toy with an explicit `ToyWithAudio` shape that documents `renderer`, `rendererReady`, `analyser`, `audioCleanup`, and `initAudio` (`assets/js/utils/toy-audio-bootstrap.ts`).
- Narrow the analyser frequency buffer assertion used with `getByteFrequencyData` to `Uint8Array<ArrayBuffer>` to avoid an unscoped `any` cast (`assets/js/utils/audio-handler.ts`).

### Testing
- Ran `bun run typecheck` (TypeScript check) which passed.
- Ran `bun run check` (Biome + typecheck + tests) which surfaced unrelated runtime test errors in the test suite (`PerspectiveCamera` export issue) causing the test phase to fail; typechecking portion completed as part of the script.
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988bff0b4088332bdc1392e09857ffe)