### PR TITLE
Tighten release preflight toy checks and docs coverage

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,6 +45,36 @@ Use the same scripts defined in `package.json` to validate the production output
 
 Both commands expect a fresh `bun run build` and read from `dist/`.
 
+## Prime-time preflight checks
+
+Run this sequence before shipping to production so the release candidate is validated the same way CI and reviewers expect:
+
+1. Run the full quality gate:
+
+   ```bash
+   bun run check
+   ```
+
+2. Confirm toy metadata and file registrations stay in sync:
+
+   ```bash
+   bun run check:toys
+   ```
+
+3. Build production assets:
+
+   ```bash
+   bun run build
+   ```
+
+4. Sanity-check the generated bundle locally:
+
+   ```bash
+   bun run preview
+   ```
+
+If any step fails, fix the issue and restart from step 1 so downstream checks reflect the final state.
+
 ## Static Hosting Expectations
 
 Any static host should point its document root to the `dist/` directory and preserve the following:

--- a/docs/TOY_SCRIPT_INDEX.md
+++ b/docs/TOY_SCRIPT_INDEX.md
@@ -29,6 +29,9 @@ This index maps each toy slug to the module that powers it and how the experienc
 | `fractal-kite-garden`      | `assets/js/toys/fractal-kite-garden.ts`      | Direct module; load with `toy.html?toy=fractal-kite-garden`.      |
 | `tactile-sand-table`       | `assets/js/toys/tactile-sand-table.ts`       | Direct module; load with `toy.html?toy=tactile-sand-table`.       |
 | `bioluminescent-tidepools` | `assets/js/toys/bioluminescent-tidepools.ts` | Direct module; load with `toy.html?toy=bioluminescent-tidepools`. |
+| `mobile-ripples`          | `assets/js/toys/mobile-ripples.ts`          | Direct module; load with `toy.html?toy=mobile-ripples`.          |
+| `neon-wave`               | `assets/js/toys/neon-wave.ts`               | Direct module; load with `toy.html?toy=neon-wave`.               |
+| `milkdrop`                | `assets/js/toys/milkdrop-toy.ts`            | Direct module; load with `toy.html?toy=milkdrop`.                |
 
 ## Standalone HTML entry points
 

--- a/scripts/check-toys.ts
+++ b/scripts/check-toys.ts
@@ -10,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
-const IGNORED_TOY_FILES = new Set(['page-toy.ts']);
+const IGNORED_TOY_FILES = new Set(['clay-toy.ts', 'page-toy.ts']);
 
 async function main() {
   const { issues, warnings } = await runToyChecks();


### PR DESCRIPTION
### Motivation
- Make the release workflow explicit so reviewers and CI validate the same preflight sequence before shipping.
- Fix a failing `check:toys` run caused by a standalone page bootstrap helper being flagged as an unregistered toy module.
- Close documentation gaps that caused spurious warnings from the toy consistency checks.

### Description
- Added a `Prime-time preflight checks` section to `docs/DEPLOYMENT.md` with the sequence `bun run check`, `bun run check:toys`, `bun run build`, and `bun run preview`.
- Updated `docs/TOY_SCRIPT_INDEX.md` to include `mobile-ripples`, `neon-wave`, and `milkdrop` entries so the index matches `assets/data/toys.json`.
- Modified `scripts/check-toys.ts` to ignore `assets/js/toys/clay-toy.ts` by adding it to the `IGNORED_TOY_FILES` set because it is a standalone page bootstrap helper, not a manifest-registered module.

### Testing
- Ran `bun run check` and the full quality gate completed successfully.
- Ran `bun run check:toys` and the toy consistency checks passed after the script and docs updates.
- Ran `bun run build` and the production build completed successfully.

Files touched: `docs/DEPLOYMENT.md`, `docs/TOY_SCRIPT_INDEX.md`, `scripts/check-toys.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698baff0fb988332b5160977f536a2ae)