### PR TITLE
Harden pattern recognizer comparisons

### DIFF
--- a/assets/js/utils/patternRecognition.ts
+++ b/assets/js/utils/patternRecognition.ts
@@ -60,15 +60,24 @@ class PatternRecognizer {
     pattern2: Uint8Array,
     tolerance = 0.85,
   ): boolean {
-    // Higher tolerance for stricter matching
-    // Calculate similarity score between two patterns
+    if (pattern1.length === 0 || pattern1.length !== pattern2.length) {
+      return false;
+    }
+
+    // Higher tolerance means stricter matching.
+    const normalizedTolerance = Number.isFinite(tolerance)
+      ? Math.min(1, Math.max(0, tolerance))
+      : 0.85;
+    const maxDifference = 255 * (1 - normalizedTolerance);
+
+    // Calculate similarity score between two patterns.
     let matchCount = 0;
     for (let i = 0; i < pattern1.length; i++) {
-      if (Math.abs(pattern1[i] - pattern2[i]) < 255 * (1 - tolerance)) {
+      if (Math.abs(pattern1[i] - pattern2[i]) < maxDifference) {
         matchCount++;
       }
     }
-    return matchCount / pattern1.length >= tolerance;
+    return matchCount / pattern1.length >= normalizedTolerance;
   }
 }
 

--- a/tests/pattern-recognizer.test.js
+++ b/tests/pattern-recognizer.test.js
@@ -82,4 +82,43 @@ describe('PatternRecognizer', () => {
     const result = recognizer.detectPattern();
     expect(result).toBeNull();
   });
+
+  test('comparePatterns returns false for empty or uneven patterns', () => {
+    const analyser = createAnalyser([new Uint8Array([1])]);
+    const recognizer = new PatternRecognizer(analyser, 2);
+
+    expect(
+      recognizer.comparePatterns(new Uint8Array([]), new Uint8Array([])),
+    ).toBe(false);
+    expect(
+      recognizer.comparePatterns(new Uint8Array([1, 2]), new Uint8Array([1])),
+    ).toBe(false);
+  });
+
+  test('comparePatterns clamps invalid tolerance values', () => {
+    const analyser = createAnalyser([new Uint8Array([1])]);
+    const recognizer = new PatternRecognizer(analyser, 2);
+
+    expect(
+      recognizer.comparePatterns(
+        new Uint8Array([10, 10]),
+        new Uint8Array([10, 10]),
+        Number.NaN,
+      ),
+    ).toBe(true);
+    expect(
+      recognizer.comparePatterns(
+        new Uint8Array([10, 10]),
+        new Uint8Array([15, 15]),
+        -1,
+      ),
+    ).toBe(true);
+    expect(
+      recognizer.comparePatterns(
+        new Uint8Array([10, 10]),
+        new Uint8Array([10, 11]),
+        2,
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent incorrect or unstable comparisons in `PatternRecognizer` when callers pass empty or unequal-length buffers or invalid tolerance values.
- Make the similarity check robust by normalizing/clamping the `tolerance` parameter and avoiding division/logic on malformed inputs.

### Description

- Added early guard to return `false` when `pattern1` is empty or lengths differ between `pattern1` and `pattern2` in `comparePatterns` in `assets/js/utils/patternRecognition.ts`.
- Normalized and clamped the `tolerance` parameter (fallback to `0.85` for non-finite inputs) and precomputed `maxDifference = 255 * (1 - normalizedTolerance)` for stable comparisons.
- Updated the comparison loop to use the computed `maxDifference` and compare against `normalizedTolerance` for the final similarity decision.
- Added unit tests in `tests/pattern-recognizer.test.js` covering empty/uneven patterns and out-of-range/`NaN` tolerance values.

### Testing

- Ran the full quality gate with `bun run check`, which performs Biome checks, TypeScript typecheck, and the test suite, and it completed successfully with all tests passing (111 passed, 2 skipped, 0 failed).
- The updated `tests/pattern-recognizer.test.js` passed and verifies the new edge-case behavior for `comparePatterns`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6659d0dc8332a0db86b56255a0dd)