### PR TITLE
Redesign homepage quick-start layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -3608,3 +3608,99 @@ footer {
     transform: none;
   }
 }
+
+/* Minimal home refresh */
+section.intro,
+.quick-starts,
+.library-search,
+.system-check,
+.github {
+  background: color-mix(in srgb, var(--card-bg) 95%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 72%, transparent);
+  box-shadow: none;
+}
+
+section.intro::before,
+section.intro::after,
+.hero::before,
+.hero::after,
+.system-check::before {
+  display: none;
+}
+
+section.intro {
+  display: grid;
+  gap: 0.85rem;
+  justify-items: center;
+  padding-block: clamp(1.1rem, 2vw + 0.5rem, 1.7rem);
+}
+
+.intro-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+}
+
+.intro-actions .cta-button {
+  min-width: 8.75rem;
+  border-radius: 11px;
+  box-shadow: none;
+}
+
+.intro-secondary-links {
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.section-heading,
+.hero-copy,
+.intro-highlights,
+.search-row,
+.daily-streak,
+.starter-picks {
+  gap: 0.75rem;
+}
+
+.intro-highlights,
+.hero-callouts {
+  display: none;
+}
+
+.quick-start-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.quick-card {
+  background: color-mix(in srgb, var(--card-bg) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 68%, transparent);
+  box-shadow: none;
+  padding: 1rem 1rem 0.9rem;
+}
+
+.quick-card h3 {
+  font-size: 1.03rem;
+}
+
+@media (max-width: 980px) {
+  .quick-start-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .intro-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .intro-actions .cta-button {
+    width: 100%;
+  }
+
+  .quick-start-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -138,38 +138,14 @@
         </div>
       </header>
 
-      <section class="intro" id="intro">
-        <div class="section-heading">
-          <p class="eyebrow">Audio-reactive visuals • Instant play</p>
-          <h1>Stim library</h1>
-          <p class="section-description">
-            Open a visual in seconds—no signups, just sound, touch, and flow.
-          </p>
-          <div class="intro-highlights" aria-label="Library highlights">
-            <article class="intro-highlight-card">
-              <p class="intro-highlight-card__label">Built for low friction</p>
-              <p class="intro-highlight-card__value">Open, react, repeat</p>
-              <p class="intro-highlight-card__copy">Everything launches in-browser with no account wall.</p>
-            </article>
-            <article class="intro-highlight-card">
-              <p class="intro-highlight-card__label">Best session flow</p>
-              <p class="intro-highlight-card__value">Touch + audio + motion</p>
-              <p class="intro-highlight-card__copy">Mix interactions to find the right intensity for your moment.</p>
-            </article>
-          </div>
-          <ul class="intro-pills" aria-label="Quick highlights">
-            <li class="intro-pill">✨ Featured: Halo Flow</li>
-            <li class="intro-pill">🎧 Mic or demo audio</li>
-            <li class="intro-pill">🖐️ Touch-friendly on all screens</li>
-          </ul>
-        </div>
-        <div class="cta-row hero-cta-row">
+      <section class="intro" id="intro" aria-label="Primary quick actions">
+        <div class="intro-actions" role="group" aria-label="Start options">
           <a
             href="toy.html?toy=holy"
             class="cta-button primary"
             data-quickstart-slug="holy"
           >
-            Start now on this device
+            Start now
           </a>
           <a
             href="toy.html?toy=spiral-burst"
@@ -178,14 +154,18 @@
             data-quickstart-pool="energetic"
             data-quickstart-audio="demo"
           >
-            Surprise me
+            Surprise
+          </a>
+          <a
+            href="toy.html?toy=aurora-painter"
+            class="cta-button ghost"
+            data-quickstart-mode="random"
+            data-quickstart-pool="calming"
+            data-quickstart-flow="true"
+          >
+            Flow mode
           </a>
         </div>
-        <ul class="intro-pills" aria-label="Best with">
-          <li class="intro-pill">Best with 🎤 Mic</li>
-          <li class="intro-pill">Best with 🎧 Demo audio</li>
-          <li class="intro-pill">Best with 🧭 Motion</li>
-        </ul>
         <div class="intro-secondary-links">
           <a href="#toy-list" class="text-link intro-secondary-link">Browse all stims</a>
           <a
@@ -200,14 +180,13 @@
             Party mode
           </a>
         </div>
-        <p class="section-helper" data-hero-flow-note>Ready for this device.</p>
       </section>
 
       <section class="quick-starts" id="quick-starts" aria-label="Quick start suggestions">
         <div class="section-heading">
           <p class="eyebrow">Quick start</p>
-          <h2>Start playing fast</h2>
-          <p class="section-description">Pick a path: featured, flow mode, or surprise me.</p>
+          <h2>Quick picks</h2>
+          <p class="section-description">Choose a vibe and jump in.</p>
         </div>
         <div class="quick-start-grid">
           <article class="quick-card">
@@ -250,15 +229,6 @@
                 Surprise me
               </a>
               <a href="#library" class="text-link">Browse all</a>
-            </div>
-          </article>
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">For parties</p>
-            <h3>Built with the community</h3>
-            <p>Share feedback, pick the next toy, or help ship a release.</p>
-            <div class="quick-card__actions">
-              <a href="https://github.com/zz-plant/stims" class="cta-button ghost" target="_blank" rel="noopener noreferrer">Open GitHub</a>
-              <a href="https://github.com/zz-plant/stims/issues/new/choose" class="text-link" target="_blank" rel="noopener noreferrer">Suggest a toy</a>
             </div>
           </article>
         </div>


### PR DESCRIPTION
### Motivation
- Simplify the library landing so visitors can act immediately by surfacing three direct start paths instead of a large hero block.
- Make quick-start content easier to scan and more mobile-friendly by tightening copy and reducing visual clutter.
- Improve the minimal visual treatment so the intro actions and quick cards feel balanced across desktop and mobile.

### Description
- Replaced the hero intro in `index.html` with a compact action group (`.intro-actions`) offering `Start now`, `Surprise`, and `Flow mode`, plus the existing secondary links.
- Renamed the quick-start heading to `Quick picks`, tightened supporting copy, and removed the community quick-card from the first fold in `index.html`.
- Added and adjusted minimal homepage styles in `assets/css/index.css` including `.intro-actions`, updated spacing, and a responsive `.quick-start-grid` (3 columns desktop / 2 tablet / 1 mobile).
- Ran project formatting and type/test checks to ensure no regressions in code style or behavior.

### Testing
- Ran `bun run format` which succeeded. 
- Ran the full quality gate via `bun run check` which includes typechecking and tests, and it completed with all tests passing: `132` passed, `2` skipped, `0` failed.
- No documentation files were changed in this change (`Docs: None`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d0e333708332ae7ab790c22305e8)