### PR TITLE
Further improve mobile nav semantics and focus behavior

### DIFF
--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { initNavigation } from '../assets/js/ui/nav.ts';
+
+type MatchMediaListener = (event: MediaQueryListEvent) => void;
+
+function createMatchMediaStub(matches = true) {
+  const listeners = new Set<MatchMediaListener>();
+  const mediaQueryList: MediaQueryList = {
+    matches,
+    media: '(max-width: 520px)',
+    onchange: null,
+    addEventListener: (
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) => {
+      if (typeof listener === 'function') {
+        listeners.add(listener as MatchMediaListener);
+      }
+    },
+    removeEventListener: (
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) => {
+      if (typeof listener === 'function') {
+        listeners.delete(listener as MatchMediaListener);
+      }
+    },
+    addListener: (
+      listener: (this: MediaQueryList, event: MediaQueryListEvent) => void,
+    ) => {
+      listeners.add(listener as MatchMediaListener);
+    },
+    removeListener: (
+      listener: (this: MediaQueryList, event: MediaQueryListEvent) => void,
+    ) => {
+      listeners.delete(listener as MatchMediaListener);
+    },
+    dispatchEvent: () => true,
+  };
+
+  return {
+    matchMedia: () => mediaQueryList,
+    getListenerCount: () => listeners.size,
+  };
+}
+
+describe('library navigation interactions', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="nav"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('Escape closes mobile menu and restores focus to menu toggle', () => {
+    const { matchMedia } = createMatchMediaStub();
+    window.matchMedia = matchMedia;
+
+    const container = document.getElementById('nav') as HTMLElement;
+    initNavigation(container, { mode: 'library' });
+
+    const toggle = container.querySelector('.nav-toggle') as HTMLButtonElement;
+    toggle.click();
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+    document.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Escape' }),
+    );
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  test('menu toggle exposes stateful aria-label text on mobile', () => {
+    const { matchMedia } = createMatchMediaStub();
+    window.matchMedia = matchMedia;
+
+    const container = document.getElementById('nav') as HTMLElement;
+    initNavigation(container, { mode: 'library' });
+
+    const toggle = container.querySelector('.nav-toggle') as HTMLButtonElement;
+    const actions = container.querySelector('#nav-actions') as HTMLElement;
+
+    expect(toggle.getAttribute('aria-label')).toBe('Open navigation menu');
+    expect(actions.getAttribute('aria-hidden')).toBe('true');
+    expect(actions.hasAttribute('inert')).toBeTrue();
+
+    toggle.click();
+    expect(toggle.getAttribute('aria-label')).toBe('Close navigation menu');
+    expect(actions.getAttribute('aria-hidden')).toBe('false');
+    expect(actions.hasAttribute('inert')).toBeFalse();
+  });
+
+  test('desktop viewport keeps nav actions visible and interactive', () => {
+    const { matchMedia } = createMatchMediaStub(false);
+    window.matchMedia = matchMedia;
+
+    const container = document.getElementById('nav') as HTMLElement;
+    initNavigation(container, { mode: 'library' });
+
+    const toggle = container.querySelector('.nav-toggle') as HTMLButtonElement;
+    const actions = container.querySelector('#nav-actions') as HTMLElement;
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(actions.getAttribute('aria-hidden')).toBe('false');
+    expect(actions.hasAttribute('inert')).toBeFalse();
+  });
+
+  test('re-rendering library nav cleans up previous media-query listener', () => {
+    const { matchMedia, getListenerCount } = createMatchMediaStub();
+    window.matchMedia = matchMedia;
+
+    const container = document.getElementById('nav') as HTMLElement;
+    initNavigation(container, { mode: 'library' });
+    expect(getListenerCount()).toBe(1);
+
+    initNavigation(container, { mode: 'library' });
+    expect(getListenerCount()).toBe(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ globalThis.GPUTextureUsage = {
   TEXTURE_BINDING: 4,
   STORAGE_BINDING: 8,
   RENDER_ATTACHMENT: 16,
+  TRANSIENT_ATTACHMENT: 32,
 };
 globalThis.GPUMapMode = {
   READ: 1,


### PR DESCRIPTION
### Motivation
- Make the library navigation more accessible by ensuring the mobile menu content is announced and non-interactive when collapsed. 
- Close the mobile menu when keyboard focus moves outside it to match expected keyboard navigation flow. 
- Verify listener lifecycle and semantics remain correct on re-renders.

### Description
- Update `assets/js/ui/nav.ts` to set `aria-hidden` and `inert` on `#nav-actions` in sync with the toggle `aria-expanded` and label text so collapsed actions are non-interactive for assistive tech. 
- Add a `focusin` document listener that collapses the mobile menu when focus moves outside the nav, complementing existing Escape and outside-click handlers, and register balanced removal in the cleanup closure. 
- Ensure viewport sync/resize handling is wired consistently and factor prior reset logic via `resetNavigationState` (already invoked by `initNavigation`). 
- Expand tests in `tests/nav.test.ts` to cover mobile semantic state (`aria-hidden`/`inert`), desktop visibility semantics, Escape/focus behavior, and media-query listener cleanup, and add a small WebGPU stub field in `tests/setup.ts` (`TRANSIENT_ATTACHMENT`).

### Testing
- Ran the focused navigation tests with `bun run test tests/nav.test.ts` and they passed. 
- Ran the full quality gate with `bun run check` (including `biome` checks, `tsc`, and the full test suite) and it completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edbc7046083329386b346b1e6de00)