### PR TITLE
Improve mobile device detection heuristics

### DIFF
--- a/assets/js/utils/device-detect.ts
+++ b/assets/js/utils/device-detect.ts
@@ -1,11 +1,26 @@
 type NavigatorWithUserAgentData = Navigator & {
   userAgentData?: {
     mobile?: boolean;
+    platform?: string;
   };
   platform?: string;
   maxTouchPoints?: number;
   userAgent?: string;
 };
+
+function hasCoarsePrimaryPointer() {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false;
+  }
+
+  return (
+    window.matchMedia('(pointer: coarse)').matches &&
+    !window.matchMedia('(hover: hover)').matches
+  );
+}
 
 export function isMobileDevice() {
   if (typeof navigator === 'undefined') return false;
@@ -25,6 +40,18 @@ export function isMobileDevice() {
   const platform = nav.platform ?? '';
   const maxTouchPoints = nav.maxTouchPoints ?? 0;
   if (platform === 'MacIntel' && maxTouchPoints > 1) {
+    return true;
+  }
+
+  const userAgentPlatform = nav.userAgentData?.platform ?? '';
+  if (
+    maxTouchPoints > 0 &&
+    /android|ios|iphone|ipad|ipod/i.test(userAgentPlatform)
+  ) {
+    return true;
+  }
+
+  if (maxTouchPoints > 0 && hasCoarsePrimaryPointer()) {
     return true;
   }
 

--- a/tests/device-detect.test.ts
+++ b/tests/device-detect.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { isMobileDevice } from '../assets/js/utils/device-detect';
+
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: unknown;
+};
+
+type NavSnapshot = {
+  userAgent: string;
+  platform: string;
+  maxTouchPoints: number;
+  userAgentData: unknown;
+};
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121 Safari/537.36';
+
+const mobileMatchMedia = ((query: string) =>
+  ({
+    media: query,
+    matches: query === '(pointer: coarse)',
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }) as MediaQueryList) as typeof window.matchMedia;
+
+const desktopMatchMedia = ((query: string) =>
+  ({
+    media: query,
+    matches: query === '(hover: hover)',
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }) as MediaQueryList) as typeof window.matchMedia;
+
+let snapshot: NavSnapshot;
+let originalMatchMedia: typeof window.matchMedia;
+
+function setNavigatorField<K extends keyof NavSnapshot>(
+  key: K,
+  value: NavSnapshot[K],
+) {
+  Object.defineProperty(navigator, key, {
+    value,
+    configurable: true,
+  });
+}
+
+describe('isMobileDevice', () => {
+  beforeEach(() => {
+    snapshot = {
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+      maxTouchPoints: navigator.maxTouchPoints,
+      userAgentData: (navigator as NavigatorWithUserAgentData).userAgentData,
+    };
+    originalMatchMedia = window.matchMedia;
+
+    setNavigatorField('userAgent', DESKTOP_UA);
+    setNavigatorField('platform', 'Linux x86_64');
+    setNavigatorField('maxTouchPoints', 0);
+    setNavigatorField('userAgentData', undefined);
+    window.matchMedia = desktopMatchMedia;
+  });
+
+  afterEach(() => {
+    setNavigatorField('userAgent', snapshot.userAgent);
+    setNavigatorField('platform', snapshot.platform);
+    setNavigatorField('maxTouchPoints', snapshot.maxTouchPoints);
+    setNavigatorField('userAgentData', snapshot.userAgentData);
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('detects mobile from user agent data mobile hint', () => {
+    setNavigatorField('userAgentData', {
+      brands: [],
+      mobile: true,
+      platform: 'Android',
+      getHighEntropyValues: async () => ({}),
+      toJSON: () => ({}),
+    });
+
+    expect(isMobileDevice()).toBe(true);
+  });
+
+  test('detects iPadOS masquerading as Mac when touch points are present', () => {
+    setNavigatorField('platform', 'MacIntel');
+    setNavigatorField('maxTouchPoints', 5);
+
+    expect(isMobileDevice()).toBe(true);
+  });
+
+  test('detects contemporary touch devices when user agent is desktop-like', () => {
+    setNavigatorField('maxTouchPoints', 5);
+    window.matchMedia = mobileMatchMedia;
+
+    expect(isMobileDevice()).toBe(true);
+  });
+
+  test('keeps desktop devices classified as non-mobile', () => {
+    expect(isMobileDevice()).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Contemporary mobile and touch-first devices can hide traditional user-agent signals or present desktop-like platforms (for example iPadOS on MacIntel), so detection needs more robust heuristics to choose mobile-friendly presets and fallbacks.
- The change aims to ensure toys and UI controls use sensible defaults (touch gestures, mobile presets, and capped pixel ratios) on real handheld devices even when UA strings are reduced.

### Description
- Enhanced `isMobileDevice` in `assets/js/utils/device-detect.ts` to consult `navigator.userAgentData.platform`, treat MacIntel+touch as iPadOS, and add a `hasCoarsePrimaryPointer` matchMedia heuristic that combines `(pointer: coarse)` with `!(hover: hover)` as a fallback when touchpoints exist.
- Added a focused unit test file `tests/device-detect.test.ts` that covers `userAgentData.mobile`, iPadOS/MacIntel touch detection, coarse-pointer detection on desktop-like UAs, and a desktop non-mobile case.
- Applied formatting fixes so the new code follows repository styling rules.

### Testing
- Ran `bun run test tests/device-detect.test.ts` which passed all 4 tests.
- Ran the repo quality gate `bun run check` (which runs `biome`, `tsc`, and the full test suite) where the device-detect tests passed but the overall command exited non-zero due to pre-existing unrelated failures in `tests/pocket-pulse.test.ts` and `tests/mobile-ripples.test.ts` (three.js export/import issues), so the full check did not complete successfully.
- Ran `bunx biome format --write` to fix formatting issues introduced during edits and confirmed formatting changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900e6b02bc83328f29482956b97e0d)