### PR TITLE
Trim low-value helper copy across library landing

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1249,7 +1249,7 @@ export function createLibraryView({
       streakCopy.textContent =
         streak > 0
           ? 'Keep the momentum by opening one stim today.'
-          : 'Open one stim each day to build a relaxing routine.';
+          : 'Open one stim each day.';
     }
 
     const dailyToy = resolveDailyToy();
@@ -1264,7 +1264,7 @@ export function createLibraryView({
     if (dailyLabel) {
       dailyLabel.textContent = dailyToy
         ? `Today's focus toy: ${dailyToy.title}.`
-        : "We'll choose a fresh toy every day.";
+        : 'Daily pick updates each day.';
     }
 
     const recentToy = allToys.find((toy) => toy.slug === state?.lastPlayedSlug);

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           <p class="eyebrow">Audio-reactive visuals • Instant play</p>
           <h1>Stim library</h1>
           <p class="section-description">
-            Pick a stim, crank it up, and let the library keep the momentum.
+            Pick a stim and play.
           </p>
           <ul class="intro-pills" aria-label="Quick highlights">
             <li class="intro-pill">✨ Featured: Halo Flow</li>
@@ -182,9 +182,7 @@
             Surprise me
           </a>
         </div>
-        <p class="section-helper" data-hero-flow-note>
-          Optimized for this device right now: start instantly, then refine only if you want.
-        </p>
+        <p class="section-helper" data-hero-flow-note>Ready for this device.</p>
       </section>
 
 
@@ -200,7 +198,7 @@
           <section class="starter-picks" aria-label="Recommended starter picks">
             <div class="starter-picks__header">
               <h3>Starter picks</h3>
-              <p>Not sure where to begin? These are the easiest first wins.</p>
+              <p>Easy first picks.</p>
             </div>
             <div class="starter-picks__grid">
               <a href="toy.html?toy=holy" class="starter-pick" data-quickstart-slug="holy">
@@ -222,7 +220,7 @@
               <p class="daily-streak__eyebrow">Daily momentum</p>
               <p class="daily-streak__title">
                 <strong data-daily-streak-count>Start your streak</strong>
-                <span data-daily-streak-copy>Open one stim each day to build a relaxing routine.</span>
+                <span data-daily-streak-copy>Open one stim each day.</span>
               </p>
             </div>
             <div class="daily-streak__actions">
@@ -234,12 +232,12 @@
               </button>
             </div>
             <p class="daily-streak__note" data-daily-pick-label>
-              We'll choose a fresh toy every day.
+              Daily pick updates each day.
             </p>
           </section>
           <div class="search-heading">
             <h3>Find a stim</h3>
-            <p>Search by name or mood first, then open advanced filters if needed.</p>
+            <p>Search by name or mood.</p>
           </div>
           <div class="search-row">
             <label class="sr-only" for="toy-search">Search the library</label>
@@ -249,7 +247,7 @@
                 id="toy-search"
                 type="search"
                 name="toy-search"
-                placeholder="Try calm, spiral, microphone, or webgpu"
+                placeholder="Search stims"
                 autocomplete="off"
                 aria-describedby="toy-search-hint"
                 inputmode="search"
@@ -286,7 +284,7 @@
               >
                 Loading library…
               </p>
-              <p class="search-meta__note">Start with a name or mood, then refine results.</p>
+              <p class="search-meta__note">Use filters to refine.</p>
             </div>
           </div>
           <div class="active-filters" data-active-filters hidden>


### PR DESCRIPTION
### Motivation
- Reduce verbose helper text and microcopy on the library landing to make the discovery flow more concise and less repetitive.
- Keep runtime UI strings aligned with the simplified static copy so dynamic updates match the new tone.

### Description
- Shortened hero description and device helper line in `index.html` to a compact message.
- Simplified starter picks helper, daily engagement copy, search heading, search placeholder, and search meta note in `index.html`.
- Updated `assets/js/library-view.js` to align the runtime daily engagement fallback text with the new static copy.
- No functional or behavioral changes beyond copy updates; files modified: `index.html` and `assets/js/library-view.js`.

### Testing
- Ran `bun run check` (Biome lint/format, TypeScript typecheck, and the test suite), which completed successfully with `104 pass`, `2 skip`, and `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf57e20bc8332a1003ebecc569be8)