### PR TITLE
Simplify library navigation layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -332,7 +332,7 @@ footer {
 .nav-actions {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.55rem;
   flex-wrap: wrap;
 }
 
@@ -371,36 +371,17 @@ footer {
 .nav-section {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
-}
-
-.nav-section__label {
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: var(--text-muted);
-  padding: 0 0.35rem;
 }
 
 .nav-section--jump {
-  padding: 0.2rem 0.35rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--surface-border);
-  background: transparent;
-  box-shadow: none;
+  padding-right: 0.15rem;
+  border-right: 1px solid var(--surface-border);
 }
 
 .nav-section--utilities {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  flex-wrap: wrap;
-  padding: 0.2rem 0.35rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--surface-border);
-  background: transparent;
+  padding-left: 0.2rem;
 }
 
 .nav-link--section {
@@ -3499,13 +3480,8 @@ footer {
     flex-direction: column;
     align-items: stretch;
     gap: 0.45rem;
-    padding: 0.45rem;
-    border-radius: var(--radius-md);
-  }
-
-  .nav-section__label {
-    width: 100%;
-    padding: 0 0.35rem;
+    padding: 0;
+    border: 0;
   }
 
   .top-nav {

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -108,20 +108,14 @@ function renderLibraryNav(container: HTMLElement, _doc: Document) {
       </button>
       <div class="nav-actions" id="nav-actions">
         <div class="nav-section nav-section--jump" aria-label="Jump to">
-          <span class="nav-section__label">Jump</span>
-          <a class="nav-link nav-link--section" data-section-link href="#intro">Intro</a>
-          <a class="nav-link nav-link--section" data-section-link href="#quick-starts">Quick start</a>
+          <a class="nav-link nav-link--section" data-section-link href="#intro">Overview</a>
           <a class="nav-link nav-link--section" data-section-link href="#system-check">System check</a>
           <a class="nav-link nav-link--section" data-section-link href="#library">Library</a>
-          <a class="nav-link nav-link--section" data-section-link href="#github">GitHub</a>
           <a class="nav-link nav-link--section" data-section-link href="#site-footer">Connect</a>
         </div>
         <div class="nav-section nav-section--utilities" aria-label="Utilities">
-          <span class="nav-section__label">Utilities</span>
           <a class="nav-link" href="#toy-list">Browse</a>
           <a class="nav-link" href="https://github.com/zz-plant/stims" target="_blank" rel="noopener noreferrer">GitHub</a>
-          <a class="nav-link" href="https://github.com/zz-plant/stims/issues" target="_blank" rel="noopener noreferrer">Issues</a>
-          <a class="nav-link" href="https://github.com/zz-plant/stims/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">Changelog</a>
           <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" aria-label="Switch to dark mode">
             <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
             <span class="theme-toggle__label" data-theme-label>Dark mode</span>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the top library navigation so core actions are more prominent and the header reads lighter on both desktop and mobile.
- Remove duplicated secondary utility links that are already available in footer/context to streamline destinations and focus quick navigation.

### Description
- Trimmed the library nav markup in `assets/js/ui/nav.ts` to keep only core jump links (`Overview`, `System check`, `Library`, `Connect`) and a compact utilities group (`Browse`, `GitHub`, theme toggle), removing extra links like `Issues` and `Changelog` and the section labels.
- Adjusted spacing and grouping in `assets/css/index.css` by tightening gaps, removing the `.nav-section__label` styling, adding a subtle divider (`border-right`) between jump and utility groups, and simplifying mobile stacked padding/border behavior.
- Kept existing accessibility and interactive behavior (menu toggle, aria attributes, mobile stacking) intact while simplifying visuals and markup structure.

### Testing
- Ran the full quality gate with `bun run check` which runs Biome checks, TypeScript typechecking, and the test suite; result: success (Ran 137 tests: 135 passed, 2 skipped, 0 failed).
- Verified library navigation interactions tests (including mobile menu behavior) passed as part of the suite (see `tests/nav.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914d7320c48332893700c9ddfe6f98)