### PR TITLE
Feature-detect WebGPU instead of blocking by user-agent

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -1,6 +1,5 @@
 /* global GPUAdapter, GPUDevice, GPU */
 
-import { isMobileDevice } from '../utils/device-detect';
 import { isCompatibilityModeEnabled } from './render-preferences.ts';
 
 export type RendererBackend = 'webgl' | 'webgpu';
@@ -36,8 +35,6 @@ let cachedCapabilities: RendererCapabilities | null = null;
 let cachedEnvironmentKey: unknown = null;
 let telemetryHandler: RendererTelemetryHandler | null = null;
 let telemetryReportedKey: unknown = null;
-
-const isMobileUserAgent = isMobileDevice();
 
 const buildFallback = (
   fallbackReason: string,
@@ -100,16 +97,6 @@ async function probeRendererCapabilities(): Promise<RendererCapabilities> {
       }),
     );
   }
-
-  if (isMobileUserAgent) {
-    return cacheResult(
-      buildFallback('WebGPU is disabled on mobile devices. Using WebGL.', {
-        triedWebGPU: false,
-        shouldRetryWebGPU: false,
-      }),
-    );
-  }
-
   const { gpu } = navigator as Navigator & { gpu?: GPU };
   if (!gpu?.requestAdapter) {
     return cacheResult(

--- a/assets/js/toys/bioluminescent-tidepools.ts
+++ b/assets/js/toys/bioluminescent-tidepools.ts
@@ -604,7 +604,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'bioluminescent-tidepools',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           initializeScene();
           applyPalette(activePaletteIndex);

--- a/assets/js/toys/cosmic-particles.ts
+++ b/assets/js/toys/cosmic-particles.ts
@@ -359,7 +359,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'cosmic-particles',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           setActivePreset(activePresetKey);
         },

--- a/assets/js/toys/fractal-kite-garden.ts
+++ b/assets/js/toys/fractal-kite-garden.ts
@@ -336,7 +336,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'fractal-kite-garden',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           init();
         },
         update: ({ frequencyData, time }) => {

--- a/assets/js/toys/mobile-ripples.ts
+++ b/assets/js/toys/mobile-ripples.ts
@@ -173,7 +173,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'mobile-ripples',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           rebuildRings();
         },

--- a/assets/js/toys/pocket-pulse.ts
+++ b/assets/js/toys/pocket-pulse.ts
@@ -247,7 +247,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'pocket-pulse',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           rebuildField();
         },

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -241,7 +241,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'rainbow-tunnel',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           rebuildScene();
         },

--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -690,7 +690,9 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'spiral-burst',
-        setup: ({ toy }) => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
+          const { toy } = runtimeInstance;
           toy.scene.add(spiralContainer);
           setupSettingsPanel();
           buildSpiralArms();

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -400,7 +400,8 @@ export function start({ container }: ToyStartOptions = {}) {
     plugins: [
       {
         name: 'star-field',
-        setup: () => {
+        setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           starField = createStarField();
           createNebula();

--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -372,6 +372,7 @@ export function start({ container }: ToyStartOptions = {}) {
       {
         name: 'three-d-toy',
         setup: (runtimeInstance) => {
+          runtime = runtimeInstance;
           setupSettingsPanel();
           const controlPanel = createControlPanel();
           controlState = controlPanel.getState();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ flowchart LR
   applyRendererSettings]
 ```
 
-- **Capability probe**: `renderer-capabilities.ts` caches the adapter/device decision and records fallback reasons so the UI can surface retry prompts.
+- **Capability probe**: `renderer-capabilities.ts` caches the adapter/device decision and records fallback reasons so the UI can surface retry prompts. WebGPU probing is feature-based (`navigator.gpu`) rather than user-agent gated, so supported mobile browsers can use WebGPU.
 - **Initialization**: `renderer-setup.ts` builds a renderer using the preferred backend, applies tone mapping, sets pixel ratio/size, and returns metadata consumed by `web-toy.ts`.
 - **Quality presets**: `settings-panel.ts` and `iframe-quality-sync.ts` broadcast max pixel ratio, render scale, and exposure; `WebToy.updateRendererSettings` re-applies them without a reload.
 - **Renderer settings**: `renderer-settings.ts` merges quality presets, render preferences, and per-toy overrides so pooled renderers can be reconfigured on the fly.

--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -83,7 +83,7 @@ Use the scaffold script whenever possible; it wires up metadata, docs, and optio
 7. **Manual spot-checks**:
    - Confirm the Back to Library control returns to the grid and removes your DOM nodes (cleanup).
    - Verify microphone permission flows (granted, denied, and sample-audio fallback) if you request audio.
-   - For WebGPU toys, confirm the fallback/warning screen appears on non-WebGPU browsers.
+   - For WebGPU toys, test both a WebGPU-capable browser (desktop or mobile) and a non-WebGPU browser. The runtime now probes `navigator.gpu` directly instead of blocking WebGPU by user-agent, so capable mobile devices should use WebGPU.
 
 8. **Document any special controls** inside your module (inline comments) or in a short note in `README.md` if they differ from other toys.
 

--- a/tests/renderer-capabilities.test.js
+++ b/tests/renderer-capabilities.test.js
@@ -56,6 +56,25 @@ describe('renderer capabilities', () => {
     expect(second.preferredBackend).toBe('webgpu');
   });
 
+  test('probes WebGPU on mobile user agents when GPU APIs are present', async () => {
+    const { requestAdapter, requestDevice } = mockNavigatorWithGPU({
+      device: { label: 'mobile-device' },
+    });
+
+    Object.defineProperty(global.navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    });
+
+    const result = await getRendererCapabilities({ forceRetry: true });
+
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+    expect(requestDevice).toHaveBeenCalledTimes(1);
+    expect(result.preferredBackend).toBe('webgpu');
+    expect(result.fallbackReason).toBeNull();
+  });
+
   test('falls back to WebGL when WebGPU is missing', async () => {
     Object.defineProperty(global, 'navigator', {
       writable: true,


### PR DESCRIPTION
### Motivation
- Modern mobile browsers increasingly expose WebGPU via `navigator.gpu`, so blocking WebGPU by user-agent prevents capable devices from using enhanced rendering.
- The runtime should gate WebGPU by feature availability rather than heuristics to avoid unnecessary WebGL fallbacks.
- Tests and docs must reflect the updated behavior so authors validate toys on capable mobile browsers.

### Description
- Remove the mobile user-agent block from `assets/js/core/renderer-capabilities.ts` so probing is driven by `navigator.gpu` feature presence and adapter/device acquisition.
- Add a unit test in `tests/renderer-capabilities.test.js` that simulates a mobile user agent with GPU APIs and verifies WebGPU is selected when available.
- Update docs in `docs/TOY_DEVELOPMENT.md` and `docs/ARCHITECTURE.md` to state that WebGPU probing is feature-based and advise testing WebGPU toys on both capable and non-capable browsers (including mobile).
- Run formatting (`biome format`) and lint/type checks as part of the change to keep code style consistent.

### Testing
- Ran `bun run check` (Biome + typecheck + tests) which completed successfully and the test suite passed (127 pass, 2 skip, 0 fail). 
- Ran `bun run format` to normalize formatting and ensure no formatting errors remained. 
- Performed a lightweight compatibility check against Can I Use data to confirm broader WebGPU adoption trends for desktop and mobile browsers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901196eac4833296ff47d918427481)