### PR TITLE
Tighten energetic quickstart pool selection

### DIFF
--- a/assets/js/utils/init-quickstart.ts
+++ b/assets/js/utils/init-quickstart.ts
@@ -51,6 +51,7 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         'dance',
         'neon',
         'pulse',
+        'pulsing',
       ]);
 
       const isEnergeticToy = (toy: QuickstartToy) => {
@@ -60,7 +61,7 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         const hasEnergeticTag = metadata.some((value) =>
           energeticTags.has(value),
         );
-        return hasEnergeticTag || Boolean(toy.capabilities?.demoAudio);
+        return hasEnergeticTag;
       };
 
       let pool: QuickstartToy[];

--- a/tests/init-quickstart.test.ts
+++ b/tests/init-quickstart.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import toyManifest from '../assets/js/data/toy-manifest.ts';
+import { initQuickstartCta } from '../assets/js/utils/init-quickstart.ts';
+
+const energeticTags = new Set([
+  'energetic',
+  'high-energy',
+  'party',
+  'hype',
+  'dance',
+  'neon',
+  'pulse',
+  'pulsing',
+]);
+
+const isEnergetic = (slug: string) => {
+  const toy = toyManifest.find((entry) => entry.slug === slug);
+  if (!toy) return false;
+  const metadata = [...(toy.moods ?? []), ...(toy.tags ?? [])].map((value) =>
+    value.toLowerCase(),
+  );
+  return metadata.some((value) => energeticTags.has(value));
+};
+
+describe('quickstart energetic pool', () => {
+  const originalRandom = Math.random;
+
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<a href="#" data-quickstart-mode="random" data-quickstart-pool="energetic">Surprise me</a>';
+    mock.restore();
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    document.body.innerHTML = '';
+    mock.restore();
+  });
+
+  test('filters random energetic picks to energetic-tagged toys only', () => {
+    const loadToy = mock();
+
+    Math.random = () => 1 / toyManifest.length;
+
+    initQuickstartCta({
+      loadToy:
+        loadToy as unknown as typeof import('../assets/js/loader.ts').loadToy,
+    });
+
+    const cta = document.querySelector('[data-quickstart-pool="energetic"]');
+    expect(cta).not.toBeNull();
+    cta?.dispatchEvent(
+      new window.MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    expect(loadToy).toHaveBeenCalledTimes(1);
+
+    const selectedSlug = loadToy.mock.calls[0]?.[0] as string;
+    expect(selectedSlug).not.toBe('aurora-painter');
+    expect(isEnergetic(selectedSlug)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- The `energetic` quickstart pool was including any toy with `capabilities.demoAudio`, which made the energetic filter ineffective because `demoAudio` is broadly marked across the catalog. 
- This caused Party mode / Surprise me to randomly launch non-energetic toys instead of a focused high-energy subset, regressing the intended quickstart behavior.

### Description
- Updated `assets/js/utils/init-quickstart.ts` to remove the `demoAudio` include condition and rely on energetic-related `moods`/`tags` only when resolving the `energetic` pool. 
- Added `pulsing` to the energetic token set used to match metadata. 
- Added a regression test `tests/init-quickstart.test.ts` that simulates the energetic random CTA click and verifies the selected toy is energetic-tagged (and not a known non-energetic case). 
- Formatted files and committed the changes under the branch with the message: `Tighten energetic quickstart pool selection`.

### Testing
- Ran the targeted test with `bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/init-quickstart.test.ts`, which passed. 
- Ran the full quality gate with `bun run check` (Biome format/lint, TypeScript `tsc`, and the test suite), which completed successfully with the test suite reporting all tests passed (100 pass, 2 skip).
- Docs: None updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd78931888332869f567e933874ba)