### PR TITLE
Handle calming quickstart pool selection

### DIFF
--- a/assets/js/utils/init-quickstart.ts
+++ b/assets/js/utils/init-quickstart.ts
@@ -53,16 +53,27 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         'pulse',
         'pulsing',
       ]);
+      const calmingTags = new Set([
+        'calming',
+        'calm',
+        'serene',
+        'ambient',
+        'focus',
+        'grounded',
+      ]);
 
-      const isEnergeticToy = (toy: QuickstartToy) => {
+      const hasMatchingMetadata = (toy: QuickstartToy, values: Set<string>) => {
         const metadata = [...(toy.moods ?? []), ...(toy.tags ?? [])].map(
           (value) => value.toLowerCase(),
         );
-        const hasEnergeticTag = metadata.some((value) =>
-          energeticTags.has(value),
-        );
-        return hasEnergeticTag;
+        return metadata.some((value) => values.has(value));
       };
+
+      const isEnergeticToy = (toy: QuickstartToy) =>
+        hasMatchingMetadata(toy, energeticTags);
+
+      const isCalmingToy = (toy: QuickstartToy) =>
+        hasMatchingMetadata(toy, calmingTags);
 
       let pool: QuickstartToy[];
       if (normalizedPool === 'featured') {
@@ -71,6 +82,8 @@ export const initQuickstartCta = ({ loadToy }: InitQuickstartOptions) => {
         );
       } else if (normalizedPool === 'energetic') {
         pool = quickstartToys.filter((toy) => isEnergeticToy(toy));
+      } else if (normalizedPool === 'calming') {
+        pool = quickstartToys.filter((toy) => isCalmingToy(toy));
       } else {
         pool = quickstartToys;
       }

--- a/tests/init-quickstart.test.ts
+++ b/tests/init-quickstart.test.ts
@@ -14,6 +14,15 @@ const energeticTags = new Set([
   'pulsing',
 ]);
 
+const calmingTags = new Set([
+  'calming',
+  'calm',
+  'serene',
+  'ambient',
+  'focus',
+  'grounded',
+]);
+
 const isEnergetic = (slug: string) => {
   const toy = toyManifest.find((entry) => entry.slug === slug);
   if (!toy) return false;
@@ -21,6 +30,15 @@ const isEnergetic = (slug: string) => {
     value.toLowerCase(),
   );
   return metadata.some((value) => energeticTags.has(value));
+};
+
+const isCalming = (slug: string) => {
+  const toy = toyManifest.find((entry) => entry.slug === slug);
+  if (!toy) return false;
+  const metadata = [...(toy.moods ?? []), ...(toy.tags ?? [])].map((value) =>
+    value.toLowerCase(),
+  );
+  return metadata.some((value) => calmingTags.has(value));
 };
 
 describe('quickstart energetic pool', () => {
@@ -59,5 +77,43 @@ describe('quickstart energetic pool', () => {
     const selectedSlug = loadToy.mock.calls[0]?.[0] as string;
     expect(selectedSlug).not.toBe('aurora-painter');
     expect(isEnergetic(selectedSlug)).toBe(true);
+  });
+});
+
+describe('quickstart calming pool', () => {
+  const originalRandom = Math.random;
+
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<a href="#" data-quickstart-mode="random" data-quickstart-pool="calming">Start flow mode</a>';
+    mock.restore();
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    document.body.innerHTML = '';
+    mock.restore();
+  });
+
+  test('filters random calming picks to calming-tagged toys only', () => {
+    const loadToy = mock();
+
+    Math.random = () => 1 / toyManifest.length;
+
+    initQuickstartCta({
+      loadToy:
+        loadToy as unknown as typeof import('../assets/js/loader.ts').loadToy,
+    });
+
+    const cta = document.querySelector('[data-quickstart-pool="calming"]');
+    expect(cta).not.toBeNull();
+    cta?.dispatchEvent(
+      new window.MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    expect(loadToy).toHaveBeenCalledTimes(1);
+
+    const selectedSlug = loadToy.mock.calls[0]?.[0] as string;
+    expect(isCalming(selectedSlug)).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation

- Flow-mode CTAs set `data-quickstart-pool="calming"` but `initQuickstartCta` only treated `featured` and `energetic` specially and fell back to the full toy list for other pools, so clicking “Start flow mode” could launch non-calming toys.

### Description

- Add an explicit `calming` metadata set and branch in `resolveRandomSlug` so `data-quickstart-pool="calming"` filters picks to calming-tagged toys in `assets/js/utils/init-quickstart.ts`.
- Introduce a shared metadata matcher `hasMatchingMetadata` and use it to implement both `isEnergeticToy` and `isCalmingToy` to keep filtering consistent.
- Extend `tests/init-quickstart.test.ts` with calming tag fixtures and a `quickstart calming pool` test that verifies random CTA launches only calming-tagged toys.
- Files changed: `assets/js/utils/init-quickstart.ts`, `tests/init-quickstart.test.ts`.

### Testing

- Ran `bun run test tests/init-quickstart.test.ts`, which passed (the energetic and calming quickstart tests passed).
- Ran the full gate with `bun run check`, which surfaced unrelated failures in `tests/library-filter-state.test.ts` (`ReferenceError: HTMLButtonElement is not defined` in `assets/js/library-view.js`) and caused the overall check to fail.
- The new unit tests for the calming pool are green and the change is localized to quickstart selection logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e176a4df08332af7ffb1edee2a35c)