### PR TITLE
Add YAML toy metadata support alongside JSON

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "three": "^0.182.0",
+        "yaml": "^2.8.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -498,6 +499,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -67,12 +67,12 @@ The following tools are only available from the Bun/Node stdio server (`bun run 
 
 - All tool calls follow MCP stdio conventions. Successful calls return a `content` array with either `text` or `json` entries.
 - Validation errors surface when inputs don’t satisfy the schemas above (for example, passing a number for `slug`).
-- `get_toys` reads from `assets/data/toys.json`; keep that file up to date so MCP clients surface accurate metadata.
+- `get_toys` reads from the generated toy manifest (which is built from `assets/data/toys.json`, `assets/data/toys.yaml`, or `assets/data/toys.yml`); keep that file up to date so MCP clients surface accurate metadata.
 
 ## Troubleshooting tips
 
 - **Manifest resolution:** The loader summary references `/.vite/manifest.json`; when discussing loader behavior with `describe_loader`, ensure a Vite dev server or build has produced the manifest so paths resolve correctly.
-- **Slug filters:** If `get_toys` returns “No toys matched the requested filters,” double-check the slug in `assets/data/toys.json` or omit filters to retrieve the full catalog.
+- **Slug filters:** If `get_toys` returns “No toys matched the requested filters,” double-check the slug in your toy metadata registry file (`assets/data/toys.json`, `assets/data/toys.yaml`, or `assets/data/toys.yml`) or omit filters to retrieve the full catalog.
 - **Client invocation:** MCP clients must launch `bun run mcp` in the repository root; running elsewhere can block access to `README.md`, the toy data file, or the Vite manifest.
 
 ## Cloudflare Worker deployment (optional transport)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -27,7 +27,7 @@ Use this folder as a focused, progressive-disclosure overlay for agent tasks.
 ## Fast repo map
 
 - `assets/js/toys/` — toy implementations.
-- `assets/data/toys.json` — toy metadata source of truth.
+- `assets/data/toys.json` (or `assets/data/toys.yaml` / `assets/data/toys.yml`) — toy metadata source of truth.
 - `toys/` — standalone toy pages.
 - `tests/` — automated test suite.
 - `docs/` — contributor and architecture docs.

--- a/docs/agents/reference-docs.md
+++ b/docs/agents/reference-docs.md
@@ -11,7 +11,7 @@
 ## High-signal code locations
 
 - `assets/js/toys/` — toy modules.
-- `assets/data/toys.json` — toy metadata source of truth.
+- `assets/data/toys.json` (or `assets/data/toys.yaml` / `assets/data/toys.yml`) — toy metadata source of truth.
 - `assets/js/loader.ts` — loader/query param routing.
 - `assets/js/core/toy-runtime.ts` — shared toy runtime plumbing.
 - `assets/js/utils/start-audio.ts` — mic/demo audio unlock path.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "three": "^0.182.0",
+    "yaml": "^2.8.2",
     "zod": "^4.3.6"
   }
 }

--- a/scripts/check-toys.ts
+++ b/scripts/check-toys.ts
@@ -5,6 +5,7 @@ import {
   type ToyManifest,
   toyManifestSchema,
 } from '../assets/js/data/toy-schema.ts';
+import { loadToyRegistry } from './toy-registry.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -54,9 +55,14 @@ export async function runToyChecks(root = repoRoot) {
 }
 
 async function loadToyData(root = repoRoot) {
-  const dataPath = path.join(root, 'assets/data/toys.json');
-  const source = await fs.readFile(dataPath, 'utf8');
-  return toyManifestSchema.parse(JSON.parse(source));
+  const { entries, relativePath } = await loadToyRegistry(root);
+  try {
+    return toyManifestSchema.parse(entries);
+  } catch (error) {
+    throw new Error(
+      `Toy metadata validation failed for ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 async function validateEntries(

--- a/scripts/mcp-shared.ts
+++ b/scripts/mcp-shared.ts
@@ -199,7 +199,7 @@ function registerTools(server: McpServer) {
     'get_toys',
     {
       description:
-        'Return structured toy metadata (including controls and module info) from assets/data/toys.json with optional slug or WebGPU filters.',
+        'Return structured toy metadata (including controls and module info) from assets/data/toys.json (or `assets/data/toys.yaml` / `assets/data/toys.yml`) with optional slug or WebGPU filters.',
       inputSchema: z
         .object({
           slug: z

--- a/scripts/toy-registry.ts
+++ b/scripts/toy-registry.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import type { ToyManifest } from '../assets/js/data/toy-schema.ts';
+
+const TOY_DATA_RELATIVE_PATHS = [
+  'assets/data/toys.json',
+  'assets/data/toys.yaml',
+  'assets/data/toys.yml',
+] as const;
+
+type ToyRegistryFormat = 'json' | 'yaml';
+
+export type LoadedToyRegistry = {
+  entries: unknown;
+  dataPath: string;
+  relativePath: string;
+  format: ToyRegistryFormat;
+};
+
+export async function loadToyRegistry(
+  root: string,
+): Promise<LoadedToyRegistry> {
+  const matches = await Promise.all(
+    TOY_DATA_RELATIVE_PATHS.map(async (relativePath) => {
+      const dataPath = path.join(root, relativePath);
+      try {
+        await fs.access(dataPath);
+        return { dataPath, relativePath };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const existing = matches.filter((entry) => entry !== null);
+  if (!existing.length) {
+    throw new Error(
+      `No toy metadata file found. Expected one of: ${TOY_DATA_RELATIVE_PATHS.join(', ')}`,
+    );
+  }
+
+  if (existing.length > 1) {
+    const paths = existing.map((entry) => entry.relativePath).join(', ');
+    throw new Error(
+      `Multiple toy metadata files found (${paths}). Keep only one source of truth.`,
+    );
+  }
+
+  const selected = existing[0];
+  const source = await fs.readFile(selected.dataPath, 'utf8');
+  const format = selected.relativePath.endsWith('.json')
+    ? ('json' as const)
+    : ('yaml' as const);
+
+  const entries =
+    format === 'json'
+      ? (JSON.parse(source) as unknown)
+      : (parseYaml(source) as unknown);
+
+  return {
+    entries,
+    dataPath: selected.dataPath,
+    relativePath: selected.relativePath,
+    format,
+  };
+}
+
+export async function saveToyRegistry(
+  root: string,
+  relativePath: string,
+  entries: ToyManifest,
+): Promise<void> {
+  const dataPath = path.join(root, relativePath);
+  const format = relativePath.endsWith('.json') ? 'json' : 'yaml';
+  const serialized =
+    format === 'json'
+      ? `${JSON.stringify(entries, null, 2)}\n`
+      : `${stringifyYaml(entries, { indent: 2 })}`;
+
+  await fs.writeFile(dataPath, serialized, 'utf8');
+}

--- a/tests/check-toys.test.ts
+++ b/tests/check-toys.test.ts
@@ -78,6 +78,35 @@ describe('check-toys script', () => {
     expect(result.issues).toHaveLength(0);
   });
 
+  test('passes when metadata is defined in YAML', async () => {
+    const root = await createTempRepo();
+    const slug = 'yaml-aligned';
+
+    await writeToyModule(root, slug);
+    await fs.rm(path.join(root, 'assets/data/toys.json'));
+    await fs.writeFile(
+      path.join(root, 'assets/data/toys.yaml'),
+      `- slug: ${slug}
+  title: YAML Aligned
+  description: ok
+  module: assets/js/toys/${slug}.ts
+  type: module
+  requiresWebGPU: false
+  capabilities:
+    microphone: true
+    demoAudio: true
+    motion: false
+`,
+    );
+    await fs.appendFile(
+      path.join(root, 'docs/TOY_SCRIPT_INDEX.md'),
+      `| \`${slug}\` | \`assets/js/toys/${slug}.ts\` | Direct module |
+`,
+    );
+
+    const result = await runToyChecks(root);
+    expect(result.issues).toHaveLength(0);
+  });
   test('flags missing entry files', async () => {
     const root = await createTempRepo();
     const slug = 'missing-entry';

--- a/tests/scaffold-toy.test.ts
+++ b/tests/scaffold-toy.test.ts
@@ -123,6 +123,30 @@ describe('scaffold-toy CLI helpers', () => {
     ).rejects.toThrow(/already exists/);
   });
 
+  test('appends metadata to YAML registry when JSON is absent', async () => {
+    const root = await createTempRepo();
+    const slug = 'yaml-ripple';
+
+    await fs.rm(path.join(root, 'assets/data/toys.json'));
+    await fs.writeFile(path.join(root, 'assets/data/toys.yaml'), '[]\n');
+
+    await scaffoldToy({
+      slug,
+      title: 'YAML Ripple',
+      description: 'YAML-backed toy metadata.',
+      type: 'module',
+      createTest: false,
+      root,
+    });
+
+    const yamlData = await fs.readFile(
+      path.join(root, 'assets/data/toys.yaml'),
+      'utf8',
+    );
+    expect(yamlData).toContain(`slug: ${slug}`);
+    expect(yamlData).toContain('title: YAML Ripple');
+  });
+
   test('creates a standalone HTML entry point and validates metadata', async () => {
     const root = await createTempRepo();
     const slug = 'portal-frame';


### PR DESCRIPTION
### Motivation

- Allow each stim to be defined as YAML or JSON by supporting alternative metadata files and preserving the original format when tooling writes updates.
- Make toy metadata workflows (validation, manifest generation, scaffolding) agnostic to registry file format so authors can use their preferred authoring format.

### Description

- Add `scripts/toy-registry.ts` which locates a single metadata source among `assets/data/toys.json`, `assets/data/toys.yaml`, and `assets/data/toys.yml`, parses JSON/YAML, and writes back in the same format.
- Update metadata workflows to use the shared registry: `scripts/check-toys.ts`, `scripts/generate-toy-manifest.ts`, and `scripts/scaffold-toy.ts` now load via `loadToyRegistry` and `saveToyRegistry` to preserve source format.
- Add `yaml` dependency and modify `package.json` accordingly, and update MCP/agent docs and tool descriptions to document JSON-or-YAML toy metadata support (`docs/MCP_SERVER.md`, `docs/agents/README.md`, `docs/agents/reference-docs.md`, `scripts/mcp-shared.ts`).
- Extend tests to cover YAML cases and scaffold behavior (`tests/check-toys.test.ts`, `tests/scaffold-toy.test.ts`).

### Testing

- Ran the project quality gate with `bun run check` (Biome lint/format, `tsc --noEmit`, and the test suite) and it completed successfully with all checks passing.
- The test suite run shows: `Ran 157 tests across 40 files` with `155 pass`, `2 skip`, and `0 fail`, and the updated YAML-focused tests passed.
- Updated/added tests run: `tests/check-toys.test.ts` and `tests/scaffold-toy.test.ts` include YAML scenarios and passed under the same `bun run check` invocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934e98d46483329a36dc56058751b6)