### PR TITLE
Implement iteration 2 UX recommendations in library flow

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1307,6 +1307,17 @@ header.hero {
   grid-column: 1 / -1;
 }
 
+.intro-secondary-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: -0.15rem;
+}
+
+.intro-secondary-link {
+  margin-top: 0;
+}
+
 .section-helper {
   margin: 0.25rem 0 0;
   color: var(--text-muted);
@@ -2287,6 +2298,35 @@ html.light .active-filters__label {
   gap: 0.65rem;
   margin-left: auto;
   flex-wrap: wrap;
+}
+
+.filter-actions--primary {
+  margin-left: auto;
+}
+
+.filter-toggle {
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 30%, var(--surface-border));
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-color);
+  border-radius: var(--radius-pill);
+  padding: 0.5rem 0.95rem;
+  min-height: 44px;
+  min-width: 44px;
+  font-weight: 600;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.filter-toggle:hover {
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: var(--shadow-soft);
+}
+
+.filter-toggle:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
 .filter-chip {

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -609,13 +609,13 @@ export function attachCapabilityPreflight({
   const description = document.createElement('p');
   description.className = 'control-panel__description';
   description.textContent =
-    'Step 1 of 2: quick check for graphics and microphone support.';
+    'Step 1 of 2: check what is ready now on this device.';
   panel.appendChild(description);
 
   const sequenceHint = document.createElement('p');
   sequenceHint.className = 'control-panel__microcopy';
   sequenceHint.textContent =
-    'After this check, continue to audio setup to choose microphone or demo audio.';
+    'Next: choose microphone or demo audio and start playing.';
   panel.appendChild(sequenceHint);
 
   const statusContainer = document.createElement('div');
@@ -630,7 +630,7 @@ export function attachCapabilityPreflight({
   details.className = 'preflight-panel__details';
   const summary = document.createElement('summary');
   summary.className = 'preflight-panel__details-summary';
-  summary.textContent = 'Why?';
+  summary.textContent = 'Details';
   details.appendChild(summary);
   const detailsContent = document.createElement('div');
   detailsContent.className = 'preflight-panel__details-content';
@@ -652,7 +652,7 @@ export function attachCapabilityPreflight({
   const performanceButton = document.createElement('button');
   performanceButton.className = 'cta-button ghost';
   performanceButton.type = 'button';
-  performanceButton.textContent = 'Enable performance mode';
+  performanceButton.textContent = 'Improve performance';
   performanceButton.hidden = true;
   actions.appendChild(performanceButton);
   if (backHref) {
@@ -673,9 +673,9 @@ export function attachCapabilityPreflight({
   actions.appendChild(continueButton);
 
   const retryButton = document.createElement('button');
-  retryButton.className = 'cta-button';
+  retryButton.className = 'text-link preflight-retry-link';
   retryButton.type = 'button';
-  retryButton.textContent = 'Retry checks';
+  retryButton.textContent = 'Run checks again';
   actions.appendChild(retryButton);
   panel.appendChild(actions);
 
@@ -686,7 +686,7 @@ export function attachCapabilityPreflight({
     if (!result.performance.lowPower) {
       performanceButton.hidden = true;
       performanceButton.disabled = false;
-      performanceButton.textContent = 'Enable performance mode';
+      performanceButton.textContent = 'Improve performance';
       return;
     }
 
@@ -703,7 +703,7 @@ export function attachCapabilityPreflight({
       performanceButton.textContent = 'Performance mode enabled';
       performanceButton.disabled = true;
     } else {
-      performanceButton.textContent = 'Enable performance mode';
+      performanceButton.textContent = 'Improve performance';
       performanceButton.disabled = false;
     }
   };

--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -174,6 +174,7 @@ export function createLoader({
       moduleUrl,
       importError,
       onBack: backToLibrary,
+      onBrowseCompatible: browseCompatibleToys,
     });
   };
 

--- a/assets/js/readiness-probe.ts
+++ b/assets/js/readiness-probe.ts
@@ -15,10 +15,10 @@ type StatusResult = {
 };
 
 const STATUS_LABELS = {
-  render: 'Graphics acceleration',
+  render: 'Visual performance',
   mic: 'Microphone input',
-  motion: 'Motion controls',
-  reduced: 'Reduced motion preference',
+  motion: 'Tilt controls',
+  reduced: 'Low-motion mode',
 };
 
 const selectStatusNodes = () => ({
@@ -149,7 +149,7 @@ export const getRenderCompatibilitySummary = () => {
 
   return {
     state: STATUS.error,
-    label: 'Graphics acceleration unavailable',
+    label: 'Visual performance unavailable',
   };
 };
 
@@ -175,7 +175,7 @@ const probeRendering = () => {
 
   return {
     state: STATUS.error,
-    message: 'Graphics acceleration unavailable on this device.',
+    message: 'Visual performance unavailable on this device.',
     detail: 'Try another browser or device.',
   };
 };

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -58,6 +58,7 @@ type ImportErrorOptions = {
   moduleUrl?: string;
   importError?: Error;
   onBack?: () => void;
+  onBrowseCompatible?: () => void;
 };
 
 type RendererStatusState = {
@@ -200,7 +201,7 @@ function buildImportErrorMessage(
 
   const message = importError?.message ?? '';
   if (typeof moduleUrl === 'string' && moduleUrl.endsWith('.ts')) {
-    return `${toy?.title ?? 'This toy'} could not be compiled. Make sure you are running through the dev server or a production build so the TypeScript bundle is available.`;
+    return `${toy?.title ?? 'This toy'} could not start on this setup yet. Try another toy, or run through the dev server / production bundle so the TypeScript output is available.`;
   }
 
   if (message.toLowerCase().includes('mime')) {
@@ -463,14 +464,18 @@ export function createToyView({
     state.activeToyMeta = toy ?? state.activeToyMeta;
     state.status = {
       variant: 'error',
-      title: 'Unable to load this toy',
+      title: "This toy couldn't start here yet",
       message: buildImportErrorMessage(toy, options),
       actionsClassName: 'active-toy-status__actions',
       actions: [
         {
-          label: 'Back to library',
+          label: 'Try another toy',
           onClick: options.onBack,
           primary: true,
+        },
+        {
+          label: 'Browse compatible toys',
+          onClick: options.onBrowseCompatible,
         },
       ],
     };

--- a/assets/js/utils/init-library.ts
+++ b/assets/js/utils/init-library.ts
@@ -77,11 +77,36 @@ export const initLibraryView = async ({
       syncChipVisibility(expanded);
     };
 
-    advancedChips.forEach((chip) => {
-      chip.addEventListener('click', () => {
-        window.requestAnimationFrame(refreshVisibility);
-      });
+    const scheduleRefresh = () => {
+      window.requestAnimationFrame(refreshVisibility);
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      const hasClassChange = mutations.some(
+        (mutation) =>
+          mutation.type === 'attributes' && mutation.attributeName === 'class',
+      );
+      if (hasClassChange) {
+        scheduleRefresh();
+      }
     });
+
+    advancedChips.forEach((chip) => {
+      observer.observe(chip, {
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+      chip.addEventListener('click', scheduleRefresh);
+    });
+
+    window.addEventListener('popstate', scheduleRefresh);
+
+    document
+      .querySelector('[data-filter-reset]')
+      ?.addEventListener('click', scheduleRefresh);
+    document
+      .querySelector('[data-active-filters-clear]')
+      ?.addEventListener('click', scheduleRefresh);
 
     toggle.addEventListener('click', () => {
       const expanded = toggle.getAttribute('aria-expanded') === 'true';

--- a/assets/js/utils/init-library.ts
+++ b/assets/js/utils/init-library.ts
@@ -29,6 +29,66 @@ export const initLibraryView = async ({
   initNavigation,
   loadFromQuery,
 }: InitLibraryViewOptions) => {
+  const bindAdvancedFiltersToggle = () => {
+    if (typeof document === 'undefined') return;
+    const toggle = document.querySelector<HTMLElement>(
+      '[data-advanced-filters-toggle]',
+    );
+    const advancedFilters = document.querySelector<HTMLElement>(
+      '[data-advanced-filters]',
+    );
+
+    if (!toggle || !advancedFilters) return;
+
+    const advancedChips = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-filter-advanced]'),
+    );
+
+    const hasAdvancedFiltersInUrl = () => {
+      if (typeof window === 'undefined') return false;
+      const params = new URLSearchParams(window.location.search);
+      const filters = (params.get('filters') ?? '').toLowerCase();
+      return (
+        filters.includes('capability:motion') ||
+        filters.includes('capability:demoaudio') ||
+        filters.includes('feature:webgpu')
+      );
+    };
+
+    const syncChipVisibility = (expanded: boolean) => {
+      advancedChips.forEach((chip) => {
+        const isActive = chip.classList.contains('is-active');
+        chip.hidden = !(expanded || isActive);
+      });
+    };
+
+    const setExpanded = (expanded: boolean) => {
+      toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      toggle.textContent = expanded ? 'Hide refinements' : 'Refine results';
+      advancedFilters.hidden = !expanded;
+      syncChipVisibility(expanded);
+    };
+
+    const shouldStartExpanded = hasAdvancedFiltersInUrl();
+    setExpanded(shouldStartExpanded);
+
+    const refreshVisibility = () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      syncChipVisibility(expanded);
+    };
+
+    advancedChips.forEach((chip) => {
+      chip.addEventListener('click', () => {
+        window.requestAnimationFrame(refreshVisibility);
+      });
+    });
+
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      setExpanded(!expanded);
+    });
+  };
+
   const libraryView = createLibraryView({
     toys: [],
     loadToy,
@@ -47,6 +107,7 @@ export const initLibraryView = async ({
   const resolvedToys = await resolveToys();
   libraryView.setToys(resolvedToys);
   libraryView.init();
+  bindAdvancedFiltersToggle();
   document.body.dataset.libraryEnhanced = 'true';
 
   return libraryView;

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,9 @@ This directory is organized by **audience + workflow** so contributors and agent
 - [`stim-assessment.md`](./stim-assessment.md)
 - [`stim-user-critiques.md`](./stim-user-critiques.md)
 - [`USER_JOURNEY_CRITIQUE.md`](./USER_JOURNEY_CRITIQUE.md)
+- [`UX_AUDIT_2026-02.md`](./UX_AUDIT_2026-02.md)
+- [`UX_AUDIT_2026-02_FOLLOWUP.md`](./UX_AUDIT_2026-02_FOLLOWUP.md)
+- [`UX_AUDIT_2026-02_ITERATION_2.md`](./UX_AUDIT_2026-02_ITERATION_2.md)
 - [`LITERATURE.md`](./LITERATURE.md)
 - [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
 

--- a/docs/UX_AUDIT_2026-02.md
+++ b/docs/UX_AUDIT_2026-02.md
@@ -1,0 +1,115 @@
+# UX audit (Constructive + Kondo-style)
+
+Date: 2026-02-11  
+Scope: Library home and toy shell (`/`, `/toy.html?toy=...`) in local dev.
+
+## Method
+
+- Reviewed desktop and mobile renders in local dev server.
+- Focused on first-run clarity, interaction confidence, visual hierarchy, and friction.
+- Framed recommendations using a **Kondo lens**:
+  - **Remove**: delete low-value clutter.
+  - **Move**: relocate useful elements to where users need them.
+  - **Modify**: keep the intent but improve wording/behavior/priority.
+
+## What currently sparks joy
+
+1. **Fast orientation at the top of the library.** The page gives immediate context (“Stim library”), tags, and a primary CTA without hiding the experience behind marketing copy.
+2. **Strong capability framing.** “Pick your starting mode” + “Check your device” reduce anxiety for users who are unsure whether their browser/device can run graphics/audio features.
+3. **Toy shell safety rails are thoughtful.** The quick-check panel and direct fallback actions (“Back to library”, “Retry checks”) reduce dead ends when permissions or graphics fail.
+4. **Visual language is cohesive.** Soft glow cards, rounded containers, and gentle gradients align with the sensory-play goal.
+
+## Friction points (with Kondo actions)
+
+### 1) Header and hero controls feel dense on first glance
+
+- **Symptoms:** Many pills/toggles/actions compete in the same viewport band. On first load, users must parse navigation, filters, and onboarding cues at once.
+- **Remove:**
+  - Defer secondary chips in the top hero row that are not essential for first action.
+  - Collapse low-frequency controls behind a “More filters” disclosure.
+- **Move:**
+  - Keep one dominant primary action in the hero (“Start browsing” or “Start with recommendations”) and move secondary utilities to below-the-fold anchor sections.
+- **Modify:**
+  - Convert parallel CTAs into a progressive sequence: primary CTA → optional refinement.
+
+### 2) “Check your device” card competes with “Browse all stims” card
+
+- **Symptoms:** Device diagnostics and discovery grid both look like primary content blocks. Users may pause before understanding where to click first.
+- **Remove:**
+  - Trim explanatory text in diagnostics to the shortest actionable sentence.
+- **Move:**
+  - Demote full diagnostics below the first set of toy cards, keeping only a compact status summary near the top.
+- **Modify:**
+  - Use explicit state labels: “Ready now”, “Works with fallback”, “Needs browser change”.
+
+### 3) Search/filter area has high control count for first-time users
+
+- **Symptoms:** Search input + multiple chips + selects + sorting controls appear together, increasing cognitive load.
+- **Remove:**
+  - Hide advanced filtering (multi-tag logic, rare capabilities) until user opts in.
+- **Move:**
+  - Keep only search + one high-impact filter row in the default view.
+- **Modify:**
+  - Add plain-language helper text under search, e.g., “Try ‘microphone’ or ‘calming’.”
+
+### 4) Toy shell quick-check panel is useful but visually heavy
+
+- **Symptoms:** On failure states, the right-side panel draws more attention than the central toy status message and can feel intimidating for non-technical users.
+- **Remove:**
+  - Remove deeply technical labels from default view (e.g., adapter details) unless user expands “Details”.
+- **Move:**
+  - Move contextual explanation right next to the primary action button users need now.
+- **Modify:**
+  - Reword from diagnostic-first to action-first copy: “You can continue with demo audio” / “Try browser X for full mode.”
+
+### 5) Error state messaging can be gentler and more outcome-driven
+
+- **Symptoms:** “Unable to load this toy” is clear but emotionally harsh, and the fix path can feel uncertain.
+- **Remove:**
+  - Remove stack-like implementation hints from primary copy in user-facing mode.
+- **Move:**
+  - Put “Try another toy” and “Open compatibility-friendly picks” at the same visual priority as “Back to library”.
+- **Modify:**
+  - Rewrite headings to “This toy couldn’t start here yet” with one-sentence next step.
+
+### 6) Mobile top section still feels utility-first vs delight-first
+
+- **Symptoms:** Small viewport shows compact controls quickly, but joy signal (visual preview / featured toy momentum) arrives late.
+- **Remove:**
+  - Reduce top-level button count on mobile by default.
+- **Move:**
+  - Move one featured playable card above deeper filter tooling.
+- **Modify:**
+  - Use a larger “Start now” touch target and one-line promise (“Best on your device right now”).
+
+## Prioritized action plan
+
+## Now (1–2 sprints)
+
+1. **Simplify first screen hierarchy**: one primary CTA + condensed secondary options.
+2. **Reduce default filter surface area** to search + essential chips.
+3. **Refactor toy error copy** to action-oriented guidance with 2–3 obvious exits.
+
+## Next (2–4 sprints)
+
+1. **Progressive diagnostics**: compact summary by default, expandable technical details.
+2. **Mobile-first onboarding strip** featuring one recommended toy with immediate launch.
+3. **Consistent status taxonomy** across home and toy shell (Ready/Fallback/Unsupported).
+
+## Later
+
+1. Personalization memory (remember preferred mode and capabilities).
+2. A/B test concise vs descriptive hero copy for first-run conversion.
+3. Add lightweight “Why this recommendation?” transparency near suggested picks.
+
+## Suggested UX success metrics
+
+- Time to first toy launch (new visitors).
+- First-session completion rate (toy successfully started).
+- Filter interaction depth before launch (lower can mean clearer defaults).
+- Bounce rate from toy error state.
+- Mobile launch success vs desktop launch success.
+
+## One-line Kondo north star
+
+> Keep only the controls that help someone start delightfully in under 10 seconds; hide or defer everything else.

--- a/docs/UX_AUDIT_2026-02_FOLLOWUP.md
+++ b/docs/UX_AUDIT_2026-02_FOLLOWUP.md
@@ -1,0 +1,116 @@
+# UX audit follow-up (Constructive + Kondo-style)
+
+Date: 2026-02-11  
+Scope: Post-implementation review of the library landing and toy shell.
+
+## Method
+
+- Reviewed current local dev renders for desktop and mobile (`/` and toy shell routes).
+- Evaluated first-run clarity, hierarchy, interaction confidence, and friction recovery.
+- Applied a Kondo lens to recommendations:
+  - **Remove** low-value noise.
+  - **Move** important actions where intent is highest.
+  - **Modify** copy/interaction to reduce hesitation.
+
+## What improved (and now sparks joy)
+
+1. **Hero intent is clearer.** A single dominant “start now” CTA lowers the first-click decision burden.
+2. **Filter complexity is better staged.** Progressive disclosure for advanced filters reduces immediate cognitive load.
+3. **Diagnostics no longer steal the top funnel.** Moving full system-check content below browsing keeps discovery momentum.
+4. **Toy failure actions are gentler.** “Try another toy” and “Browse compatible toys” make recovery less punishing.
+
+## Remaining friction and recommendations
+
+### 1) Quick-start section still duplicates first-step intent
+
+- **Symptoms:** Hero already answers “what should I do first?”; “Pick your starting mode” repeats that decision and can reintroduce pause.
+- **Remove:**
+  - Remove one of the three quick-start cards from the default fold (prefer keeping Guided + Surprise).
+- **Move:**
+  - Move “Auto-flow mode” into a secondary “Explore modes” drawer below initial cards.
+- **Modify:**
+  - Add tiny confidence labels per card: “Easiest”, “Most playful”, “Hands-free”.
+
+### 2) Search block is cleaner, but still visually dense near first cards
+
+- **Symptoms:** Starter picks + search + filter row + advanced toggle still create a heavy control band before card browsing continues.
+- **Remove:**
+  - Remove “search scope” token list from default view (keep in help/tooltip).
+- **Move:**
+  - Move “Starter picks” above search on mobile only, so users can launch before parsing controls.
+- **Modify:**
+  - Change filter toggle label from “More filters” to “Refine results” for plain-language intent.
+
+### 3) “More filters” can hide active context
+
+- **Symptoms:** When advanced chips are active, users can lose visibility of why results are filtered if the panel is collapsed.
+- **Remove:**
+  - Remove hidden-state ambiguity by never hiding chips that are currently active.
+- **Move:**
+  - Move active advanced chips into the “Active” summary row even when advanced controls are collapsed.
+- **Modify:**
+  - Auto-open advanced controls if URL filter state includes advanced keys.
+
+### 4) Device-readiness labels could be more outcome-based
+
+- **Symptoms:** Current labels are clear but still system-ish (“Graphics acceleration”, “Motion comfort”).
+- **Remove:**
+  - Remove jargon-heavy phrasing where user outcome can be stated directly.
+- **Move:**
+  - Move detailed technical explanations behind “Details” only.
+- **Modify:**
+  - Translate to user outcomes: “Visual performance”, “Microphone access”, “Tilt controls”, “Low-motion mode”.
+
+### 5) Toy error cards could provide one “smart next” action
+
+- **Symptoms:** Recovery options are better, but users may still choose between two equal-weight exits without guidance.
+- **Remove:**
+  - Remove equal visual weight when one path is contextually best.
+- **Move:**
+  - Move “Best next step” to primary and demote alternate option.
+- **Modify:**
+  - Context-aware primary button copy:
+    - compile/import issue → “Open another toy now”
+    - capability issue → “Show compatible toys”.
+
+### 6) Mobile experience still needs a stronger joy-above-controls moment
+
+- **Symptoms:** Mobile first viewport remains action-safe but still control-forward.
+- **Remove:**
+  - Remove one secondary line in hero helper copy on mobile.
+- **Move:**
+  - Move a single featured toy card (with thumbnail + one tap CTA) directly below hero.
+- **Modify:**
+  - Add one-liner reassurance: “Designed to run smoothly on this device.”
+
+## Priority roadmap
+
+### Now (1 sprint)
+
+1. Keep active advanced filters visible even when controls collapse.
+2. Reduce quick-start card count in first fold.
+3. Improve label language from system terms to user outcomes.
+
+### Next (1–2 sprints)
+
+1. Mobile ordering: featured launch card before full search controls.
+2. Context-aware primary recovery action on toy error cards.
+3. Rename and refine filter toggle copy (“Refine results”).
+
+### Later
+
+1. Personalize first CTA using last successful launch mode.
+2. Add lightweight onboarding coachmarks that dismiss permanently.
+3. Run A/B tests on quick-start card count and hero helper microcopy.
+
+## Suggested metrics to validate this pass
+
+- Time to first successful toy launch (new and returning users).
+- Search/control interactions before first launch (aim lower for first-run users).
+- Advanced-filter usage rate vs launch conversion.
+- Toy error recovery rate (exit vs successful re-entry).
+- Mobile first-session launch success.
+
+## Kondo north star (follow-up)
+
+> Keep only what helps users launch delightfully in one confident tap, and reveal everything else only when they ask for it.

--- a/docs/UX_AUDIT_2026-02_ITERATION_2.md
+++ b/docs/UX_AUDIT_2026-02_ITERATION_2.md
@@ -1,0 +1,119 @@
+# UX audit iteration 2 (Constructive + Kondo-style)
+
+Date: 2026-02-11  
+Scope: Current library landing, search/filter stack, and toy preflight/error entry flow.
+
+## Method
+
+- Reviewed local desktop and mobile renders on current branch after recent UX refactors.
+- Focused on first-click confidence, discoverability, control density, and failure recovery clarity.
+- Recommendations use a Kondo lens:
+  - **Remove** what adds decision noise.
+  - **Move** what is useful but misplaced.
+  - **Modify** what is good but needs clearer intent.
+
+## What’s working better now
+
+1. **Top-of-page decision load is materially lower.** The hero has one dominant action and a cleaner hierarchy.
+2. **Discovery is prioritized over diagnostics.** Putting full system check below the library keeps momentum.
+3. **Filter controls are more staged.** Progressive reveal helps avoid overwhelming first-time users.
+4. **Recovery language is gentler than before.** Toy-start failures are less abrupt and offer alternatives.
+
+## Remaining friction (remove / move / modify)
+
+### 1) Quick-start and hero still duplicate the same decision
+
+- **Symptoms:** Hero says “start now,” then quick-start asks users to choose another path immediately.
+- **Remove:**
+  - Remove the “Quick start” heading block on desktop once hero CTA is visible above the fold.
+- **Move:**
+  - Move “Surprise stim” into a compact inline option next to the hero secondary link.
+- **Modify:**
+  - If quick-start remains, rename it to “Or try” to signal optionality instead of another required decision.
+
+### 2) Search/filter rail still feels control-heavy before delight
+
+- **Symptoms:** Starter picks + search + filters + refine controls create a dense command center before visual payoff.
+- **Remove:**
+  - Remove one starter pick from default desktop row (keep 2 max).
+- **Move:**
+  - Move “Refine results” after initial card row for first-time sessions (can reappear sticky after scroll).
+- **Modify:**
+  - Add placeholder microcopy tuned to outcomes (“Try calming, rhythm, or microphone”).
+
+### 3) Refine toggle state can still hide why results changed
+
+- **Symptoms:** Advanced chips can remain hidden unless active, but users still may not understand source-of-truth between active row and hidden controls.
+- **Remove:**
+  - Remove duplicated state communication between chips and active-filter badges.
+- **Move:**
+  - Move advanced active chips exclusively into the Active row when collapsed, and keep filter rail itself minimal.
+- **Modify:**
+  - Rename “Active” row label to “Applied filters” for clarity.
+
+### 4) System-check labels improved, but status language is still implementation-flavored
+
+- **Symptoms:** Some status copy remains technical (“WebGL fallback”, “Secure context”) in high-salience panel states.
+- **Remove:**
+  - Remove backend terminology from the default collapsed status summaries.
+- **Move:**
+  - Move backend/runtime details under “Details” only.
+- **Modify:**
+  - Use user-outcome summaries first, e.g.:
+    - “Runs in compatible mode”
+    - “Microphone will ask permission when you start”
+    - “You can continue now”
+
+### 5) Preflight modal action stack is still too equal-weight
+
+- **Symptoms:** “Improve performance”, “Back to library”, “Continue to audio setup”, and “Retry checks” all compete visually in a compact area.
+- **Remove:**
+  - Remove one secondary CTA from default state (suggest hiding “Improve performance” unless low-power condition is detected).
+- **Move:**
+  - Move “Retry checks” to inline text action below statuses.
+- **Modify:**
+  - Keep one primary action per state:
+    - Ready → “Continue to audio setup”
+    - Blocked → “Browse compatible toys”
+
+### 6) Mobile first viewport still under-delivers immediate delight
+
+- **Symptoms:** Mobile screens remain clear but utilitarian; emotional “wow” arrives after scroll.
+- **Remove:**
+  - Remove one line of helper/supporting text in hero on small screens.
+- **Move:**
+  - Move one visual featured-card preview directly below hero CTA (before quick-start/search).
+- **Modify:**
+  - Add one sentence reassurance: “Optimized for this device right now.”
+
+## Prioritized recommendations
+
+### Now (high impact, low-medium effort)
+
+1. De-duplicate hero vs quick-start decision prompts.
+2. Reduce starter picks to two and demote refine controls for first session.
+3. Simplify preflight actions to one dominant CTA per state.
+
+### Next
+
+1. Consolidate active-filter communication into one canonical location.
+2. Shift default preflight copy fully to outcome-first language.
+3. Add mobile featured visual card ahead of utility controls.
+
+### Later
+
+1. Personalize launch affordances based on previous successful toy types.
+2. Session-aware UI that starts minimal and progressively unlocks controls.
+3. A/B test “hero-only launch” vs “hero + quick-start.”
+
+## Suggested metrics for this iteration
+
+- First-action latency (landing view → first click).
+- Time to first successful toy start.
+- Scroll depth before first toy launch.
+- Refine-controls open rate vs launch conversion.
+- Preflight modal completion vs abandonment rate.
+
+## Kondo north star (iteration 2)
+
+> Keep one obvious next action in every viewport; defer every other control until intent is explicit.

--- a/index.html
+++ b/index.html
@@ -157,160 +157,26 @@
             class="cta-button primary"
             data-quickstart-slug="holy"
           >
-            Start instantly (recommended)
+            Start now on this device
           </a>
-          <a href="#toy-list" class="cta-button ghost">Browse all stims</a>
+        </div>
+        <div class="intro-secondary-links">
+          <a href="#toy-list" class="text-link intro-secondary-link">Browse all stims</a>
+          <a
+            href="toy.html?toy=spiral-burst"
+            class="text-link intro-secondary-link"
+            data-quickstart-mode="random"
+            data-quickstart-pool="featured"
+            data-quickstart-audio="demo"
+          >
+            Surprise me
+          </a>
         </div>
         <p class="section-helper" data-hero-flow-note>
-          No mic? Use demo audio in one tap. On mobile? Motion-enabled stims are marked on each
-          card.
+          Optimized for this device right now: start instantly, then refine only if you want.
         </p>
       </section>
 
-      <section class="quick-starts" id="quick-starts">
-        <div class="section-heading">
-          <p class="eyebrow">Quick start</p>
-          <h2>Pick your starting mode</h2>
-          <p class="section-description">
-            Three fast routes to first delight depending on your setup and energy.
-          </p>
-        </div>
-        <div class="quick-start-grid">
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Guided</p>
-            <h3>Open Halo Flow</h3>
-            <p>Balanced visuals with simple controls if you want a reliable first run.</p>
-            <div class="quick-card__actions">
-              <a href="toy.html?toy=holy" class="cta-button primary" data-quickstart-slug="holy"
-                >Start now</a
-              >
-            </div>
-          </article>
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Hands-free</p>
-            <h3>Auto-flow mode</h3>
-            <p>Rotate through featured stims every ~45s with demo audio ready.</p>
-            <div class="quick-card__actions">
-              <a
-                href="toy.html?toy=spiral-burst"
-                class="cta-button cta-button--muted"
-                data-quickstart-mode="random"
-                data-quickstart-pool="featured"
-                data-quickstart-audio="demo"
-                data-quickstart-flow="true"
-                >Start flow mode</a
-              >
-            </div>
-          </article>
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Random</p>
-            <h3>Surprise stim</h3>
-            <p>Jump to a random featured stim when you want novelty without setup.</p>
-            <div class="quick-card__actions">
-              <a
-                href="toy.html?toy=spiral-burst"
-                class="cta-button cta-button--accent"
-                data-quickstart-mode="random"
-                data-quickstart-pool="featured"
-                data-quickstart-audio="demo"
-                >Surprise me</a
-              >
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <section class="system-check" id="system-check">
-        <div class="section-heading">
-          <p class="eyebrow">System check</p>
-          <h2>Check your device</h2>
-          <p class="section-description">Live status while we scan.</p>
-          <p
-            class="section-description details-panel"
-            data-details-panel
-            id="system-check-details"
-          >
-            Graphics, mic, motion, comfort.
-          </p>
-          <button
-            type="button"
-            class="text-link details-toggle"
-            data-details-toggle
-            aria-expanded="false"
-            aria-controls="system-check-details"
-          >
-            <span data-details-label="open">Details</span>
-            <span data-details-label="close">Hide details</span>
-          </button>
-        </div>
-        <ul class="system-legend" aria-label="System signals">
-          <li class="system-legend__item">🖥️ Graphics</li>
-          <li class="system-legend__item">🎙️ Mic</li>
-          <li class="system-legend__item">🧭 Motion</li>
-          <li class="system-legend__item">🫧 Comfort</li>
-        </ul>
-        <div class="system-grid">
-          <div class="readiness-panel" data-readiness-panel>
-            <div class="readiness-header">
-              <h3 class="readiness-title">Live readiness</h3>
-              <p class="readiness-subtitle" data-details-panel>
-                We’ll keep these signals updated so you know what’s available.
-              </p>
-            </div>
-            <ul class="readiness-list">
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="render"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Graphics acceleration</span>
-                </div>
-                <p class="readiness-note" data-status-note="render">
-                  Checking graphics…
-                </p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span class="readiness-dot" data-status-dot="mic" aria-hidden="true"></span>
-                  <span class="readiness-name">Microphone</span>
-                </div>
-                <p class="readiness-note" data-status-note="mic">Checking mic…</p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="motion"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion input</span>
-                </div>
-                <p class="readiness-note" data-status-note="motion">Checking motion…</p>
-              </li>
-              <li class="readiness-item">
-                <div class="readiness-label">
-                  <span
-                    class="readiness-dot"
-                    data-status-dot="reduced"
-                    aria-hidden="true"
-                  ></span>
-                  <span class="readiness-name">Motion comfort</span>
-                </div>
-                <p class="readiness-note" data-status-note="reduced">Reading comfort…</p>
-              </li>
-            </ul>
-          </div>
-          <div class="system-controls" data-system-controls></div>
-        </div>
-        <div class="cta-row system-actions">
-          <button type="button" class="cta-button primary" data-open-preflight>
-            Open system check
-          </button>
-          <a href="#toy-list" class="text-link">Skip to library</a>
-        </div>
-      </section>
 
       <section class="library" id="library">
         <div class="section-heading">
@@ -339,19 +205,11 @@
                 <strong>Aurora Painter</strong>
                 <span>Gesture-led and dreamy</span>
               </a>
-              <a
-                href="toy.html?toy=spiral-burst"
-                class="starter-pick"
-                data-quickstart-slug="spiral-burst"
-              >
-                <strong>Spiral Burst</strong>
-                <span>High-energy beat response</span>
-              </a>
             </div>
           </section>
           <div class="search-heading">
             <h3>Find a stim</h3>
-            <p>Search by name, mood, tags, or capability and move fast.</p>
+            <p>Search by name or mood first, then open advanced filters if needed.</p>
           </div>
           <div class="search-row">
             <label class="sr-only" for="toy-search">Search the library</label>
@@ -398,17 +256,11 @@
               >
                 Loading library…
               </p>
-              <p class="search-meta__note">Search scope</p>
-              <ul class="search-meta__tokens" aria-hidden="true">
-                <li>Name</li>
-                <li>Mood</li>
-                <li>Tags</li>
-                <li>Capabilities</li>
-              </ul>
+              <p class="search-meta__note">Start with a name or mood, then refine results.</p>
             </div>
           </div>
           <div class="active-filters" data-active-filters hidden>
-            <span class="active-filters__label">Active</span>
+            <span class="active-filters__label">Applied filters</span>
             <div class="active-filters__chips" data-active-filters-chips></div>
             <button
               type="button"
@@ -453,6 +305,7 @@
                 data-filter-chip
                 data-filter-type="capability"
                 data-filter-value="motion"
+                data-filter-advanced
               >
                 Motion
               </button>
@@ -462,6 +315,7 @@
                 data-filter-chip
                 data-filter-type="capability"
                 data-filter-value="demoAudio"
+                data-filter-advanced
               >
                 Demo audio
               </button>
@@ -471,11 +325,23 @@
                 data-filter-chip
                 data-filter-type="feature"
                 data-filter-value="webgpu"
+                data-filter-advanced
               >
                 WebGPU
               </button>
             </div>
-            <div class="filter-actions">
+            <div class="filter-actions filter-actions--primary">
+              <button
+                type="button"
+                class="filter-toggle"
+                data-advanced-filters-toggle
+                aria-expanded="false"
+                aria-controls="advanced-filters"
+              >
+                Refine results
+              </button>
+            </div>
+            <div class="filter-actions" id="advanced-filters" data-advanced-filters hidden>
               <button type="button" class="filter-reset" data-filter-reset>
                 Clear filters
               </button>
@@ -492,6 +358,98 @@
           </div>
         </search>
         <main id="toy-list" class="webtoy-container"></main>
+      </section>
+
+      <section class="system-check" id="system-check">
+        <div class="section-heading">
+          <p class="eyebrow">System check</p>
+          <h2>Check your device</h2>
+          <p class="section-description">Quick readiness summary for graphics, mic, and motion.</p>
+          <p
+            class="section-description details-panel"
+            data-details-panel
+            id="system-check-details"
+          >
+            Graphics, mic, motion, comfort.
+          </p>
+          <button
+            type="button"
+            class="text-link details-toggle"
+            data-details-toggle
+            aria-expanded="false"
+            aria-controls="system-check-details"
+          >
+            <span data-details-label="open">Details</span>
+            <span data-details-label="close">Hide details</span>
+          </button>
+        </div>
+        <ul class="system-legend" aria-label="System signals">
+          <li class="system-legend__item">🖥️ Graphics</li>
+          <li class="system-legend__item">🎙️ Mic</li>
+          <li class="system-legend__item">🧭 Motion</li>
+          <li class="system-legend__item">🫧 Comfort</li>
+        </ul>
+        <div class="system-grid">
+          <div class="readiness-panel" data-readiness-panel>
+            <div class="readiness-header">
+              <h3 class="readiness-title">Ready now?</h3>
+              <p class="readiness-subtitle" data-details-panel>
+                We’ll keep these signals updated so you know what’s available.
+              </p>
+            </div>
+            <ul class="readiness-list">
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="render"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Visual performance</span>
+                </div>
+                <p class="readiness-note" data-status-note="render">
+                  Checking graphics…
+                </p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span class="readiness-dot" data-status-dot="mic" aria-hidden="true"></span>
+                  <span class="readiness-name">Microphone</span>
+                </div>
+                <p class="readiness-note" data-status-note="mic">Checking mic…</p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="motion"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Tilt controls</span>
+                </div>
+                <p class="readiness-note" data-status-note="motion">Checking motion…</p>
+              </li>
+              <li class="readiness-item">
+                <div class="readiness-label">
+                  <span
+                    class="readiness-dot"
+                    data-status-dot="reduced"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="readiness-name">Low-motion mode</span>
+                </div>
+                <p class="readiness-note" data-status-note="reduced">Reading comfort…</p>
+              </li>
+            </ul>
+          </div>
+          <div class="system-controls" data-system-controls></div>
+        </div>
+        <div class="cta-row system-actions">
+          <button type="button" class="cta-button primary" data-open-preflight>
+            Open full system check
+          </button>
+          <a href="#toy-list" class="text-link">Back to library</a>
+        </div>
       </section>
 
       <section class="github" id="github">

--- a/tests/toy-view.test.js
+++ b/tests/toy-view.test.js
@@ -65,7 +65,7 @@ describe('toy view helpers', () => {
       { moduleUrl: 'assets/js/toys/broken.ts' },
     );
 
-    expect(status?.textContent).toContain('could not be compiled');
+    expect(status?.textContent).toContain('could not start on this setup yet');
     expect(
       status?.querySelector('.active-toy-status__actions button'),
     ).not.toBeNull();


### PR DESCRIPTION
### Motivation
- Reduce first‑screen decision friction by de‑duplicating hero actions and moving lower‑value secondary CTAs out of the primary hero band.
- Stage filter complexity so advanced controls are hidden by default but still surface active advanced chips and auto‑expand when advanced URL filters are present.
- Soften and simplify toy preflight and import error affordances to prioritize clear, action‑oriented recovery paths.

### Description
- De‑duplicated hero controls and surfaced a compact “Surprise me” secondary action next to “Browse all stims” by updating `index.html` and adding `.intro-secondary-links` styles in `assets/css/index.css`.
- Removed the standalone quick‑start block and reduced starter picks from three to two in `index.html`, and updated search helper copy to encourage name/mood searches first.
- Moved and clarified the system check area under the library content and converted system labels to outcome‑focused text (e.g. `Visual performance`, `Tilt controls`) in `index.html` and `assets/js/readiness-probe.ts`.
- Added a progressive advanced‑filter toggle and visibility sync logic in `assets/js/utils/init-library.ts` that sets the toggle text to `Refine results` / `Hide refinements`, preserves active advanced chips when collapsed, and auto‑expands when advanced filters are present in the URL.
- Demoted preflight retry affordance to a lower‑emphasis text link and updated copy to `Run checks again`, and changed a few messaging strings to be action‑focused in `assets/js/core/capability-preflight.ts`.
- Improved import‑error handling and recovery by wiring a `onBrowseCompatible` callback path through `assets/js/loader.ts`, adding the option to `toy-view` import error UI, and softening the import error text in `assets/js/toy-view.ts`.
- Added UI styles for the filter toggle and adjusted several CSS rules to support the new layout in `assets/css/index.css`.
- Updated a unit expectation in `tests/toy-view.test.js` to reflect the new import error copy.
- Updated docs index and added the UX audit artifacts: `docs/README.md`, `docs/UX_AUDIT_2026-02.md`, `docs/UX_AUDIT_2026-02_FOLLOWUP.md`, and `docs/UX_AUDIT_2026-02_ITERATION_2.md`.

### Testing
- Ran `bun x biome check` on modified files (no fixes applied) and `biome check` as part of precommit formatting (passed for the repo subset checked).
- Ran `bun run check` which performs lint/type/tests; this run surfaced two pre‑existing unrelated failures (`tests/pocket-pulse.test.ts` and `tests/mobile-ripples.test.ts` referencing a `PerspectiveCamera` export), so the overall `check` step failed but the failures are outside the scope of these UX changes.
- Ran targeted tests `bun run test tests/app-shell.test.js tests/library-filter-state.test.ts` which passed.
- Executed `bun run test` in CI context during development which showed the same two unrelated toy module failures; all other tests passed.
- Started the dev server (`bun run dev`) and captured desktop/mobile screenshots via Playwright for manual verification, which completed successfully.

Files touched: `index.html`, `assets/css/index.css`, `assets/js/utils/init-library.ts`, `assets/js/core/capability-preflight.ts`, `assets/js/readiness-probe.ts`, `assets/js/loader.ts`, `assets/js/toy-view.ts`, `tests/toy-view.test.js`, and docs under `docs/` (index + three UX audit files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0a77d32c83328d8bda7dbea1c1b5)