### PR TITLE
Preserve demo launch path for keyboard button activation

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1910,6 +1910,11 @@ export function createLibraryView({
         event.stopPropagation();
         openToy(toy, { preferDemoAudio: true });
       });
+      playDemo.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.stopPropagation();
+        }
+      });
 
       actions.appendChild(playDemo);
       card.appendChild(actions);

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -8,6 +8,9 @@ const toyLibrary = [
     module: 'assets/js/toys/aurora-painter.ts',
     type: 'module',
     requiresWebGPU: false,
+    capabilities: {
+      demoAudio: true,
+    },
   },
   {
     slug: 'evol',
@@ -121,6 +124,24 @@ describe('app shell user journeys', () => {
     expect(mockLoadToy).toHaveBeenCalledWith('aurora-painter', {
       pushState: true,
       preferDemoAudio: false,
+    });
+  });
+
+  test('demo button keyboard activation keeps demo-audio launch path', async () => {
+    await loadAppShell();
+
+    const playDemo = document.querySelector('.webtoy-card-actions button');
+    expect(playDemo).not.toBeNull();
+
+    playDemo?.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    playDemo?.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(mockLoadToy).toHaveBeenCalledTimes(1);
+    expect(mockLoadToy).toHaveBeenCalledWith('aurora-painter', {
+      pushState: true,
+      preferDemoAudio: true,
     });
   });
 


### PR DESCRIPTION
### Motivation
- Prevent Enter/Space pressed on the new “Play demo now” control from bubbling to the card-level keyboard handler so keyboard users reliably trigger the demo-audio path.

### Description
- Stop `Enter`/`Space` keydown propagation on the demo button by adding a `keydown` listener that calls `event.stopPropagation()` in `assets/js/library-view.js`.
- Add a regression test that marks the test fixture as demo-audio capable and verifies a keyboard-activated demo button calls `loadToy` with `preferDemoAudio: true` in `tests/app-shell.test.js`.
- Minor test helper change: simulate the demo button click with `new Event('click')` for the test environment.

### Testing
- Ran `bun run test tests/app-shell.test.js`, which passed (new test included).
- Ran `bun run check` and `biome format`; `biome`/`tsc` steps succeeded locally but full `bun run check` in this environment reports unrelated failures in `tests/mobile-ripples.test.ts` and `tests/pocket-pulse.test.ts` (external to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2bfe76b88332bb049c60b60f0c49)