### PR TITLE
Sync advanced chip visibility across programmatic filter updates

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1372,6 +1372,11 @@ export function createLibraryView({
     chip.setAttribute('aria-pressed', String(isActive));
   };
 
+  const emitFilterStateChange = () => {
+    if (typeof document === 'undefined') return;
+    document.dispatchEvent(new Event('library:filters-changed'));
+  };
+
   const resolveQuickLaunchToy = (list, query) => {
     const trimmedQuery = query.trim().toLowerCase();
     if (!trimmedQuery || list.length === 0) return null;
@@ -1425,7 +1430,11 @@ export function createLibraryView({
     sortBy = 'featured';
 
     const chips = document.querySelectorAll('[data-filter-chip].is-active');
-    chips.forEach((chip) => chip.classList.remove('is-active'));
+    chips.forEach((chip) => {
+      chip.classList.remove('is-active');
+      updateFilterChipA11y(chip, false);
+    });
+    emitFilterStateChange();
 
     if (searchInputId) {
       const search = document.getElementById(searchInputId);
@@ -1753,6 +1762,7 @@ export function createLibraryView({
       chip.classList.toggle('is-active', isActive);
       updateFilterChipA11y(chip, isActive);
     });
+    emitFilterStateChange();
 
     const sortControl = document.querySelector('[data-sort-control]');
     if (sortControl && sortControl.tagName === 'SELECT') {
@@ -2143,6 +2153,7 @@ export function createLibraryView({
       chip.classList.remove('is-active');
       updateFilterChipA11y(chip, false);
     });
+    emitFilterStateChange();
     commitState({ replace: false });
     renderToys(applyFilters());
     updateFilterResetState();
@@ -2157,6 +2168,7 @@ export function createLibraryView({
       chip.classList.remove('is-active');
       updateFilterChipA11y(chip, false);
     });
+    emitFilterStateChange();
 
     if (searchInputId) {
       const search = document.getElementById(searchInputId);
@@ -2188,6 +2200,7 @@ export function createLibraryView({
         updateFilterChipA11y(chip, false);
       }
     });
+    emitFilterStateChange();
     commitState({ replace: false });
     renderToys(applyFilters());
     updateFilterResetState();
@@ -2230,6 +2243,7 @@ export function createLibraryView({
         const token = `${type}:${value.toLowerCase()}`;
         const isActive = chip.classList.toggle('is-active');
         updateFilterChipA11y(chip, isActive);
+        emitFilterStateChange();
         if (isActive) {
           activeFilters.add(token);
         } else {

--- a/assets/js/utils/init-library.ts
+++ b/assets/js/utils/init-library.ts
@@ -81,25 +81,12 @@ export const initLibraryView = async ({
       window.requestAnimationFrame(refreshVisibility);
     };
 
-    const observer = new MutationObserver((mutations) => {
-      const hasClassChange = mutations.some(
-        (mutation) =>
-          mutation.type === 'attributes' && mutation.attributeName === 'class',
-      );
-      if (hasClassChange) {
-        scheduleRefresh();
-      }
-    });
-
     advancedChips.forEach((chip) => {
-      observer.observe(chip, {
-        attributes: true,
-        attributeFilter: ['class'],
-      });
       chip.addEventListener('click', scheduleRefresh);
     });
 
     window.addEventListener('popstate', scheduleRefresh);
+    document.addEventListener('library:filters-changed', scheduleRefresh);
 
     document
       .querySelector('[data-filter-reset]')


### PR DESCRIPTION
### Motivation
- Advanced refinement chips could become incorrectly visible or hidden when filters were changed by non-click flows (`Clear all`, `Clear filters`, `popstate`/`applyState`, and programmatic token removal), making the UI out of sync with the actual active filters. 
- The goal is to ensure collapsed advanced chips always reflect the true active filter state regardless of how that state changes.

### Description
- Added a library-level event emitter `library:filters-changed` in `assets/js/library-view.js` via a new `emitFilterStateChange` helper and invoked it from `applyState`, `resetFiltersAndSearch`, `clearFilters`, `clearAllFilters`, `removeFilterToken`, and the chip click handler so programmatic updates notify listeners. 
- Updated `assets/js/utils/init-library.ts` to listen for `library:filters-changed` and call the existing refresh flow (`scheduleRefresh`) instead of relying on a `MutationObserver`, ensuring collapsed advanced chips hide/show immediately after non-click updates. 
- Kept accessibility updates by calling `updateFilterChipA11y` where chips are toggled and ensured the new event is only dispatched in browser contexts.

### Testing
- Ran the project quality gate with `bun run check` (Biome, TypeScript, and test suite) which completed successfully with all tests passing except 2 intentionally skipped tests. 
- Executed a Playwright smoke script against a dev server that exercised the advanced toggle, activated an advanced chip, collapsed the panel, cleared active filters, and captured a screenshot to validate the UI sync behavior, which completed successfully. 
- No documentation files were changed in this PR (`None`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c15e9c0908332aecb257fe2356448)