### PR TITLE
Improve library search and filter chip mobile interactions

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1986,6 +1986,22 @@ html.light .experience-card {
   position: sticky;
   top: clamp(4.6rem, 9vh, 6rem);
   z-index: 6;
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.25s ease;
+}
+
+.library-search:focus-within {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 38%,
+    var(--surface-border)
+  );
+  box-shadow:
+    var(--shadow-strong),
+    0 0 0 1px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  transform: translateY(-1px);
 }
 
 .search-heading {
@@ -2333,6 +2349,8 @@ html.light .active-filters__label {
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
+  position: relative;
+  scroll-padding-inline: 0.25rem;
 }
 
 .filter-actions {
@@ -3192,8 +3210,29 @@ footer {
 
   .chip-row {
     overflow-x: auto;
+    flex-wrap: nowrap;
     padding-bottom: 0.2rem;
     scrollbar-width: thin;
+    scroll-snap-type: x proximity;
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      #000 1rem,
+      #000 calc(100% - 1rem),
+      transparent
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      #000 1rem,
+      #000 calc(100% - 1rem),
+      transparent
+    );
+  }
+
+  .chip-row > * {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
   }
 
   .preview-controls {
@@ -3458,5 +3497,15 @@ footer {
 
   .search-meta__tokens {
     display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .library-search {
+    transition: none;
+  }
+
+  .library-search:focus-within {
+    transform: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the library search area feel more intentional and easier to track when active by adding a subtle focus treatment and motion. 
- Improve filter chip usability on small screens so chips are discoverable and touch-friendly via horizontal scrolling and snap behavior. 
- Preserve accessibility preferences by disabling the new motion for users who request reduced motion.

### Description
- Added a `:focus-within` visual treatment and transition to the library search panel in `assets/css/index.css` to emphasize the active search area. 
- Added `scroll-padding-inline` to the chip row and enabled horizontal snap scrolling with edge fade masks for mobile by adjusting `.chip-row` behavior in `assets/css/index.css`. 
- Ensured child chips are non-wrapping on small screens and set `scroll-snap-align` for touch-friendly snapping. 
- Added a `prefers-reduced-motion` media query to disable the transition and transform for users who prefer reduced motion.

### Testing
- Ran the project quality gate with `bun run check`, which completed successfully and ran typecheck and the test suite. 
- Test summary: `104` tests passed, `2` tests skipped, `0` failed (results produced by the `bun run check` pipeline).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d86a9bcac8332b4d7b69e306535c9)