### PR TITLE
Remove binary OG artifacts and switch SEO generator to SVG-only with validator

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,6 +49,7 @@ bun install --frozen-lockfile
 | Quick quality gate | `bun run check:quick` |
 | Toy consistency check | `bun run check:toys` |
 | Generate SEO artifacts | `bun run generate:seo` |
+| Validate generated SEO artifacts | `bun run check:seo` |
 | Serve `dist/` | `bun run serve:dist` |
 | Cloudflare Pages local | `bun run pages:dev` |
 | Cloudflare Pages deploy | `bun run pages:deploy` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This directory is organized by **audience + workflow** so contributors and agent
 
 - [`FEATURE_SPECIFICATIONS.md`](./FEATURE_SPECIFICATIONS.md)
 - [`FEATURE_AUDIT.md`](./FEATURE_AUDIT.md)
+- [`SEO_AUDIT.md`](./SEO_AUDIT.md)
 - [`stim-assessment.md`](./stim-assessment.md)
 - [`stim-user-critiques.md`](./stim-user-critiques.md)
 - [`USER_JOURNEY_CRITIQUE.md`](./USER_JOURNEY_CRITIQUE.md)

--- a/docs/SEO_AUDIT.md
+++ b/docs/SEO_AUDIT.md
@@ -1,0 +1,96 @@
+# SEO Audit (2026-02-11)
+
+## Scope
+
+This audit reviews the current static SEO surface for the Stim Webtoys Library:
+
+- Core homepage metadata (`index.html`)
+- Programmatically generated landing pages (`public/toys`, `public/tags`, `public/moods`, `public/capabilities`)
+- Discovery assets (`public/robots.txt`, `public/sitemap.xml`, `public/sitemap-1.xml`)
+- SEO generation workflow (`scripts/generate-seo.ts`)
+
+## Executive summary
+
+The project has a **strong SEO baseline** for a static creative site:
+
+- Canonical URLs and social metadata are present on the homepage and generated hub/detail pages.
+- JSON-LD is implemented for `WebSite`, `CollectionPage`, `ItemList`, `FAQPage`, and breadcrumbs.
+- Crawl directives and sitemap discovery are configured via `robots.txt` + sitemap index/chunk files.
+- The SEO page surface is generated from toy metadata, which improves consistency and scale.
+
+Primary opportunities are around **social preview robustness**, **richer crawl hints**, and **ongoing audit automation**.
+
+## Strengths observed
+
+1. **Homepage metadata completeness**
+   - Includes canonical, Open Graph, Twitter, description, robots, and structured data graph.
+2. **Programmatic SEO coverage**
+   - Dedicated index pages exist for toys, tags, moods, and capabilities.
+   - Toy detail pages include FAQs and breadcrumbs in both UI and JSON-LD.
+3. **Crawlability**
+   - `robots.txt` allows crawling and links the sitemap index.
+   - Sitemap index references chunked sitemap files for scale.
+4. **Deterministic SEO generation pipeline**
+   - `bun run generate:seo` can regenerate OG images/pages/sitemaps from metadata.
+
+## Risks and recommendations
+
+### 1) Use PNG/JPG Open Graph images in addition to SVG
+
+- **Why:** Some social/link unfurlers inconsistently render SVG OG assets.
+- **Current state:** Generated SEO pages frequently point `og:image` to `.svg` assets under `/og/`.
+- **Recommendation:** Generate PNG derivatives for each OG card and set:
+  - `og:image` to PNG,
+  - `og:image:type` to `image/png`,
+  - dimensions (`og:image:width`, `og:image:height`) across generated pages.
+- **Priority:** High (share-preview reliability)
+
+### 2) Add `lastmod` to each URL entry in sitemap chunks
+
+- **Why:** Per-URL freshness signals can help crawlers prioritize recrawls.
+- **Current state:** Sitemap index has `lastmod`; chunk entries should also carry `lastmod` where possible.
+- **Recommendation:** Extend `scripts/generate-seo.ts` to emit per-URL `lastmod` values in `sitemap-*.xml`.
+- **Priority:** Medium
+
+### 3) Validate canonical consistency between `/` and `/index.html`
+
+- **Why:** Duplicate home URLs can split equity if canonical behavior diverges across hosts/CDNs.
+- **Current state:** Canonical points to `/`; generated pages mostly link to directory-style canonicals.
+- **Recommendation:** Keep strict redirects from `/index.html` → `/` at edge/server level and periodically verify in production.
+- **Priority:** Medium
+
+### 4) Add a repeatable SEO audit script/check
+
+- **Why:** Prevents regressions as metadata/page templates evolve.
+- **Current state:** SEO generation exists; automated SEO validation is not yet explicit.
+- **Recommendation:** Add a lightweight `seo:check` script to verify:
+  - required meta tags,
+  - canonical presence,
+  - structured-data JSON parseability,
+  - sitemap URL validity,
+  - robots sitemap pointer.
+- **Priority:** Medium
+
+### 5) Optional: Add image sitemap support for OG assets
+
+- **Why:** Can improve image discoverability for rich cards/asset surfaces.
+- **Current state:** Standard sitemap coverage exists.
+- **Recommendation:** Evaluate image sitemap only if image search/referral becomes a KPI.
+- **Priority:** Low
+
+## Suggested implementation plan
+
+1. Update SEO generator to produce PNG OG assets and enriched OG meta fields.
+2. Add per-URL `lastmod` in sitemap chunks.
+3. Add `seo:check` script and include it in CI or scheduled checks.
+4. Run a production crawl sample (e.g., homepage + 3 toy pages + 3 taxonomy pages) after deploy.
+
+## Validation commands run for this audit
+
+- `bun run generate:seo`
+- `sed -n '1,120p' index.html`
+- `sed -n '1,220p' public/toys/index.html`
+- `sed -n '1,220p' public/toys/cube-wave/index.html`
+- `cat public/robots.txt`
+- `sed -n '1,220p' public/sitemap.xml`
+- `sed -n '1,260p' scripts/generate-seo.ts`

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -50,6 +50,12 @@ bun run check:quick
   bun run check:toys
   ```
 
+- Generated SEO artifacts validation:
+
+  ```bash
+  bun run check:seo
+  ```
+
 - Targeted test execution:
 
   ```bash

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "health:toys": "bun run scripts/toy-health-check.ts",
     "test:agent": "bun test tests/agent-integration.test.ts",
     "prepare": "husky install",
-    "postinstall": "bun scripts/postinstall.mjs || node scripts/postinstall.mjs"
+    "postinstall": "bun scripts/postinstall.mjs || node scripts/postinstall.mjs",
+    "check:seo": "bun run scripts/check-seo.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",

--- a/public/capabilities/demo-audio/index.html
+++ b/public/capabilities/demo-audio/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/demo-audio/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/capabilities/index.html
+++ b/public/capabilities/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/capabilities/microphone/index.html
+++ b/public/capabilities/microphone/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/microphone/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/capabilities/motion/index.html
+++ b/public/capabilities/motion/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/motion/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/capabilities/webgpu/index.html
+++ b/public/capabilities/webgpu/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/webgpu/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/calming/index.html
+++ b/public/moods/calming/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/calming/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/celestial/index.html
+++ b/public/moods/celestial/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/celestial/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/cosmic/index.html
+++ b/public/moods/cosmic/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/cosmic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/dreamy/index.html
+++ b/public/moods/dreamy/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/dreamy/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/drifting/index.html
+++ b/public/moods/drifting/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/drifting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/energetic/index.html
+++ b/public/moods/energetic/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/energetic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/ethereal/index.html
+++ b/public/moods/ethereal/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/ethereal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/fiery/index.html
+++ b/public/moods/fiery/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/fiery/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/focus/index.html
+++ b/public/moods/focus/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/focus/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/glow/index.html
+++ b/public/moods/glow/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/glow/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/grounded/index.html
+++ b/public/moods/grounded/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/grounded/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/immersive/index.html
+++ b/public/moods/immersive/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/immersive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/index.html
+++ b/public/moods/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/luminous/index.html
+++ b/public/moods/luminous/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/luminous/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/minimal/index.html
+++ b/public/moods/minimal/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/minimal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/playful/index.html
+++ b/public/moods/playful/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/playful/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/psychedelic/index.html
+++ b/public/moods/psychedelic/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/psychedelic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/pulsing/index.html
+++ b/public/moods/pulsing/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/pulsing/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/serene/index.html
+++ b/public/moods/serene/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/serene/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/tactile/index.html
+++ b/public/moods/tactile/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/tactile/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/moods/uplifting/index.html
+++ b/public/moods/uplifting/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/uplifting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/sitemap-1.xml
+++ b/public/sitemap-1.xml
@@ -2,679 +2,679 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://no.toil.fyi/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/index.html</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/3dtoy/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/aurora-painter/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/clay/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/evol/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/geom/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/holy/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/multi/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/seary/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/legible/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/symph/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cube-wave/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bubble-harmonics/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/pocket-pulse/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/mobile-ripples/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cosmic-particles/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/lights/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/spiral-burst/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/rainbow-tunnel/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/star-field/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/fractal-kite-garden/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/tactile-sand-table/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bioluminescent-tidepools/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/neon-wave/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/milkdrop/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/3d/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ambient/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/audio-mapped/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/aurora/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bioluminescent/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bloom/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bubbles/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/burst/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/calming/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/caustics/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/cyberpunk/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/evolutionary/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/feedback/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/fractal/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/generative/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/geometry/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/gestural/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/glitch/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/grid/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/halos/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/haptics/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/harmonics/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/hybrid/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/immersive/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/kite/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/legacy/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/lights/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/microphone/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mobile/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mode-switch/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/motion/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/nebula/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ocean/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/palette/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/particles/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/patterns/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pottery/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pulses/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/rainbow/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/reactive/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/retro/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ribbons/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ripples/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sand/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sculpting/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/shader/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spectrograph/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spirals/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/stars/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/swirl/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synesthetic/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synthwave/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/text/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tilt/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/touch/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tunnel/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/visualizer/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/warp/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/waves/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/calming/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/celestial/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/cosmic/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/dreamy/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/drifting/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/energetic/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/ethereal/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/fiery/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/focus/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/glow/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/grounded/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/immersive/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/luminous/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/minimal/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/playful/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/psychedelic/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/pulsing/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/serene/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/tactile/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/uplifting/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/microphone/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/demo-audio/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/motion/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/webgpu/</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://no.toil.fyi/sitemap-1.xml</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-02-11</lastmod>
   </sitemap>
 </sitemapindex>

--- a/public/tags/3d/index.html
+++ b/public/tags/3d/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/3d/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/ambient/index.html
+++ b/public/tags/ambient/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ambient/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/audio-mapped/index.html
+++ b/public/tags/audio-mapped/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/audio-mapped/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/aurora/index.html
+++ b/public/tags/aurora/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/aurora/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/bioluminescent/index.html
+++ b/public/tags/bioluminescent/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bioluminescent/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/bloom/index.html
+++ b/public/tags/bloom/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bloom/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/bubbles/index.html
+++ b/public/tags/bubbles/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bubbles/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/burst/index.html
+++ b/public/tags/burst/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/burst/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/calming/index.html
+++ b/public/tags/calming/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/calming/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/caustics/index.html
+++ b/public/tags/caustics/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/caustics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/cyberpunk/index.html
+++ b/public/tags/cyberpunk/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/cyberpunk/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/evolutionary/index.html
+++ b/public/tags/evolutionary/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/evolutionary/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/feedback/index.html
+++ b/public/tags/feedback/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/feedback/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/fractal/index.html
+++ b/public/tags/fractal/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/fractal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/generative/index.html
+++ b/public/tags/generative/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/generative/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/geometry/index.html
+++ b/public/tags/geometry/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/geometry/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/gestural/index.html
+++ b/public/tags/gestural/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/gestural/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/glitch/index.html
+++ b/public/tags/glitch/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/glitch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/grid/index.html
+++ b/public/tags/grid/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/grid/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/halos/index.html
+++ b/public/tags/halos/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/halos/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/haptics/index.html
+++ b/public/tags/haptics/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/haptics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/harmonics/index.html
+++ b/public/tags/harmonics/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/harmonics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/hybrid/index.html
+++ b/public/tags/hybrid/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/hybrid/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/immersive/index.html
+++ b/public/tags/immersive/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/immersive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/kite/index.html
+++ b/public/tags/kite/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/kite/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/legacy/index.html
+++ b/public/tags/legacy/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/legacy/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/lights/index.html
+++ b/public/tags/lights/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/lights/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/microphone/index.html
+++ b/public/tags/microphone/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/microphone/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/mobile/index.html
+++ b/public/tags/mobile/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mobile/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/mode-switch/index.html
+++ b/public/tags/mode-switch/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mode-switch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/motion/index.html
+++ b/public/tags/motion/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/motion/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/nebula/index.html
+++ b/public/tags/nebula/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/nebula/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/ocean/index.html
+++ b/public/tags/ocean/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ocean/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/palette/index.html
+++ b/public/tags/palette/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/palette/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/particles/index.html
+++ b/public/tags/particles/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/particles/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/patterns/index.html
+++ b/public/tags/patterns/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/patterns/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/pottery/index.html
+++ b/public/tags/pottery/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pottery/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/pulses/index.html
+++ b/public/tags/pulses/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pulses/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/rainbow/index.html
+++ b/public/tags/rainbow/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/rainbow/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/reactive/index.html
+++ b/public/tags/reactive/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/reactive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/retro/index.html
+++ b/public/tags/retro/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/retro/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/ribbons/index.html
+++ b/public/tags/ribbons/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ribbons/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/ripples/index.html
+++ b/public/tags/ripples/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ripples/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/sand/index.html
+++ b/public/tags/sand/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sand/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/sculpting/index.html
+++ b/public/tags/sculpting/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sculpting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/shader/index.html
+++ b/public/tags/shader/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/shader/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/spectrograph/index.html
+++ b/public/tags/spectrograph/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spectrograph/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/spirals/index.html
+++ b/public/tags/spirals/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spirals/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/stars/index.html
+++ b/public/tags/stars/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/stars/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/swirl/index.html
+++ b/public/tags/swirl/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/swirl/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/synesthetic/index.html
+++ b/public/tags/synesthetic/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synesthetic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/synthwave/index.html
+++ b/public/tags/synthwave/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synthwave/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/text/index.html
+++ b/public/tags/text/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/text/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/tilt/index.html
+++ b/public/tags/tilt/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tilt/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/touch/index.html
+++ b/public/tags/touch/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/touch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/tunnel/index.html
+++ b/public/tags/tunnel/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tunnel/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/visualizer/index.html
+++ b/public/tags/visualizer/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/visualizer/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/warp/index.html
+++ b/public/tags/warp/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/warp/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/tags/waves/index.html
+++ b/public/tags/waves/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/waves/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/3dtoy/index.html
+++ b/public/toys/3dtoy/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/3dtoy/" />
     <meta property="og:image" content="https://no.toil.fyi/og/3dtoy.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="3D Toy preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/aurora-painter/index.html
+++ b/public/toys/aurora-painter/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/aurora-painter/" />
     <meta property="og:image" content="https://no.toil.fyi/og/aurora-painter.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Aurora Painter preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/bioluminescent-tidepools/index.html
+++ b/public/toys/bioluminescent-tidepools/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/bioluminescent-tidepools/" />
     <meta property="og:image" content="https://no.toil.fyi/og/bioluminescent-tidepools.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Bioluminescent Tidepools preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/bubble-harmonics/index.html
+++ b/public/toys/bubble-harmonics/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/bubble-harmonics/" />
     <meta property="og:image" content="https://no.toil.fyi/og/bubble-harmonics.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Bubble Harmonics preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/clay/index.html
+++ b/public/toys/clay/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/clay/" />
     <meta property="og:image" content="https://no.toil.fyi/og/clay.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Pottery Wheel Sculptor preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/cosmic-particles/index.html
+++ b/public/toys/cosmic-particles/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/cosmic-particles/" />
     <meta property="og:image" content="https://no.toil.fyi/og/cosmic-particles.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Cosmic Particles preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/cube-wave/index.html
+++ b/public/toys/cube-wave/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/cube-wave/" />
     <meta property="og:image" content="https://no.toil.fyi/og/cube-wave.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Grid Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/evol/index.html
+++ b/public/toys/evol/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/evol/" />
     <meta property="og:image" content="https://no.toil.fyi/og/evol.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Evolutionary Weirdcore preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/fractal-kite-garden/index.html
+++ b/public/toys/fractal-kite-garden/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/fractal-kite-garden/" />
     <meta property="og:image" content="https://no.toil.fyi/og/fractal-kite-garden.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Fractal Kite Garden preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/geom/index.html
+++ b/public/toys/geom/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/geom/" />
     <meta property="og:image" content="https://no.toil.fyi/og/geom.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Microphone Geometry Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/holy/index.html
+++ b/public/toys/holy/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/holy/" />
     <meta property="og:image" content="https://no.toil.fyi/og/holy.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Halo Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/index.html
+++ b/public/toys/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/" />
     <meta property="og:image" content="https://no.toil.fyi/og/default.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Stim Webtoys collection preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/legible/index.html
+++ b/public/toys/legible/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/legible/" />
     <meta property="og:image" content="https://no.toil.fyi/og/legible.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Terminal Word Grid preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/lights/index.html
+++ b/public/toys/lights/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/lights/" />
     <meta property="og:image" content="https://no.toil.fyi/og/lights.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Audio Light Show preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/milkdrop/index.html
+++ b/public/toys/milkdrop/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/milkdrop/" />
     <meta property="og:image" content="https://no.toil.fyi/og/milkdrop.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="MilkDrop Proto preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/mobile-ripples/index.html
+++ b/public/toys/mobile-ripples/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/mobile-ripples/" />
     <meta property="og:image" content="https://no.toil.fyi/og/mobile-ripples.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Mobile Ripples preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/multi/index.html
+++ b/public/toys/multi/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/multi/" />
     <meta property="og:image" content="https://no.toil.fyi/og/multi.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Multi-Capability Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/neon-wave/index.html
+++ b/public/toys/neon-wave/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/neon-wave/" />
     <meta property="og:image" content="https://no.toil.fyi/og/neon-wave.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Neon Wave preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/pocket-pulse/index.html
+++ b/public/toys/pocket-pulse/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/pocket-pulse/" />
     <meta property="og:image" content="https://no.toil.fyi/og/pocket-pulse.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Pocket Pulse preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/rainbow-tunnel/index.html
+++ b/public/toys/rainbow-tunnel/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/rainbow-tunnel/" />
     <meta property="og:image" content="https://no.toil.fyi/og/rainbow-tunnel.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Rainbow Tunnel preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/seary/index.html
+++ b/public/toys/seary/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/seary/" />
     <meta property="og:image" content="https://no.toil.fyi/og/seary.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Synesthetic Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/spiral-burst/index.html
+++ b/public/toys/spiral-burst/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/spiral-burst/" />
     <meta property="og:image" content="https://no.toil.fyi/og/spiral-burst.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Spiral Burst preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/star-field/index.html
+++ b/public/toys/star-field/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/star-field/" />
     <meta property="og:image" content="https://no.toil.fyi/og/star-field.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Star Field preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/symph/index.html
+++ b/public/toys/symph/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/symph/" />
     <meta property="og:image" content="https://no.toil.fyi/og/symph.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Spectrograph preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/public/toys/tactile-sand-table/index.html
+++ b/public/toys/tactile-sand-table/index.html
@@ -11,6 +11,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/tactile-sand-table/" />
     <meta property="og:image" content="https://no.toil.fyi/og/tactile-sand-table.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Tactile Sand Table preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />

--- a/scripts/check-seo.ts
+++ b/scripts/check-seo.ts
@@ -1,0 +1,96 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+const publicDir = path.join(rootDir, 'public');
+
+type CheckResult = {
+  name: string;
+  passed: boolean;
+  details?: string;
+};
+
+const requiredInIndexHtml = [
+  '<link rel="canonical" href="https://no.toil.fyi/" />',
+  '<meta property="og:title"',
+  '<meta property="og:image"',
+  '<meta name="twitter:card" content="summary_large_image"',
+  '<script type="application/ld+json">',
+];
+
+const requiredInGeneratedToyPage = [
+  '<meta property="og:image:type" content="image/svg+xml"',
+  '<meta property="og:image:width" content="1200"',
+  '<meta property="og:image:height" content="630"',
+  '<link rel="canonical" href="https://no.toil.fyi/toys/cube-wave/" />',
+];
+
+const run = async () => {
+  const results: CheckResult[] = [];
+
+  const homepage = await readFile(path.join(rootDir, 'index.html'), 'utf8');
+  for (const snippet of requiredInIndexHtml) {
+    results.push({
+      name: `Homepage contains ${snippet}`,
+      passed: homepage.includes(snippet),
+      details: 'index.html',
+    });
+  }
+
+  const toyPage = await readFile(
+    path.join(publicDir, 'toys', 'cube-wave', 'index.html'),
+    'utf8',
+  );
+  for (const snippet of requiredInGeneratedToyPage) {
+    results.push({
+      name: `Generated toy page contains ${snippet}`,
+      passed: toyPage.includes(snippet),
+      details: 'public/toys/cube-wave/index.html',
+    });
+  }
+
+  const robots = await readFile(path.join(publicDir, 'robots.txt'), 'utf8');
+  results.push({
+    name: 'robots.txt references sitemap index',
+    passed: robots.includes('Sitemap: https://no.toil.fyi/sitemap.xml'),
+    details: 'public/robots.txt',
+  });
+
+  const sitemapIndex = await readFile(
+    path.join(publicDir, 'sitemap.xml'),
+    'utf8',
+  );
+  results.push({
+    name: 'Sitemap index contains sitemap-1.xml location',
+    passed: sitemapIndex.includes(
+      '<loc>https://no.toil.fyi/sitemap-1.xml</loc>',
+    ),
+    details: 'public/sitemap.xml',
+  });
+
+  const sitemapChunk = await readFile(
+    path.join(publicDir, 'sitemap-1.xml'),
+    'utf8',
+  );
+  const hasUrlLastmod =
+    sitemapChunk.includes('<loc>https://no.toil.fyi/toys/cube-wave/</loc>') &&
+    sitemapChunk.includes('<lastmod>');
+  results.push({
+    name: 'Sitemap chunk includes per-URL lastmod fields',
+    passed: hasUrlLastmod,
+    details: 'public/sitemap-1.xml',
+  });
+
+  const failures = results.filter((result) => !result.passed);
+  for (const result of results) {
+    const icon = result.passed ? '✅' : '❌';
+    const suffix = result.details ? ` (${result.details})` : '';
+    console.log(`${icon} ${result.name}${suffix}`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`SEO checks failed: ${failures.length} issue(s) detected.`);
+  }
+};
+
+await run();

--- a/scripts/generate-seo.ts
+++ b/scripts/generate-seo.ts
@@ -7,6 +7,8 @@ const rootDir = process.cwd();
 const publicDir = path.join(rootDir, 'public');
 const generatedDirs = ['toys', 'tags', 'moods', 'capabilities'];
 const sitemapChunkSize = 5000;
+const ogWidth = 1200;
+const ogHeight = 630;
 
 const slugify = (value: string) =>
   value
@@ -37,14 +39,14 @@ const buildOgSvg = ({
 }: {
   title: string;
   subtitle: string;
-}) => `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${escapeHtml(title)}">
+}) => `<svg xmlns="http://www.w3.org/2000/svg" width="${ogWidth}" height="${ogHeight}" viewBox="0 0 ${ogWidth} ${ogHeight}" role="img" aria-label="${escapeHtml(title)}">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0b1024" />
       <stop offset="100%" stop-color="#26377f" />
     </linearGradient>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect width="${ogWidth}" height="${ogHeight}" fill="url(#bg)" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
   <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
@@ -71,6 +73,9 @@ const renderPage = ({
   extraHead = '',
   socialImage = iconUrl,
   socialImageAlt = 'Stim Webtoys Library icon',
+  socialImageType = 'image/svg+xml',
+  socialImageWidth = 512,
+  socialImageHeight = 512,
 }: {
   title: string;
   description: string;
@@ -80,6 +85,9 @@ const renderPage = ({
   extraHead?: string;
   socialImage?: string;
   socialImageAlt?: string;
+  socialImageType?: string;
+  socialImageWidth?: number;
+  socialImageHeight?: number;
 }) => `<!doctype html>
 <html lang="en">
   <head>
@@ -93,6 +101,9 @@ const renderPage = ({
     <meta property="og:type" content="website" />
     <meta property="og:url" content="${canonical}" />
     <meta property="og:image" content="${socialImage}" />
+    <meta property="og:image:type" content="${socialImageType}" />
+    <meta property="og:image:width" content="${socialImageWidth}" />
+    <meta property="og:image:height" content="${socialImageHeight}" />
     <meta property="og:image:alt" content="${escapeHtml(socialImageAlt)}" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
@@ -537,6 +548,9 @@ const generateSeo = async () => {
     )}</script>
 `,
       socialImage: `${baseUrl}/og/default.svg`,
+      socialImageType: 'image/svg+xml',
+      socialImageWidth: ogWidth,
+      socialImageHeight: ogHeight,
       socialImageAlt: 'Stim Webtoys collection preview image',
     }),
   );
@@ -636,6 +650,9 @@ const generateSeo = async () => {
 ${extraHead}
 `,
         socialImage: `${baseUrl}/og/${toy.slug}.svg`,
+        socialImageType: 'image/svg+xml',
+        socialImageWidth: ogWidth,
+        socialImageHeight: ogHeight,
         socialImageAlt: `${toy.title} preview image`,
       }),
     );


### PR DESCRIPTION
### Motivation
- Remove binary PNG Open Graph artifacts from the repository and simplify the SEO asset pipeline to avoid storing binary files while preserving explicit OG metadata for social previews. 
- Keep generated pages explicit about OG image type and dimensions so social engines can read `og:image:type`, `og:image:width`, and `og:image:height`. 
- Add a lightweight automated SEO check to prevent regressions in canonical/meta/sitemap wiring.

### Description
- Removed PNG OG artifacts under `public/og/` and removed the `@resvg/resvg-js` PNG-rendering step so the generator writes SVG-only OG cards and no longer emits PNG derivatives. 
- Updated `scripts/generate-seo.ts` to use constants for OG dimensions (`1200x630`), write `.svg` assets, and include `og:image:type`, `og:image:width`, and `og:image:height` metadata for collection and toy pages. 
- Added `scripts/check-seo.ts` and `package.json` script `check:seo` to validate homepage canonical/meta, generated toy OG metadata (`image/svg+xml` + dims), `robots.txt`→sitemap linkage, and per-URL `lastmod` in sitemap chunks. 
- Regenerated/updated many programmatic `public/*` HTML pages to reference SVG OG images and added `docs/SEO_AUDIT.md` plus updates to `docs/DEVELOPMENT.md`, `docs/README.md`, and `docs/agents/tooling-and-quality.md` to document the audit and new validation step.

### Testing
- Ran `bun run generate:seo` and the script completed successfully with SVG assets written and PNGs removed (passed). 
- Ran `bun run check:seo` and all SEO assertions passed (homepage meta, generated toy OG meta with `image/svg+xml` and dimensions, robots→sitemap, sitemap chunk `lastmod`). 
- Ran the full quality gate `bun run check` (Biome checks, `tsc --noEmit`, and test suite) and all tests passed (`92 pass`, `2 skip`, `0 fail`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bedd662e8833298fd47bc64173f4d)