### PR TITLE
Use punchier copy on library landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           <p class="eyebrow">Audio-reactive visuals • Instant play</p>
           <h1>Stim library</h1>
           <p class="section-description">
-            Choose a starting point, then refine in the library.
+            Pick a stim, crank it up, and let the library keep the momentum.
           </p>
           <ul class="intro-pills" aria-label="Quick highlights">
             <li class="intro-pill">✨ Featured: Halo Flow</li>
@@ -187,13 +187,13 @@
           <p class="eyebrow">Library</p>
           <h2>Browse all stims</h2>
           <p class="section-description">
-            Tap a card to launch.
+            Hit a card and jump straight in.
           </p>
         </div>
         <search class="library-search">
           <div class="search-heading">
             <h3>Find a stim</h3>
-            <p>Search by name, mood, tags, and capabilities.</p>
+            <p>Search by name, mood, tags, or capability and move fast.</p>
           </div>
           <div class="search-row">
             <label class="sr-only" for="toy-search">Search the library</label>


### PR DESCRIPTION
### Motivation
- Make the library/homepage copy more direct and energetic so the site reads less restrained and less polite while preserving existing layout and accessibility attributes.

### Description
- Updated three marketing strings in `index.html`: the intro section description, the “Browse all stims” description, and the search helper copy to use more assertive, action-oriented phrasing.

### Testing
- Ran `bun run check:quick` (Biome checks + TypeScript) which completed with no errors.
- Served the site and captured a Playwright screenshot for visual verification via `python3 -m http.server 4173` and an automated Playwright script, which succeeded; docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5b2ece28833286a570f5d4a39d00)