### PR TITLE
Adaptive Flow mode cadence based on user engagement

### DIFF
--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -189,7 +189,7 @@ function renderToyNav(
   const safeTitle = escapeHtml(options.title ?? 'Web toy');
   const safeSlug = options.slug ? escapeHtml(options.slug) : '';
   const hintText = isMobileDevice()
-    ? 'Tap Flow mode to auto-switch every 45s. Use Back to return.'
+    ? 'Tap Flow mode to auto-switch every 25–50s. Use Back to return.'
     : 'Press Esc or use Back to return to the library.';
   const randomChallenge =
     TOY_MICRO_CHALLENGES[

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -147,6 +147,44 @@ afterEach(() => {
   });
 });
 
+describe('flow cadence helper', () => {
+  test('uses the warmup interval for the first flow cycle', async () => {
+    const { getFlowIntervalMs } = await import('../assets/js/loader.ts');
+
+    const interval = getFlowIntervalMs({
+      cycleCount: 0,
+      lastInteractionAt: 1_000,
+      now: 10_000,
+    });
+
+    expect(interval).toBe(25_000);
+  });
+
+  test('uses the engaged interval when recent interaction is detected', async () => {
+    const { getFlowIntervalMs } = await import('../assets/js/loader.ts');
+
+    const interval = getFlowIntervalMs({
+      cycleCount: 2,
+      lastInteractionAt: 100_000,
+      now: 180_000,
+    });
+
+    expect(interval).toBe(35_000);
+  });
+
+  test('uses the idle interval when interaction is stale', async () => {
+    const { getFlowIntervalMs } = await import('../assets/js/loader.ts');
+
+    const interval = getFlowIntervalMs({
+      cycleCount: 2,
+      lastInteractionAt: 100_000,
+      now: 240_001,
+    });
+
+    expect(interval).toBe(50_000);
+  });
+});
+
 describe('loadToy', () => {
   test('loads module toy without mutating history when pushState is false', async () => {
     const { loader, manifestClient } = await buildLoader();


### PR DESCRIPTION
### Motivation
- Increase hourly active usage by making Flow mode adapt to user engagement so active sessions rotate toys more frequently while idle sessions rotate more gently.

### Description
- Replace the single fixed `FLOW_INTERVAL_MS` with warmup, engaged, and idle intervals and expose a helper `getFlowIntervalMs` to choose the cadence.
- Switch from a fixed `setInterval` to a timeout-based scheduler and track `flowCycleCount` so automatic transitions can adapt over successive cycles.  
- Add lightweight interaction tracking (`pointerdown`, `keydown`, `touchstart`) via `initInteractionTracking` and `markInteraction`, and wire tracking into loader startup and navigation so cadence decisions are activity-aware.
- Update mobile toy-nav hint copy to reflect the new adaptive cadence and add unit tests in `tests/loader.test.js` that verify warmup, engaged, and idle branches; key files changed: `assets/js/loader.ts`, `assets/js/ui/nav.ts`, and `tests/loader.test.js`.

### Testing
- Ran `bun run check`, which surfaced pre-existing unrelated failures in `tests/library-filter-state.test.ts` (`HTMLButtonElement is not defined`) and is not caused by these changes.  
- Ran targeted unit tests with `bun run test tests/loader.test.js` and all tests in that file passed.  
- Ran code formatting (`biome format`) as part of the quality gate during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdc4f0b1483329694f37a9b7f3206)