### PR TITLE
Tone down mobile toy nav styling

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -437,6 +437,36 @@ body {
   transform: translateY(0);
 }
 
+.toy-nav__mobile-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  margin-top: 6px;
+  padding: 6px 11px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 165, 180, 0.35);
+  background: rgba(148, 165, 180, 0.08);
+  color: rgba(233, 251, 255, 0.94);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.toy-nav__mobile-toggle[aria-expanded="true"] {
+  background: rgba(148, 165, 180, 0.14);
+  border-color: rgba(148, 165, 180, 0.48);
+}
+
+.toy-nav__mobile-toggle:focus-visible {
+  outline: 2px solid rgba(148, 165, 180, 0.6);
+  outline-offset: 2px;
+}
+
 .toy-nav__share-status,
 .toy-nav__pip-status,
 .toy-nav__next-status,
@@ -1423,10 +1453,28 @@ body {
     grid-template-columns: 1fr;
     align-items: stretch;
     gap: 8px;
-    padding: 8px;
+    padding: 10px;
+    border-radius: 16px;
+    border-color: rgba(148, 165, 180, 0.3);
+    background: rgba(6, 11, 22, 0.92);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
     max-height: min(48svh, calc(100dvh - env(safe-area-inset-top) - 10px));
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+  }
+
+  .active-toy-nav__pill {
+    padding: 4px 9px;
+    border-color: rgba(148, 165, 180, 0.35);
+    background: rgba(148, 165, 180, 0.11);
+    box-shadow: none;
+    font-size: 0.88rem;
+  }
+
+  .toy-nav__mobile-toggle {
+    display: inline-flex;
+    width: auto;
+    justify-self: start;
   }
 
   .active-toy-nav__actions {
@@ -1464,7 +1512,12 @@ body {
     width: 100%;
     min-height: 40px;
     padding: 8px 10px;
-    font-size: 0.92rem;
+    border-radius: 10px;
+    border-color: rgba(148, 165, 180, 0.35);
+    background: rgba(148, 165, 180, 0.08);
+    box-shadow: none;
+    font-size: 0.9rem;
+    font-weight: 600;
   }
 
   .toy-nav__back {
@@ -1473,6 +1526,10 @@ body {
     min-height: 40px;
     padding: 8px 10px;
     justify-content: center;
+  }
+
+  .active-toy-nav__actions[data-toy-actions-expanded="false"] {
+    display: none;
   }
 
   .control-panel--floating {

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1598,14 +1598,18 @@ body {
 
 @media (max-width: 520px) {
   .active-toy-nav__actions {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 6px;
   }
 
   .active-toy-nav {
-    top: calc(env(safe-area-inset-top) + 4px);
-    width: calc(100% - 10px);
-    padding: 6px;
+    top: max(4px, env(safe-area-inset-top));
+    width: calc(
+      100% -
+      max(8px, env(safe-area-inset-left)) -
+      max(8px, env(safe-area-inset-right))
+    );
+    padding: 8px;
     border-radius: 14px;
   }
 
@@ -1667,6 +1671,12 @@ body {
     flex: 1 1 auto;
     padding: 6px 10px;
     font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .active-toy-nav__actions {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1458,7 +1458,7 @@ body {
     border-color: rgba(148, 165, 180, 0.3);
     background: rgba(6, 11, 22, 0.92);
     box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
-    max-height: min(48svh, calc(100dvh - env(safe-area-inset-top) - 10px));
+    max-height: min(44svh, calc(100dvh - env(safe-area-inset-top) - 10px));
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }
@@ -1534,16 +1534,28 @@ body {
 
   .control-panel--floating {
     top: max(
-      var(--toy-nav-floating-offset, 102px),
-      calc(env(safe-area-inset-top) + 88px)
+      var(--toy-nav-floating-offset, 108px),
+      calc(env(safe-area-inset-top) + 92px)
     );
     max-height: min(
-      44svh,
+      38svh,
       calc(
         100dvh -
-        var(--toy-nav-floating-offset, 102px) -
+        var(--toy-nav-floating-offset, 108px) -
         env(safe-area-inset-bottom) -
         12px
+      )
+    );
+  }
+
+  :root[data-toy-controls-expanded="true"] .control-panel--floating {
+    max-height: min(
+      30svh,
+      calc(
+        100dvh -
+        var(--toy-nav-floating-offset, 108px) -
+        env(safe-area-inset-bottom) -
+        16px
       )
     );
   }
@@ -1635,16 +1647,28 @@ body {
 
   .control-panel--floating {
     top: max(
-      var(--toy-nav-floating-offset, 102px),
-      calc(env(safe-area-inset-top) + 76px)
+      var(--toy-nav-floating-offset, 108px),
+      calc(env(safe-area-inset-top) + 78px)
     );
     max-height: min(
-      40svh,
+      34svh,
       calc(
         100dvh -
-        var(--toy-nav-floating-offset, 102px) -
+        var(--toy-nav-floating-offset, 108px) -
         env(safe-area-inset-bottom) -
         10px
+      )
+    );
+  }
+
+  :root[data-toy-controls-expanded="true"] .control-panel--floating {
+    max-height: min(
+      26svh,
+      calc(
+        100dvh -
+        var(--toy-nav-floating-offset, 108px) -
+        env(safe-area-inset-bottom) -
+        14px
       )
     );
   }

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -73,6 +73,9 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
   container.ownerDocument.documentElement.style.removeProperty(
     '--toy-nav-floating-offset',
   );
+  container.ownerDocument.documentElement.removeAttribute(
+    'data-toy-controls-expanded',
+  );
 
   container.innerHTML = `
     <nav class="top-nav" data-top-nav aria-label="Primary" data-nav-expanded="true">
@@ -271,6 +274,10 @@ function renderToyNav(
       'data-toy-actions-expanded',
       expanded ? 'true' : 'false',
     );
+    doc.documentElement.setAttribute(
+      'data-toy-controls-expanded',
+      expanded ? 'true' : 'false',
+    );
     actionsToggleBtn?.setAttribute(
       'aria-expanded',
       expanded ? 'true' : 'false',
@@ -431,7 +438,7 @@ function setupToyNavFloatingOffset(container: ToyNavContainer, doc: Document) {
   const root = doc.documentElement;
   const updateOffset = () => {
     const navBottom = Math.ceil(container.getBoundingClientRect().bottom);
-    root.style.setProperty('--toy-nav-floating-offset', `${navBottom + 10}px`);
+    root.style.setProperty('--toy-nav-floating-offset', `${navBottom + 14}px`);
   };
 
   updateOffset();

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -191,12 +191,13 @@ function renderToyNav(
         type="button"
         class="toy-nav__mobile-toggle"
         data-toy-actions-toggle="true"
+        aria-controls="toy-nav-actions"
         aria-expanded="false"
       >
         Controls
       </button>
     </div>
-    <div class="active-toy-nav__actions" data-toy-actions-expanded="true">
+    <div class="active-toy-nav__actions" id="toy-nav-actions" data-toy-actions-expanded="true">
       <div class="renderer-status-container"></div>
       ${
         options.onNextToy
@@ -460,6 +461,7 @@ function setupToyNavFloatingOffset(container: ToyNavContainer, doc: Document) {
 
   win?.addEventListener('resize', updateOffset);
   win?.visualViewport?.addEventListener('resize', updateOffset);
+  win?.visualViewport?.addEventListener('scroll', updateOffset);
 
   container.__toyNavOffsetCleanup = () => {
     if (typeof rafHandle === 'number') {
@@ -472,6 +474,7 @@ function setupToyNavFloatingOffset(container: ToyNavContainer, doc: Document) {
     mutationObserver?.disconnect();
     win?.removeEventListener('resize', updateOffset);
     win?.visualViewport?.removeEventListener('resize', updateOffset);
+    win?.visualViewport?.removeEventListener('scroll', updateOffset);
   };
 }
 

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -187,8 +187,16 @@ function renderToyNav(
       <p class="active-toy-nav__title">${safeTitle}</p>
       <p class="active-toy-nav__hint">${hintText}</p>
       ${safeSlug ? `<span class="active-toy-nav__pill">${safeSlug}</span>` : ''}
+      <button
+        type="button"
+        class="toy-nav__mobile-toggle"
+        data-toy-actions-toggle="true"
+        aria-expanded="false"
+      >
+        Controls
+      </button>
     </div>
-    <div class="active-toy-nav__actions">
+    <div class="active-toy-nav__actions" data-toy-actions-expanded="true">
       <div class="renderer-status-container"></div>
       ${
         options.onNextToy
@@ -245,6 +253,49 @@ function renderToyNav(
 
   const backBtn = container.querySelector('.toy-nav__back');
   backBtn?.addEventListener('click', () => options.onBack?.());
+
+  const actionsContainer = container.querySelector(
+    '.active-toy-nav__actions',
+  ) as HTMLElement | null;
+  const actionsToggleBtn = container.querySelector(
+    '[data-toy-actions-toggle="true"]',
+  ) as HTMLButtonElement | null;
+  const mobileActionsMediaQuery = getMediaQueryList(
+    maxWidthQuery(BREAKPOINTS.md),
+  );
+  let actionsExpanded = !isBelowBreakpoint(BREAKPOINTS.md);
+
+  const applyActionsState = (expanded: boolean) => {
+    actionsContainer?.setAttribute(
+      'data-toy-actions-expanded',
+      expanded ? 'true' : 'false',
+    );
+    actionsToggleBtn?.setAttribute(
+      'aria-expanded',
+      expanded ? 'true' : 'false',
+    );
+    if (actionsToggleBtn) {
+      actionsToggleBtn.textContent = expanded ? 'Hide controls' : 'Controls';
+    }
+  };
+
+  const syncActionsForViewport = () => {
+    actionsExpanded = !isBelowBreakpoint(BREAKPOINTS.md);
+    applyActionsState(actionsExpanded);
+  };
+
+  syncActionsForViewport();
+
+  actionsToggleBtn?.addEventListener('click', () => {
+    actionsExpanded = !actionsExpanded;
+    applyActionsState(actionsExpanded);
+  });
+
+  if (mobileActionsMediaQuery) {
+    mobileActionsMediaQuery.addEventListener('change', syncActionsForViewport);
+  } else {
+    window.addEventListener('resize', syncActionsForViewport);
+  }
 
   const shareBtn = container.querySelector('.toy-nav__share');
   const shareStatus = container.querySelector(


### PR DESCRIPTION
### Motivation
- Reduce the visual intensity of the mobile toy navigation so it feels cleaner and less "tacky" on small screens while preserving the compact, on-demand controls UX and accessibility state.
- Use a simpler label for the collapsed mobile toggle and keep responsive behavior so controls remain expanded on larger viewports.

### Description
- Simplified the mobile toggle visuals in `assets/css/base.css` by removing heavy gradients/glows, adding subtler surface and border styles, and introducing modest focus/transition treatments for a cleaner look.
- Toned down the active mobile nav container and action controls in `assets/css/base.css` by adjusting spacing, border-radius, background, box-shadow, pill and button treatments, and by keeping action-button styles neutral and compact.
- Updated `assets/js/ui/nav.ts` to use the cleaner collapsed label (`Controls`) and ensure the toggle continues to set `aria-expanded` and `data-toy-actions-expanded`, with viewport-sync logic preserved for responsive collapse/expand behavior.

### Testing
- Ran `bun run format` and formatting completed successfully.
- Ran `bun run check` (Biome checks + `tsc` + tests) and the test suite passed: 87 passed, 2 skipped, 0 failed.
- Ran `bun run dev:host` for manual visual verification on mobile and executed a Playwright script to capture mobile screenshots confirming the updated collapsed and expanded states.

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3d61dc388332aebb717df99d01cd)