### PR TITLE
Follow-up: restrict legacy OK keycode fallback to remote-style key events

### DIFF
--- a/assets/js/utils/gamepad-navigation.ts
+++ b/assets/js/utils/gamepad-navigation.ts
@@ -408,9 +408,16 @@ const isBackKey = (event: KeyboardEvent) => {
   return LEGACY_BACK_KEY_CODES.has(keyCode);
 };
 
+const isRemoteLegacyKeyEvent = (event: KeyboardEvent) => {
+  return event.key === 'Unidentified';
+};
+
 const isEnterLikeKey = (event: KeyboardEvent) => {
   if (ENTER_KEYS.has(event.key)) {
     return true;
+  }
+  if (!isRemoteLegacyKeyEvent(event)) {
+    return false;
   }
   const keyCode = event.keyCode || event.which || 0;
   return LEGACY_ENTER_KEY_CODES.has(keyCode);

--- a/tests/gamepad-navigation.test.ts
+++ b/tests/gamepad-navigation.test.ts
@@ -32,14 +32,17 @@ describe('remote key mapping', () => {
 
   test('recognizes modern and legacy enter/ok keys', () => {
     expect(shouldHandleEnterLikeKey(keyEvent('Enter'))).toBeTrue();
+    expect(shouldHandleEnterLikeKey(keyEvent('Spacebar'))).toBeTrue();
     expect(shouldHandleEnterLikeKey(keyEvent('NumpadEnter'))).toBeTrue();
     expect(shouldHandleEnterLikeKey(keyEvent('Select'))).toBeTrue();
     expect(shouldHandleEnterLikeKey(keyEvent('Return'))).toBeTrue();
     expect(shouldHandleEnterLikeKey(keyEvent('Unidentified', 23))).toBeTrue();
+    expect(shouldHandleEnterLikeKey(keyEvent('Unidentified', 32))).toBeTrue();
   });
 
   test('ignores unrelated keys', () => {
     expect(shouldHandleBackKey(keyEvent('ArrowLeft'))).toBeFalse();
     expect(shouldHandleEnterLikeKey(keyEvent('ArrowRight'))).toBeFalse();
+    expect(shouldHandleEnterLikeKey(keyEvent(' ', 32))).toBeFalse();
   });
 });


### PR DESCRIPTION
### Motivation
- Legacy fallback treated keyCode `32` (Space) as an Enter/OK action for all `keydown` events which caused accidental activations and blocked Space behavior on normal keyboards. 
- The intent is to keep remote/legacy device support (where `event.key` can be `Unidentified`) while preventing desktop keyboards from being affected. 

### Description
- Add a helper `isRemoteLegacyKeyEvent` that returns true when `event.key === 'Unidentified'` and gate legacy keycode checks behind this predicate in `isEnterLikeKey` so legacy keyCode handling only applies to remote-style events. 
- Preserve existing modern enter-like key handling via the `ENTER_KEYS` set. 
- Add regression tests in `tests/gamepad-navigation.test.ts` to assert that `Unidentified + 32` is still treated as enter-like and that a normal Space (`' '` + 32) is not. 
- Changed files: `assets/js/utils/gamepad-navigation.ts` and `tests/gamepad-navigation.test.ts` with commit message `Restrict legacy OK keycodes to remote events`. 

### Testing
- Ran the project quality gate with `bun run check`, which runs Biome, TypeScript typecheck, and the test suite. 
- Test results: `153` total tests run (151 passed, 2 skipped, 0 failed) and the gamepad navigation tests covering the updated behavior passed. 
- Docs touched: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b59704dc8332be9302e976465de1)