### PR TITLE
Clarify deployment tracks and MCP tiering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Use these commands before opening a PR:
 - `bun run dev:host` — start Vite on LAN.
 - `bun run build` — production build.
 - `bun run preview` — preview built output.
+- `bun run pages:deploy` — default production deploy for the static site (Track A).
 - `bun run lint` / `bun run lint:fix` — Biome linting.
 - `bun run format` / `bun run format:check` — Biome formatting.
 - `bun run typecheck` — TypeScript no-emit checks.
@@ -78,7 +79,7 @@ Use these commands before opening a PR:
 
 ## Documentation expectations
 
-When workflows or structure change, update docs in the same PR:
+When workflows or structure change, update docs in the same PR (including deployment-track guidance in `docs/DEPLOYMENT.md` when release flow changes):
 
 - Start from [`docs/README.md`](./docs/README.md) (docs map by audience + purpose).
 - Keep contributor and agent entry points aligned:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,13 @@ This document summarizes how the Stim Webtoys app is assembled, from the entry H
 
 Use this section as a quick compass: if you need to change how a toy starts or stops, look at the loader and core runtime; if you need to change UI state or status messaging, look at the views; if you need to change toy behavior, look at the toy modules and `WebToy` helpers.
 
+## Architecture tiers (what is required vs optional)
+
+- **Tier 0: Site runtime (required).** HTML entry points, loader/router, views, runtime core, and toy modules. This tier is enough to run and deploy the web toy experience.
+- **Tier 1: Automation and external transports (optional).** MCP stdio/Worker transports and agent-oriented automation workflows. This tier is only needed when integrating MCP clients or agent tooling.
+
+Use this split when making trade-offs: keep Tier 0 reliable first, and treat Tier 1 as an add-on surface that can evolve independently.
+
 ## Runtime Layers
 
 - **HTML entry points** (`toy.html`, `holy.html`, etc.) load the bundled shell and pass query params like `?toy=<slug>`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,43 @@
 # Deployment Guide
 
-This guide covers how to build the Stim Webtoys Library, validate the production bundle locally, and ship the site and MCP Worker to production targets. Commands reference the scripts in `package.json` so you can copy/paste without drift.
+This guide covers how to build the Stim Webtoys Library, validate the production bundle locally, and ship it to production. Commands reference the scripts in `package.json` so you can copy/paste without drift.
+
+## Choose your deployment track
+
+- **Track A (default): Static site on Cloudflare Pages.** Most releases only need this track.
+- **Track B (optional): MCP Worker transport.** Use this when you are shipping MCP HTTP/WebSocket endpoint changes.
+
+If you only need to deploy the toy site, follow Track A and skip the Worker sections.
+
+## Track A quick path (minimum production flow)
+
+Use this baseline sequence when shipping the site:
+
+1. Run the quality gate:
+
+   ```bash
+   bun run check
+   ```
+
+2. Build production assets:
+
+   ```bash
+   bun run build
+   ```
+
+3. Sanity-check locally:
+
+   ```bash
+   bun run preview
+   ```
+
+4. Deploy Pages assets:
+
+   ```bash
+   bun run pages:deploy
+   ```
+
+Advanced variants such as `--reuse` are documented later for prebuilt artifacts and CI restores.
 
 ## Build the Site
 
@@ -118,7 +155,7 @@ Expected artifacts for both commands:
 - `dist/.vite/manifest.json` co-located with the assets (required for debugging and any server-side asset lookups).
 - A Wrangler-generated preview URL during `pages:dev` and a production deployment URL during `pages:deploy` (visible in the command output and the Cloudflare dashboard).
 
-## Cloudflare Worker (MCP) Deployment
+## Track B (optional): Cloudflare Worker (MCP) deployment
 
 The MCP HTTP/WebSocket endpoint lives in [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Deploy it with Wrangler using the existing [`wrangler.toml`](../wrangler.toml) (name, compatibility date, and Pages output dir are already defined).
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,8 +4,10 @@ This guide covers how to build the Stim Webtoys Library, validate the production
 
 ## Choose your deployment track
 
-- **Track A (default): Static site on Cloudflare Pages.** Most releases only need this track.
-- **Track B (optional): MCP Worker transport.** Use this when you are shipping MCP HTTP/WebSocket endpoint changes.
+| Track | Use when | Required commands |
+| --- | --- | --- |
+| **Track A (default): Static site on Cloudflare Pages** | Nearly all toy/site releases. | `bun run check`, `bun run build`, `bun run preview`, `bun run pages:deploy` |
+| **Track B (optional): MCP Worker transport** | You changed MCP HTTP/WebSocket transport behavior or Worker-only MCP deployment settings. | Track A commands + Worker deploy command(s) in the Track B section |
 
 If you only need to deploy the toy site, follow Track A and skip the Worker sections.
 
@@ -19,19 +21,25 @@ Use this baseline sequence when shipping the site:
    bun run check
    ```
 
-2. Build production assets:
+2. Confirm toy metadata and docs registration remain aligned:
+
+   ```bash
+   bun run check:toys
+   ```
+
+3. Build production assets:
 
    ```bash
    bun run build
    ```
 
-3. Sanity-check locally:
+4. Sanity-check locally:
 
    ```bash
    bun run preview
    ```
 
-4. Deploy Pages assets:
+5. Deploy Pages assets:
 
    ```bash
    bun run pages:deploy
@@ -84,31 +92,12 @@ Both commands expect a fresh `bun run build` and read from `dist/`.
 
 ## Prime-time preflight checks
 
-Run this sequence before shipping to production so the release candidate is validated the same way CI and reviewers expect:
+Track A quick path above is the default release preflight. Use this section as the same checklist reference before production deploys:
 
-1. Run the full quality gate:
-
-   ```bash
-   bun run check
-   ```
-
-2. Confirm toy metadata and file registrations stay in sync:
-
-   ```bash
-   bun run check:toys
-   ```
-
-3. Build production assets:
-
-   ```bash
-   bun run build
-   ```
-
-4. Sanity-check the generated bundle locally:
-
-   ```bash
-   bun run preview
-   ```
+1. `bun run check`
+2. `bun run check:toys`
+3. `bun run build`
+4. `bun run preview`
 
 If any step fails, fix the issue and restart from step 1 so downstream checks reflect the final state.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP stdio server guide
 
-The repository includes a Model Context Protocol (MCP) stdio server at [`scripts/mcp-server.ts`](../scripts/mcp-server.ts) and a Cloudflare Worker transport at [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Both expose documentation, toy metadata, loader behavior, and development command references so MCP-compatible clients can retrieve structured information without scraping markdown.
+The repository includes a Model Context Protocol (MCP) stdio server at [`scripts/mcp-server.ts`](../scripts/mcp-server.ts) and a Cloudflare Worker transport at [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts). Both expose documentation, toy metadata, loader behavior, and development command references so MCP-compatible clients can retrieve structured information without scraping markdown. The stdio server is the baseline path for local/tooling use; the Worker transport is an optional deployment target when remote MCP access is needed.
 
 ## Starting the server
 
@@ -13,7 +13,7 @@ The repository includes a Model Context Protocol (MCP) stdio server at [`scripts
 
 ## Registered tools
 
-All tools are registered on the `stim-webtoys-mcp` server name and use zod-based schemas for validation.
+All tools are registered on the logical MCP server name `stim-webtoys-mcp` and use zod-based schemas for validation. Deployment targets can still use the Cloudflare Worker name `stims` (from `wrangler.toml`) without changing tool behavior.
 
 - **`list_docs`**
   - **Input:** none.
@@ -75,7 +75,7 @@ The following tools are only available from the Bun/Node stdio server (`bun run 
 - **Slug filters:** If `get_toys` returns “No toys matched the requested filters,” double-check the slug in `assets/data/toys.json` or omit filters to retrieve the full catalog.
 - **Client invocation:** MCP clients must launch `bun run mcp` in the repository root; running elsewhere can block access to `README.md`, the toy data file, or the Vite manifest.
 
-## Cloudflare Worker deployment
+## Cloudflare Worker deployment (optional transport)
 
 [`scripts/mcp-worker.ts`](../scripts/mcp-worker.ts) serves the same tools over Streamable HTTP (POST requests for JSON-RPC, GET + `text/event-stream` for streaming responses) and WebSocket upgrades on the `/mcp` route. The worker bundles markdown and toy metadata at build time via `?raw` imports, so it does not rely on file system access in production.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -13,7 +13,7 @@ The repository includes a Model Context Protocol (MCP) stdio server at [`scripts
 
 ## Registered tools
 
-All tools are registered on the logical MCP server name `stim-webtoys-mcp` and use zod-based schemas for validation. Deployment targets can still use the Cloudflare Worker name `stims` (from `wrangler.toml`) without changing tool behavior.
+All tools are registered on the logical MCP server name `stim-webtoys-mcp` and use zod-based schemas for validation. The Cloudflare Worker deploy name (`stims` in this repository) can differ from the logical MCP server name without changing tool behavior.
 
 - **`list_docs`**
   - **Input:** none.
@@ -87,7 +87,7 @@ The following tools are only available from the Bun/Node stdio server (`bun run 
 The Worker uses the repository’s pinned compatibility date (`2024-10-20`) to keep WebSocket support consistent with `wrangler.toml` and the deployment snippets in `docs/DEPLOYMENT.md`.
 
 ```toml
-name = "stim-webtoys-mcp"
+name = "stims"
 main = "scripts/mcp-worker.ts"
 compatibility_date = "2024-10-20"
 workers_dev = true
@@ -97,11 +97,12 @@ compatibility_flags = ["nodejs_compat"]
 ### Deploying
 
 1. Install dependencies (`bun install`), ensuring `@cfworker/json-schema` is available for the Worker build.
-2. Deploy with Wrangler:
+2. Keep Worker naming aligned with `wrangler.toml` unless you intentionally override `--name` for a separate environment.
+3. Deploy with Wrangler:
    ```bash
    bunx wrangler deploy scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
    ```
-3. Local preview (Worker fetch + WebSocket support):
+4. Local preview (Worker fetch + WebSocket support):
    ```bash
    bunx wrangler dev scripts/mcp-worker.ts --name stims --compatibility-date=2024-10-20
    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This directory is organized by **audience + workflow** so contributors and agent
 
 - [`DEVELOPMENT.md`](./DEVELOPMENT.md) — setup, scripts, and local workflows.
 - [`QA_PLAN.md`](./QA_PLAN.md) — high-impact QA paths and automated coverage.
-- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — build/preview/deploy guidance.
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Track A static-site deploy path plus optional Track B MCP Worker deploy guidance.
 
 ### Implementation references
 


### PR DESCRIPTION
### Motivation

- Make deployment guidance clearer by separating the common static-site flow from the optional MCP Worker path so contributors follow a minimal path for most releases. 
- Make architecture intent explicit by separating required site runtime concerns from optional automation and transport components.

### Description

- Add a deployment track section to `docs/DEPLOYMENT.md` that defines **Track A** (default: Cloudflare Pages static site) and **Track B** (optional: MCP Worker transport) and a minimal production flow (`bun run check`, `bun run build`, `bun run preview`, `bun run pages:deploy`).
- Add `Tier 0`/`Tier 1` framing to `docs/ARCHITECTURE.md` to distinguish the required site runtime from optional automation/transports.
- Clarify `docs/MCP_SERVER.md` to state that the stdio MCP server is the baseline for local/tooling use, the Worker is an optional transport, and that the logical MCP server name `stim-webtoys-mcp` can differ from the Worker deployment name (for example, `stims`).
- Docs modified: `docs/DEPLOYMENT.md`, `docs/ARCHITECTURE.md`, `docs/MCP_SERVER.md`.

### Testing

- Ran the quick quality gate with `bun run check:quick` which executed `biome` checks and `tsc --noEmit`, and it succeeded (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990085c4f48833291e1680c2b5b6a49)