### PR TITLE
Implement UX audit improvements across library experience

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -758,6 +758,66 @@ header.hero {
   align-items: center;
 }
 
+.starter-picks {
+  display: grid;
+  gap: 0.9rem;
+  margin-bottom: 1.1rem;
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-strong) 84%, transparent);
+  border: 1px solid var(--surface-border);
+}
+
+.starter-picks__header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.starter-picks__header h3,
+.starter-picks__header p {
+  margin: 0;
+}
+
+.starter-picks__header p {
+  color: var(--text-muted);
+}
+
+.starter-picks__grid {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.starter-pick {
+  display: grid;
+  gap: 0.2rem;
+  text-decoration: none;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.85rem;
+  min-height: 44px;
+  background: var(--surface-gradient);
+}
+
+.starter-pick strong {
+  color: var(--text-color);
+}
+
+.starter-pick span {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.starter-pick:focus-visible,
+.starter-pick:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 60%,
+    var(--surface-border)
+  );
+  box-shadow: var(--shadow-soft);
+}
+
 .system-check {
   display: grid;
   gap: 1.4rem;
@@ -2152,6 +2212,24 @@ html.light .active-filters__label {
   padding-left: 0.2rem;
 }
 
+.search-shortcuts-toggle {
+  justify-self: start;
+  grid-column: 1 / -1;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted);
+  min-height: 36px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.76rem;
+}
+
+.search-shortcuts-toggle:hover,
+.search-shortcuts-toggle:focus-visible {
+  color: var(--text-color);
+  border-color: rgba(96, 165, 250, 0.65);
+}
+
 .search-clear {
   border: 1px solid transparent;
   background: rgba(255, 255, 255, 0.08);
@@ -2528,6 +2606,14 @@ html:not(.light) .webtoy-card {
   font-size: 0.86rem;
   color: var(--text-muted);
   line-height: 1.5;
+}
+
+.webtoy-card-description {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .webtoy-card-bestfor {

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1263,6 +1263,17 @@ export function createLibraryView({
     return (toyMoods ?? []).some((mood) => accepted.has(mood.toLowerCase()));
   };
 
+  const normalizeFilterToken = (token) => {
+    if (typeof token !== 'string') return null;
+    const [type, ...valueParts] = token.split(':');
+    const value = valueParts.join(':').trim();
+    if (!type || !value) return null;
+    if (type === 'mood') {
+      return `mood:${normalizeMoodToken(value)}`;
+    }
+    return `${type}:${value.toLowerCase()}`;
+  };
+
   const formatTokenLabel = (token) => {
     const [type, value = ''] = token.split(':');
     if (!type) return token;
@@ -1719,7 +1730,10 @@ export function createLibraryView({
     searchQuery = state.query ?? '';
     sortBy = state.sort ?? 'featured';
     activeFilters.clear();
-    (state.filters ?? []).forEach((token) => activeFilters.add(token));
+    (state.filters ?? [])
+      .map((token) => normalizeFilterToken(token))
+      .filter(Boolean)
+      .forEach((token) => activeFilters.add(token));
     lastCommittedQuery = searchQuery.trim();
 
     if (searchInputId) {
@@ -2292,7 +2306,11 @@ export function createLibraryView({
       '[data-search-shortcuts-toggle]',
     );
     const shortcutsHint = document.getElementById('toy-search-hint');
-    if (shortcutsToggle instanceof HTMLButtonElement && shortcutsHint) {
+    if (
+      shortcutsToggle instanceof HTMLElement &&
+      shortcutsToggle.tagName === 'BUTTON' &&
+      shortcutsHint
+    ) {
       shortcutsToggle.addEventListener('click', () => {
         const expanded =
           shortcutsToggle.getAttribute('aria-expanded') === 'true';

--- a/index.html
+++ b/index.html
@@ -157,32 +157,159 @@
             class="cta-button primary"
             data-quickstart-slug="holy"
           >
-            Open Halo Flow
-          </a>
-          <a
-            href="toy.html?toy=spiral-burst"
-            class="cta-button cta-button--muted"
-            data-quickstart-mode="random"
-            data-quickstart-pool="featured"
-            data-quickstart-audio="demo"
-            data-quickstart-flow="true"
-          >
-            Start flow mode
-          </a>
-          <a
-            href="toy.html?toy=spiral-burst"
-            class="cta-button cta-button--accent"
-            data-quickstart-mode="random"
-            data-quickstart-pool="featured"
-            data-quickstart-audio="demo"
-          >
-            Surprise me
+            Start instantly (recommended)
           </a>
           <a href="#toy-list" class="cta-button ghost">Browse all stims</a>
         </div>
         <p class="section-helper" data-hero-flow-note>
-          Step 1 opens a quick compatibility check, then you can choose your audio source.
+          No mic? Use demo audio in one tap. On mobile? Motion-enabled stims are marked on each
+          card.
         </p>
+      </section>
+
+      <section class="quick-starts" id="quick-starts">
+        <div class="section-heading">
+          <p class="eyebrow">Quick start</p>
+          <h2>Pick your starting mode</h2>
+          <p class="section-description">
+            Three fast routes to first delight depending on your setup and energy.
+          </p>
+        </div>
+        <div class="quick-start-grid">
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Guided</p>
+            <h3>Open Halo Flow</h3>
+            <p>Balanced visuals with simple controls if you want a reliable first run.</p>
+            <div class="quick-card__actions">
+              <a href="toy.html?toy=holy" class="cta-button primary" data-quickstart-slug="holy"
+                >Start now</a
+              >
+            </div>
+          </article>
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Hands-free</p>
+            <h3>Auto-flow mode</h3>
+            <p>Rotate through featured stims every ~45s with demo audio ready.</p>
+            <div class="quick-card__actions">
+              <a
+                href="toy.html?toy=spiral-burst"
+                class="cta-button cta-button--muted"
+                data-quickstart-mode="random"
+                data-quickstart-pool="featured"
+                data-quickstart-audio="demo"
+                data-quickstart-flow="true"
+                >Start flow mode</a
+              >
+            </div>
+          </article>
+          <article class="quick-card">
+            <p class="quick-card__eyebrow">Random</p>
+            <h3>Surprise stim</h3>
+            <p>Jump to a random featured stim when you want novelty without setup.</p>
+            <div class="quick-card__actions">
+              <a
+                href="toy.html?toy=spiral-burst"
+                class="cta-button cta-button--accent"
+                data-quickstart-mode="random"
+                data-quickstart-pool="featured"
+                data-quickstart-audio="demo"
+                >Surprise me</a
+              >
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="system-check" id="system-check">
+        <div class="section-heading">
+          <p class="eyebrow">System check</p>
+          <h2>Check your device</h2>
+          <p class="section-description">Live status while we scan.</p>
+          <p
+            class="section-description details-panel"
+            data-details-panel
+            id="system-check-details"
+          >
+            Graphics, mic, motion, comfort.
+          </p>
+          <button
+            type="button"
+            class="text-link details-toggle"
+            data-details-toggle
+            aria-expanded="false"
+            aria-controls="system-check-details"
+          >
+            <span data-details-label="open">Details</span>
+            <span data-details-label="close">Hide details</span>
+          </button>
+        </div>
+        <ul class="system-legend" aria-label="System signals">
+          <li class="system-legend__item">🖥️ Graphics</li>
+          <li class="system-legend__item">🎙️ Mic</li>
+          <li class="system-legend__item">🧭 Motion</li>
+          <li class="system-legend__item">🫧 Comfort</li>
+        </ul>
+        <div class="system-grid">
+          <div class="readiness-panel" data-readiness-panel>
+            <div class="readiness-header">
+              <h3 class="readiness-title">Live readiness</h3>
+              <p class="readiness-subtitle" data-details-panel>
+                We’ll keep these signals updated so you know what’s available.
+              </p>
+            </div>
+            <ul class="readiness-list">
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="render"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Graphics acceleration</span>
+                </div>
+                <p class="readiness-note" data-status-note="render">
+                  Checking graphics…
+                </p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span class="readiness-dot" data-status-dot="mic" aria-hidden="true"></span>
+                  <span class="readiness-name">Microphone</span>
+                </div>
+                <p class="readiness-note" data-status-note="mic">Checking mic…</p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="motion"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Motion input</span>
+                </div>
+                <p class="readiness-note" data-status-note="motion">Checking motion…</p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="reduced"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Motion comfort</span>
+                </div>
+                <p class="readiness-note" data-status-note="reduced">Reading comfort…</p>
+              </li>
+            </ul>
+          </div>
+          <div class="system-controls" data-system-controls></div>
+        </div>
+        <div class="cta-row system-actions">
+          <button type="button" class="cta-button primary" data-open-preflight>
+            Open system check
+          </button>
+          <a href="#toy-list" class="text-link">Skip to library</a>
+        </div>
       </section>
 
       <section class="library" id="library">
@@ -194,6 +321,34 @@
           </p>
         </div>
         <search class="library-search">
+          <section class="starter-picks" aria-label="Recommended starter picks">
+            <div class="starter-picks__header">
+              <h3>Starter picks</h3>
+              <p>Not sure where to begin? These are the easiest first wins.</p>
+            </div>
+            <div class="starter-picks__grid">
+              <a href="toy.html?toy=holy" class="starter-pick" data-quickstart-slug="holy">
+                <strong>Halo Flow</strong>
+                <span>Balanced and calm-friendly</span>
+              </a>
+              <a
+                href="toy.html?toy=aurora-painter"
+                class="starter-pick"
+                data-quickstart-slug="aurora-painter"
+              >
+                <strong>Aurora Painter</strong>
+                <span>Gesture-led and dreamy</span>
+              </a>
+              <a
+                href="toy.html?toy=spiral-burst"
+                class="starter-pick"
+                data-quickstart-slug="spiral-burst"
+              >
+                <strong>Spiral Burst</strong>
+                <span>High-energy beat response</span>
+              </a>
+            </div>
+          </section>
           <div class="search-heading">
             <h3>Find a stim</h3>
             <p>Search by name, mood, tags, or capability and move fast.</p>
@@ -220,7 +375,16 @@
               >
                 Clear
               </button>
-              <span id="toy-search-hint" class="search-field__hint">
+              <button
+                type="button"
+                class="search-shortcuts-toggle"
+                data-search-shortcuts-toggle
+                aria-expanded="false"
+                aria-controls="toy-search-hint"
+              >
+                Keyboard shortcuts
+              </button>
+              <span id="toy-search-hint" class="search-field__hint" hidden>
                 / focus • esc clear • ↵ open top match
               </span>
               <datalist id="toy-search-suggestions"></datalist>
@@ -261,7 +425,7 @@
                 class="filter-chip"
                 data-filter-chip
                 data-filter-type="mood"
-                data-filter-value="calm"
+                data-filter-value="calming"
               >
                 Calm
               </button>
@@ -455,108 +619,6 @@
             Prefer docs? Start with the README and feature specs inside the
             repository.
           </p>
-        </div>
-      </section>
-
-      <section class="system-check" id="system-check">
-        <div class="section-heading">
-          <p class="eyebrow">System check</p>
-          <h2>Check your device</h2>
-          <p class="section-description">Live status while we scan.</p>
-          <p
-            class="section-description details-panel"
-            data-details-panel
-            id="system-check-details"
-          >
-            Graphics, mic, motion, comfort.
-          </p>
-          <button
-            type="button"
-            class="text-link details-toggle"
-            data-details-toggle
-            aria-expanded="false"
-            aria-controls="system-check-details"
-          >
-            <span data-details-label="open">Details</span>
-            <span data-details-label="close">Hide details</span>
-          </button>
-        </div>
-        <ul class="system-legend" aria-label="System signals">
-          <li class="system-legend__item">🖥️ Graphics</li>
-          <li class="system-legend__item">🎙️ Mic</li>
-          <li class="system-legend__item">🧭 Motion</li>
-          <li class="system-legend__item">🫧 Comfort</li>
-        </ul>
-        <div class="system-grid">
-          <div class="readiness-panel" data-readiness-panel>
-            <div class="readiness-header">
-              <h3 class="readiness-title">Live readiness</h3>
-              <p class="readiness-subtitle" data-details-panel>
-                We’ll keep these signals updated so you know what’s available.
-              </p>
-            </div>
-            <ul class="readiness-list">
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="render"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Graphics acceleration</span>
-                </div>
-                <p class="readiness-note" data-status-note="render">
-                  Checking graphics…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="mic"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Microphone</span>
-                </div>
-                <p class="readiness-note" data-status-note="mic">
-                  Checking mic…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="motion"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion input</span>
-                </div>
-                <p class="readiness-note" data-status-note="motion">
-                  Checking motion…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="reduced"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion comfort</span>
-                </div>
-                <p class="readiness-note" data-status-note="reduced">
-                  Reading comfort…
-                </p>
-              </li>
-            </ul>
-          </div>
-          <div class="system-controls" data-system-controls></div>
-        </div>
-        <div class="cta-row system-actions">
-          <button type="button" class="cta-button primary" data-open-preflight>
-            Open system check
-          </button>
-          <a href="#toy-list" class="text-link">Skip to library</a>
         </div>
       </section>
 

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { createLibraryView } from '../assets/js/library-view.js';
+
+const toys = [
+  {
+    slug: 'calm-flow',
+    title: 'Calm Flow',
+    description: 'Soft visuals for calm sessions.',
+    module: 'assets/js/toys/calm-flow.ts',
+    type: 'module',
+    requiresWebGPU: false,
+    moods: ['calming'],
+    capabilities: {
+      demoAudio: true,
+      microphone: true,
+      motion: false,
+    },
+  },
+];
+
+describe('library filter state normalization', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="toy-search" />
+      <form data-search-form></form>
+      <button data-search-clear type="button">Clear</button>
+      <datalist id="toy-search-suggestions"></datalist>
+      <p data-search-results></p>
+      <div data-active-filters hidden>
+        <div data-active-filters-chips></div>
+        <button data-active-filters-clear type="button">Clear all</button>
+      </div>
+      <button data-filter-chip data-filter-type="mood" data-filter-value="calming" type="button">Calm</button>
+      <button data-filter-reset type="button">Reset</button>
+      <select data-sort-control>
+        <option value="featured">Featured</option>
+      </select>
+      <div id="toy-list"></div>
+    `;
+  });
+
+  test('normalizes legacy mood:calm state to mood:calming so chip toggles correctly', async () => {
+    window.sessionStorage.setItem(
+      'stims-library-state',
+      JSON.stringify({ query: '', filters: ['mood:calm'], sort: 'featured' }),
+    );
+
+    const view = createLibraryView({
+      toys,
+      searchInputId: 'toy-search',
+    });
+
+    await view.init();
+
+    const calmChip = document.querySelector('[data-filter-chip]');
+    expect(calmChip?.classList.contains('is-active')).toBe(true);
+
+    calmChip?.dispatchEvent(new Event('click', { bubbles: true }));
+
+    const persisted = window.sessionStorage.getItem('stims-library-state');
+    expect(persisted).not.toBeNull();
+    expect(JSON.parse(persisted ?? '{}').filters).toEqual([]);
+    expect(calmChip?.classList.contains('is-active')).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
+  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,


### PR DESCRIPTION
### Motivation
- Reduce first-use friction by simplifying hero CTAs, making launch choices clearer, and surfacing recommended starter content. 
- Surface device readiness earlier so users know if mic/motion/WebGPU are available before browsing. 
- Improve discoverability and filter reliability by adding a starter-picks rail, progressive-disclosure for search shortcuts, and normalizing mood tokens.

### Description
- Simplified hero CTA hierarchy and added a new `#quick-starts` section with three starter paths (guided, auto-flow, surprise) and updated hero helper language in `index.html`.
- Inserted a `Starter picks` rail above search and added styles in `assets/css/index.css` to present recommended entry-point cards.
- Reordered content so the `System check` section appears earlier, added search shortcut toggle with progressive disclosure, clamped card descriptions, and consolidated per-card primary action to a unified `Play`/`Play demo` button in `assets/js/library-view.js`.
- Updated mood filter token from `calm` to `calming` and implemented `normalizeMoodToken`/`matchesMoodToken` with aliases so legacy queries like `calm` still match, and added `GPUTextureUsage.TRANSIENT_ATTACHMENT` to `tests/setup.ts` to satisfy current typings.

### Testing
- Ran `bun run check` (Biome lint/format + TypeScript typecheck + test suite) and it completed successfully. 
- Unit test run produced `92 pass` and `2 skip` with `bun test` as executed by the check workflow. 
- Formatting fixes were applied via `bun run format` as part of the validation step and the repo passed the quality gates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf6d8ceec8332839ed0b3f9f84b09)