### PR TITLE
Simplify library and preflight frontend controls

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1919,6 +1919,11 @@ body {
   margin-top: 12px;
 }
 
+.preflight-retry-link {
+  align-self: flex-start;
+  margin-top: 8px;
+}
+
 .preflight-status__label {
   font-size: 0.8rem;
   text-transform: uppercase;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -768,20 +768,6 @@ header.hero {
   border: 1px solid var(--surface-border);
 }
 
-.starter-picks__header {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.starter-picks__header h3,
-.starter-picks__header p {
-  margin: 0;
-}
-
-.starter-picks__header p {
-  color: var(--text-muted);
-}
-
 .starter-picks__grid {
   display: grid;
   gap: 0.6rem;
@@ -3247,6 +3233,10 @@ footer {
   .hero-readiness__action {
     width: 100%;
     justify-content: center;
+  }
+
+  .section-helper[data-hero-flow-note] {
+    display: none;
   }
 
   header.hero {

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -227,10 +227,10 @@ function updateStatusList(
   const rendererStatus = buildStatusBadge(
     'Rendering',
     result.rendering.rendererBackend === 'webgpu'
-      ? 'Ready (WebGPU)'
+      ? 'Best visual mode ready'
       : result.rendering.rendererBackend === 'webgl'
-        ? 'WebGL fallback'
-        : 'Unavailable',
+        ? 'Runs in compatible mode'
+        : 'Needs a different browser or device',
     result.rendering.rendererBackend
       ? result.rendering.rendererBackend === 'webgpu'
         ? 'ok'
@@ -242,10 +242,10 @@ function updateStatusList(
   rendererNote.className = 'preflight-status__note';
   rendererNote.textContent =
     result.rendering.rendererBackend === 'webgpu'
-      ? 'WebGPU enabled.'
+      ? 'You can continue with full visuals.'
       : result.rendering.rendererBackend === 'webgl'
-        ? 'WebGL in use.'
-        : 'No GPU acceleration.';
+        ? 'You can continue with compatible visuals.'
+        : 'Try another browser or device for visuals.';
   rendererStatus.appendChild(rendererNote);
 
   const microphoneStatus = buildStatusBadge(
@@ -278,7 +278,9 @@ function updateStatusList(
 
   const environmentStatus = buildStatusBadge(
     'Environment',
-    result.environment.secureContext ? 'Secure context' : 'Insecure context',
+    result.environment.secureContext
+      ? 'Ready for modern browser features'
+      : 'Some features may be limited',
     result.environment.secureContext ? 'ok' : 'warn',
   );
 
@@ -355,7 +357,7 @@ function updateWhyDetails(
       'This page is not in a secure context, so some APIs may be limited.',
     );
   } else {
-    items.push('Secure context enables modern browser APIs.');
+    items.push('Secure browsing mode is active, so modern features can run.');
   }
 
   items.push(
@@ -457,7 +459,6 @@ export function attachCapabilityPreflight({
   host = document.body,
   heading = 'Quick system check',
   backHref,
-  backLabel = 'Back to library',
   onComplete,
   onRetry,
   openOnAttach = true,
@@ -467,7 +468,6 @@ export function attachCapabilityPreflight({
   host?: HTMLElement;
   heading?: string;
   backHref?: string;
-  backLabel?: string;
   onComplete?: (result: CapabilityPreflightResult) => void;
   onRetry?: (result: CapabilityPreflightResult) => void;
   openOnAttach?: boolean;
@@ -655,11 +655,13 @@ export function attachCapabilityPreflight({
   performanceButton.textContent = 'Improve performance';
   performanceButton.hidden = true;
   actions.appendChild(performanceButton);
+  let backLink: HTMLAnchorElement | null = null;
   if (backHref) {
-    const backLink = document.createElement('a');
+    backLink = document.createElement('a');
     backLink.className = 'cta-button ghost';
     backLink.href = backHref;
-    backLink.textContent = backLabel;
+    backLink.textContent = 'Browse compatible toys';
+    backLink.hidden = true;
     actions.appendChild(backLink);
   }
   const continueButton = document.createElement('button');
@@ -672,12 +674,13 @@ export function attachCapabilityPreflight({
   });
   actions.appendChild(continueButton);
 
+  panel.appendChild(actions);
+
   const retryButton = document.createElement('button');
   retryButton.className = 'text-link preflight-retry-link';
   retryButton.type = 'button';
   retryButton.textContent = 'Run checks again';
-  actions.appendChild(retryButton);
-  panel.appendChild(actions);
+  panel.appendChild(retryButton);
 
   let latestResult: CapabilityPreflightResult | null = null;
 
@@ -724,6 +727,9 @@ export function attachCapabilityPreflight({
     panel.dataset.state = result.canProceed ? 'ready' : 'blocked';
     retryButton.disabled = false;
     continueButton.hidden = !result.canProceed;
+    if (backLink) {
+      backLink.hidden = result.canProceed;
+    }
     updateStatusList(statusContainer, result);
     renderIssueList(issueContainer, result);
     updateWhyDetails(detailsContent, result);

--- a/index.html
+++ b/index.html
@@ -196,10 +196,6 @@
         </div>
         <search class="library-search">
           <section class="starter-picks" aria-label="Recommended starter picks">
-            <div class="starter-picks__header">
-              <h3>Starter picks</h3>
-              <p>Easy first picks.</p>
-            </div>
             <div class="starter-picks__grid">
               <a href="toy.html?toy=holy" class="starter-pick" data-quickstart-slug="holy">
                 <strong>Halo Flow</strong>
@@ -906,10 +902,6 @@
           const trimmedQuery = query.trim();
           if (trimmedQuery) {
             parts.push(`“${trimmedQuery}”`);
-          }
-          const filterLabels = getActiveFilterLabels();
-          if (filterLabels.length > 0) {
-            parts.push(filterLabels.join(', '));
           }
           parts.push(getSortLabel());
           searchResults.textContent = parts.join(' • ');


### PR DESCRIPTION
### Motivation

- Reduce duplicate decision copy and density on the library landing so the hero and starter picks don’t compete for attention.
- Make the system preflight panel clearer by surfacing outcome-first status copy and simplifying action affordances.
- Keep the active filter chips as the single source of truth for applied filters to avoid redundant metadata lines.
- Improve mobile first-viewport clarity by hiding a low-value helper line.

### Description

- Removed the starter-picks heading block while keeping the two starter cards to reduce duplicate top-of-page prompts (`index.html`).
- Stopped injecting active-filter labels into the search results meta string so applied filters are only shown via the active-chips row (`index.html`).
- Hid the small-screen hero helper line with a targeted CSS rule (`assets/css/index.css`).
- Reworded preflight status copy to be outcome-first for rendering and environment messages, simplified the secure-context detail text, and adjusted preflight action behavior so a “Browse compatible toys” link is only shown in blocked states while the primary continue action remains for ready states (`assets/js/core/capability-preflight.ts`).
- Moved the retry control to an inline text action below the statuses and added a small helper CSS rule for spacing (`assets/css/base.css`).

### Testing

- `bun run check` — ran the full quality gate and test suite and reported 2 failing tests in the library filter state suite (`library filter state normalization` tests) that appear unrelated to the touched files and originate from `assets/js/library-view.js` (`HTMLButtonElement is not defined`).
- `bun run test tests/toy-view.test.js` — executed and passed for the modified UI behavior in the toy view.
- `bun run test` (full suite) — ran and reproduced the same 2 failing `library-filter-state` tests; all other tests passed.

Docs

- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d793a91c48332934ac7cf9105f737)