### PR TITLE
Improve discovery, audio onboarding, and WebGPU compatibility flows

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1006,6 +1006,12 @@ body {
   color: rgba(233, 251, 255, 0.82);
 }
 
+.control-panel__microcopy {
+  font-size: 0.76rem;
+  color: rgba(233, 251, 255, 0.68);
+  line-height: 1.35;
+}
+
 .control-panel__advanced {
   display: grid;
   gap: 8px;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2483,6 +2483,14 @@ html:not(.light) .webtoy-card {
   line-height: 1.5;
 }
 
+.webtoy-card-bestfor {
+  margin-top: -0.15rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--accent-color) 62%, var(--text-color) 38%);
+}
+
 .webtoy-card-match {
   margin-top: -2px;
   margin-bottom: 2px;
@@ -2515,6 +2523,20 @@ html:not(.light) .webtoy-card {
   padding-top: 0.9rem;
   position: relative;
   z-index: 2;
+}
+
+.webtoy-card-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 0.3rem;
+  position: relative;
+  z-index: 2;
+}
+
+.webtoy-card-actions .cta-button {
+  min-height: 36px;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.78rem;
 }
 
 .webtoy-card-meta::before {

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -50,6 +50,7 @@ type CapabilityOptions = {
   allowFallback?: boolean;
   onBack?: () => void;
   onContinue?: () => void;
+  onBrowseCompatible?: () => void;
   details?: string | null;
 };
 
@@ -536,6 +537,10 @@ export function createToyView({
         {
           label: 'Back to Library',
           onClick: options.onBack,
+        },
+        {
+          label: 'Browse compatible toys',
+          onClick: options.onBrowseCompatible,
         },
         ...(options.allowFallback && options.onContinue
           ? [

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -60,6 +60,7 @@ export function initAudioControls(
       <div class="control-panel__text">
         <span class="control-panel__label">Live mic</span>
         <span class="control-panel__subtext">Best for live instruments, voice, and ambient sound.</span>
+        <span class="control-panel__microcopy">Reacts to your room in real time. Requires microphone permission.</span>
       </div>
       <button id="start-audio-btn" class="cta-button primary" type="button">
         Use microphone
@@ -69,6 +70,7 @@ export function initAudioControls(
       <div class="control-panel__text">
         <span class="control-panel__label">Curated demo</span>
         <span class="control-panel__subtext">Fastest way to preview visuals without permissions.</span>
+        <span class="control-panel__microcopy">Starts instantly with built-in audio. Great first try when privacy-sensitive.</span>
       </div>
       <button id="use-demo-audio" class="cta-button primary" type="button">Use demo audio</button>
     </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ This directory is organized by **audience + workflow** so contributors and agent
 - [`FEATURE_AUDIT.md`](./FEATURE_AUDIT.md)
 - [`stim-assessment.md`](./stim-assessment.md)
 - [`stim-user-critiques.md`](./stim-user-critiques.md)
+- [`USER_JOURNEY_CRITIQUE.md`](./USER_JOURNEY_CRITIQUE.md)
 - [`LITERATURE.md`](./LITERATURE.md)
 - [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
 

--- a/docs/USER_JOURNEY_CRITIQUE.md
+++ b/docs/USER_JOURNEY_CRITIQUE.md
@@ -1,0 +1,73 @@
+# Three typical user journeys: constructive critique
+
+This note walks through three high-frequency journeys in Stim and calls out what is already working plus practical improvements.
+
+## Journey 1: First-time visitor trying to find a fitting toy quickly
+
+### Typical path
+1. Land on the library page and scan hero CTAs.
+2. Use search (for terms like “calm”, “microphone”, or “webgpu”) and curated filter chips.
+3. Open a card from the resulting list.
+
+### What works well
+- The hero section gives immediate “start now” options and an explicit path to the full library.
+- Search guidance is specific (“name, mood, tags, capabilities”), and search has focused affordances (keyboard hint, clear button, result status).
+- The search haystack includes title, slug, description, tags, moods, capabilities, and WebGPU markers, so user wording is likely to match.
+
+### Friction observed
+- The search hint promises broad discovery, but users still need to infer *which* capability matters for their context (mic required vs demo audio available vs motion).
+- If users are undecided, the current card experience can still feel metadata-heavy before they experience visual “wow”.
+
+### Constructive improvements
+- Add a compact “best for” line on cards (e.g., “quiet room”, “headphones”, “mobile tilt”) to reduce cognitive load before click-through.
+- Add one-click “Play in demo mode” secondary actions on cards where demo audio is available, so users can skip permission anxiety at discovery time.
+- Consider a tiny “new user route” toggle near search (e.g., “show me easiest starts first”) that boosts toys with low setup friction.
+
+## Journey 2: Permission-cautious user launching a toy
+
+### Typical path
+1. Open `toy.html?toy=<slug>` from library or direct link.
+2. Encounter capability preflight and audio source controls.
+3. Choose between microphone, demo audio, or advanced capture options.
+
+### What works well
+- Audio controls now present microphone and demo audio as parallel first-class choices instead of hiding demo behind failure states.
+- Preflight logic explicitly prefers demo audio when microphone is unsupported/denied and communicates fallback guidance.
+- Starter tips and status messaging reduce ambiguity during first interaction.
+
+### Friction observed
+- “Choose how this toy listens” is clear, but users who are privacy-sensitive may still hesitate because tradeoffs are not summarized inline at decision moment.
+- Advanced options (tab/YouTube) are useful, but users may not know when to use them versus demo audio.
+
+### Constructive improvements
+- Add one sentence under the row labels comparing outcomes (“Mic reacts to your room now; demo starts instantly with no permissions”).
+- Add a subtle default badge (e.g., “Recommended first try”) that follows preflight outcomes (demo when mic denied; mic otherwise).
+- For advanced options, include trigger copy such as “Use these when you want to react to media already playing.”
+
+## Journey 3: User on unsupported hardware/browser opening a WebGPU-first toy
+
+### Typical path
+1. Open a WebGPU-first toy (for example `multi`).
+2. Hit capability handling in the toy shell.
+3. Either continue with WebGL fallback (when allowed) or return to library.
+
+### What works well
+- The capability error copy is concrete: it distinguishes “works best with WebGPU” from “requires WebGPU”.
+- The fallback path is action-oriented (“Continue with WebGL”) and not just a dead-end warning.
+- Messaging points users to browser alternatives for best quality.
+
+### Friction observed
+- The decision still happens after context switch into the toy page; for many users this feels like a false start.
+- If a user sees repeated WebGPU limitations across toys, there is no immediate “show me compatible toys only” escape hatch in-place.
+
+### Constructive improvements
+- In the capability warning action area, add a direct “Browse compatible toys” action that pre-applies filters in library view.
+- Surface compatibility confidence earlier in card previews (e.g., “Runs best in WebGPU, fallback available”).
+- Persist a short-lived “compatibility mode” preference after fallback so subsequent opens bias toward smoother defaults.
+
+## Suggested prioritization
+
+1. **Fast win (copy/UI only):** clarify mic vs demo tradeoffs inline in audio rows.
+2. **Fast win (routing):** add “Browse compatible toys” from capability warnings.
+3. **Medium effort:** card-level “Play demo now” quick action and “best for” labels.
+4. **Higher leverage:** compatibility-mode preference that adapts future launches.

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -120,6 +120,7 @@ describe('app shell user journeys', () => {
     expect(mockLoadToy).toHaveBeenCalledTimes(1);
     expect(mockLoadToy).toHaveBeenCalledWith('aurora-painter', {
       pushState: true,
+      preferDemoAudio: false,
     });
   });
 

--- a/tests/toy-view.test.js
+++ b/tests/toy-view.test.js
@@ -37,21 +37,24 @@ describe('toy view helpers', () => {
     const view = createToyView();
     const onBack = mock();
     const onContinue = mock();
+    const onBrowseCompatible = mock();
 
     const status = view.showCapabilityError(
       { slug: 'webgpu-toy', title: 'Fancy WebGPU' },
-      { allowFallback: true, onBack, onContinue },
+      { allowFallback: true, onBack, onContinue, onBrowseCompatible },
     );
 
     expect(status?.classList.contains('is-warning')).toBe(true);
 
     const buttons = status?.querySelectorAll('button');
-    expect(buttons?.length).toBe(2);
+    expect(buttons?.length).toBe(3);
 
     buttons?.[0].dispatchEvent(new Event('click', { bubbles: true }));
     buttons?.[1].dispatchEvent(new Event('click', { bubbles: true }));
+    buttons?.[2].dispatchEvent(new Event('click', { bubbles: true }));
 
     expect(onBack).toHaveBeenCalledTimes(1);
+    expect(onBrowseCompatible).toHaveBeenCalledTimes(1);
     expect(onContinue).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Motivation
- Reduce friction across three common journeys: library discovery, permission‑cautious toy launch, and WebGPU fallback handling.
- Give users clearer decision copy at the moment of choice (mic vs demo) and quicker ways to preview without granting permissions.
- Provide an escape and persistence for users on devices/browsers that lack WebGPU so subsequent interactions prefer compatible toys.

### Description
- Add inline microcopy to the audio control rows and a small CSS rule so the mic vs demo tradeoffs are explicit (`assets/js/ui/audio-controls.ts`, `assets/css/base.css`).
- Add per-card “Best for …” labels and a one-click `Play demo now` action that launches module toys with `preferDemoAudio` set, plus styles for card actions (`assets/js/library-view.js`, `assets/css/index.css`).
- Wire `preferDemoAudio` through `openToy` → `loadToy` so demo playback can be triggered from the library (`assets/js/library-view.js`, `assets/js/loader.ts`).
- Add a `Browse compatible toys` action to WebGPU capability warnings and implement a route back to the library that pre-applies a `feature:compatible` filter and persists a short-lived compatibility preference in session storage under `stims-compatibility-mode` (`assets/js/toy-view.ts`, `assets/js/loader.ts`, `assets/js/library-view.js`).
- Teach the library filter logic about the new `feature:compatible` token so it surfaces toys that either do not require WebGPU or allow WebGL fallback (`assets/js/library-view.js`).
- Add docs and index entry for the user-journey critique (`docs/USER_JOURNEY_CRITIQUE.md`, `docs/README.md`).
- Update tests to reflect the new `preferDemoAudio` parameter and the expanded capability-error actions (`tests/app-shell.test.js`, `tests/toy-view.test.js`).

### Testing
- Ran formatting and lint/type/test pipeline via `bun run format` and `bun run check` which includes `tsc` and the test suite; the suite passed after fixes (`87 pass, 2 skip, 0 fail` in the final run).
- Performed a local dev preview (`bun run dev`) and captured a visual smoke-check screenshot of the library with the new UI affordances (artifact saved during rollout).
- Updated unit tests: `tests/app-shell.test.js` and `tests/toy-view.test.js` were modified and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1a0bbd148332a49455bf958d1bcc)