### PR TITLE
Use non-call microphone defaults on mobile

### DIFF
--- a/assets/js/core/services/audio-service.ts
+++ b/assets/js/core/services/audio-service.ts
@@ -1,6 +1,7 @@
 import type * as THREE from 'three';
 import {
   type AudioInitOptions,
+  DEFAULT_MICROPHONE_CONSTRAINTS,
   type FrequencyAnalyser,
   getMicrophonePermissionState,
   initAudio,
@@ -43,7 +44,7 @@ async function getOrCreateStream(constraints?: MediaStreamConstraints) {
   if (streamPromise) return streamPromise;
 
   streamPromise = navigator.mediaDevices
-    ?.getUserMedia(constraints ?? { audio: { echoCancellation: true } })
+    ?.getUserMedia(constraints ?? DEFAULT_MICROPHONE_CONSTRAINTS)
     .catch((error) => {
       streamPromise = null;
       throw error;

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -245,6 +245,14 @@ export type AudioInitOptions = {
   monitorInput?: boolean;
 };
 
+export const DEFAULT_MICROPHONE_CONSTRAINTS: MediaStreamConstraints = {
+  audio: {
+    echoCancellation: { ideal: false },
+    noiseSuppression: { ideal: false },
+    autoGainControl: { ideal: false },
+  },
+};
+
 export function createSyntheticAudioStream({
   frequency = 220,
   type = 'sawtooth',
@@ -436,7 +444,7 @@ export async function initAudio(options: AudioInitOptions = {}) {
       }
 
       resolvedStream = await navigator.mediaDevices.getUserMedia(
-        constraints ?? { audio: { echoCancellation: true } },
+        constraints ?? DEFAULT_MICROPHONE_CONSTRAINTS,
       );
       ownsStream = true;
       permissionState = permissionState ?? 'granted';

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -11,6 +11,7 @@ import {
 
 let originalNavigatorDesc;
 let initAudio;
+let DEFAULT_MICROPHONE_CONSTRAINTS;
 let getFrequencyData;
 let originalAudioContext;
 let originalAudioWorkletNode;
@@ -106,9 +107,8 @@ beforeAll(async () => {
     };
   });
 
-  ({ initAudio, getFrequencyData } = await import(
-    '../assets/js/utils/audio-handler.ts'
-  ));
+  ({ DEFAULT_MICROPHONE_CONSTRAINTS, initAudio, getFrequencyData } =
+    await import('../assets/js/utils/audio-handler.ts'));
 });
 
 describe('audio-handler utilities', () => {
@@ -158,6 +158,14 @@ describe('audio-handler utilities', () => {
     expect(listener).toBeDefined();
     expect(audio).toBeDefined();
     expect(stream).toBeDefined();
+  });
+
+  test('initAudio requests microphone with non-call defaults', async () => {
+    await initAudio();
+
+    expect(global.navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
+      DEFAULT_MICROPHONE_CONSTRAINTS,
+    );
   });
 
   test('initAudio disables monitoring by default to prevent microphone echo', async () => {

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -14,6 +14,7 @@ import {
   resetRendererPool,
 } from '../assets/js/core/services/render-service.ts';
 import type { FrequencyAnalyser } from '../assets/js/utils/audio-handler.ts';
+import { DEFAULT_MICROPHONE_CONSTRAINTS } from '../assets/js/utils/audio-handler.ts';
 
 describe('render-service pooling', () => {
   const fakeRenderer = {
@@ -91,6 +92,9 @@ describe('audio-service pooling', () => {
     const second = await acquireAudioHandle({ initAudioImpl });
 
     expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledWith(
+      DEFAULT_MICROPHONE_CONSTRAINTS,
+    );
     expect(first.stream).toBe(second.stream);
 
     second.release();


### PR DESCRIPTION
### Motivation
- Mobile devices may route microphone streams into a phone-call audio path when voice processing constraints are enabled, which can change routing/processing and break intended audio-reactive behavior.

### Description
- Introduced `DEFAULT_MICROPHONE_CONSTRAINTS` in `assets/js/utils/audio-handler.ts` that sets `echoCancellation`, `noiseSuppression`, and `autoGainControl` to `ideal: false` to prefer non-voice-processing capture.
- Wired the shared `DEFAULT_MICROPHONE_CONSTRAINTS` into `initAudio` (used by `initAudio`) and the pooled acquisition path in `assets/js/core/services/audio-service.ts` so both direct and pooled `getUserMedia` callers use the same defaults.
- Added regression checks to `tests/audio-handler.test.js` and `tests/services-pool.test.ts` to assert that `navigator.mediaDevices.getUserMedia` is invoked with `DEFAULT_MICROPHONE_CONSTRAINTS`.

### Testing
- Ran the full quality gate with `bun run check`, which performs Biome checks, TypeScript typecheck, and the test suite, and it completed successfully with all tests passing and no failures (tests ran; most suites passed and 2 tests skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cec6b4b083328b57f5b7d248e4ed)