### PR TITLE
Add PR metadata guard, Dependabot, CODEOWNERS and CI hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default reviewers
+* @zz-plant
+
+# Workflow and automation changes
+/.github/ @zz-plant
+
+# Toy implementation and metadata
+/assets/js/toys/ @zz-plant
+/assets/data/toys.json @zz-plant
+/toys/ @zz-plant
+
+# Tests
+/tests/ @zz-plant

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
+
+github:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+toys:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'assets/js/toys/**'
+          - 'assets/data/toys.json'
+          - 'toys/**'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**'
+
+scripts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'scripts/**'
+          - 'package.json'
+          - 'bun.lock'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,15 @@
 
 -
 
+## Docs touched
+
+<!-- List docs updated/added, or write "None". -->
+
+-
+
 ## Checklist
 
 - [ ] Linting (`bun run lint`) if applicable
-- [ ] Tests (`bun test`) if applicable
+- [ ] Tests (`bun run test`) if applicable
 - [ ] Build (`bun run build`) if applicable
 - [ ] Type checking (`bun run typecheck`) if applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,39 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:
-    name: quality checks
+    name: Quality checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
+
+      - name: Restore Bun cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -24,11 +44,8 @@ jobs:
       - name: Dev server check
         run: bun run dev:check
 
-      - name: Biome Check
-        run: bun run check:quick
+      - name: Full quality gate
+        run: bun run check
 
       - name: Build
         run: bun run build
-
-      - name: Test
-        run: bun run test

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label pull request by changed files
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,64 @@
+name: PR metadata guard
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-body:
+    name: Validate PR summary/testing/docs sections
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce PR metadata sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+
+            const requiredSections = ["Summary", "Testing", "Docs touched"];
+            const missingHeaders = requiredSections.filter((section) => {
+              const headerRegex = new RegExp(`^##\\s+${section}\\s*$`, "im");
+              return !headerRegex.test(body);
+            });
+
+            const extractSection = (heading) => {
+              const sectionRegex = new RegExp(
+                `##\\s+${heading}\\s*[\\r\\n]+([\\s\\S]*?)(?=\\n##\\s+|$)`,
+                "i"
+              );
+              const match = body.match(sectionRegex);
+              return match ? match[1].trim() : "";
+            };
+
+            const sectionContentIssues = [];
+            for (const section of requiredSections) {
+              const content = extractSection(section);
+              const isDocsSection = section === "Docs touched";
+              const invalidPlaceholder = !content || content === "-" || (!isDocsSection && content === "None");
+              if (invalidPlaceholder) {
+                sectionContentIssues.push(section);
+              }
+            }
+
+            const errors = [];
+            if (missingHeaders.length) {
+              errors.push(`Missing required section headers: ${missingHeaders.join(", ")}.`);
+            }
+            if (sectionContentIssues.length) {
+              errors.push(
+                `These sections need concrete content (not empty / '-' / 'None' where inappropriate): ${sectionContentIssues.join(", ")}.`
+              );
+            }
+
+            if (errors.length) {
+              core.setFailed(
+                [
+                  "PR metadata requirements failed.",
+                  ...errors,
+                  "Please update the PR description to include a short summary, explicit tests, and docs touched/added."
+                ].join("\n")
+              );
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Stale triage
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark stale issues and pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale
+        uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been inactive for 45 days and has been marked stale. It will close in 14 days unless there is new activity.'
+          stale-pr-message: 'This pull request has been inactive for 30 days and has been marked stale. It will close in 7 days unless there is new activity.'
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-issue-stale: 45
+          days-before-pr-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-close: 7
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned,security


### PR DESCRIPTION
### Motivation
- Improve repository automation and review hygiene by ensuring PRs include a short summary, explicit tests, and docs metadata. 
- Harden CI so merge-queue and incoming changes run the same quality gate and take advantage of Bun caching. 
- Surface dependency updates and automate triage/labeling to reduce manual maintenance overhead.

### Description
- Update CI pipeline (`.github/workflows/ci.yml`) to include `merge_group`, add Bun setup and cache restore, run the full quality gate via `bun run check`, and add concurrency/timeout and explicit permissions. 
- Add a PR metadata guard workflow (`.github/workflows/pr-metadata.yml`) that validates `## Summary`, `## Testing`, and `## Docs touched` headers and treats the `Docs touched` section permissively for `None`. 
- Add dependency automation including `dependabot.yml` for npm/GitHub Actions and a `dependency-review` workflow using `actions/dependency-review-action`. 
- Add labeling and triage automation with `labeler.yml`, a labeler workflow (`.github/workflows/labeler.yml`), a stale triage workflow (`.github/workflows/stale.yml`), a `CODEOWNERS` file, and updates to the PR template (`.github/pull_request_template.md`).

### Testing
- Ran `biome check` and `biome format` which completed without applying fixes. 
- Ran `bun run check` which failed due to a pre-existing TypeScript error in `tests/setup.ts` (missing `TRANSIENT_ATTACHMENT` on mocked `GPUTextureUsage`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eae784acc8332a79882b1a0d66d12)