### PR TITLE
Add daily streak prompts to boost repeat library sessions

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -818,6 +818,63 @@ header.hero {
   box-shadow: var(--shadow-soft);
 }
 
+.daily-streak {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.1rem;
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent-color) 20%, transparent),
+      transparent 60%
+    ),
+    color-mix(in srgb, var(--surface-strong) 86%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 30%, var(--surface-border));
+}
+
+.daily-streak__header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.daily-streak__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.daily-streak__title {
+  margin: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.daily-streak__title strong {
+  font-size: 1.04rem;
+}
+
+.daily-streak__title span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.daily-streak__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.daily-streak__note {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+}
+
 .system-check {
   display: grid;
   gap: 1.4rem;

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1134,6 +1134,7 @@ export function createLibraryView({
   themeToggleId = 'theme-toggle',
 } = {}) {
   const STORAGE_KEY = 'stims-library-state';
+  const ENGAGEMENT_KEY = 'stims-engagement-state';
   const COMPATIBILITY_MODE_KEY = 'stims-compatibility-mode';
   const QUERY_PARAM = 'q';
   const FILTER_PARAM = 'filters';
@@ -1154,6 +1155,133 @@ export function createLibraryView({
   let activeFiltersChips;
   let activeFiltersClear;
   const activeFilters = new Set();
+
+  const toDateKey = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  const shiftDateKey = (dateKey, amount) => {
+    const [year, month, day] = dateKey.split('-').map(Number);
+    if (![year, month, day].every(Number.isFinite)) return null;
+    const shifted = new Date(year, month - 1, day);
+    shifted.setDate(shifted.getDate() + amount);
+    return toDateKey(shifted);
+  };
+
+  const getTodayKey = () => toDateKey(new Date());
+
+  const readEngagementState = () => {
+    try {
+      const raw = window.localStorage.getItem(ENGAGEMENT_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') return null;
+      return parsed;
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  const saveEngagementState = (state) => {
+    try {
+      window.localStorage.setItem(ENGAGEMENT_KEY, JSON.stringify(state));
+    } catch (_error) {
+      // Ignore storage access issues.
+    }
+  };
+
+  const recordToyLaunch = (toy) => {
+    const current = readEngagementState() ?? {
+      streak: 0,
+    };
+    const today = getTodayKey();
+    const yesterday = shiftDateKey(today, -1);
+
+    let streak = Number.isFinite(current.streak) ? current.streak : 0;
+    if (current.lastActiveDay !== today) {
+      if (current.lastActiveDay && current.lastActiveDay === yesterday) {
+        streak += 1;
+      } else {
+        streak = 1;
+      }
+    }
+
+    const nextState = {
+      ...current,
+      streak,
+      lastActiveDay: today,
+      lastPlayedSlug: toy.slug,
+      lastPlayedTitle: toy.title,
+      lastPlayedAt: new Date().toISOString(),
+    };
+    saveEngagementState(nextState);
+  };
+
+  const resolveDailyToy = () => {
+    if (!allToys.length) return null;
+    const dayIndex = Math.floor(Date.now() / 86400000);
+    const safeIndex =
+      ((dayIndex % allToys.length) + allToys.length) % allToys.length;
+    return allToys[safeIndex] ?? null;
+  };
+
+  const updateDailyEngagement = () => {
+    const container = document.querySelector('[data-daily-engagement]');
+    if (!(container instanceof HTMLElement)) return;
+
+    const streakCount = container.querySelector('[data-daily-streak-count]');
+    const streakCopy = container.querySelector('[data-daily-streak-copy]');
+    const dailyAction = container.querySelector('[data-daily-pick-action]');
+    const recentAction = container.querySelector('[data-recent-pick-action]');
+    const dailyLabel = container.querySelector('[data-daily-pick-label]');
+
+    const state = readEngagementState();
+    const streak = Number.isFinite(state?.streak) ? Number(state.streak) : 0;
+
+    if (streakCount) {
+      streakCount.textContent =
+        streak > 0 ? `${streak}-day streak` : 'Start your streak';
+    }
+    if (streakCopy) {
+      streakCopy.textContent =
+        streak > 0
+          ? 'Keep the momentum by opening one stim today.'
+          : 'Open one stim each day to build a relaxing routine.';
+    }
+
+    const dailyToy = resolveDailyToy();
+    if (dailyAction instanceof HTMLButtonElement && dailyToy) {
+      dailyAction.textContent = `Play today’s pick: ${dailyToy.title}`;
+      dailyAction.onclick = () =>
+        openToy(dailyToy, {
+          preferDemoAudio: Boolean(dailyToy.capabilities?.demoAudio),
+        });
+    }
+
+    if (dailyLabel) {
+      dailyLabel.textContent = dailyToy
+        ? `Today's focus toy: ${dailyToy.title}.`
+        : "We'll choose a fresh toy every day.";
+    }
+
+    const recentToy = allToys.find((toy) => toy.slug === state?.lastPlayedSlug);
+    if (recentAction instanceof HTMLButtonElement) {
+      if (recentToy) {
+        recentAction.hidden = false;
+        recentAction.textContent = `Continue: ${recentToy.title}`;
+        recentAction.onclick = () =>
+          openToy(recentToy, {
+            preferDemoAudio: Boolean(recentToy.capabilities?.demoAudio),
+          });
+      } else {
+        recentAction.hidden = true;
+        recentAction.onclick = null;
+      }
+    }
+  };
 
   const ensureMetaNode = () => {
     if (!resultsMeta) {
@@ -1782,6 +1910,8 @@ export function createLibraryView({
   };
 
   const openToy = (toy, { preferDemoAudio = false } = {}) => {
+    recordToyLaunch(toy);
+    updateDailyEngagement();
     if (toy.type === 'module' && typeof loadToy === 'function') {
       loadToy(toy.slug, { pushState: true, preferDemoAudio });
     } else if (toy.module) {
@@ -2459,6 +2589,7 @@ export function createLibraryView({
     }
 
     renderToys(applyFilters());
+    updateDailyEngagement();
 
     if (enableDarkModeToggle) {
       setupDarkModeToggle(themeToggleId);

--- a/index.html
+++ b/index.html
@@ -217,6 +217,26 @@
               </a>
             </div>
           </section>
+          <section class="daily-streak" aria-label="Daily return recommendations" data-daily-engagement>
+            <div class="daily-streak__header">
+              <p class="daily-streak__eyebrow">Daily momentum</p>
+              <p class="daily-streak__title">
+                <strong data-daily-streak-count>Start your streak</strong>
+                <span data-daily-streak-copy>Open one stim each day to build a relaxing routine.</span>
+              </p>
+            </div>
+            <div class="daily-streak__actions">
+              <button type="button" class="cta-button" data-daily-pick-action>
+                Play today's pick
+              </button>
+              <button type="button" class="cta-button cta-button--muted" data-recent-pick-action hidden>
+                Continue previous stim
+              </button>
+            </div>
+            <p class="daily-streak__note" data-daily-pick-label>
+              We'll choose a fresh toy every day.
+            </p>
+          </section>
           <div class="search-heading">
             <h3>Find a stim</h3>
             <p>Search by name or mood first, then open advanced filters if needed.</p>

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -23,6 +23,7 @@ describe('library filter state normalization', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/');
     window.sessionStorage.clear();
+    window.localStorage.clear();
 
     document.body.innerHTML = `
       <input id="toy-search" />
@@ -39,6 +40,13 @@ describe('library filter state normalization', () => {
       <select data-sort-control>
         <option value="featured">Featured</option>
       </select>
+      <section data-daily-engagement>
+        <strong data-daily-streak-count></strong>
+        <span data-daily-streak-copy></span>
+        <button data-daily-pick-action type="button"></button>
+        <button data-recent-pick-action type="button" hidden></button>
+        <p data-daily-pick-label></p>
+      </section>
       <div id="toy-list"></div>
     `;
   });
@@ -65,5 +73,28 @@ describe('library filter state normalization', () => {
     expect(persisted).not.toBeNull();
     expect(JSON.parse(persisted ?? '{}').filters).toEqual([]);
     expect(calmChip?.classList.contains('is-active')).toBe(false);
+  });
+
+  test('records launches so daily streak and continue action are available', async () => {
+    const view = createLibraryView({
+      toys,
+      searchInputId: 'toy-search',
+      loadToy: () => {},
+    });
+
+    await view.init();
+
+    const card = document.querySelector('.webtoy-card');
+    expect(card).not.toBeNull();
+    card?.dispatchEvent(new Event('click', { bubbles: true }));
+
+    const persisted = window.localStorage.getItem('stims-engagement-state');
+    expect(persisted).not.toBeNull();
+    const parsed = JSON.parse(persisted ?? '{}');
+    expect(parsed.lastPlayedSlug).toBe('calm-flow');
+    expect(parsed.streak).toBe(1);
+
+    const continueButton = document.querySelector('[data-recent-pick-action]');
+    expect(continueButton?.hasAttribute('hidden')).toBe(false);
   });
 });

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -113,6 +113,7 @@ async function buildLoader({
 }
 
 beforeEach(() => {
+  window.history.replaceState({}, '', '/');
   document.body.innerHTML = '<div id="toy-list"></div>';
   capabilitiesMock = {
     getRendererCapabilities: mock(async () => defaultCapabilities),


### PR DESCRIPTION
### Motivation
- Encourage repeat visits and increase daily active usage by surfacing a lightweight daily pick and a continue action on the library page.
- Make return behavior persistent and visible by tracking last-played toy and a simple per-day streak in `localStorage`.

### Description
- Added a new `Daily momentum` UI block to the library (`index.html`) with a daily pick CTA, streak text, and a continue previous-stim CTA wired to the library state.
- Added styles for the panel in `assets/css/index.css` so the new block visually matches the starter cards and library layout.
- Extended `createLibraryView` (`assets/js/library-view.js`) with `ENGAGEMENT_KEY` persistence, helpers to read/save engagement state, `recordToyLaunch`, `resolveDailyToy`, and `updateDailyEngagement`, and hooked updates into `init` and `openToy` so the panel refreshes on load and on toy launches.
- Added tests and minor test hardening: `tests/library-filter-state.test.ts` now clears `localStorage` and includes a test for engagement state persistence, and `tests/loader.test.js` resets `history` in `beforeEach` to avoid leaked query state between specs.

### Testing
- Ran the repo quality gate with `bun run check` which runs Biome, TypeScript typecheck, and the test suite; all automated checks passed (unit suite: 101 passed, 2 skipped, 0 failed).
- Ran a dev server (`bun run dev --host 0.0.0.0 --port 4173`) and captured a Playwright screenshot to visually validate the new panel (artifact: `artifacts/daily-streak-library.png`).
- Updated/added tests under `tests/` and confirmed they pass as part of `bun run check`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd973938c833280bc8e1b6c1f0d57)