### PR TITLE
Expose agent skills and workflows over MCP

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -22,7 +22,7 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
   - **Input:** optional `slug` (string) to fetch a single toy and optional `requiresWebGPU` (boolean) to filter by WebGPU requirements.
   - **Output:** `json` array of `{ slug, title, description, requiresWebGPU, controls, module, type, allowWebGLFallback, url }` entries. Returns a helpful text message when no toys match the filters. Optional fields default to sensible fallbacks when missing from `assets/data/toys.json`.
 - **`read_doc_section`**
-  - **Input:** required `file` enum (e.g., `README.md`, `docs/MCP_SERVER.md`) and optional `heading` string.
+  - **Input:** required `file` enum (e.g., `README.md`, `docs/MCP_SERVER.md`, `docs/agents/README.md`, `.agent/skills/play-toy/SKILL.md`) and optional `heading` string.
   - **Output:** `text` response containing the full markdown file when no heading is provided, or the matching section beginning at the requested heading. Returns a friendly error when the file or heading cannot be found.
 - **`search_docs`**
   - **Input:** required `query` string plus optional `file` enum to limit search scope and optional `limit` (1-20) for result count.
@@ -30,6 +30,12 @@ All tools are registered on the `stim-webtoys-mcp` server name and use zod-based
 - **`describe_loader`**
   - **Input:** none.
   - **Output:** `text` summary of how the toy loader resolves entries and errors, including manifest resolution (`/.vite/manifest.json`), URL/history handling, WebGPU gating, and the recovery states shown when imports fail.
+- **`list_agent_capabilities`**
+  - **Input:** optional `kind` enum (`skill`, `workflow`) to filter results.
+  - **Output:** `json` array describing reusable capabilities from `.agent/skills/*` and `.agent/workflows/*`, including command aliases and file paths so agentic LLMs can decide which playbook to invoke.
+- **`read_agent_capability`**
+  - **Input:** required `kind` enum (`skill`, `workflow`) and required `name` (string such as `play-toy` or `ship-toy-change`).
+  - **Output:** `text` response with the selected capability metadata plus full markdown instructions, letting MCP clients execute the same workflow steps as local agents.
 - **`dev_commands`**
   - **Input:** optional `scope` enum (`setup`, `dev`, `build`, `test`, `lint`) to narrow the result.
   - **Output:** `text` response containing the requested setup or workflow commands from `README.md`. Without a scope, the tool returns all development snippets including **Biome** and Bun references.

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from 'node:stream';
 import {
   defaultQualityGateTimeoutMs,
   getDocSectionContent,
+  markdownSources,
   normalizeToys,
   resolveQualityGateCommand,
   runCommand,
@@ -89,6 +90,27 @@ describe('searchMarkdownSources', () => {
     const results = await searchMarkdownSources('this should not match');
 
     expect(results).toHaveLength(0);
+  });
+});
+
+describe('agent capability markdown availability', () => {
+  test('exposes skill and workflow markdown files for MCP reads', () => {
+    expect(
+      markdownSources['.agent/skills/play-toy/SKILL.md'].length,
+    ).toBeGreaterThan(0);
+    expect(
+      markdownSources['.agent/workflows/play-toy.md'].length,
+    ).toBeGreaterThan(0);
+  });
+
+  test('searches agent docs content through shared markdown index', async () => {
+    const results = await searchMarkdownSources('progressive-disclosure', {
+      file: 'docs/agents/README.md',
+      limit: 3,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.file).toBe('docs/agents/README.md');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Let agentic LLM clients discover and execute the repository's agent playbooks (skills and workflows) programmatically via the existing MCP surface so assistants can support human users with repo-native playbooks.

### Description
- Add `.agent/skills/*`, `.agent/workflows/*`, and `docs/agents/README.md` to the MCP shared markdown index so agent playbooks are bundle-readable at runtime.
- Introduce a typed `AgentCapability` catalog and populate `agentCapabilities` with skill/workflow entries and command aliases for discovery.
- Register two MCP tools: `list_agent_capabilities` to list/filter available skills/workflows and `read_agent_capability` to return full markdown plus metadata for a named capability.
- Update `docs/MCP_SERVER.md` to document the new tools and extend readable-file examples, and export the new `AgentCapability` type from the shared module.

### Testing
- Ran `bun run check` (Biome format/lint, TypeScript typecheck, and the test suite) which completed and all tests passed.
- Updated/added tests in `tests/mcp-server.test.ts` to verify agent markdown availability and that `searchMarkdownSources` finds agent docs, and the test run passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699005254c9483329005c4b0133eb0d9)