### PR TITLE
Improve usability for three stim pages (holy, legible, geom)

### DIFF
--- a/toys/geom.html
+++ b/toys/geom.html
@@ -365,7 +365,7 @@
 
       startButton.addEventListener('click', async () => {
         startButton.disabled = true;
-        startButton.style.display = 'none';
+        startButton.textContent = 'Connecting…';
         clearError('error-message');
 
         try {
@@ -376,6 +376,9 @@
               fallbackToSynthetic: true,
             },
             {
+              onSuccess: () => {
+                startButton.textContent = 'Visualizer running';
+              },
               onError: (error) => {
                 console.error('Error starting audio:', error);
               },
@@ -383,7 +386,7 @@
           );
         } catch (error) {
           startButton.disabled = false;
-          startButton.style.display = 'inline-block';
+          startButton.textContent = 'Retry Microphone Visualizer';
 
           if (error instanceof AudioAccessError) {
             showError('error-message', error.message);

--- a/toys/holy.html
+++ b/toys/holy.html
@@ -184,9 +184,9 @@
 
     <!-- Control Buttons -->
     <button id="startButton">Start Visualizer</button>
-    <button id="infoButton">?</button>
-    <button id="settingsButton">⚙️</button>
-    <button id="fullscreenButton">⛶</button>
+    <button id="infoButton" aria-label="Open help panel" title="Help">?</button>
+    <button id="settingsButton" aria-label="Open settings panel" title="Settings">⚙️</button>
+    <button id="fullscreenButton" aria-label="Toggle fullscreen" title="Fullscreen">⛶</button>
 
     <!-- Info Panel -->
     <div id="infoPanel">
@@ -485,6 +485,18 @@
         fullscreenButton.addEventListener('click', toggleFullscreen);
         closeInfoButton?.addEventListener('click', toggleInfoPanel);
         closeSettingsButton?.addEventListener('click', toggleSettingsPanel);
+        window.addEventListener('keydown', onKeydown);
+      }
+
+      function togglePanel(panel) {
+        const isVisible = getComputedStyle(panel).display !== 'none';
+        panel.style.display = isVisible ? 'none' : 'block';
+      }
+
+      function onKeydown(event) {
+        if (event.key !== 'Escape') return;
+        infoPanel.style.display = 'none';
+        settingsPanel.style.display = 'none';
       }
 
       // Add Lighting to the Scene
@@ -789,14 +801,12 @@
 
       // Toggle Info Panel
       function toggleInfoPanel() {
-        infoPanel.style.display =
-          infoPanel.style.display === 'none' ? 'block' : 'none';
+        togglePanel(infoPanel);
       }
 
       // Toggle Settings Panel
       function toggleSettingsPanel() {
-        settingsPanel.style.display =
-          settingsPanel.style.display === 'none' ? 'block' : 'none';
+        togglePanel(settingsPanel);
       }
 
       // Toggle Fullscreen Mode
@@ -910,6 +920,7 @@
 
       window.addEventListener('pagehide', () => {
         unifiedInput?.dispose();
+        window.removeEventListener('keydown', onKeydown);
       });
 
       // Prevent Context Menu on Long Press

--- a/toys/legible.html
+++ b/toys/legible.html
@@ -192,7 +192,10 @@
       const colorSchemeSelect = document.getElementById('color-scheme');
       let sensitivity = parseFloat(sensitivitySlider.value);
       let wordIndex = 0;
-      const cyclingActive = true;
+      let cyclingActive = true;
+      let cyclingTimer = null;
+      const GRID_COLUMNS = 30;
+      const GRID_ROWS = 15;
       let beatPeak = 0.12;
       let trebleGlow = 0;
       const errorDisplayId = 'error-message';
@@ -316,7 +319,7 @@
         gridElement.innerHTML = ''; // Clear the grid before regenerating
         const fragment = document.createDocumentFragment();
 
-        for (let i = 0; i < 450; i++) {
+        for (let i = 0; i < GRID_COLUMNS * GRID_ROWS; i++) {
           // Fixed number of cells for better performance
           const cell = document.createElement('div');
           cell.classList.add('cell');
@@ -334,17 +337,21 @@
       function cycleRandomCharacters() {
         const gridCells = document.querySelectorAll('.cell');
         const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+        if (cyclingTimer) {
+          window.clearTimeout(cyclingTimer);
+        }
+
         function updateCharacters() {
-          if (cyclingActive) {
-            gridCells.forEach((cell) => {
-              if (!cell.dataset.fixed) {
-                cell.textContent = chars.charAt(
-                  Math.floor(Math.random() * chars.length)
-                );
-              }
-            });
-            setTimeout(updateCharacters, 100); // Use setTimeout to avoid overwhelming the browser
-          }
+          if (!cyclingActive) return;
+          gridCells.forEach((cell) => {
+            if (!cell.dataset.fixed) {
+              cell.textContent = chars.charAt(
+                Math.floor(Math.random() * chars.length)
+              );
+            }
+          });
+          cyclingTimer = window.setTimeout(updateCharacters, 100);
         }
         updateCharacters();
       }
@@ -425,38 +432,48 @@
       }
 
       function revealWordAtRandomLocation() {
-        if (wordIndex < words.length) {
-          const word = words[wordIndex];
-          const gridCells = document.querySelectorAll('.cell');
-          const maxCol = Math.sqrt(gridCells.length) - word.length;
+        if (wordIndex >= words.length) return;
 
-          let randomIndex;
-          do {
-            randomIndex = Math.floor(
-              Math.random() * (gridCells.length - word.length)
-            );
-          } while (isOverlap(randomIndex, word.length));
-
-          const wordElements = [];
-
-          for (let i = 0; i < word.length; i++) {
-            const cell = gridCells[randomIndex + i];
-            cell.textContent = word[i];
-            cell.dataset.fixed = true;
-            cell.classList.add('is-word');
-            cell.classList.add('flicker');
-
-            wordElements.push(cell);
-          }
-
-          revealedLocations.push({ index: randomIndex, length: word.length });
-
-          wordElements.forEach((cell) => {
-            cell.addEventListener('click', () => dissolveWord(wordElements));
-          });
-
+        const word = words[wordIndex];
+        const gridCells = document.querySelectorAll('.cell');
+        if (word.length > GRID_COLUMNS || !gridCells.length) {
           wordIndex++;
+          return;
         }
+
+        const candidates = [];
+        for (let row = 0; row < GRID_ROWS; row++) {
+          for (let col = 0; col <= GRID_COLUMNS - word.length; col++) {
+            const startIndex = row * GRID_COLUMNS + col;
+            if (!isOverlap(startIndex, word.length)) {
+              candidates.push(startIndex);
+            }
+          }
+        }
+
+        if (!candidates.length) return;
+
+        const randomIndex =
+          candidates[Math.floor(Math.random() * candidates.length)];
+        const wordElements = [];
+
+        for (let i = 0; i < word.length; i++) {
+          const cell = gridCells[randomIndex + i];
+          cell.textContent = word[i];
+          cell.dataset.fixed = true;
+          cell.classList.add('is-word');
+          cell.classList.add('flicker');
+
+          wordElements.push(cell);
+        }
+
+        revealedLocations.push({ index: randomIndex, length: word.length });
+
+        wordElements.forEach((cell) => {
+          cell.addEventListener('click', () => dissolveWord(wordElements));
+        });
+
+        wordIndex++;
       }
 
       function isOverlap(index, length) {


### PR DESCRIPTION
### Motivation
- Make three randomly selected toy pages easier and safer to use by improving accessibility, UI feedback, and robustness of interactive behaviors.
- Reduce flaky UX states (hidden start buttons, duplicate timers, out-of-bounds word placement) that interfere with microphone-driven interactions and touch controls.

### Description
- toys/holy.html: add `aria-label` and `title` to icon buttons, introduce a `togglePanel` helper, wire Escape key (`onKeydown`) to dismiss panels, and remove the old direct display toggling for more reliable panel state; remove `onKeydown` on `pagehide` for cleanup.
- toys/legible.html: introduce `GRID_COLUMNS` and `GRID_ROWS` constants, add `cyclingTimer` to prevent duplicate character-cycling timers, and change the word-reveal logic to build row-aware non-overlapping candidate slots before placing words so revealed words stay within grid rows.
- toys/geom.html: improve start-button UX by keeping the control visible and cycling its label through `Connecting…`, `Visualizer running`, and `Retry Microphone Visualizer` states, and add an `onSuccess` handler to update the label when audio starts.

### Testing
- Ran the full quality gate with `bun run check` (Biome lint/format, TypeScript typecheck, and tests), which completed successfully with the test suite passing (automated tests passed; some integration skips as expected). 
- Launched the dev server (`bun run dev`) and validated pages by capturing Playwright screenshots of `/toys/holy.html`, `/toys/legible.html`, and `/toys/geom.html`, which ran successfully and produced artifacts.
- Linted/formatted changed files via the repository checks invoked during commit (Biome formatting applied where necessary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940c444a2c8332a661c76249575e3c)