### PR TITLE
Pin Bun version in CI and update WebGPU test stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,7 +47,6 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
-  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,


### PR DESCRIPTION
### Motivation
- Stabilize CI by pinning the Bun toolchain to the repository-managed version to avoid toolchain drift between runs.
- Fix a TypeScript/WebGPU mismatch surfaced during `tsc --noEmit` by aligning the WebGPU test stub with current typings.

### Description
- Change CI workflow to read the Bun version from the repository file by using `bun-version-file: .bun-version` in `.github/workflows/ci.yml`.
- Add `.bun-version` with `1.3.8` to lock the Bun toolchain used in CI.
- Remove the unsupported `TRANSIENT_ATTACHMENT` property from the `GPUTextureUsage` stub in `tests/setup.ts` so the test environment matches current WebGPU typings.

### Testing
- Run `bun run check` which executes Biome lint/format checks, TypeScript typecheck, and the test suite, and completed successfully.
- Test summary: `94` tests run across `26` files with `92` pass, `2` skip, and `0` fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd609ecc08332b5c79de263fe816e)