### PR TITLE
Remove keyword search from library browsing

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -109,7 +109,6 @@ const startApp = async () => {
           initNavigation,
           loadFromQuery,
           targetId: 'toy-list',
-          searchInputId: 'toy-search',
           cardElement: 'a',
           enableIcons: false,
           enableCapabilityBadges: true,

--- a/assets/js/utils/init-library.ts
+++ b/assets/js/utils/init-library.ts
@@ -113,7 +113,6 @@ export const initLibraryView = async ({
     initNavigation,
     loadFromQuery,
     targetId: 'toy-list',
-    searchInputId: 'toy-search',
     cardElement: 'a',
     enableIcons: true,
     enableCapabilityBadges: true,

--- a/index.html
+++ b/index.html
@@ -204,57 +204,16 @@
               </a>
             </div>
           </section>
-          <div class="search-heading">
-            <h3>Find a stim</h3>
-            <p>Search by name or mood.</p>
-          </div>
-          <div class="search-row">
-            <label class="sr-only" for="toy-search">Search the library</label>
-            <form class="search-field" role="search" data-search-form>
-              <span class="search-field__icon" aria-hidden="true">⌕</span>
-              <input
-                id="toy-search"
-                type="search"
-                name="toy-search"
-                placeholder="Search stims"
-                autocomplete="off"
-                aria-describedby="toy-search-hint"
-                inputmode="search"
-                list="toy-search-suggestions"
-              />
-              <button
-                type="button"
-                class="search-clear"
-                data-search-clear
-                aria-label="Clear search"
-              >
-                Clear
-              </button>
-              <button
-                type="button"
-                class="search-shortcuts-toggle"
-                data-search-shortcuts-toggle
-                aria-expanded="false"
-                aria-controls="toy-search-hint"
-              >
-                Keyboard shortcuts
-              </button>
-              <span id="toy-search-hint" class="search-field__hint" hidden>
-                / focus • esc clear • ↵ open top match
-              </span>
-              <datalist id="toy-search-suggestions"></datalist>
-            </form>
-            <div class="search-meta">
-              <p
-                class="search-meta__results"
-                data-search-results
-                role="status"
-                aria-live="polite"
-              >
-                Loading library…
-              </p>
-              <p class="search-meta__note">Use filters to refine.</p>
-            </div>
+          <div class="search-meta">
+            <p
+              class="search-meta__results"
+              data-search-results
+              role="status"
+              aria-live="polite"
+            >
+              Loading library…
+            </p>
+            <p class="search-meta__note">Use filters to refine.</p>
           </div>
           <div class="active-filters" data-active-filters hidden>
             <span class="active-filters__label">Applied filters</span>

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -63,8 +63,7 @@ describe('app shell user journeys', () => {
 
   beforeEach(() => {
     mock.restore();
-    document.body.innerHTML =
-      '<input id="toy-search" /><div id="toy-list"></div>';
+    document.body.innerHTML = '<div id="toy-list"></div>';
     document.body.dataset.page = 'library';
     try {
       window.sessionStorage.clear();
@@ -92,71 +91,6 @@ describe('app shell user journeys', () => {
     expect(cards).toHaveLength(toyLibrary.length);
     expect(mockInitNavigation).toHaveBeenCalledTimes(1);
     expect(mockLoadFromQuery).toHaveBeenCalledTimes(1);
-  });
-
-  test('searching filters the visible toys by title or description', async () => {
-    await loadAppShell();
-
-    const search = document.getElementById('toy-search');
-    search.value = 'weirdcore';
-    search.dispatchEvent(new Event('input', { bubbles: true }));
-
-    const visibleTitles = Array.from(
-      document.querySelectorAll('.webtoy-card h3'),
-    ).map((node) => node.textContent);
-
-    expect(visibleTitles).toEqual(['Evolutionary Weirdcore']);
-  });
-
-  test('escape clears active library search query', async () => {
-    await loadAppShell();
-
-    const search = document.getElementById('toy-search');
-    expect(search?.tagName).toBe('INPUT');
-
-    search.value = 'aurora';
-    search.dispatchEvent(new Event('input', { bubbles: true }));
-
-    search.dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Escape' }),
-    );
-
-    expect(search.value).toBe('');
-    expect(document.querySelectorAll('.webtoy-card')).toHaveLength(
-      toyLibrary.length,
-    );
-  });
-
-  test('enter launches the best search match', async () => {
-    await loadAppShell();
-
-    const search = document.getElementById('toy-search');
-    search.value = 'aurora painter';
-    search.dispatchEvent(new Event('input', { bubbles: true }));
-
-    search.dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-    );
-
-    expect(mockLoadToy).toHaveBeenCalledTimes(1);
-    expect(mockLoadToy).toHaveBeenCalledWith('aurora-painter', {
-      pushState: true,
-      preferDemoAudio: false,
-    });
-  });
-
-  test('ambiguous searches boost lower-setup toys first', async () => {
-    await loadAppShell();
-
-    const search = document.getElementById('toy-search');
-    search.value = 'visual';
-    search.dispatchEvent(new Event('input', { bubbles: true }));
-
-    const visibleTitles = Array.from(
-      document.querySelectorAll('.webtoy-card h3'),
-    ).map((node) => node.textContent);
-
-    expect(visibleTitles[0]).toBe('Visual Breeze');
   });
 
   test('demo button keyboard activation keeps demo-audio launch path', async () => {

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -26,10 +26,6 @@ describe('library filter state normalization', () => {
     window.localStorage.clear();
 
     document.body.innerHTML = `
-      <input id="toy-search" />
-      <form data-search-form></form>
-      <button data-search-clear type="button">Clear</button>
-      <datalist id="toy-search-suggestions"></datalist>
       <p data-search-results></p>
       <div data-active-filters hidden>
         <div data-active-filters-chips></div>
@@ -52,7 +48,6 @@ describe('library filter state normalization', () => {
 
     const view = createLibraryView({
       toys,
-      searchInputId: 'toy-search',
     });
 
     await view.init();


### PR DESCRIPTION
### Motivation
- Simplify the library discovery experience by removing the free-text keyword search and focusing on starter picks, curated filters, and result metadata.
- Remove query persistence and query-driven matching to reduce surface area for state syncing and make filter-only browsing the default.

### Description
- Removed the keyword search input and its UI markup from the library page (`index.html`).
- Stopped wiring a `searchInputId` into the library initialization in `assets/js/app.ts` and `assets/js/utils/init-library.ts` so the app no longer activates keyboard/search handlers by default.
- Removed query-based filtering and query param persistence from `assets/js/library-view.js`, including haystack/token matching, search suggestions, query persistence (`q`), and search-result quick-launch behavior, while preserving filter and sort behaviour.
- Updated tests to reflect the no-keyword-search flow by removing search-specific DOM setup and assertions in `tests/app-shell.test.js` and `tests/library-filter-state.test.ts`.

### Testing
- Ran the full quality gate with `bun run check`, which runs Biome lint/format, TypeScript typecheck, and the test suite, and it completed successfully.
- Automated tests executed: the repository test suite ran (`bun run test`) as part of the check and passed (132 pass, 2 skip, 0 fail).
- Docs touched: None (UI/behavior change only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699176466e5c8332b14fce17eef1e9d7)