### PR TITLE
Strengthen toy start export smoke tests

### DIFF
--- a/tests/mobile-ripples.test.ts
+++ b/tests/mobile-ripples.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
 
 describe('mobile-ripples toy module', () => {
-  test('exports a start function', () => {
-    const source = readFileSync('assets/js/toys/mobile-ripples.ts', 'utf8');
-    expect(source).toContain('export function start');
+  test('exports a callable start function', async () => {
+    const moduleExports = await import('../assets/js/toys/mobile-ripples.ts');
+    const moduleRecord = moduleExports as {
+      start?: unknown;
+      default?: { start?: unknown };
+    };
+    const startCandidate = moduleRecord.start ?? moduleRecord.default?.start;
+
+    expect(typeof startCandidate).toBe('function');
   });
 });

--- a/tests/pocket-pulse.test.ts
+++ b/tests/pocket-pulse.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
 
 describe('pocket-pulse toy module', () => {
-  test('exports a start function', () => {
-    const source = readFileSync('assets/js/toys/pocket-pulse.ts', 'utf8');
-    expect(source).toContain('export function start');
+  test('exports a callable start function', async () => {
+    const moduleExports = await import('../assets/js/toys/pocket-pulse.ts');
+    const moduleRecord = moduleExports as {
+      start?: unknown;
+      default?: { start?: unknown };
+    };
+    const startCandidate = moduleRecord.start ?? moduleRecord.default?.start;
+
+    expect(typeof startCandidate).toBe('function');
   });
 });


### PR DESCRIPTION
### Motivation

- The original smoke tests only asserted a source-text substring which can falsely pass or fail and does not validate runtime exports.
- The module loader consumes a callable `start` export (or `default.start`), so tests should validate the actual runtime export contract.

### Description

- Replaced substring assertions in `tests/pocket-pulse.test.ts` and `tests/mobile-ripples.test.ts` with runtime `import(...)` and a check for `module.start ?? module.default?.start` being a function.
- Added a narrow `moduleRecord` type cast to avoid TypeScript errors when referencing `default` on the imported module.
- Applied formatter/quality checks during the change so the test files are formatted to project standards.

### Testing

- Ran `bun test tests/pocket-pulse.test.ts tests/mobile-ripples.test.ts` and both tests passed.
- Ran the full quality gate with `bun run check` and the check completed successfully (test suite passed, with the same skips as before).
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989477dd7e48332bc44f9f5d3d252b9)