### PR TITLE
Remove agent-ready stim while keeping improved scaffold flow

### DIFF
--- a/docs/TOY_DEVELOPMENT.md
+++ b/docs/TOY_DEVELOPMENT.md
@@ -66,11 +66,12 @@ Use the scaffold script whenever possible; it wires up metadata, docs, and optio
    ```bash
    bun run scripts/scaffold-toy.ts --slug pocket-pulse --title "Pocket Pulse" --type module --with-test
    ```
-   The script creates `assets/js/toys/<slug>.ts`, appends the metadata entry in `assets/data/toys.json`, updates `docs/TOY_SCRIPT_INDEX.md`, and generates a minimal test in `tests/`.
+   The script creates `assets/js/toys/<slug>.ts` with a typed `ToyStartFunction` + `WebToy` cleanup starter, appends the metadata entry in `assets/data/toys.json`, updates `docs/TOY_SCRIPT_INDEX.md`, and generates a minimal test in `tests/`. After scaffolding, add a short entry to `docs/toys.md` so contributor notes cover the new stim.
 3. **Manual alternative** (if you skipped the scaffold):
    - Create `assets/js/toys/<slug>.ts` and export `start({ container, canvas?, audioContext? })`.
    - Add the entry to `assets/data/toys.json` (include `title`, `description`, `module`, `type`, and any `lifecycleStage` metadata).
    - Add the slug row to `docs/TOY_SCRIPT_INDEX.md` so the loader docs stay in sync.
+   - Add a short section to `docs/toys.md` with any controls/preset notes worth preserving for future contributors.
    - Create `toys/<slug>.html` only if the toy uses a standalone page.
 4. **Wire the runtime**: use `createToyRuntimeStarter` or `createToyRuntime` so audio, renderer, input, and settings panel behavior matches the rest of the library. Keep all DOM work scoped to the provided `container`.
 5. **Verify locally**: run `bun run dev` and load `http://localhost:5173/toy.html?toy=<slug>` to confirm the new card loads, starts audio, and cleans up on exit.

--- a/tests/scaffold-toy.test.ts
+++ b/tests/scaffold-toy.test.ts
@@ -55,7 +55,9 @@ describe('scaffold-toy CLI helpers', () => {
 
     const modulePath = path.join(root, 'assets/js/toys', `${slug}.ts`);
     const moduleContents = await fs.readFile(modulePath, 'utf8');
-    expect(moduleContents).toContain('export async function start');
+    expect(moduleContents).toContain('export const start: ToyStartFunction');
+    expect(moduleContents).toContain('import WebToy');
+    expect(moduleContents).toContain('toy.dispose()');
 
     const data = await fs.readFile(
       path.join(root, 'assets/data/toys.json'),


### PR DESCRIPTION
### Motivation

- Remove the one-off `agent-ready-stim` example that should not be part of the canonical toy catalog while preserving the improved, repeatable scaffold flow for creating new toys.
- Keep documentation and tooling generic so future contributors can re-create a polished, agent-ready toy more easily.

### Description

- Deleted the example module and its test at `assets/js/toys/agent-ready-stim.ts` and `tests/agent-ready-stim.test.ts` and removed its metadata entry from `assets/data/toys.json`.
- Removed the `agent-ready-stim` row from `docs/TOY_SCRIPT_INDEX.md` and the example section from `docs/toys.md`, and removed the one-off example URL from `docs/TOY_DEVELOPMENT.md` while preserving the scaffold checklist.
- Kept and improved the scaffolding template in `scripts/scaffold-toy.ts` so new modules are generated with a typed `ToyStartFunction` + `WebToy` cleanup starter, and updated `tests/scaffold-toy.test.ts` expectations to match the new template.

### Testing

- Ran `bun run check:toys` which reported all toys registered and entry points healthy.
- Ran the full quality gate with `bun run check` (Biome format/lint, TypeScript `tsc`, and the test suite) and all automated checks passed.
- The test run completed with the suite result: 136 passed, 2 skipped, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916291a0048332a39de2af4acaa63a)