### PR TITLE
Remove homepage Quick picks and related engagement/challenges

### DIFF
--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -37,14 +37,6 @@ type ToyNavContainer = HTMLElement & {
   __libraryNavCleanup?: () => void;
 };
 
-const TOY_MICRO_CHALLENGES = [
-  'Tap around the scene and find your favorite rhythm pocket.',
-  'Try both microphone and demo audio, then compare the mood shift.',
-  'Hit Next stim and see which toy surprises you most.',
-  'Push intensity up, then dial it back to find your sweet spot.',
-  'Switch to picture-in-picture and keep the visuals ambient while multitasking.',
-];
-
 function escapeHtml(value: string) {
   return value.replace(/[&<>"']/g, (match) => {
     switch (match) {
@@ -246,10 +238,6 @@ function renderToyNav(
   const hintText = isMobileDevice()
     ? 'Swipe or tap Back to return to the library.'
     : 'Press Esc or use Back to return to the library.';
-  const randomChallenge =
-    TOY_MICRO_CHALLENGES[
-      Math.floor(Math.random() * TOY_MICRO_CHALLENGES.length)
-    ] ?? TOY_MICRO_CHALLENGES[0];
   container.className = 'active-toy-nav';
   container.innerHTML = `
     <div class="active-toy-nav__content">
@@ -298,12 +286,6 @@ function renderToyNav(
             </div>`
           : ''
       }
-      <div class="toy-nav__challenge-wrapper">
-        <button type="button" class="toy-nav__challenge" data-challenge-refresh="true">
-          New mini challenge
-        </button>
-        <span class="toy-nav__challenge-status" role="status" aria-live="polite">${escapeHtml(randomChallenge)}</span>
-      </div>
       <div class="toy-nav__pip-wrapper">
         <button type="button" class="toy-nav__pip" data-toy-pip="true" aria-pressed="false">
           Picture in picture
@@ -400,12 +382,6 @@ function renderToyNav(
   const nextStatus = container.querySelector(
     '.toy-nav__next-status',
   ) as HTMLElement | null;
-  const challengeBtn = container.querySelector(
-    '.toy-nav__challenge',
-  ) as HTMLButtonElement | null;
-  const challengeStatus = container.querySelector(
-    '.toy-nav__challenge-status',
-  ) as HTMLElement | null;
   let hapticsActive = Boolean(options.hapticsActive);
   const hapticsBtn = container.querySelector(
     '[data-haptics-toggle="true"]',
@@ -413,16 +389,6 @@ function renderToyNav(
   const hapticsStatus = container.querySelector(
     '[data-haptics-status]',
   ) as HTMLElement | null;
-
-  challengeBtn?.addEventListener('click', () => {
-    const nextChallenge =
-      TOY_MICRO_CHALLENGES[
-        Math.floor(Math.random() * TOY_MICRO_CHALLENGES.length)
-      ] ?? TOY_MICRO_CHALLENGES[0];
-    if (challengeStatus) {
-      challengeStatus.textContent = nextChallenge;
-    }
-  });
 
   const showShareStatus = (message: string) => {
     if (!shareStatus) return;

--- a/index.html
+++ b/index.html
@@ -204,26 +204,6 @@
               </a>
             </div>
           </section>
-          <section class="daily-streak" aria-label="Daily return recommendations" data-daily-engagement>
-            <div class="daily-streak__header">
-              <p class="daily-streak__eyebrow">Streaks</p>
-              <p class="daily-streak__title">
-                <strong data-daily-streak-count>Start your streak</strong>
-                <span data-daily-streak-copy>Open one stim each day.</span>
-              </p>
-            </div>
-            <p class="daily-streak__note" data-daily-pick-label>
-              Today's pick updates each day.
-            </p>
-            <div class="daily-streak__actions">
-              <button type="button" class="cta-button" data-daily-pick-action>
-                Play today's pick
-              </button>
-              <button type="button" class="cta-button cta-button--muted" data-recent-pick-action hidden>
-                Continue previous stim
-              </button>
-            </div>
-          </section>
           <div class="search-heading">
             <h3>Find a stim</h3>
             <p>Search by name or mood.</p>
@@ -378,56 +358,6 @@
       </section>
 
       <div class="home-support-grid">
-        <section class="quick-starts" id="quick-starts" aria-label="Quick start suggestions">
-          <div class="section-heading">
-            <p class="eyebrow">Quick start</p>
-            <h2>Quick picks</h2>
-            <p class="section-description">Choose a vibe and jump in.</p>
-          </div>
-          <div class="quick-start-grid">
-            <article class="quick-card">
-              <p class="quick-card__eyebrow">Featured</p>
-              <h3>Halo Flow</h3>
-              <p>Soft visuals that react to audio and touch.</p>
-              <div class="quick-card__actions">
-                <a href="toy.html?toy=holy" class="cta-button primary" data-quickstart-slug="holy">Open Halo Flow</a>
-                <a href="#library" class="text-link">See similar stims</a>
-              </div>
-            </article>
-            <article class="quick-card">
-              <p class="quick-card__eyebrow">Calming</p>
-              <h3>Settle into Aurora Painter</h3>
-              <p>Start with gesture-led visuals built for a softer pace.</p>
-              <div class="quick-card__actions">
-                <a
-                  href="toy.html?toy=aurora-painter"
-                  class="cta-button ghost"
-                  data-quickstart-slug="aurora-painter"
-                >
-                  Open Aurora Painter
-                </a>
-                <a href="#library" class="text-link">Choose a pool</a>
-              </div>
-            </article>
-            <article class="quick-card">
-              <p class="quick-card__eyebrow">Surprise me</p>
-              <h3>Shuffle a fresh stim</h3>
-              <p>Jump into a featured toy when you want something new.</p>
-              <div class="quick-card__actions">
-                <a
-                  href="toy.html?toy=spiral-burst"
-                  class="cta-button cta-button--accent"
-                  data-quickstart-mode="random"
-                  data-quickstart-pool="featured"
-                >
-                  Surprise me
-                </a>
-                <a href="#library" class="text-link">Browse all</a>
-              </div>
-            </article>
-          </div>
-        </section>
-
         <section class="system-check" id="system-check">
         <div class="section-heading">
           <p class="eyebrow">System check</p>

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -40,13 +40,6 @@ describe('library filter state normalization', () => {
       <select data-sort-control>
         <option value="featured">Featured</option>
       </select>
-      <section data-daily-engagement>
-        <strong data-daily-streak-count></strong>
-        <span data-daily-streak-copy></span>
-        <button data-daily-pick-action type="button"></button>
-        <button data-recent-pick-action type="button" hidden></button>
-        <p data-daily-pick-label></p>
-      </section>
       <div id="toy-list"></div>
     `;
   });
@@ -73,28 +66,5 @@ describe('library filter state normalization', () => {
     expect(persisted).not.toBeNull();
     expect(JSON.parse(persisted ?? '{}').filters).toEqual([]);
     expect(calmChip?.classList.contains('is-active')).toBe(false);
-  });
-
-  test('records launches so daily streak and continue action are available', async () => {
-    const view = createLibraryView({
-      toys,
-      searchInputId: 'toy-search',
-      loadToy: () => {},
-    });
-
-    await view.init();
-
-    const card = document.querySelector('.webtoy-card');
-    expect(card).not.toBeNull();
-    card?.dispatchEvent(new Event('click', { bubbles: true }));
-
-    const persisted = window.localStorage.getItem('stims-engagement-state');
-    expect(persisted).not.toBeNull();
-    const parsed = JSON.parse(persisted ?? '{}');
-    expect(parsed.lastPlayedSlug).toBe('calm-flow');
-    expect(parsed.streak).toBe(1);
-
-    const continueButton = document.querySelector('[data-recent-pick-action]');
-    expect(continueButton?.hasAttribute('hidden')).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Remove the Quick picks quick-start UI from the homepage and the associated ephemeral engagement and micro-challenge features that are no longer desired in the library UX.
- Simplify library and toy navigation code paths by deleting now-unused streak/quick-start and micro-challenge state and markup.

### Description
- Deleted the Quick picks markup from `index.html` so the `home-support-grid` flows directly into the `system-check` section and no quick-start cards are rendered.
- Removed engagement/streak logic and daily-pick wiring from `assets/js/library-view.js`, including `ENGAGEMENT_KEY`, `readEngagementState`, `saveEngagementState`, `recordToyLaunch`, `resolveDailyToy`, `updateDailyEngagement`, and their invocation sites.
- Removed the toy micro-challenges array and the challenge button/UI and handlers from `assets/js/ui/nav.ts` so the toy nav no longer renders or cycles a mini-challenge.
- Updated `tests/library-filter-state.test.ts` to remove the daily-streak test scaffolding that relied on the engagement UI.

### Testing
- Ran the quality gate via `bun run check` which completed successfully with no lint/type failures.
- Ran the test suite with `bun test` which completed with all tests passing for changed areas (137 tests run: 135 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699161fb31bc833286a605940938fa74)