### PR TITLE
Finish Smart TV remote key support and TV defaults with tests

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -15,6 +15,7 @@ import { createRouter } from './router.ts';
 import { initAudioControls } from './ui/audio-controls.ts';
 import { initNavigation as initTopNav } from './ui/nav.ts';
 import { initSystemControls } from './ui/system-controls.ts';
+import { isSmartTvDevice } from './utils/device-detect.ts';
 import { initGamepadNavigation } from './utils/gamepad-navigation.ts';
 import { initLibraryView } from './utils/init-library.ts';
 import { initNavScrollEffects } from './utils/init-nav-scroll.ts';
@@ -150,6 +151,17 @@ const startApp = async () => {
     const toyWindow = window as unknown as ToyWindow;
 
     const buildAudioInitState = (result: CapabilityPreflightResult | null) => {
+      if (isSmartTvDevice()) {
+        return {
+          preferDemoAudio: true,
+          initialStatus: {
+            message:
+              'TV mode enabled. Demo audio is selected first for easier remote setup, but microphone and tab audio are still available.',
+            variant: 'success' as const,
+          },
+        };
+      }
+
       if (!result) return {};
 
       const microphone = result.microphone;

--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -27,6 +27,15 @@ export const DEFAULT_QUALITY_PRESETS: QualityPreset[] = [
     particleScale: 0.5,
   },
   {
+    id: 'tv',
+    label: 'TV balanced',
+    description:
+      'Comfortable 10-foot visuals with lower DPI for steady frame pacing.',
+    maxPixelRatio: 1.25,
+    renderScale: 0.9,
+    particleScale: 0.75,
+  },
+  {
     id: 'balanced',
     label: 'Balanced (default)',
     description: 'Native look with capped DPI for most laptops and desktops.',

--- a/assets/js/utils/device-detect.ts
+++ b/assets/js/utils/device-detect.ts
@@ -57,3 +57,14 @@ export function isMobileDevice() {
 
   return false;
 }
+
+export function isSmartTvDevice() {
+  if (typeof navigator === 'undefined') return false;
+
+  const nav = navigator as NavigatorWithUserAgentData;
+  const userAgent = (nav.userAgent ?? '').toLowerCase();
+
+  return /(smart-tv|smarttv|hbbtv|appletv|googletv|android tv|aftb|aftt|aftm|tizen|web0s|webos|viera|netcast|roku|bravia|xbox|playstation)/i.test(
+    userAgent,
+  );
+}

--- a/assets/js/utils/gamepad-navigation.ts
+++ b/assets/js/utils/gamepad-navigation.ts
@@ -238,6 +238,9 @@ const dispatchEscape = (doc: Document) => {
   doc.dispatchEvent(event);
 };
 
+export const shouldDispatchEscapeFallback = (originKey: string) =>
+  originKey !== 'Escape';
+
 const DIRECTIONAL_KEYS = {
   ArrowUp: 'up',
   ArrowDown: 'down',
@@ -278,6 +281,12 @@ export const initGamepadNavigation = (
   const setActive = () => {
     if (!body.classList.contains(resolved.activeClass)) {
       body.classList.add(resolved.activeClass);
+    }
+  };
+
+  const triggerBackOrEscape = (originKey: string = 'Escape') => {
+    if (!triggerBackAction(doc) && shouldDispatchEscapeFallback(originKey)) {
+      dispatchEscape(doc);
     }
   };
 
@@ -358,9 +367,7 @@ export const initGamepadNavigation = (
 
     if (bPressed) {
       setActive();
-      if (!triggerBackAction(doc)) {
-        dispatchEscape(doc);
-      }
+      triggerBackOrEscape('GamepadB');
     }
 
     if (leftBumper) {
@@ -417,9 +424,7 @@ export const initGamepadNavigation = (
 
     if (BACK_KEYS.has(event.key)) {
       setActive();
-      if (!triggerBackAction(doc)) {
-        dispatchEscape(doc);
-      }
+      triggerBackOrEscape(event.key);
       event.preventDefault();
     }
   };

--- a/docs/FEATURE_SPECIFICATIONS.md
+++ b/docs/FEATURE_SPECIFICATIONS.md
@@ -12,7 +12,7 @@ This document captures the **current, shipped feature set** of the Stim Webtoys 
 | Audio input options | Mic, demo audio, tab capture, and YouTube capture are available. | `assets/js/ui/audio-controls.ts`, `assets/js/ui/youtube-controller.ts` |
 | Renderer fallback | WebGPU preferred with WebGL fallback + compatibility mode. | `assets/js/core/renderer-capabilities.ts`, `assets/js/core/render-preferences.ts` |
 | Personalization & persistence | Theme, quality presets, render/motion preferences, and search state persist. | `assets/js/library-view.js`, `assets/js/core/settings-panel.ts` |
-| Gamepad navigation | Focus + input support is enabled on library and toy pages. | `assets/js/utils/gamepad-navigation.ts`, `assets/js/app.ts` |
+| Gamepad + remote navigation | Focus + input support is enabled on library and toy pages for gamepads and keyboard-style TV remotes. | `assets/js/utils/gamepad-navigation.ts`, `assets/js/app.ts` |
 | Toy catalog metadata | Registry includes titles, tags, moods, controls, and lifecycle stage. | `assets/data/toys.json` |
 
 ## Library landing page & discovery
@@ -87,10 +87,17 @@ This document captures the **current, shipped feature set** of the Stim Webtoys 
 - **Resolution + pixel ratio controls**: Range sliders with live value labels.
 - **Reset**: Clears custom overrides to match the active preset.
 
-### Gamepad navigation
-- **Focus movement**: D-pad/axes move focus through focusable elements.
-- **Range input support**: Left/right updates sliders in the settings panel.
-- **Back handling**: Gamepad “back” dispatches Escape or triggers back-to-library when available.
+### Gamepad and remote navigation
+- **Focus movement**: D-pad/axes and Arrow keys move focus with spatial direction matching before fallback cycling.
+- **Range input support**: Left/right updates sliders in the settings panel when a range control is focused.
+- **Activation + back handling**: Gamepad A/Enter activate the focused control; gamepad back, Escape, or Backspace dispatch back-to-library/Escape behavior.
+
+
+### TV mode defaults
+- **Quality preset**: Adds a “TV balanced” preset tuned for lower DPI and steadier frame pacing.
+- **Smart TV auto-default**: On Smart TV-class user agents, system controls default to the TV preset.
+- **Conservative renderer defaults**: On first run in TV mode, compatibility mode is enabled and render scale / max pixel ratio are lowered unless user overrides already exist.
+- **Audio startup bias**: TV mode prefers demo audio by default while keeping microphone/tab capture options available.
 
 ## Toy catalog metadata
 

--- a/tests/device-detect.test.ts
+++ b/tests/device-detect.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { isMobileDevice } from '../assets/js/utils/device-detect';
+import {
+  isMobileDevice,
+  isSmartTvDevice,
+} from '../assets/js/utils/device-detect';
 
 type NavigatorWithUserAgentData = Navigator & {
   userAgentData?: unknown;
@@ -105,5 +108,37 @@ describe('isMobileDevice', () => {
 
   test('keeps desktop devices classified as non-mobile', () => {
     expect(isMobileDevice()).toBe(false);
+  });
+});
+
+describe('isSmartTvDevice', () => {
+  beforeEach(() => {
+    snapshot = {
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+      maxTouchPoints: navigator.maxTouchPoints,
+      userAgentData: (navigator as NavigatorWithUserAgentData).userAgentData,
+    };
+    setNavigatorField('userAgent', DESKTOP_UA);
+  });
+
+  afterEach(() => {
+    setNavigatorField('userAgent', snapshot.userAgent);
+    setNavigatorField('platform', snapshot.platform);
+    setNavigatorField('maxTouchPoints', snapshot.maxTouchPoints);
+    setNavigatorField('userAgentData', snapshot.userAgentData);
+  });
+
+  test('detects smart tv user agents', () => {
+    setNavigatorField(
+      'userAgent',
+      'Mozilla/5.0 (SMART-TV; Linux; Tizen 7.0) AppleWebKit/537.36',
+    );
+
+    expect(isSmartTvDevice()).toBe(true);
+  });
+
+  test('keeps desktop user agents out of tv mode', () => {
+    expect(isSmartTvDevice()).toBe(false);
   });
 });

--- a/tests/gamepad-navigation.test.ts
+++ b/tests/gamepad-navigation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldDispatchEscapeFallback } from '../assets/js/utils/gamepad-navigation.ts';
+
+describe('gamepad navigation back fallback guard', () => {
+  test('does not redispatch when origin key is Escape', () => {
+    expect(shouldDispatchEscapeFallback('Escape')).toBeFalse();
+  });
+
+  test('redispatches fallback Escape for non-Escape back keys', () => {
+    expect(shouldDispatchEscapeFallback('Backspace')).toBeTrue();
+    expect(shouldDispatchEscapeFallback('BrowserBack')).toBeTrue();
+    expect(shouldDispatchEscapeFallback('GoBack')).toBeTrue();
+  });
+});

--- a/tests/settings-panel.test.ts
+++ b/tests/settings-panel.test.ts
@@ -89,6 +89,12 @@ describe('quality preset subscriptions', () => {
     );
   });
 
+  test('includes a tv-friendly quality preset', () => {
+    const preset = DEFAULT_QUALITY_PRESETS.find((entry) => entry.id === 'tv');
+    expect(preset).toBeDefined();
+    expect(preset?.label).toBe('TV balanced');
+  });
+
   test('quality presets show profile-specific scope for custom storage keys', () => {
     const panel = getSettingsPanel();
 

--- a/tests/system-controls-tv-mode.test.ts
+++ b/tests/system-controls-tv-mode.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  COMPATIBILITY_MODE_KEY,
+  MAX_PIXEL_RATIO_KEY,
+  RENDER_SCALE_KEY,
+  resetRenderPreferencesState,
+} from '../assets/js/core/render-preferences.ts';
+import { resetSettingsPanelState } from '../assets/js/core/settings-panel.ts';
+import { initSystemControls } from '../assets/js/ui/system-controls.ts';
+
+type NavSnapshot = {
+  userAgent: string;
+};
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121 Safari/537.36';
+const TV_UA =
+  'Mozilla/5.0 (SMART-TV; Linux; Tizen 7.0) AppleWebKit/537.36 (KHTML, like Gecko)';
+
+let snapshot: NavSnapshot;
+
+const setUserAgent = (userAgent: string) => {
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent,
+  });
+};
+
+describe('system controls tv defaults', () => {
+  beforeEach(() => {
+    snapshot = {
+      userAgent: navigator.userAgent,
+    };
+    localStorage.clear();
+    document.body.innerHTML = '';
+    resetRenderPreferencesState();
+    resetSettingsPanelState({ removePanel: true });
+  });
+
+  afterEach(() => {
+    setUserAgent(snapshot.userAgent);
+    localStorage.clear();
+    document.body.innerHTML = '';
+    resetRenderPreferencesState();
+    resetSettingsPanelState({ removePanel: true });
+  });
+
+  test('applies tv defaults when no render preferences are stored', () => {
+    setUserAgent(TV_UA);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    initSystemControls(host);
+
+    const presetSelect = host.querySelector('select');
+    expect(presetSelect).toBeTruthy();
+    expect((presetSelect as HTMLSelectElement).value).toBe('tv');
+
+    expect(localStorage.getItem(COMPATIBILITY_MODE_KEY)).toBe('true');
+    expect(localStorage.getItem(MAX_PIXEL_RATIO_KEY)).toBe('1.25');
+    expect(localStorage.getItem(RENDER_SCALE_KEY)).toBe('0.9');
+  });
+
+  test('does not overwrite existing stored render preferences', () => {
+    setUserAgent(TV_UA);
+    localStorage.setItem(COMPATIBILITY_MODE_KEY, 'false');
+    localStorage.setItem(MAX_PIXEL_RATIO_KEY, '2');
+    localStorage.setItem(RENDER_SCALE_KEY, '1');
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    initSystemControls(host);
+
+    expect(localStorage.getItem(COMPATIBILITY_MODE_KEY)).toBe('false');
+    expect(localStorage.getItem(MAX_PIXEL_RATIO_KEY)).toBe('2');
+    expect(localStorage.getItem(RENDER_SCALE_KEY)).toBe('1');
+  });
+
+  test('keeps non-tv defaults on desktop devices', () => {
+    setUserAgent(DESKTOP_UA);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    initSystemControls(host);
+
+    const presetSelect = host.querySelector(
+      'select',
+    ) as HTMLSelectElement | null;
+    expect(presetSelect?.value).toBe('balanced');
+  });
+});


### PR DESCRIPTION
### Motivation
- Make remote-style keyboards and legacy TV remotes behave reliably by widening key coverage and preserving existing gamepad flows.
- Improve directional focus ergonomics on TV and large-screen layouts by preferring spatial directional targets over naive sequential wrapping.
- Provide conservative, TV-friendly renderer defaults and a dedicated quality preset for first-run Smart TV-class devices to improve frame pacing on constrained GPUs.

### Description
- Broadened remote/keyboard handling in `initGamepadNavigation` to include legacy directional keys (`Up/Down/Left/Right`), additional select keys (`NumpadEnter`, `OK`, `Select`), and additional back keys (`GoBack`, `BrowserBack`), while keeping gamepad button behavior intact (`assets/js/utils/gamepad-navigation.ts`).
- Reworked directional handling to use explicit spatial directions (`up/down/left/right`) from gamepad axes/buttons and added spatial directional targeting (`findDirectionalFocusTarget`) that scores element geometry before falling back to wrapped sequential focus (`assets/js/utils/gamepad-navigation.ts`).
- Added Smart TV detection helper `isSmartTvDevice()` and wired TV behavior into startup and system controls to bias demo audio and to auto-select/apply a `TV balanced` quality preset and conservative renderer defaults only when no user overrides exist (`assets/js/utils/device-detect.ts`, `assets/js/app.ts`, `assets/js/ui/system-controls.ts`, `assets/js/core/settings-panel.ts`).
- Updated docs to reflect remote semantics and TV-mode behavior and added automated coverage for Smart TV detection and TV defaults (`docs/FEATURE_SPECIFICATIONS.md`, `tests/system-controls-tv-mode.test.ts`, `tests/device-detect.test.ts`).

### Testing
- Ran `bun run lint:fix` and code formatting/linting passed (auto-fix applied where applicable).
- Ran the repository quality gate via `bun run check` (formatter/linter, TypeScript typecheck, and test suite) and the full test suite passed with no failures.
- Added targeted tests `tests/system-controls-tv-mode.test.ts` and extended `tests/device-detect.test.ts`, and these new/updated tests passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992017765e08332854fa6d6773a97cb)