### PR TITLE
Refactor render preferences normalization and storage handling

### DIFF
--- a/tests/render-preferences.test.ts
+++ b/tests/render-preferences.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  COMPATIBILITY_MODE_KEY,
+  getActiveRenderPreferences,
+  MAX_PIXEL_RATIO_KEY,
+  RENDER_SCALE_KEY,
+  resetRenderPreferencesState,
+  setRenderPreferences,
+} from '../assets/js/core/render-preferences';
+
+describe('render preferences', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetRenderPreferencesState();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    resetRenderPreferencesState();
+  });
+
+  test('clamps numeric preferences to supported bounds', () => {
+    const updated = setRenderPreferences({
+      compatibilityMode: true,
+      maxPixelRatio: 4,
+      renderScale: 0.4,
+    });
+
+    expect(updated).toEqual({
+      compatibilityMode: true,
+      maxPixelRatio: 3,
+      renderScale: 0.6,
+    });
+  });
+
+  test('persists and clears nullable numeric values in localStorage', () => {
+    setRenderPreferences({
+      compatibilityMode: true,
+      maxPixelRatio: 2.4,
+      renderScale: 1.2,
+    });
+
+    expect(window.localStorage.getItem(COMPATIBILITY_MODE_KEY)).toBe('true');
+    expect(window.localStorage.getItem(MAX_PIXEL_RATIO_KEY)).toBe('2.4');
+    expect(window.localStorage.getItem(RENDER_SCALE_KEY)).toBe('1.2');
+
+    setRenderPreferences({ maxPixelRatio: null, renderScale: null });
+
+    expect(window.localStorage.getItem(COMPATIBILITY_MODE_KEY)).toBe('true');
+    expect(window.localStorage.getItem(MAX_PIXEL_RATIO_KEY)).toBeNull();
+    expect(window.localStorage.getItem(RENDER_SCALE_KEY)).toBeNull();
+  });
+
+  test('ignores invalid numeric values loaded from localStorage', () => {
+    window.localStorage.setItem(COMPATIBILITY_MODE_KEY, 'true');
+    window.localStorage.setItem(MAX_PIXEL_RATIO_KEY, 'not-a-number');
+    window.localStorage.setItem(RENDER_SCALE_KEY, '1.1');
+
+    expect(getActiveRenderPreferences()).toEqual({
+      compatibilityMode: true,
+      maxPixelRatio: null,
+      renderScale: 1.1,
+    });
+  });
+});

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -17,8 +17,9 @@ import type { FrequencyAnalyser } from '../assets/js/utils/audio-handler.ts';
 import { DEFAULT_MICROPHONE_CONSTRAINTS } from '../assets/js/utils/audio-handler.ts';
 
 describe('render-service pooling', () => {
+  const setPixelRatioMock = mock();
   const fakeRenderer = {
-    setPixelRatio: mock(),
+    setPixelRatio: setPixelRatioMock,
     setSize: mock(),
     setAnimationLoop: mock(),
     dispose: mock(),
@@ -28,6 +29,7 @@ describe('render-service pooling', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     resetRendererPool({ dispose: true });
+    window.localStorage.clear();
   });
 
   test('reuses renderer handle between toys', async () => {


### PR DESCRIPTION
### Motivation
- Reduce duplicated, key-specific logic for numeric render preferences to improve maintainability and make it easier to add new numeric preferences in the future.
- Improve robustness when reading invalid values from storage and centralize nullable-storage writes to avoid repeated conditional branches.

### Description
- Introduced `NUMERIC_PREFERENCE_SETTINGS` and a `NumericPreferenceKey` type to centralize `min`, `max`, and `storageKey` metadata for numeric preferences like `maxPixelRatio` and `renderScale`.
- Added `normalizeNumericPreference` and `setNullableStorageValue` helper functions and refactored `readFromStorage` and `persistToStorage` to iterate these settings instead of handling each field inline.
- Updated `normalizePreferences` to use the new helper and preserved existing public APIs (`getActiveRenderPreferences`, `setRenderPreferences`, etc.), and added unit tests at `tests/render-preferences.test.ts` covering clamping, persistence/clearing, and invalid stored values.

### Testing
- Ran `bun run check` (Biome lint/format, TypeScript, and test suite) and it completed successfully with all tests passing: `135 pass`, `2 skip`, `0 fail`, and the new `tests/render-preferences.test.ts` tests passed.
- No documentation files were modified in this change (`None`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699177592de08332997487bf74c4af77)