### PR TITLE
Expand audio mapper utility behavior

### DIFF
--- a/assets/js/utils/audio-mapper.ts
+++ b/assets/js/utils/audio-mapper.ts
@@ -1,5 +1,33 @@
 export type AudioMapperOptions = {
   fallbackValue?: number;
+  sampleWindow?: 'single' | 'average';
+};
+
+const DEFAULT_SAMPLE_WINDOW: NonNullable<AudioMapperOptions['sampleWindow']> =
+  'single';
+
+const getFallbackValue = (fallbackValue?: number): number =>
+  Number.isFinite(fallbackValue) ? (fallbackValue as number) : 0;
+
+const getSampleValue = (
+  data: Uint8Array,
+  start: number,
+  end: number,
+  sampleWindow: NonNullable<AudioMapperOptions['sampleWindow']>,
+  fallbackValue: number,
+): number => {
+  if (data.length === 0 || start >= data.length) return fallbackValue;
+
+  if (sampleWindow !== 'average') {
+    return data[start] ?? fallbackValue;
+  }
+
+  const clampedEnd = Math.max(start + 1, Math.min(data.length, end));
+  let sum = 0;
+  for (let i = start; i < clampedEnd; i += 1) {
+    sum += data[i] ?? fallbackValue;
+  }
+  return sum / (clampedEnd - start);
 };
 
 export function mapFrequencyToItems<T>(
@@ -11,11 +39,13 @@ export function mapFrequencyToItems<T>(
   if (items.length === 0) return;
 
   const binsPerItem = data.length / items.length;
-  const { fallbackValue } = options;
+  const fallbackValue = getFallbackValue(options.fallbackValue);
+  const sampleWindow = options.sampleWindow ?? DEFAULT_SAMPLE_WINDOW;
 
   items.forEach((item, index) => {
-    const binIndex = Math.floor(index * binsPerItem);
-    const value = data[binIndex] || fallbackValue || 0;
+    const start = Math.floor(index * binsPerItem);
+    const end = Math.floor((index + 1) * binsPerItem);
+    const value = getSampleValue(data, start, end, sampleWindow, fallbackValue);
     callback(item, index, value);
   });
 }

--- a/tests/audio-mapper.test.ts
+++ b/tests/audio-mapper.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import { mapFrequencyToItems } from '../assets/js/utils/audio-mapper';
+
+describe('mapFrequencyToItems', () => {
+  test('maps bins to items with single-sample mode by default', () => {
+    const items = ['a', 'b', 'c'];
+    const values: number[] = [];
+
+    mapFrequencyToItems(
+      new Uint8Array([10, 20, 30, 40, 50, 60]),
+      items,
+      (_item, _index, value) => {
+        values.push(value);
+      },
+    );
+
+    expect(values).toEqual([10, 30, 50]);
+  });
+
+  test('can average each item bin range when requested', () => {
+    const items = ['a', 'b', 'c'];
+    const values: number[] = [];
+
+    mapFrequencyToItems(
+      new Uint8Array([10, 20, 30, 40, 50, 60]),
+      items,
+      (_item, _index, value) => {
+        values.push(value);
+      },
+      { sampleWindow: 'average' },
+    );
+
+    expect(values).toEqual([15, 35, 55]);
+  });
+
+  test('uses explicit fallback values including zero', () => {
+    const firstValues: number[] = [];
+    const secondValues: number[] = [];
+
+    mapFrequencyToItems(new Uint8Array([]), ['a'], (_item, _index, value) => {
+      firstValues.push(value);
+    });
+
+    mapFrequencyToItems(
+      new Uint8Array([]),
+      ['a'],
+      (_item, _index, value) => {
+        secondValues.push(value);
+      },
+      { fallbackValue: 0 },
+    );
+
+    expect(firstValues).toEqual([0]);
+    expect(secondValues).toEqual([0]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve robustness of FFT-to-item mapping so callers can opt for averaged sampling across bin ranges and receive deterministic fallback values.
- Make fallback handling explicit and resilient to empty or out-of-range FFT buffers so downstream toys have predictable inputs.
- Provide a small targeted test suite to lock in the default behavior and the new averaging and fallback contracts.

### Description
- Extend `AudioMapperOptions` with `sampleWindow?: 'single' | 'average'` and add `DEFAULT_SAMPLE_WINDOW` to preserve current defaults.  
- Add helpers `getFallbackValue` and `getSampleValue` and update `mapFrequencyToItems` to compute `start`/`end` bin ranges and sample either a single bin or an averaged range.  
- Add `tests/audio-mapper.test.ts` covering default single-sample mapping, averaged-bin mapping, and explicit fallback-value handling.  

### Testing
- Ran the targeted tests with `bun run test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/audio-mapper.test.ts` and they passed.  
- Ran the full quality gate with `bun run check` (Biome + typecheck + tests) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914691bcb4833282103a42ff4a847c)