### PR TITLE
Improve mobile UX: quick back, collapsed suggestions, and landscape compaction

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -467,6 +467,41 @@ body {
   outline-offset: 2px;
 }
 
+.active-toy-nav__mobile-actions {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.toy-nav__back-quick {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  margin-top: 6px;
+  padding: 6px 11px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 165, 180, 0.35);
+  background: rgba(148, 165, 180, 0.08);
+  color: rgba(233, 251, 255, 0.94);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.toy-nav__back-quick:focus-visible {
+  outline: 2px solid rgba(148, 165, 180, 0.6);
+  outline-offset: 2px;
+}
+
+.toy-nav__back-quick span[aria-hidden="true"] {
+  filter: drop-shadow(0 0 5px rgba(148, 165, 180, 0.5));
+}
+
 .toy-nav__share-status,
 .toy-nav__pip-status,
 .toy-nav__next-status,
@@ -1497,10 +1532,16 @@ body {
     font-size: 0.88rem;
   }
 
-  .toy-nav__mobile-toggle {
+  .active-toy-nav__mobile-actions {
+    display: flex;
+  }
+
+  .toy-nav__mobile-toggle,
+  .toy-nav__back-quick {
     display: inline-flex;
+    flex: 1 1 0;
     width: auto;
-    justify-self: start;
+    justify-content: center;
   }
 
   .active-toy-nav__actions {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2345,6 +2345,47 @@ html.light .active-filters__label {
   color: var(--text-muted);
 }
 
+.empty-state__suggestions {
+  width: 100%;
+  max-width: 420px;
+  text-align: left;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--surface-border);
+  background: color-mix(in srgb, var(--surface-strong) 78%, transparent);
+  padding: 0.35rem 0.55rem 0.6rem;
+}
+
+.empty-state__suggestions summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-color);
+  list-style: none;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.empty-state__suggestions summary::-webkit-details-marker {
+  display: none;
+}
+
+.empty-state__suggestions summary::after {
+  content: "▾";
+  margin-left: auto;
+  color: var(--text-muted);
+  transition: transform 180ms ease;
+}
+
+.empty-state__suggestions[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.empty-state__suggestions .webtoy-card-actions {
+  margin-top: 0.35rem;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
 .webtoy-card {
   background:
     var(--surface-highlight), var(--surface-texture), var(--surface-gradient);
@@ -3035,6 +3076,36 @@ footer {
 
   .preview-card {
     padding: 1rem;
+  }
+}
+
+@media (max-width: 920px) and (max-height: 520px) and (orientation: landscape) {
+  .content {
+    gap: 1rem;
+  }
+
+  .top-nav {
+    padding: 0.4rem 0.55rem;
+  }
+
+  .hero {
+    padding-block: 0.8rem 0.6rem;
+  }
+
+  .hero-grid {
+    gap: 0.75rem;
+  }
+
+  .hero-copy {
+    gap: 0.6rem;
+  }
+
+  .hero-cta-row {
+    gap: 0.5rem;
+  }
+
+  header.hero {
+    min-height: auto;
   }
 }
 

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -2050,9 +2050,28 @@ export function createLibraryView({
         quickActions.appendChild(button);
       });
 
+      const collapseSuggestions =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(max-width: 600px)').matches;
+
       emptyState.appendChild(message);
       emptyState.appendChild(resetButton);
-      emptyState.appendChild(quickActions);
+
+      if (collapseSuggestions) {
+        const suggestionsDisclosure = document.createElement('details');
+        suggestionsDisclosure.className = 'empty-state__suggestions';
+
+        const summary = document.createElement('summary');
+        summary.textContent = 'Try suggestions';
+
+        suggestionsDisclosure.appendChild(summary);
+        suggestionsDisclosure.appendChild(quickActions);
+        emptyState.appendChild(suggestionsDisclosure);
+      } else {
+        emptyState.appendChild(quickActions);
+      }
+
       list.appendChild(emptyState);
       updateResultsMeta(0);
       updateActiveFiltersSummary();

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -190,15 +190,24 @@ function renderToyNav(
       <p class="active-toy-nav__title">${safeTitle}</p>
       <p class="active-toy-nav__hint">${hintText}</p>
       ${safeSlug ? `<span class="active-toy-nav__pill">${safeSlug}</span>` : ''}
-      <button
-        type="button"
-        class="toy-nav__mobile-toggle"
-        data-toy-actions-toggle="true"
-        aria-controls="toy-nav-actions"
-        aria-expanded="false"
-      >
-        Controls
-      </button>
+      <div class="active-toy-nav__mobile-actions">
+        <button
+          type="button"
+          class="toy-nav__back-quick"
+          data-back-to-library-quick="true"
+        >
+          <span aria-hidden="true">←</span><span>Back</span>
+        </button>
+        <button
+          type="button"
+          class="toy-nav__mobile-toggle"
+          data-toy-actions-toggle="true"
+          aria-controls="toy-nav-actions"
+          aria-expanded="false"
+        >
+          Controls
+        </button>
+      </div>
     </div>
     <div class="active-toy-nav__actions" id="toy-nav-actions" data-toy-actions-expanded="true">
       <div class="renderer-status-container"></div>
@@ -257,6 +266,9 @@ function renderToyNav(
 
   const backBtn = container.querySelector('.toy-nav__back');
   backBtn?.addEventListener('click', () => options.onBack?.());
+
+  const quickBackBtn = container.querySelector('.toy-nav__back-quick');
+  quickBackBtn?.addEventListener('click', () => options.onBack?.());
 
   const actionsContainer = container.querySelector(
     '.active-toy-nav__actions',

--- a/docs/USABILITY_AUDIT.md
+++ b/docs/USABILITY_AUDIT.md
@@ -26,3 +26,29 @@
    People who want to try a toy without granting mic access cannot choose demo audio from the initial control panel because the fallback button starts hidden and only appears when error handling toggles it. That delays exploration and may cause abandonment at the permission prompt.  
    **Recommendation:** present both "Use microphone" and "Use demo audio" as parallel primary buttons by default, with concise copy about what each does.  
    **Evidence:** the fallback button is rendered but hidden by default in the toy entry UI, leaving only the mic-based CTA visible on first load.【F:toy.html†L11-L27】
+
+## Mobile journey walkthrough (iPhone 13 viewport)
+
+### Journey 1: “I just want to try something fast” (Library → Play demo now)
+
+- **Path tested:** open library on mobile, tap `Play demo now` from the first visible card.
+- **Observed behavior:** this flow is quick and low-friction; the card-level action opens the toy flow directly via `openToy(toy, { preferDemoAudio: true })`, which keeps momentum high for first-time users on phones.
+- **Constructive critique:** in practice, users enter an in-page toy state with no obvious close affordance at the top of the viewport. This can feel modal-like, but without a clearly signposted “exit” in the same visual zone as the start controls.
+- **Recommendation:** add a persistent top-row “Back to library”/“Close toy” action inside the initial mobile viewport whenever `?toy=` is active, so users do not need to hunt for escape routes.
+- **Evidence:** card-level `Play demo now` action wiring and toy-opening behavior in the library renderer.【F:assets/js/library-view.js†L1947-L1957】【F:assets/js/library-view.js†L1739-L1748】
+
+### Journey 2: “I’m filtering to find the right stim for this moment” (Search → No matches → recover)
+
+- **Path tested:** enter a no-match mobile query, review empty state, attempt to recover to a full list.
+- **Observed behavior:** empty-state messaging is explicit and supportive, and it includes one-tap recovery plus suggested follow-up searches.
+- **Constructive critique:** there are now multiple recovery choices (`Reset search and filters` plus suggested query chips). On small screens, this can add decision overhead when users are already in an error-recovery mindset.
+- **Recommendation:** keep the primary reset action visually dominant and demote suggestion chips behind a “Try suggestions” disclosure on narrow viewports.
+- **Evidence:** empty-state copy, reset CTA, and suggested query buttons are rendered together in the fallback state.【F:assets/js/library-view.js†L2010-L2050】
+
+### Journey 3: “I’m browsing in one hand and rotating my phone” (Portrait → landscape continuity)
+
+- **Path tested:** load library in portrait, rotate to landscape, continue scanning controls/content.
+- **Observed behavior:** controls remain functional, but the header/hero region can consume a large share of vertical space in landscape. This pushes card content and actionable controls below the fold, increasing scroll before interaction.
+- **Constructive critique:** this is not a blocker, but it weakens “quick pick” ergonomics in short-height mobile contexts.
+- **Recommendation:** apply a landscape+short-height compaction mode (reduced hero spacing, condensed nav blocks, and earlier exposure of library controls/cards) for better first-action visibility.
+- **Evidence:** current mobile breakpoints optimize max-width, but there is no dedicated landscape/short-height compaction rule in the existing responsive blocks shown here.【F:assets/css/index.css†L3041-L3116】


### PR DESCRIPTION
### Motivation
- Add a clear, persistent exit affordance when a toy is opened from mobile so users can return to the library quickly without opening the full controls panel.
- Reduce decision overhead in the library empty-state on small screens by demoting suggestion chips while keeping the reset action primary.
- Improve first-action visibility on short-height mobile landscape viewports by compacting hero/nav spacing.

### Description
- Add a compact mobile action row with a persistent quick `Back` button wired to the existing back handler in `assets/js/ui/nav.ts` and register its click handler to reuse the current `onBack` flow.  (files changed: `assets/js/ui/nav.ts`, `assets/css/base.css`).
- Collapse empty-state suggestion chips behind a `details/summary` pattern on narrow viewports by changing the empty-state render logic in `assets/js/library-view.js` and adding supporting styles in `assets/css/index.css` so `Reset search and filters` remains the primary visible recovery action.
- Add a short-height landscape compaction media query to `assets/css/index.css` to reduce header/hero footprint and expose actionable content sooner on mobile landscape orientations.

### Testing
- Ran the project quality gate with `bun run check`, which performs formatting/linting, type checking, and tests, and it completed successfully. The test run reported `92 pass, 2 skip, 0 fail`.
- Executed the automated Playwright script against the local dev server to capture mobile screenshots of the empty-state disclosure and the mobile toy nav, and the script completed successfully and produced artifacts.  Commands used: `bun run dev:host --port 4173` and the Playwright script run shown in CI logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba7d5f3908332b7b81746b5b77b7a)