### PR TITLE
Improve three random stims rendering behavior

### DIFF
--- a/assets/js/toys/aurora-painter.ts
+++ b/assets/js/toys/aurora-painter.ts
@@ -162,12 +162,10 @@ export function start({ container }: ToyStartOptions = {}) {
 
   function updateRibbon(
     ribbon: (typeof ribbons)[number],
-    data: Uint8Array,
+    metrics: { avg: number; bass: number; treble: number },
     time: number,
   ) {
-    const avg = getWeightedAverageFrequency(data);
-    const bass = getBandAverage(data, 0, 0.32);
-    const treble = getBandAverage(data, 0.65, 1);
+    const { avg, bass, treble } = metrics;
 
     for (let i = ribbon.points.length - 1; i > 0; i -= 1) {
       ribbon.points[i].copy(ribbon.points[i - 1]);
@@ -210,12 +208,17 @@ export function start({ container }: ToyStartOptions = {}) {
   }
 
   function animate(data: Uint8Array, time: number) {
+    const metrics = {
+      avg: getWeightedAverageFrequency(data),
+      bass: getBandAverage(data, 0, 0.32),
+      treble: getBandAverage(data, 0.65, 1),
+    };
     controls.speed = THREE.MathUtils.lerp(controls.speed, targetSpeed, 0.08);
     controls.glow = THREE.MathUtils.lerp(controls.glow, targetGlow, 0.08);
 
     const scaledTime = time * 1.5 * controls.speed;
 
-    ribbons.forEach((ribbon) => updateRibbon(ribbon, data, scaledTime));
+    ribbons.forEach((ribbon) => updateRibbon(ribbon, metrics, scaledTime));
 
     runtime.toy.camera.position.z = 45 + Math.sin(scaledTime * 0.35) * 2.2;
     runtime.toy.camera.lookAt(0, 0, -4);

--- a/assets/js/toys/bubble-harmonics.ts
+++ b/assets/js/toys/bubble-harmonics.ts
@@ -41,6 +41,10 @@ export function start({ container }: ToyStartOptions = {}) {
 
   const bubbles: Bubble[] = [];
   const tempScale = new THREE.Vector3();
+  const tempDrift = new THREE.Vector3();
+  const tempVelocity = new THREE.Vector3();
+  const tempBaseColor = new THREE.Color();
+  const tempHighlightColor = new THREE.Color();
   const harmonicBubbles: HarmonicBubble[] = [];
   const bubbleGroup = new THREE.Group();
   let bubbleGeometry: THREE.SphereGeometry | null = null;
@@ -248,25 +252,28 @@ export function start({ container }: ToyStartOptions = {}) {
         tempScale.setScalar(scaleTarget);
         bubble.mesh.scale.lerp(tempScale, 0.08);
 
-        const drift = new THREE.Vector3(
+        const drift = tempDrift.set(
           Math.sin(time * 0.45 + index) * 0.002,
           0.003 + energy * 0.014 + normalizedAvg * 0.01,
           Math.cos(time * 0.38 + index) * 0.002,
         );
 
-        bubble.mesh.position.add(bubble.velocity.clone().add(drift));
+        tempVelocity.copy(bubble.velocity).add(drift);
+        bubble.mesh.position.add(tempVelocity);
 
         if (bubble.mesh.position.length() > 38) {
           bubble.mesh.position.multiplyScalar(-0.6);
         }
 
         const hueShift = (energy * 0.2 + normalizedAvg * 0.1) % 1;
-        const baseColor = new THREE.Color().setHSL(
+        const baseColor = tempBaseColor.setHSL(
           (bubble.hue + hueShift) % 1,
           0.5,
           0.45 + energy * 0.2,
         );
-        const highlightColor = baseColor.clone().offsetHSL(0.08, 0, 0.22);
+        const highlightColor = tempHighlightColor
+          .copy(baseColor)
+          .offsetHSL(0.08, 0, 0.22);
         const material = bubble.mesh.material;
         material.uniforms.time.value = time + index * 0.2;
         material.uniforms.baseColor.value.copy(baseColor);

--- a/assets/js/toys/neon-wave.ts
+++ b/assets/js/toys/neon-wave.ts
@@ -145,6 +145,7 @@ export function start({ container }: ToyStartOptions = {}) {
   let particleGeometry: BufferGeometry | null = null;
   let particleMaterial: PointsMaterial | null = null;
   let particleVelocities: Float32Array | null = null;
+  let particleBaseColors: Float32Array | null = null;
 
   // Horizon sun/moon
   let horizonMesh: Mesh | null = null;
@@ -328,6 +329,7 @@ export function start({ container }: ToyStartOptions = {}) {
     particleGeometry = new BufferGeometry();
     const positions = new Float32Array(count * 3);
     const colors = new Float32Array(count * 3);
+    particleBaseColors = new Float32Array(count * 3);
     particleVelocities = new Float32Array(count);
 
     const primaryCol = new Color(palette.primary);
@@ -348,6 +350,9 @@ export function start({ container }: ToyStartOptions = {}) {
       colors[i3] = mixColor.r;
       colors[i3 + 1] = mixColor.g;
       colors[i3 + 2] = mixColor.b;
+      particleBaseColors[i3] = mixColor.r;
+      particleBaseColors[i3 + 1] = mixColor.g;
+      particleBaseColors[i3 + 2] = mixColor.b;
     }
 
     particleGeometry.setAttribute(
@@ -544,6 +549,7 @@ export function start({ container }: ToyStartOptions = {}) {
     if (
       particles &&
       particleVelocities &&
+      particleBaseColors &&
       particleGeometry &&
       particleMaterial
     ) {
@@ -570,12 +576,13 @@ export function start({ container }: ToyStartOptions = {}) {
 
         // Color pulse
         const brightness = Math.min(1, 0.5 + smoothedHighs);
-        colors[i3] *= brightness;
-        colors[i3 + 1] *= brightness;
-        colors[i3 + 2] *= brightness;
+        colors[i3] = particleBaseColors[i3] * brightness;
+        colors[i3 + 1] = particleBaseColors[i3 + 1] * brightness;
+        colors[i3 + 2] = particleBaseColors[i3 + 2] * brightness;
       }
 
       particleGeometry.attributes.position.needsUpdate = true;
+      particleGeometry.attributes.color.needsUpdate = true;
       particleMaterial.size = 1.5 + smoothedBass * 3;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce per-frame allocations and improve runtime stability for a few high-cost toys by reusing temporaries and avoiding repeated recomputation of audio metrics.
- Fix particle color pulsing regressions that caused particles to permanently darken over time.
- Improve update efficiency for ribbon animations by computing shared audio metrics once per frame and passing them into per-ribbon updates.

### Description
- `assets/js/toys/bubble-harmonics.ts`: added reusable temporaries (`tempDrift`, `tempVelocity`, `tempBaseColor`, `tempHighlightColor`) and replaced per-bubble `new` allocations with in-place updates to reduce GC pressure during `animateBubbles`.
- `assets/js/toys/aurora-painter.ts`: compute audio metrics once per frame in `animate()` and pass a `metrics` object into `updateRibbon()` rather than recalculating band averages for every ribbon.
- `assets/js/toys/neon-wave.ts`: introduce `particleBaseColors` to store immutable base colors and derive pulsed colors each frame from that source, and mark the color attribute dirty with `particleGeometry.attributes.color.needsUpdate = true` so colors update correctly on the GPU.

### Testing
- Ran the full quality gate with `bun run check` (Biome lint/format check, `tsc --noEmit`, and test suite), which completed with all tests passing: 155 passed, 2 skipped, 0 failed.
- Executed an automated Playwright capture script that loaded the three toys and saved screenshots for `bubble-harmonics`, `aurora-painter`, and `neon-wave`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940c444a2c8332a661c76249575e3c)