### PR TITLE
Consolidate documentation maintenance guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,9 @@ Stim Webtoys Library is a collection of interactive, audio-reactive web toys bui
 1. Open [`docs/agents/README.md`](./docs/agents/README.md) for progressive-disclosure guidance.
 2. Use [`docs/agents/tooling-and-quality.md`](./docs/agents/tooling-and-quality.md) before editing code.
 3. Use [`docs/agents/metadata-and-docs.md`](./docs/agents/metadata-and-docs.md) before finalizing commit/PR text.
-4. Use [`docs/README.md`](./docs/README.md) to keep contributor-facing links aligned if docs move.
+4. Use [`docs/README.md`](./docs/README.md) as the canonical docs index when restructuring or relocating docs.
+5. Follow [`docs/DOCS_MAINTENANCE.md`](./docs/DOCS_MAINTENANCE.md) for cross-link and workflow-doc synchronization requirements.
 
 ## Alignment requirements
 
-- Keep links between `AGENTS.md`, `CONTRIBUTING.md`, and `docs/README.md` in sync when restructuring docs.
-- If you add or rename scripts, update both `docs/DEVELOPMENT.md` and agent overlays that mention those scripts.
-- If you add or rename toys, update `docs/TOY_DEVELOPMENT.md`, `docs/TOY_SCRIPT_INDEX.md`, and `docs/toys.md` in the same change.
+- Keep links and workflow docs aligned according to [`docs/DOCS_MAINTENANCE.md`](./docs/DOCS_MAINTENANCE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,14 +79,10 @@ Use these commands before opening a PR:
 
 ## Documentation expectations
 
-When workflows or structure change, update docs in the same PR (including deployment-track guidance in `docs/DEPLOYMENT.md` when release flow changes):
+When workflows or structure change, update docs in the same PR (including deployment-track guidance in `docs/DEPLOYMENT.md` when release flow changes).
 
-- Start from [`docs/README.md`](./docs/README.md) (docs map by audience + purpose).
-- Keep contributor and agent entry points aligned:
-  - [`README.md`](./README.md)
-  - [`CONTRIBUTING.md`](./CONTRIBUTING.md)
-  - [`AGENTS.md`](./AGENTS.md)
-  - [`docs/agents/README.md`](./docs/agents/README.md)
+- Follow [`docs/DOCS_MAINTENANCE.md`](./docs/DOCS_MAINTENANCE.md) as the canonical docs synchronization contract.
+- Treat [`docs/README.md`](./docs/README.md) as the canonical docs index and update it whenever docs are added, renamed, moved, or deleted.
 
 ## Toy-specific changes
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,17 @@ Looking for release notes? Check out the [CHANGELOG](./CHANGELOG.md) to see what
 
 ## Documentation map
 
-Use these entry points to find the right docs quickly:
+Documentation is consolidated in [`docs/README.md`](./docs/README.md), which is the canonical docs index (with quick task routing plus the full categorized map).
 
-- [`docs/README.md`](./docs/README.md): overview of project docs plus onboarding highlights.
-- [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md): day-to-day setup, tooling, scripts, and workflow expectations.
-- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md), [`docs/TOY_SCRIPT_INDEX.md`](./docs/TOY_SCRIPT_INDEX.md), and [`docs/toys.md`](./docs/toys.md): how to build or modify toys, toy script index, and per-toy notes.
-- [`docs/QA_PLAN.md`](./docs/QA_PLAN.md): QA coverage for high-impact flows and how to run the automation that protects them.
-- [`docs/PAGE_SPECIFICATIONS.md`](./docs/PAGE_SPECIFICATIONS.md): page-level specs for the library landing and toy shell, covering data, layout, and accessibility expectations.
-- [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md): production build/preview steps, Cloudflare Pages/Workers notes, and static hosting tips.
-- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md): runtime composition, loaders, and diagrams for the core systems.
-- [`docs/MCP_SERVER.md`](./docs/MCP_SERVER.md): Model Context Protocol stdio server usage and available tools.
+Use these quick entry points:
 
-If you add new scripts, toys, or deployment options, update the relevant doc above so the workflows stay discoverable.
+- [`docs/README.md`](./docs/README.md): canonical docs index and routing.
+- [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md): setup, scripts, and day-to-day implementation.
+- [`docs/TOY_DEVELOPMENT.md`](./docs/TOY_DEVELOPMENT.md): toy implementation patterns and checklists.
+- [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md): deployment and release guidance.
+- [`docs/DOCS_MAINTENANCE.md`](./docs/DOCS_MAINTENANCE.md): synchronization checklist for doc restructures and workflow changes.
+
+When docs are added, renamed, moved, or deleted, update `docs/README.md` in the same change.
 
 ## Architecture at a glance
 

--- a/docs/DOCS_MAINTENANCE.md
+++ b/docs/DOCS_MAINTENANCE.md
@@ -1,0 +1,35 @@
+# Documentation maintenance guide
+
+Use this guide as the single source of truth for keeping documentation aligned when workflows, scripts, structure, or toy inventory changes.
+
+## Canonical docs index
+
+- `docs/README.md` is the canonical documentation index.
+- When docs are added, renamed, moved, archived, or deleted, update `docs/README.md` in the same change.
+
+## Cross-link alignment contract
+
+When restructuring docs, keep these entry points in sync:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `docs/README.md`
+- `docs/agents/README.md`
+
+## What to update by change type
+
+| Change type | Required docs updates |
+| --- | --- |
+| New script or renamed script | `docs/DEVELOPMENT.md` plus agent overlays that reference scripts. |
+| New toy / renamed toy slug | `docs/TOY_DEVELOPMENT.md`, `docs/TOY_SCRIPT_INDEX.md`, and `docs/toys.md` in the same change. |
+| Workflow behavior changes | Update the source workflow doc (for example `docs/DEVELOPMENT.md`, `docs/DEPLOYMENT.md`, `docs/QA_PLAN.md`). |
+| Docs restructuring | Update links and references across all entry points listed above. |
+
+## PR metadata expectations
+
+PR descriptions should include:
+
+- A short summary,
+- Explicit list of tests run,
+- Explicit list of docs touched/added (or `None`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Developer and Contributor Docs
+# Developer and contributor docs
 
-This directory is organized by **audience + workflow** so contributors and agents can quickly find the right guidance.
+This is the canonical documentation map for the repository. Root-level entry points (`README.md`, `CONTRIBUTING.md`, and `AGENTS.md`) should link here instead of duplicating large doc lists.
 
 ## Start here
 
@@ -8,35 +8,52 @@ This directory is organized by **audience + workflow** so contributors and agent
 - Agent contributors: [`../AGENTS.md`](../AGENTS.md) then [`agents/README.md`](./agents/README.md)
 - Day-to-day implementation: [`DEVELOPMENT.md`](./DEVELOPMENT.md)
 
-## Docs by purpose
+## Quick task routing
 
-### Build, test, and ship
+If you need to...
 
-- [`DEVELOPMENT.md`](./DEVELOPMENT.md) — setup, scripts, and local workflows.
-- [`QA_PLAN.md`](./QA_PLAN.md) — high-impact QA paths and automated coverage.
-- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Track A static-site deploy path plus optional Track B MCP Worker deploy guidance.
+- Set up locally, run scripts, or understand quality gates: [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+- Add or modify a toy: [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md)
+- Verify toy coverage/expectations: [`TOY_TESTING_SPEC.md`](./TOY_TESTING_SPEC.md)
+- Validate high-impact behavior: [`QA_PLAN.md`](./QA_PLAN.md)
+- Ship or update release flow: [`DEPLOYMENT.md`](./DEPLOYMENT.md)
+- Understand runtime architecture: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- Check page-level requirements: [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md)
+- Use the MCP server: [`MCP_SERVER.md`](./MCP_SERVER.md)
+
+## Full index by category
+
+### Core workflows
+
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md) — setup, local scripts, and implementation workflow.
+- [`DOCS_MAINTENANCE.md`](./DOCS_MAINTENANCE.md) — canonical checklist for docs synchronization and restructuring updates.
+- [`QA_PLAN.md`](./QA_PLAN.md) — high-impact QA paths and automation coverage.
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — deploy paths and release flow.
+- [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) — toy implementation patterns and checklists.
+- [`TOY_TESTING_SPEC.md`](./TOY_TESTING_SPEC.md) — toy testing expectations.
 
 ### Implementation references
 
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — runtime composition and data flow.
-- [`FULL_REFACTOR_PLAN.md`](./FULL_REFACTOR_PLAN.md) — staged roadmap for full-codebase refactor.
-- [`TOY_DEVELOPMENT.md`](./TOY_DEVELOPMENT.md) — implementation patterns for toys.
-- [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md) — slug-to-entry-point map.
-- [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md) — page-level specs.
+- [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md) — page-level UX/spec requirements.
+- [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md) — toy slug-to-entry-point map.
+- [`toys.md`](./toys.md) — per-toy notes and implementation details.
 - [`MCP_SERVER.md`](./MCP_SERVER.md) — MCP stdio server usage.
+- [`FULL_REFACTOR_PLAN.md`](./FULL_REFACTOR_PLAN.md) — staged refactor roadmap.
 
-### Product and research context
+### Product, UX, and research docs
 
 - [`FEATURE_SPECIFICATIONS.md`](./FEATURE_SPECIFICATIONS.md)
 - [`FEATURE_AUDIT.md`](./FEATURE_AUDIT.md)
 - [`SEO_AUDIT.md`](./SEO_AUDIT.md)
+- [`USER_JOURNEY_CRITIQUE.md`](./USER_JOURNEY_CRITIQUE.md)
+- [`USABILITY_AUDIT.md`](./USABILITY_AUDIT.md)
+- [`UX_AUDIT_2026-02.md`](./UX_AUDIT_2026-02.md)
+- [`AGENT_PLAYTEST_FUN_REPORT_2026-02.md`](./AGENT_PLAYTEST_FUN_REPORT_2026-02.md)
+- [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
+- [`LITERATURE.md`](./LITERATURE.md)
 - [`stim-assessment.md`](./stim-assessment.md)
 - [`stim-user-critiques.md`](./stim-user-critiques.md)
-- [`USER_JOURNEY_CRITIQUE.md`](./USER_JOURNEY_CRITIQUE.md)
-- [`UX_AUDIT_2026-02.md`](./UX_AUDIT_2026-02.md) — consolidated baseline + iteration follow-ups.
-- [`AGENT_PLAYTEST_FUN_REPORT_2026-02.md`](./AGENT_PLAYTEST_FUN_REPORT_2026-02.md)
-- [`LITERATURE.md`](./LITERATURE.md)
-- [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
 
 ### Agent overlays
 
@@ -47,22 +64,13 @@ This directory is organized by **audience + workflow** so contributors and agent
 - [`agents/toy-workflows.md`](./agents/toy-workflows.md)
 - [`agents/reference-docs.md`](./agents/reference-docs.md)
 
-## Current baseline conventions
+## Baseline conventions
 
-- Package manager: **Bun** (`bun@1.3.8` declared in `package.json`).
+- Package manager: **Bun** (`bun@1.3.8` in `package.json`).
 - Main quality gate for JS/TS work: `bun run check`.
-- Quick gate for iteration: `bun run check:quick`.
-- Toy consistency check (metadata + docs + entry points): `bun run check:toys`.
+- Quick iteration gate: `bun run check:quick`.
+- Toy consistency gate: `bun run check:toys`.
 
 ## Doc maintenance checklist
 
-When you add or change workflows:
-
-1. Update the source workflow doc (for example `DEVELOPMENT.md` or `TOY_DEVELOPMENT.md`).
-2. Update this index if a file moved or a new guide was added.
-3. Keep contributor/agent entry points aligned:
-   - `README.md`
-   - `CONTRIBUTING.md`
-   - `AGENTS.md`
-   - `docs/agents/README.md`
-4. For toy additions/renames, update `TOY_SCRIPT_INDEX.md` and `toys.md` in the same PR.
+Follow [`DOCS_MAINTENANCE.md`](./DOCS_MAINTENANCE.md) for the canonical docs synchronization contract and per-change update requirements.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -21,7 +21,8 @@ Use this folder as a focused, progressive-disclosure overlay for agent tasks.
 ### Documentation or metadata changes
 
 - [`metadata-and-docs.md`](./metadata-and-docs.md)
-- [`../README.md`](../README.md)
+- [`../README.md`](../README.md) (canonical docs index)
+- [`../DOCS_MAINTENANCE.md`](../DOCS_MAINTENANCE.md) (docs synchronization contract for add/move/rename/delete changes)
 
 ## Fast repo map
 

--- a/docs/agents/metadata-and-docs.md
+++ b/docs/agents/metadata-and-docs.md
@@ -1,4 +1,4 @@
-# Metadata and Docs Expectations
+# Metadata and docs expectations
 
 ## Commit and PR metadata
 
@@ -23,20 +23,9 @@ Docs
 
 ## Documentation upkeep rules
 
-When behavior, scripts, or structure changes:
+Use [`../DOCS_MAINTENANCE.md`](../DOCS_MAINTENANCE.md) as the canonical checklist for:
 
-1. Update the source-of-truth workflow docs under `docs/`.
-2. Update the docs map in `docs/README.md` if files moved or were added.
-3. Keep cross-links aligned across:
-   - `README.md`
-   - `CONTRIBUTING.md`
-   - `AGENTS.md`
-   - `docs/agents/README.md`
-
-## Toy docs synchronization
-
-When adding/removing/renaming toy slugs, update all related docs in the same change:
-
-- `docs/TOY_DEVELOPMENT.md`
-- `docs/TOY_SCRIPT_INDEX.md`
-- `docs/toys.md`
+- cross-link alignment between root and agent entry points,
+- docs index synchronization in `docs/README.md`,
+- per-change documentation update requirements,
+- toy docs synchronization requirements.


### PR DESCRIPTION
### Motivation

- Centralize and remove duplicated maintenance checklists so contributors and agents use a single canonical contract for doc sync and restructuring rules. 
- Reduce risk of inconsistent links or missing updates when docs, scripts, or toy slugs are added, renamed, moved, or deleted. 
- Make the `docs/README.md` the canonical index while delegating maintenance policy details to a focused maintenance guide.

### Description

- Add `docs/DOCS_MAINTENANCE.md` as the single source of truth for docs synchronization, cross-link alignment, and change-type-specific update rules. 
- Update `docs/README.md`, `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `docs/agents/README.md`, and `docs/agents/metadata-and-docs.md` to reference the new maintenance guide and remove duplicated checklist text. 
- Normalize a few headings/case differences in `docs/agents/metadata-and-docs.md` and streamline routing language to point readers to the canonical index and maintenance guide. 
- Commit message: `Consolidate documentation maintenance guidance`.

### Testing

- Ran `bun run check:toys` and it completed successfully. 
- Ran `biome lint` and `biome format` as part of the commit workflow and both completed with no fixes required. 
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f8f286988332960fe5c6613db563)