### PR TITLE
Redesign surprise me and daily streak cards

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -779,24 +779,6 @@ header.hero {
   align-items: center;
 }
 
-.quick-card__meta {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.quick-card__meta li {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  border: 1px solid color-mix(in srgb, var(--surface-border) 76%, transparent);
-  border-radius: 999px;
-  padding: 0.24rem 0.55rem;
-  background: color-mix(in srgb, var(--surface-strong) 82%, transparent);
-}
-
 .starter-picks {
   display: grid;
   gap: 0.9rem;
@@ -853,9 +835,9 @@ header.hero {
 
 .daily-streak {
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
   margin-bottom: 1.1rem;
-  padding: 1.05rem;
+  padding: 1rem;
   border-radius: var(--radius-lg);
   background:
     linear-gradient(
@@ -902,28 +884,10 @@ header.hero {
   gap: 0.55rem;
 }
 
-.daily-streak__today {
-  display: grid;
-  gap: 0.35rem;
-  border-radius: var(--radius-md);
-  border: 1px solid
-    color-mix(in srgb, var(--accent-color) 32%, var(--surface-border));
-  background: color-mix(in srgb, var(--card-bg) 88%, transparent);
-  padding: 0.65rem 0.75rem;
-}
-
-.daily-streak__today-label {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.11em;
-  font-size: 0.69rem;
-  color: var(--text-muted);
-}
-
 .daily-streak__note {
   margin: 0;
   font-size: 0.88rem;
-  color: color-mix(in srgb, var(--text-color) 82%, var(--text-muted));
+  color: var(--text-muted);
 }
 
 .system-check {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -779,6 +779,24 @@ header.hero {
   align-items: center;
 }
 
+.quick-card__meta {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.quick-card__meta li {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 76%, transparent);
+  border-radius: 999px;
+  padding: 0.24rem 0.55rem;
+  background: color-mix(in srgb, var(--surface-strong) 82%, transparent);
+}
+
 .starter-picks {
   display: grid;
   gap: 0.9rem;
@@ -835,9 +853,9 @@ header.hero {
 
 .daily-streak {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.9rem;
   margin-bottom: 1.1rem;
-  padding: 1rem;
+  padding: 1.05rem;
   border-radius: var(--radius-lg);
   background:
     linear-gradient(
@@ -884,10 +902,28 @@ header.hero {
   gap: 0.55rem;
 }
 
+.daily-streak__today {
+  display: grid;
+  gap: 0.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid
+    color-mix(in srgb, var(--accent-color) 32%, var(--surface-border));
+  background: color-mix(in srgb, var(--card-bg) 88%, transparent);
+  padding: 0.65rem 0.75rem;
+}
+
+.daily-streak__today-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  font-size: 0.69rem;
+  color: var(--text-muted);
+}
+
 .daily-streak__note {
   margin: 0;
   font-size: 0.88rem;
-  color: var(--text-muted);
+  color: color-mix(in srgb, var(--text-color) 82%, var(--text-muted));
 }
 
 .system-check {

--- a/index.html
+++ b/index.html
@@ -216,13 +216,18 @@
             </div>
           </article>
           <article class="quick-card">
-            <p class="quick-card__eyebrow">Surprise</p>
-            <h3>Random featured toy</h3>
-            <p>Jump into a featured toy, tuned for fast starts.</p>
+            <p class="quick-card__eyebrow">Surprise me</p>
+            <h3>Shuffle a fresh stim</h3>
+            <p>Roll into a featured toy when you want novelty without decision fatigue.</p>
+            <ul class="quick-card__meta" aria-label="Surprise mode highlights">
+              <li>Featured favorites</li>
+              <li>One-tap launch</li>
+              <li>Great for resets</li>
+            </ul>
             <div class="quick-card__actions">
               <a
                 href="toy.html?toy=spiral-burst"
-                class="cta-button ghost"
+                class="cta-button cta-button--accent"
                 data-quickstart-mode="random"
                 data-quickstart-pool="featured"
               >
@@ -262,10 +267,16 @@
           </section>
           <section class="daily-streak" aria-label="Daily return recommendations" data-daily-engagement>
             <div class="daily-streak__header">
-              <p class="daily-streak__eyebrow">Daily momentum</p>
+              <p class="daily-streak__eyebrow">Streaks</p>
               <p class="daily-streak__title">
                 <strong data-daily-streak-count>Start your streak</strong>
                 <span data-daily-streak-copy>Open one stim each day.</span>
+              </p>
+            </div>
+            <div class="daily-streak__today">
+              <p class="daily-streak__today-label">Today's pick</p>
+              <p class="daily-streak__note" data-daily-pick-label>
+                Daily pick updates each day.
               </p>
             </div>
             <div class="daily-streak__actions">
@@ -276,9 +287,6 @@
                 Continue previous stim
               </button>
             </div>
-            <p class="daily-streak__note" data-daily-pick-label>
-              Daily pick updates each day.
-            </p>
           </section>
           <div class="search-heading">
             <h3>Find a stim</h3>

--- a/index.html
+++ b/index.html
@@ -218,12 +218,7 @@
           <article class="quick-card">
             <p class="quick-card__eyebrow">Surprise me</p>
             <h3>Shuffle a fresh stim</h3>
-            <p>Roll into a featured toy when you want novelty without decision fatigue.</p>
-            <ul class="quick-card__meta" aria-label="Surprise mode highlights">
-              <li>Featured favorites</li>
-              <li>One-tap launch</li>
-              <li>Great for resets</li>
-            </ul>
+            <p>Jump into a featured toy when you want something new.</p>
             <div class="quick-card__actions">
               <a
                 href="toy.html?toy=spiral-burst"
@@ -273,12 +268,9 @@
                 <span data-daily-streak-copy>Open one stim each day.</span>
               </p>
             </div>
-            <div class="daily-streak__today">
-              <p class="daily-streak__today-label">Today's pick</p>
-              <p class="daily-streak__note" data-daily-pick-label>
-                Daily pick updates each day.
-              </p>
-            </div>
+            <p class="daily-streak__note" data-daily-pick-label>
+              Today's pick updates each day.
+            </p>
             <div class="daily-streak__actions">
               <button type="button" class="cta-button" data-daily-pick-action>
                 Play today's pick


### PR DESCRIPTION
### Motivation
- Improve clarity and affordance for quick-start actions by making the “Surprise me” quick-pick feel intentional and giving the daily engagement area clearer separation between streak state and Today's pick content.

### Description
- Update `index.html` to change the Quick Picks copy for Surprise me, add compact highlight chips, and promote the CTA to an accent style (file: `index.html`).
- Add a dedicated Today’s pick sub-panel and rename the streak eyebrow to “Streaks” while keeping existing data hooks (`data-daily-pick-label`, `data-daily-pick-action`, `data-recent-pick-action`) so JS behavior is preserved (file: `index.html`).
- Add styles for `.quick-card__meta` and `.daily-streak__today`, and tune spacing and color-mix treatments for the daily streak area (file: `assets/css/index.css`).
- Modified files: `index.html`, `assets/css/index.css`.

### Testing
- Ran `bun run check` (Biome format/lint + `tsc` typecheck + test suite) and all checks passed.
- Ran `bun run format` to normalize formatting and re-ran `bun run check` to confirm no remaining issues.
- Launched a dev server with `bun run dev:host --port 4173` and captured a Playwright screenshot for visual verification (artifact generated).

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d497ef4883328791960cd09aaec3)