### PR TITLE
Modernize contributor and agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Stim Webtoys Library is a collection of interactive, audio-reactive web toys bui
 
 ## Essentials
 
-- **Package manager:** Bun (run `bun install --frozen-lockfile` when dependencies change; run scripts with `bun run ...`).
+- **Package manager:** Bun (use `bun install` for dependency updates, reserve `bun install --frozen-lockfile` for reproducible/CI installs, and run scripts with `bun run ...`).
 - **Quality gate for JS/TS edits:** run `bun run check` (Biome check + typecheck + tests) before committing.
 - **Commit metadata:** use sentence case commit titles with no trailing period.
 - **PR metadata:** include a short summary plus explicit lists of tests run and docs touched/added.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,20 +4,20 @@ Stim Webtoys Library is a collection of interactive, audio-reactive web toys bui
 
 ## Essentials
 
-- **Package manager:** Bun (use `bun install --frozen-lockfile` when dependencies change; run scripts with `bun run ...`).
-- **Non-standard quality gates for JS/TS changes:** run `bun run check` (Biome + typecheck + tests) before committing.
-- **Metadata:** commit messages use sentence case with no trailing period; PR summaries include a short summary plus explicit lists of tests run and docs touched/added.
+- **Package manager:** Bun (run `bun install --frozen-lockfile` when dependencies change; run scripts with `bun run ...`).
+- **Quality gate for JS/TS edits:** run `bun run check` (Biome check + typecheck + tests) before committing.
+- **Commit metadata:** use sentence case commit titles with no trailing period.
+- **PR metadata:** include a short summary plus explicit lists of tests run and docs touched/added.
 
-## Doc structure (agent + contributor facing)
+## Recommended execution order
 
-- Start from [`docs/README.md`](./docs/README.md), which now groups docs by audience and workflow.
-- Use [`docs/agents/README.md`](./docs/agents/README.md) as the progressive-disclosure entrypoint for task-focused agent guidance.
-- Keep links between `AGENTS.md`, `CONTRIBUTING.md`, and `docs/README.md` aligned when restructuring docs.
+1. Open [`docs/agents/README.md`](./docs/agents/README.md) for progressive-disclosure guidance.
+2. Use [`docs/agents/tooling-and-quality.md`](./docs/agents/tooling-and-quality.md) before editing code.
+3. Use [`docs/agents/metadata-and-docs.md`](./docs/agents/metadata-and-docs.md) before finalizing commit/PR text.
+4. Use [`docs/README.md`](./docs/README.md) to keep contributor-facing links aligned if docs move.
 
-## More detailed guidance
+## Alignment requirements
 
-- [Tooling & quality checks](./docs/agents/tooling-and-quality.md)
-- [Metadata & documentation expectations](./docs/agents/metadata-and-docs.md)
-- [Toy development structure & patterns](./docs/agents/toy-development.md)
-- [Toy workflows & common commands](./docs/agents/toy-workflows.md)
-- [Reference documentation pointers](./docs/agents/reference-docs.md)
+- Keep links between `AGENTS.md`, `CONTRIBUTING.md`, and `docs/README.md` in sync when restructuring docs.
+- If you add or rename scripts, update both `docs/DEVELOPMENT.md` and agent overlays that mention those scripts.
+- If you add or rename toys, update `docs/TOY_DEVELOPMENT.md`, `docs/TOY_SCRIPT_INDEX.md`, and `docs/toys.md` in the same change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,13 @@ Thanks for contributing. This guide covers the current Bun-first workflow for hu
    bun install
    ```
 
-   If dependencies changed, prefer:
+   If you are updating dependencies, run:
 
    ```bash
-   bun install --frozen-lockfile
+   bun install
    ```
+
+   Use `bun install --frozen-lockfile` in CI or other reproducible-install contexts where lockfile changes must be disallowed.
 
 3. Start the dev server:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,81 +1,102 @@
 # Contributing to Stim Webtoys Library
 
-Thanks for helping build and refine the Stim Webtoys Library! This guide covers the basics for setting up your environment, running the project, and adding or updating toys.
+Thanks for contributing. This guide covers the current Bun-first workflow for humans and automation contributors.
 
-## Environment Setup
+## Quick start
 
-- Use **Bun 1.2+** for installs and test runs (the repo records this in `package.json`).
-- Install dependencies (Bun is the only lockfile tracked in git):
-  ```bash
-  bun install
-  ```
+1. Install **Bun 1.3+** (the repo declares `bun@1.3.8` in `package.json`).
+2. Install dependencies:
 
-  The repository pins installs via `bun.lock`, so use `bun install --frozen-lockfile` to honor it.
-  Bun does not automatically run `prepare` scripts, so a `postinstall` script installs Husky when your user agent starts with `bun`. If that misses your setup, run `bun x husky install` after installing dependencies.
+   ```bash
+   bun install
+   ```
 
-## Running the Dev Server
+   If dependencies changed, prefer:
 
-Start the local development server and open the site at `http://localhost:5173`:
+   ```bash
+   bun install --frozen-lockfile
+   ```
 
-```bash
-bun run dev
-```
+3. Start the dev server:
 
-## Testing, Linting, and Formatting
+   ```bash
+   bun run dev
+   ```
 
-- Run all tests:
-  ```bash
-  bun run test
-  ```
-  Always invoke the script so the pinned `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags apply, loading happy-dom globals and a Three.js stub needed for headless specs.
-- Run the Bun test runner with filters (for example, targeting specific files):
-  ```bash
-  bun run test tests/path/to/spec.test.js
-  ```
-- Lint the project:
-  ```bash
-  bun run lint
-  ```
-- Apply lint auto-fixes and formatting:
-  ```bash
-  bun run lint:fix
-  ```
-- Format the codebase:
-  ```bash
-  bun run format
-  ```
-- Check formatting without writing:
-  ```bash
-  bun run format:check
-  ```
-- Run lint, typecheck, and tests together:
+4. Open `http://localhost:5173`.
+
+## Quality checks
+
+Use these commands before opening a PR:
+
+- Full gate for JS/TS changes:
+
   ```bash
   bun run check
   ```
 
-## Branching and Pull Requests
+- Faster iteration gate (no tests):
 
-- Start from the latest `main` branch and create a feature branch for your work.
-- Keep changes focused and prefer smaller, reviewable pull requests.
-- Run tests and linting before opening a PR.
-- Provide a clear description of what changed and any testing performed.
-- If you touch documentation structure or contributor workflows, update the docs map in [`docs/README.md`](./docs/README.md) so the new structure remains discoverable.
+  ```bash
+  bun run check:quick
+  ```
 
-## Documentation entry points
+- Toy registry/docs consistency check when adding or renaming toys:
 
-Use the docs set by audience so guidance stays easy to find:
+  ```bash
+  bun run check:toys
+  ```
 
-- **Contributors (human):** this file + [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md).
-- **Toy-focused implementation work:** [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md), [`docs/toys.md`](./docs/toys.md).
-- **Agent/automation contributors:** root [`AGENTS.md`](./AGENTS.md) + [`docs/agents/README.md`](./docs/agents/README.md).
+- Run targeted tests:
 
-## Adding or Updating Webtoys
+  ```bash
+  bun run test tests/path/to/spec.test.ts
+  ```
 
-- Core toy implementations live in `assets/js/toys/` (e.g., `assets/js/toys/cube-wave.ts`). Add new toy modules there and reuse helpers from `assets/js/core/` or `assets/js/utils/` when possible.
-- Register toy metadata (labels, slugs, and settings) in `assets/data/toys.json` so the loader can find your new toy.
-- Toy entry points are served through `toy.html` using a `?toy=` query string (for example, `toy.html?toy=cube-wave`). Ensure your toy slug matches the metadata entry.
-- Shared styling and assets live under `assets/css/` and `assets/data/`. Add new static assets there when needed.
-- Update or add tests under `tests/` to cover new behaviors. You can run targeted checks by passing the spec path to `bun run test`.
-- Use `bun run scripts/scaffold-toy.ts` to scaffold a new toy: it prompts for slug/title/type, writes a starter module using the playbook template, updates `assets/data/toys.json` and `docs/TOY_SCRIPT_INDEX.md`, and can generate a minimal Bun spec that asserts `start` is exported.
+> Use `bun run test` (not raw `bun test`) so preload/importmap flags from `package.json` are always applied.
 
-Happy building!
+## Common dev commands
+
+- `bun run dev` — start local Vite server.
+- `bun run dev:host` — start Vite on LAN.
+- `bun run build` — production build.
+- `bun run preview` — preview built output.
+- `bun run lint` / `bun run lint:fix` — Biome linting.
+- `bun run format` / `bun run format:check` — Biome formatting.
+- `bun run typecheck` — TypeScript no-emit checks.
+
+## Branches, commits, and pull requests
+
+- Branch from `main` and keep PRs focused.
+- Commit messages should be sentence case with no trailing period.
+- PR descriptions should include:
+  - short summary,
+  - explicit test command list,
+  - explicit list of docs touched (or `None`).
+
+## Documentation expectations
+
+When workflows or structure change, update docs in the same PR:
+
+- Start from [`docs/README.md`](./docs/README.md) (docs map by audience + purpose).
+- Keep contributor and agent entry points aligned:
+  - [`README.md`](./README.md)
+  - [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+  - [`AGENTS.md`](./AGENTS.md)
+  - [`docs/agents/README.md`](./docs/agents/README.md)
+
+## Toy-specific changes
+
+For new or renamed toys, update all of the following together:
+
+- Toy implementation in `assets/js/toys/`.
+- Toy metadata in `assets/data/toys.json`.
+- Standalone page in `toys/` for page-backed toys.
+- `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md`.
+- Tests in `tests/` where behavior changed.
+
+Scaffold helper:
+
+```bash
+bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/zz-plant/stims?style=flat-square)](https://github.com/zz-plant/stims/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/zz-plant/stims?style=flat-square)](https://github.com/zz-plant/stims/issues)
 [![License](https://img.shields.io/github/license/zz-plant/stims?style=flat-square)](./LICENSE)
-[![Built with Bun](https://img.shields.io/badge/bun-1.2+-14151a?style=flat-square&logo=bun)](https://bun.sh)
+[![Built with Bun](https://img.shields.io/badge/bun-1.3+-14151a?style=flat-square&logo=bun)](https://bun.sh)
 
 Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to deliver playful sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play or sensory exploration, especially for neurodiverse folks.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,136 +1,80 @@
 # Development Guide
 
-This guide focuses on day-to-day development tasks for the Stim Webtoys Library. It complements the quick start notes in `README.md` and the contribution checklist in `CONTRIBUTING.md`.
+This is the day-to-day developer workflow reference for Stim Webtoys Library.
 
-If you’re spinning up the project for the first time, confirm the basics before diving into code:
+## Toolchain baseline
 
-1. Install **Bun 1.3+** (required). Run `bun --version` to confirm the runtime matches the repo’s `packageManager` entry.
+- Package manager/runtime: **Bun 1.3+** (`bun@1.3.8` declared in `package.json`).
+- Build/dev server: Vite.
+- Lint + format: Biome.
+- Typecheck: TypeScript (`tsc --noEmit`).
+- Tests: Bun test runner with repo preload/importmap wiring.
 
-2. Install dependencies with **Bun**: `bun install`. The repo tracks `bun.lock`, so keep installs aligned with `bun install --frozen-lockfile` when you need reproducibility.
-
-3. Smoke-test the dev server wiring without opening a browser:
-
-   ```bash
-   bun run dev:check
-   ```
-
-   This starts Vite on a fixed port, fetches the root page once, and exits—helpful when you’re validating a fresh clone or CI runner.
-
-4. Start the dev server for interactive work with `bun run dev`.
-
-## Tooling and Environment
-
-- **Bun 1.3+** is the default for installs, scripts, and testing. Keep your local runtime aligned with `packageManager` to avoid lockfile drift.
-- Install dependencies once per clone with Bun:
-
-  ```bash
-  bun install
-  ```
-
-  If you install with Bun and rely on Git hooks, the `postinstall` script will invoke `husky install` when `npm_config_user_agent` starts with `bun`. If hooks still don’t appear, run `bun x husky install`.
-  - Keep `bun.lock` authoritative. Use `bun install --frozen-lockfile` in CI and prefer Bun locally to keep dependency resolution consistent.
-- The project uses **TypeScript**, **Vite**, **Three.js**, **Biome**, and the Bun test runner. Use `bun run test` so the repo’s preload/import map flags are always applied.
-- Run the dev server locally with Bun:
-
-  ```bash
-  bun run dev
-  ```
-
-  The site serves from `http://localhost:5173`. For LAN/mobile testing, start the server with `bun run dev:host` to bind Vite to all interfaces.
-
-## Common Scripts (Bun-first)
-
-| Task                               | Command                   |
-| ---------------------------------- | ------------------------- |
-| Start dev server                   | `bun run dev`             |
-| Start dev server (LAN)             | `bun run dev:host`        |
-| Production build                   | `bun run build`           |
-| Preview build locally              | `bun run preview`         |
-| Run test suite                     | `bun run test`            |
-| Run test suite (watch)             | `bun run test:watch`      |
-| Lint                               | `bun run lint`            |
-| Lint with auto-fix                 | `bun run lint:fix`        |
-| Format with Biome                  | `bun run format`          |
-| Format check (no writes)           | `bun run format:check`    |
-| Type check without emit            | `bun run typecheck`       |
-| Type check (watch)                 | `bun run typecheck:watch` |
-| Dev server smoke test (no browser) | `bun run dev:check`       |
-| Validate toy registry and docs     | `bun run check:toys`      |
-| Generate SEO pages + sitemap       | `bun run generate:seo`    |
-| Quality gate (lint/typecheck/test) | `bun run check`           |
-| Quality gate (lint/typecheck)      | `bun run check:quick`     |
-| Serve built assets from `dist/`    | `bun run serve:dist`      |
-| Cloudflare Pages preview           | `bun run pages:dev`       |
-| Cloudflare Pages deploy            | `bun run pages:deploy`    |
-
-Notes:
-
-- `bun run check:toys` verifies that every toy listed in `assets/data/toys.json` has the expected TypeScript entry file, that page-backed toys have matching HTML entry points, and that `docs/TOY_SCRIPT_INDEX.md` references each slug. Run this when adding or renaming toys.
-- `bun run serve:dist` is a quick way to host the built assets without Vite’s dev server. Use it to validate the `dist/` output locally.
-- The Pages scripts rely on `wrangler`; they rebuild before starting a preview session or deploying.
-
-When debugging a single test file, run:
+## Setup
 
 ```bash
-bun run test tests/filename.test.js
+bun install
 ```
 
-### Editor Tooling
+When dependency manifests or lockfiles change:
 
-- VS Code users can install recommended extensions via `.vscode/extensions.json` (Biome and the TypeScript ESLint language service).
-- `.vscode/settings.json` configures Biome as the default formatter and enables format-on-save for common web languages.
-- `.vscode/launch.json` includes a Vite dev-server debug config (with a Bun-backed prelaunch task) and a Bun test debug config so you can attach the debugger without additional setup.
-  Use the `bun run test` script instead of raw `bun test` so the `--preload=./tests/setup.ts` and `--importmap=./tests/importmap.json` flags are always applied; they load happy-dom globals and a Three.js stub to keep specs headless and fast.
+```bash
+bun install --frozen-lockfile
+```
 
-## Project Structure
+## Command reference
 
-- `assets/js/toys/`: Individual toy implementations. Each module exports a `start` function that receives a DOM canvas/audio context.
-- `assets/js/core/`: Reusable systems such as renderer initialization, audio analysis, camera controls, and device input helpers.
-- `assets/js/utils/`: Small helpers (math, color, randomization, easing).
-- `assets/css/`: Shared styles for HTML entry points.
-- `assets/data/`: Static JSON or other payloads consumed by toys.
-- `tests/`: Bun specs covering utilities and shared behaviors.
-- HTML entry points (`toy.html`, `holy.html`, etc.) load specific toys or groups of toys.
+| Task | Command |
+| --- | --- |
+| Start dev server | `bun run dev` |
+| Start dev server on LAN | `bun run dev:host` |
+| Dev smoke check (no browser) | `bun run dev:check` |
+| Production build | `bun run build` |
+| Preview production build | `bun run preview` |
+| Run tests | `bun run test` |
+| Run tests (watch) | `bun run test:watch` |
+| Lint | `bun run lint` |
+| Lint + write fixes | `bun run lint:fix` |
+| Format | `bun run format` |
+| Format check | `bun run format:check` |
+| Typecheck | `bun run typecheck` |
+| Typecheck watch | `bun run typecheck:watch` |
+| Full quality gate | `bun run check` |
+| Quick quality gate | `bun run check:quick` |
+| Toy consistency check | `bun run check:toys` |
+| Generate SEO artifacts | `bun run generate:seo` |
+| Serve `dist/` | `bun run serve:dist` |
+| Cloudflare Pages local | `bun run pages:dev` |
+| Cloudflare Pages deploy | `bun run pages:deploy` |
 
-## Development Workflow
+## Quality gate expectations
 
-1. **Create a branch** from `main` for each change.
-2. **Run linters and tests** before committing.
-3. **Keep changes scoped**: small, reviewable pull requests are easier to land.
-4. **Document additions**: update `assets/data/toys.json` when adding toys, note any new scripts or setup steps in the docs, and review `docs/FEATURE_AUDIT.md` to keep feature coverage aligned.
-5. **Commit style**: prefer descriptive commit messages summarizing intent and outcome.
+- JS/TS code changes: run `bun run check` before commit.
+- Docs-only changes: typecheck/tests can be skipped unless docs changed executable instructions that need validation.
+- Toy additions/slug renames: run `bun run check:toys`.
 
-## Working With Audio and Input
+## Targeted testing
 
-- Toys often request microphone access. Provide clear UI messaging when microphone permissions are missing or denied.
-- When debugging audio issues, confirm `navigator.mediaDevices.getUserMedia` is available and that the page is served over HTTPS or `localhost`.
-- Device motion or touch input may be used on some toys—test on mobile-friendly viewports if you add multi-touch interactions.
+Run a single test file with:
 
-## Performance Tips
+```bash
+bun run test tests/path/to/spec.test.ts
+```
 
-- Three.js rendering defaults to `window.devicePixelRatio`; pass `maxPixelRatio` to `initRenderer` to cap DPI when targeting lower-powered devices.
-- Profile heavy scenes with the browser performance tools. Reduce geometry complexity, particle counts, or shader work when frame times exceed 16ms.
-- Debounce expensive resize handlers and cache allocations in animation loops.
-- A shared floating settings panel now exposes quality presets used across toys. Defaults:
-  - **Battery saver**: `maxPixelRatio: 1.25`, `renderScale: 0.9`, ~65% particle counts.
-  - **Balanced (default)**: `maxPixelRatio: 2`, `renderScale: 1`, 100% particle counts.
-  - **Hi-fi visuals**: `maxPixelRatio: 2.5`, `renderScale: 1`, ~135% particle counts.
-    These settings persist between toys so you can cap GPU load once per session. Updating a preset calls `toy.updateRendererSettings()` to apply the new pixel ratio without a page reload.
+Always prefer `bun run test` over `bun test` directly so preload/importmap flags in `package.json` are retained.
 
-## Testing Expectations
+## Typical development flow
 
-- Prefer fast, deterministic tests in `tests/`. Mock audio contexts or DOM APIs when real instances are unnecessary.
-- Prefer Bun’s built-in mocking (`mock.fn`, `mock.module`) and avoid CommonJS-specific globals.
-- Keep tests colocated with utilities when practical, or place shared behaviors in `tests/`.
+1. Create a branch from `main`.
+2. Implement change.
+3. Run appropriate checks (`bun run check` for JS/TS, plus `bun run check:toys` when relevant).
+4. Update docs that changed behavior or workflow.
+5. Commit with a sentence-case title and no trailing period.
 
-## Accessibility and UX
+## Related docs
 
-- Add keyboard shortcuts or focusable controls when introducing new UI elements.
-- Provide feedback for permission failures, loading states, or unsupported browsers.
-- Avoid autoplaying audio; let users control start/stop actions.
-
-## Deployment Checklist
-
-- `bun run build` completes without errors.
-- Verify the generated `dist/` assets load via `bun run preview` or a simple static server.
-- Spot-check microphone prompts and toy selection flows in the production build.
+- Contributor onboarding: [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
+- Docs map: [`README.md`](./README.md)
+- Toy implementation details: [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md)
+- Deployment: [`DEPLOYMENT.md`](./DEPLOYMENT.md)
+- Architecture: [`ARCHITECTURE.md`](./ARCHITECTURE.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,7 +16,13 @@ This is the day-to-day developer workflow reference for Stim Webtoys Library.
 bun install
 ```
 
-When dependency manifests or lockfiles change:
+When dependency manifests change and you need to update the lockfile, run:
+
+```bash
+bun install
+```
+
+For reproducible CI-style installs that must not modify `bun.lock`, run:
 
 ```bash
 bun install --frozen-lockfile

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,95 +1,63 @@
 # Developer and Contributor Docs
 
-This folder is organized by **audience + workflow** so humans and coding agents can quickly find the right guidance.
+This directory is organized by **audience + workflow** so contributors and agents can quickly find the right guidance.
 
-## Start here by audience
+## Start here
 
-- **Human contributors:** [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for setup + contribution flow, then [`DEVELOPMENT.md`](./DEVELOPMENT.md) for day-to-day commands.
-- **Toy builders:** [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md), [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md), and [`toys.md`](./toys.md).
-- **Agents / automation contributors:** root [`../AGENTS.md`](../AGENTS.md) first, then [`agents/README.md`](./agents/README.md).
+- Human contributors: [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
+- Agent contributors: [`../AGENTS.md`](../AGENTS.md) then [`agents/README.md`](./agents/README.md)
+- Day-to-day implementation: [`DEVELOPMENT.md`](./DEVELOPMENT.md)
 
-## Docs map by purpose
+## Docs by purpose
 
 ### Build, test, and ship
 
-- [`DEVELOPMENT.md`](./DEVELOPMENT.md): setup, scripts, workflow, performance/testing expectations.
-- [`QA_PLAN.md`](./QA_PLAN.md): highest-impact QA flows and automated coverage.
-- [`DEPLOYMENT.md`](./DEPLOYMENT.md): build, preview, static hosting, and Cloudflare deployment.
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md) — setup, scripts, and local workflows.
+- [`QA_PLAN.md`](./QA_PLAN.md) — high-impact QA paths and automated coverage.
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — build/preview/deploy guidance.
 
-### Runtime and implementation reference
+### Implementation references
 
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md): runtime composition, loader flow, and diagrams.
-- [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md): implementation playbook for toy work.
-- [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md): toy slug to JS/TS entry-point map.
-- [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md): page-level data/layout/accessibility expectations.
-- [`MCP_SERVER.md`](./MCP_SERVER.md): MCP stdio server usage (`scripts/mcp-server.ts`).
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — runtime composition and data flow.
+- [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) — implementation patterns for toys.
+- [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md) — slug-to-entry-point map.
+- [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md) — page-level specs.
+- [`MCP_SERVER.md`](./MCP_SERVER.md) — MCP stdio server usage.
 
-### Product, research, and assessment docs
+### Product and research context
 
-- [`FEATURE_SPECIFICATIONS.md`](./FEATURE_SPECIFICATIONS.md): current shipped behavior specs.
-- [`FEATURE_AUDIT.md`](./FEATURE_AUDIT.md): coverage matrix + open documentation gaps.
-- [`stim-assessment.md`](./stim-assessment.md): assessment findings + remediation directions.
-- [`stim-user-critiques.md`](./stim-user-critiques.md): toy-by-toy UX critique notes.
-- [`LITERATURE.md`](./LITERATURE.md): scientific references informing design.
-- [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md): capability snapshot for core tooling.
+- [`FEATURE_SPECIFICATIONS.md`](./FEATURE_SPECIFICATIONS.md)
+- [`FEATURE_AUDIT.md`](./FEATURE_AUDIT.md)
+- [`stim-assessment.md`](./stim-assessment.md)
+- [`stim-user-critiques.md`](./stim-user-critiques.md)
+- [`LITERATURE.md`](./LITERATURE.md)
+- [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
 
-### Agent-oriented overlays
+### Agent overlays
 
-- [`agents/README.md`](./agents/README.md): progressive-disclosure map for agent workflows.
-- [`agents/tooling-and-quality.md`](./agents/tooling-and-quality.md): required checks and Bun-first commands.
-- [`agents/metadata-and-docs.md`](./agents/metadata-and-docs.md): commit/PR/doc hygiene conventions.
-- [`agents/toy-development.md`](./agents/toy-development.md): code locations and toy patterns.
-- [`agents/toy-workflows.md`](./agents/toy-workflows.md): common toy-task runbooks.
-- [`agents/reference-docs.md`](./agents/reference-docs.md): fast links into core docs + code hotspots.
+- [`agents/README.md`](./agents/README.md)
+- [`agents/tooling-and-quality.md`](./agents/tooling-and-quality.md)
+- [`agents/metadata-and-docs.md`](./agents/metadata-and-docs.md)
+- [`agents/toy-development.md`](./agents/toy-development.md)
+- [`agents/toy-workflows.md`](./agents/toy-workflows.md)
+- [`agents/reference-docs.md`](./agents/reference-docs.md)
 
-If you add new tooling or patterns, update these docs so the next contributor has a reliable starting point.
+## Current baseline conventions
 
-## Architecture quick diagrams
-
-```mermaid
-flowchart LR
-  Entry[HTML entry points] --> Loader[loader + router]
-  Loader --> Views[UI views]
-  Loader --> Manifest[manifest client]
-  Manifest --> Toys[Toy modules]
-  Toys --> Core[core/web-toy.ts]
-  Core --> Services[render + audio pools]
-```
-
-```mermaid
-flowchart TD
-  Prewarm[prewarmMicrophone + renderer probe] --> Loader[loader.ts]
-  Loader --> ViewState[toy-view.ts]
-  Loader --> Import[dynamic import]
-  Import --> Start[start()/default export]
-  Start --> Cleanup[dispose + release pools]
-```
-
-## How to add or move a guide
-
-1. Create the Markdown file under `docs/` with a clear title and a short purpose statement in the first paragraph.
-2. Add or update links in this README under the **purpose category** where it best fits.
-3. Cross-link from the most relevant audience entry point (`CONTRIBUTING.md`, `AGENTS.md`, or a primary workflow doc).
-4. If the guide introduces scripts, toy entry points, or deployment steps, update the checklists and indexes they depend on.
-
-## Onboarding highlights
-
-- Use **Bun 1.3+** for installs and scripts. Run `bun install` in a fresh clone to populate `bun.lock`-aligned dependencies.
-- Run a **dev server smoke test** without opening a browser via `bun run dev:check` to confirm Vite wiring before you start coding.
-- Use `bun run check:quick` as a fast local gate to run **Biome** and TypeScript checks.
-- When adding or renaming toys, run `bun run check:toys` to ensure `assets/data/toys.json` entries, TypeScript modules, standalone HTML files, and `docs/TOY_SCRIPT_INDEX.md` stay in sync.
-
-## Navigation tips
-
-- Start with [`DEVELOPMENT.md`](./DEVELOPMENT.md) if you’re getting your environment ready; it mirrors the quick start in the repo root but adds tooling details and command matrices.
-- Jump to [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) when you’re building or adjusting an experience; it links back to reusable components in `assets/js/core/` and the toy index.
-- Check [`DEPLOYMENT.md`](./DEPLOYMENT.md) before shipping changes to production so your build/preview/Pages flow matches the current configuration.
-- Review [`ARCHITECTURE.md`](./ARCHITECTURE.md) when you need a refresher on renderer wiring, data flow, or how audio/motion inputs are shared.
+- Package manager: **Bun** (`bun@1.3.8` declared in `package.json`).
+- Main quality gate for JS/TS work: `bun run check`.
+- Quick gate for iteration: `bun run check:quick`.
+- Toy consistency check (metadata + docs + entry points): `bun run check:toys`.
 
 ## Doc maintenance checklist
 
-- Keep this file audience-oriented: if docs move, preserve a clear path for contributors, toy builders, and agents.
-- Add or update a link here whenever you create a new guide under `docs/` so contributors can discover it.
-- Cross-link new scripts or workflows from the relevant guide (for example, record new Bun scripts in `DEVELOPMENT.md` and toy-scaffolding changes in `TOY_DEVELOPMENT.md`).
-- Keep toy-related documentation synchronized: update `TOY_DEVELOPMENT.md`, `TOY_SCRIPT_INDEX.md`, and `toys.md` when adding, renaming, or removing a toy entry point.
-- Before shipping a PR, skim the docs above for stale script names, flags, or file paths introduced by your change.
+When you add or change workflows:
+
+1. Update the source workflow doc (for example `DEVELOPMENT.md` or `TOY_DEVELOPMENT.md`).
+2. Update this index if a file moved or a new guide was added.
+3. Keep contributor/agent entry points aligned:
+   - `README.md`
+   - `CONTRIBUTING.md`
+   - `AGENTS.md`
+   - `docs/agents/README.md`
+4. For toy additions/renames, update `TOY_SCRIPT_INDEX.md` and `toys.md` in the same PR.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,33 +1,33 @@
 # Agent Guidance Index
 
-Use this folder as the **agent-facing overlay** for repo docs.
+Use this folder as a focused, progressive-disclosure overlay for agent tasks.
 
-## Navigation order (agent workflow)
+## Read order
 
-1. Read root [`AGENTS.md`](../../AGENTS.md) for mandatory defaults.
-2. Open [`../README.md`](../README.md) when you need the full contributor docs map.
-3. Use the focused files below only for the task at hand (progressive disclosure).
+1. Root [`AGENTS.md`](../../AGENTS.md) for non-negotiable defaults.
+2. [`tooling-and-quality.md`](./tooling-and-quality.md) before code edits.
+3. [`metadata-and-docs.md`](./metadata-and-docs.md) before commit/PR finalization.
+4. [`reference-docs.md`](./reference-docs.md) when triaging unfamiliar areas.
 
-## Guidance by task
+## Task routing
 
-### If you are changing code
+### Code changes
 
-- [`tooling-and-quality.md`](./tooling-and-quality.md): Bun-first commands and required quality gates.
-- [`toy-development.md`](./toy-development.md): runtime structure and toy implementation patterns.
-- [`toy-workflows.md`](./toy-workflows.md): common toy workflows and command recipes.
-- [`reference-docs.md`](./reference-docs.md): high-signal code/document locations for fast triage.
+- [`tooling-and-quality.md`](./tooling-and-quality.md)
+- [`toy-development.md`](./toy-development.md)
+- [`toy-workflows.md`](./toy-workflows.md)
+- [`reference-docs.md`](./reference-docs.md)
 
-### If you are changing docs or metadata
+### Documentation or metadata changes
 
-- [`metadata-and-docs.md`](./metadata-and-docs.md): commit/PR conventions and documentation upkeep expectations.
-- [`../README.md`](../README.md): canonical docs map by audience and purpose.
+- [`metadata-and-docs.md`](./metadata-and-docs.md)
+- [`../README.md`](../README.md)
 
 ## Fast repo map
 
-- `assets/js/` - Core runtime, toy modules, and UI logic.
-- `assets/js/toys/` - Toy implementations (TypeScript).
-- `assets/data/toys.json` - Toy registry metadata.
-- `toys/` - Standalone HTML toy pages.
-- `tests/` - Automated tests.
-- `docs/` - Contributor and architecture references.
-- `.agent/skills/` - Agent skill definitions for reusable workflows.
+- `assets/js/toys/` — toy implementations.
+- `assets/data/toys.json` — toy metadata source of truth.
+- `toys/` — standalone toy pages.
+- `tests/` — automated test suite.
+- `docs/` — contributor and architecture docs.
+- `.agent/workflows/` + `.agent/skills/` — reusable automation workflows.

--- a/docs/agents/metadata-and-docs.md
+++ b/docs/agents/metadata-and-docs.md
@@ -1,24 +1,42 @@
-# Metadata & Documentation Expectations
+# Metadata and Docs Expectations
 
-## Metadata conventions
+## Commit and PR metadata
 
-- **Commit messages:** concise, descriptive titles in sentence case (no trailing period), e.g., `Add docs on data flow`.
-- **PR summaries:** include a short summary plus explicit lists of tests run and any docs touched or added so reviewers can verify coverage.
+- Commit titles: sentence case, no trailing period.
+- PR summaries must include:
+  - short summary,
+  - explicit list of tests run,
+  - explicit list of docs touched/added.
 
-### Suggested PR summary format
+Suggested PR body template:
 
-```
-Summary:
+```md
+Summary
 - <short summary>
 
-Tests:
-- <test command or "Not run (reason)">
+Tests
+- <command>
 
-Docs:
-- <doc path(s) touched, or "None">
+Docs
+- <path or None>
 ```
 
-## Documentation expectations
+## Documentation upkeep rules
 
-- Refer to `docs/README.md` for the documentation map when adding or updating docs.
-- Keep the docs in `docs/` and the root `README.md` in sync with workflow or toy changes so contributors can find updated guidance.
+When behavior, scripts, or structure changes:
+
+1. Update the source-of-truth workflow docs under `docs/`.
+2. Update the docs map in `docs/README.md` if files moved or were added.
+3. Keep cross-links aligned across:
+   - `README.md`
+   - `CONTRIBUTING.md`
+   - `AGENTS.md`
+   - `docs/agents/README.md`
+
+## Toy docs synchronization
+
+When adding/removing/renaming toy slugs, update all related docs in the same change:
+
+- `docs/TOY_DEVELOPMENT.md`
+- `docs/TOY_SCRIPT_INDEX.md`
+- `docs/toys.md`

--- a/docs/agents/reference-docs.md
+++ b/docs/agents/reference-docs.md
@@ -1,30 +1,31 @@
-# Reference Documentation
+# Reference Docs and Code Hotspots
 
-## Core reference docs
+## Primary docs
 
-- `docs/TOY_DEVELOPMENT.md` - Full toy development playbook.
-- `docs/TOY_TESTING_SPEC.md` - Automated testing specification.
-- `docs/ARCHITECTURE.md` - System architecture overview.
+- `docs/DEVELOPMENT.md` — scripts and contributor workflow baseline.
+- `docs/TOY_DEVELOPMENT.md` — full toy implementation guide.
+- `docs/TOY_TESTING_SPEC.md` — toy testing strategy.
+- `docs/ARCHITECTURE.md` — runtime architecture and flow.
+- `docs/DEPLOYMENT.md` — shipping and hosting guidance.
 
 ## High-signal code locations
 
-- `assets/js/toys/` - TypeScript toy modules (library-loaded toys).
-- `assets/data/toys.json` - Toy registry metadata (slugs, labels, caps).
-- `assets/js/loader.ts` - Toy loader for `toy.html` (routes, query params).
-- `assets/js/core/toy-runtime.ts` - Runtime scaffolding (audio + render loop).
-- `assets/js/utils/start-audio.ts` - Audio unlock + demo audio controls.
-- `toys/` - Standalone HTML toys (page-based).
-- `public/` - Static assets served as-is.
+- `assets/js/toys/` — toy modules.
+- `assets/data/toys.json` — toy metadata source of truth.
+- `assets/js/loader.ts` — loader/query param routing.
+- `assets/js/core/toy-runtime.ts` — shared toy runtime plumbing.
+- `assets/js/utils/start-audio.ts` — mic/demo audio unlock path.
+- `toys/` — standalone page-backed toy entry points.
 
-## Config + project entry points
+## Config and entry points
 
-- `vite.config.js` - Build + dev server config.
-- `package.json` - Scripts and Bun package manager config.
-- `index.html` / `toy.html` - Entry points for the library and toy runner.
+- `package.json` — scripts, package manager, tool versions.
+- `vite.config.js` — bundling and dev-server behavior.
+- `index.html` and `toy.html` — app and toy shell entry points.
 
-## Fast triage checklist
+## Fast triage
 
-1. **Toy missing from UI?** Confirm it exists in `assets/data/toys.json`.
-2. **Toy fails to load?** Check query params handling in `assets/js/loader.ts`.
-3. **Audio not reactive?** Validate `startAudio` usage and runtime setup in
-   `assets/js/core/toy-runtime.ts` and `assets/js/utils/start-audio.ts`.
+1. Toy missing in UI → verify `assets/data/toys.json` entry.
+2. Toy not loading → inspect loader behavior in `assets/js/loader.ts`.
+3. No audio response → inspect `start-audio.ts` and runtime wiring.
+4. Docs mismatch → refresh `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md`.

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -3,7 +3,13 @@
 ## Package manager and script execution
 
 - Use **Bun** for installs and scripts.
-- When dependency manifests or lockfiles change, run:
+- When dependency manifests change and lockfile updates are expected, run:
+
+  ```bash
+  bun install
+  ```
+
+- For reproducible installs that must not modify the lockfile (for example CI), run:
 
   ```bash
   bun install --frozen-lockfile

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -1,22 +1,55 @@
-# Tooling & Quality Checks
+# Tooling and Quality Checks
 
-## Package manager
+## Package manager and script execution
 
-- Prefer **Bun** tooling to match the repo `packageManager`.
-- For dependency changes, install with `bun install --frozen-lockfile`.
-- Run scripts with `bun run ...`.
+- Use **Bun** for installs and scripts.
+- When dependency manifests or lockfiles change, run:
 
-## Linting & formatting
+  ```bash
+  bun install --frozen-lockfile
+  ```
 
-- Use **Biome** for linting and formatting. Do not use ESLint or Prettier.
+- Run project scripts with:
 
-## Required checks
+  ```bash
+  bun run <script>
+  ```
 
-- For JavaScript/TypeScript changes, run the relevant quality checks before committing:
-  - `bun run check` (Biome + typecheck + tests)
-  - Optional quick pass: `bun run check:quick` (Biome + typecheck, skips tests)
+## Linting and formatting
 
-## Documentation-only changes
+- Biome is the formatter/linter of record.
+- Use the package scripts rather than ad-hoc commands where possible.
 
-- For Markdown/prose-only changes, you can skip `bun run typecheck` and `bun run test`.
-- Formatting docs is optional; there is no dedicated script for docs, but you can run `bunx biome format --write docs` if you want to normalize Markdown formatting.
+## Required gates for JS/TS changes
+
+Run before commit:
+
+```bash
+bun run check
+```
+
+This runs Biome checks, TypeScript typechecking, and tests.
+
+Useful fast path while iterating:
+
+```bash
+bun run check:quick
+```
+
+## Task-specific checks
+
+- Toy registration/docs consistency:
+
+  ```bash
+  bun run check:toys
+  ```
+
+- Targeted test execution:
+
+  ```bash
+  bun run test tests/path/to/spec.test.ts
+  ```
+
+## Docs-only updates
+
+For Markdown-only edits, you can skip typecheck/tests unless the change modifies commands, paths, or workflow-critical instructions that should be validated.

--- a/docs/agents/toy-development.md
+++ b/docs/agents/toy-development.md
@@ -1,21 +1,24 @@
-# Toy Development
+# Toy Development (Agent Quick Reference)
 
-## Project structure
+## Core locations
 
-- Toy modules: `assets/js/toys/` (TypeScript modules exporting `start()`).
-- Toy registry: `assets/data/toys.json` (slugs, metadata, capabilities).
-- Standalone HTML toys: `toys/` directory (standalone pages launched from the library UI).
-- Loader logic: `toy.html` + `assets/js/loader.ts`.
-- Audio/runtime helpers: `assets/js/core/toy-runtime.ts` and `assets/js/utils/start-audio.ts`.
+- Toy modules: `assets/js/toys/`.
+- Toy registry metadata: `assets/data/toys.json`.
+- Page-backed toy entry points: `toys/`.
+- Loader shell: `toy.html` + `assets/js/loader.ts`.
+- Runtime/audio helpers: `assets/js/core/toy-runtime.ts`, `assets/js/utils/start-audio.ts`.
 
-## Key patterns
+## Expected patterns
 
-- Every toy module exports `start({ container?, preferDemoAudio? })` for library cards or
-  `start({ container? })` when embedding a Three.js scene directly.
-- Page-based toys should call `startPageToy({ container, path, title, description, preferDemoAudio })`
-  to render the launch panel that opens the standalone HTML file.
-- Canvas-based toys should use `createToyRuntime(...)` to wire up WebGL, audio, input, and performance
-  settings in one place.
-- `start()` returns a disposable object (from `createToyRuntime` or `startPageToy`) that handles cleanup.
-- Audio reactivity uses `registerToyGlobals` to expose `startAudio` to the standalone toy pages.
-- Toys support microphone input or demo audio fallback by passing `preferDemoAudio` or `audio=demo`.
+- Toy modules export `start(...)` and return a disposable cleanup handle.
+- Canvas-heavy toys should prefer shared runtime scaffolding (`createToyRuntime(...)`) over bespoke setup.
+- Page-backed toys should use `startPageToy(...)` so launch panel behavior remains consistent.
+- Audio-reactive toys should integrate with shared audio helpers and support demo-audio fallback when applicable.
+
+## Change checklist for toy edits
+
+1. Update module in `assets/js/toys/`.
+2. Ensure `assets/data/toys.json` metadata matches slug/capabilities.
+3. Add/update standalone page in `toys/` if page-backed.
+4. Update tests for new behavior.
+5. Run `bun run check:toys` when slugs/entries changed.

--- a/docs/agents/toy-workflows.md
+++ b/docs/agents/toy-workflows.md
@@ -1,48 +1,37 @@
-# Toy Workflows & Commands
+# Toy Workflows and Commands
 
-## Agent workflows
+## Reusable agent workflows
 
-Use these workflows (in `.agent/workflows/`) to interact with toys:
+The repository includes markdown workflows under `.agent/workflows/`:
 
-| Workflow | Command | Purpose |
-| --- | --- | --- |
-| `/create-toy` | Create new toy module | Scaffold a new toy with the standard template |
-| `/play-toy` | Launch toy in browser | Start dev server and interact with toys |
-| `/test-toy` | Run toy tests | Execute automated tests for toys |
+- `/create-toy` — scaffold a new toy.
+- `/play-toy` — run and manually verify a toy.
+- `/test-toy` — execute toy-focused tests.
 
-## Quick commands
+## Common commands
 
 ```bash
-# Create a new toy
+# Scaffold a toy module and metadata/docs wiring
 bun run scripts/scaffold-toy.ts --slug my-toy --title "My Toy" --type module --with-test
 
-# Check all toys are registered correctly
+# Validate toy registration, entry points, and docs index
 bun run check:toys
 
-# Run all tests
-bun run test
-
-# Start dev server for interactive testing
+# Local development server
 bun run dev
 
-# Type check
-bun run typecheck
+# Targeted and full test passes
+bun run test tests/path/to/spec.test.ts
+bun run test
 
-# Full quality check (lint + tests)
+# Type safety and full repo gate
+bun run typecheck
 bun run check
 ```
 
-## Testing a specific toy
+## Manual verification flow
 
-1. Start dev server: `bun run dev`
-2. Navigate to: `http://localhost:5173/toy.html?toy=<slug>`
-3. Click "Use demo audio" to bypass microphone permissions
-4. Verify visuals render and respond to audio
-
-## Common toy slugs
-
-- `holy` - Ultimate Satisfying Visualizer
-- `geom` - Geometry Visualizer
-- `spiral-burst` - Spiral Burst
-- `neon-wave` - Neon Wave
-- `milkdrop` - MilkDrop Proto
+1. Run `bun run dev`.
+2. Open `http://localhost:5173/toy.html?toy=<slug>`.
+3. Use demo audio if microphone access is unavailable.
+4. Confirm render loop, controls, and cleanup behavior work as expected.


### PR DESCRIPTION
### Motivation
- Bring contributor and agent-facing docs up to a current Bun 1.3+ baseline and make onboarding faster with a clear quick-start and command matrix.
- Make agent workflows and overlays explicit, with a progressive-disclosure routing and concrete metadata/PR expectations to reduce friction for automation contributors.
- Improve doc maintenance rules so moving scripts or toys triggers the right cross-document updates and keeps indexes consistent.

### Description
- Updated root and contributor entry points to a Bun 1.3+ baseline and tightened quick-start and common command guidance in `README.md` and `CONTRIBUTING.md`.
- Reworked the docs hub and development guide to a task-oriented layout and added a consolidated command matrix in `docs/README.md` and `docs/DEVELOPMENT.md`.
- Refreshed agent overlays under `docs/agents/` and `AGENTS.md` to include recommended execution order, PR/commit metadata rules, tooling gates, toy-change checklists, and fast-triage hotspots.
- Minor editorial cleanups and alignment across the docs map so agent and human entry points (`AGENTS.md`, `CONTRIBUTING.md`, `docs/README.md`) remain in sync.

### Testing
- `bun run check:toys` was executed and failed due to pre-existing repository inconsistencies (missing `docs/TOY_SCRIPT_INDEX.md` entries and an unregistered toy module). 
- `biome lint assets scripts tests` was run (via the pre-commit hook) and completed successfully. 
- `biome format --write assets scripts tests` was run (via the pre-commit hook) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989762f67488332a30ec07c55e5b0b4)