### PR TITLE
Rethink home layout hierarchy

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -3610,6 +3610,19 @@ footer {
 }
 
 /* Minimal home refresh */
+.home-support-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.home-support-grid .quick-starts,
+.home-support-grid .system-check {
+  margin: 0;
+  height: 100%;
+}
+
 section.intro,
 .quick-starts,
 .library-search,
@@ -3669,7 +3682,7 @@ section.intro {
 }
 
 .quick-start-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.65rem;
 }
 
@@ -3682,6 +3695,16 @@ section.intro {
 
 .quick-card h3 {
   font-size: 1.03rem;
+}
+
+@media (max-width: 1100px) {
+  .home-support-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quick-start-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 980px) {

--- a/index.html
+++ b/index.html
@@ -182,59 +182,6 @@
         </div>
       </section>
 
-      <section class="quick-starts" id="quick-starts" aria-label="Quick start suggestions">
-        <div class="section-heading">
-          <p class="eyebrow">Quick start</p>
-          <h2>Quick picks</h2>
-          <p class="section-description">Choose a vibe and jump in.</p>
-        </div>
-        <div class="quick-start-grid">
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Featured</p>
-            <h3>Halo Flow</h3>
-            <p>Soft visuals that react to audio and touch.</p>
-            <div class="quick-card__actions">
-              <a href="toy.html?toy=holy" class="cta-button primary" data-quickstart-slug="holy">Open Halo Flow</a>
-              <a href="#library" class="text-link">See similar stims</a>
-            </div>
-          </article>
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Live mode</p>
-            <h3>Auto-switch playlist</h3>
-            <p>Let the library cycle through tactile tags.</p>
-            <div class="quick-card__actions">
-              <a
-                href="toy.html?toy=aurora-painter"
-                class="cta-button ghost"
-                data-quickstart-mode="random"
-                data-quickstart-pool="calming"
-                data-quickstart-flow="true"
-              >
-                Start flow mode
-              </a>
-              <a href="#library" class="text-link">Choose a pool</a>
-            </div>
-          </article>
-          <article class="quick-card">
-            <p class="quick-card__eyebrow">Surprise me</p>
-            <h3>Shuffle a fresh stim</h3>
-            <p>Jump into a featured toy when you want something new.</p>
-            <div class="quick-card__actions">
-              <a
-                href="toy.html?toy=spiral-burst"
-                class="cta-button cta-button--accent"
-                data-quickstart-mode="random"
-                data-quickstart-pool="featured"
-              >
-                Surprise me
-              </a>
-              <a href="#library" class="text-link">Browse all</a>
-            </div>
-          </article>
-        </div>
-      </section>
-
-
       <section class="library" id="library">
         <div class="section-heading">
           <p class="eyebrow">Library</p>
@@ -433,7 +380,60 @@
         <main id="toy-list" class="webtoy-container"></main>
       </section>
 
-      <section class="system-check" id="system-check">
+      <div class="home-support-grid">
+        <section class="quick-starts" id="quick-starts" aria-label="Quick start suggestions">
+          <div class="section-heading">
+            <p class="eyebrow">Quick start</p>
+            <h2>Quick picks</h2>
+            <p class="section-description">Choose a vibe and jump in.</p>
+          </div>
+          <div class="quick-start-grid">
+            <article class="quick-card">
+              <p class="quick-card__eyebrow">Featured</p>
+              <h3>Halo Flow</h3>
+              <p>Soft visuals that react to audio and touch.</p>
+              <div class="quick-card__actions">
+                <a href="toy.html?toy=holy" class="cta-button primary" data-quickstart-slug="holy">Open Halo Flow</a>
+                <a href="#library" class="text-link">See similar stims</a>
+              </div>
+            </article>
+            <article class="quick-card">
+              <p class="quick-card__eyebrow">Live mode</p>
+              <h3>Auto-switch playlist</h3>
+              <p>Let the library cycle through tactile tags.</p>
+              <div class="quick-card__actions">
+                <a
+                  href="toy.html?toy=aurora-painter"
+                  class="cta-button ghost"
+                  data-quickstart-mode="random"
+                  data-quickstart-pool="calming"
+                  data-quickstart-flow="true"
+                >
+                  Start flow mode
+                </a>
+                <a href="#library" class="text-link">Choose a pool</a>
+              </div>
+            </article>
+            <article class="quick-card">
+              <p class="quick-card__eyebrow">Surprise me</p>
+              <h3>Shuffle a fresh stim</h3>
+              <p>Jump into a featured toy when you want something new.</p>
+              <div class="quick-card__actions">
+                <a
+                  href="toy.html?toy=spiral-burst"
+                  class="cta-button cta-button--accent"
+                  data-quickstart-mode="random"
+                  data-quickstart-pool="featured"
+                >
+                  Surprise me
+                </a>
+                <a href="#library" class="text-link">Browse all</a>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="system-check" id="system-check">
         <div class="section-heading">
           <p class="eyebrow">System check</p>
           <h2>Check your device</h2>
@@ -523,7 +523,8 @@
           </button>
           <a href="#toy-list" class="text-link">Back to library</a>
         </div>
-      </section>
+        </section>
+      </div>
 
       <section class="github" id="github">
         <div class="section-heading">


### PR DESCRIPTION
### Motivation

- Make the library the primary next step after the intro so users can browse all stims immediately. 
- Reduce hero/hero-CTA friction by moving supporting tools (quick picks and system check) into a single support area that sits after the library.

### Description

- Moved the existing Quick picks markup into a new `.home-support-grid` section alongside the `system-check` content so quick-starts and device readiness appear as a paired support column next to each other on wide viewports (`index.html`).
- Added `.home-support-grid` styles and adjusted `.quick-start-grid` column behavior and responsive breakpoints to support a two-column support layout that collapses to one column below `1100px` (`assets/css/index.css`).
- Preserved all existing links, data attributes, and quick-start behaviors so runtime wiring and analytics remain unchanged, and did not modify any toy metadata or docs (Docs: None).

### Testing

- Ran the full quality gate with `bun run check` (Biome lint, TypeScript typecheck, and tests) and it completed successfully. 
- Ran the test suite (`bun run test`) as part of the check and the run completed with 134 tests: 132 passed, 2 skipped, and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990e6900328833285b6a6d0af8467c7)