### PR TITLE
Improve three random visualizers for performance and accessibility

### DIFF
--- a/toys/holy.html
+++ b/toys/holy.html
@@ -184,12 +184,12 @@
 
     <!-- Control Buttons -->
     <button id="startButton">Start Visualizer</button>
-    <button id="infoButton">?</button>
-    <button id="settingsButton">⚙️</button>
-    <button id="fullscreenButton">⛶</button>
+    <button id="infoButton" type="button" aria-label="Open instructions" title="Open instructions">?</button>
+    <button id="settingsButton" type="button" aria-label="Open settings" title="Open settings">⚙️</button>
+    <button id="fullscreenButton" type="button" aria-label="Toggle fullscreen" title="Toggle fullscreen">⛶</button>
 
     <!-- Info Panel -->
-    <div id="infoPanel">
+    <div id="infoPanel" role="dialog" aria-label="How to use" aria-hidden="true">
       <div class="panel-header">
         <h2>How to Use</h2>
         <button id="closeInfoButton" class="closeButton">×</button>
@@ -204,7 +204,7 @@
     </div>
 
     <!-- Settings Panel -->
-    <div id="settingsPanel">
+    <div id="settingsPanel" role="dialog" aria-label="Settings" aria-hidden="true">
       <div class="panel-header">
         <h2>Settings</h2>
         <button id="closeSettingsButton" class="closeButton">×</button>
@@ -345,6 +345,9 @@
       const settingsPanel = document.getElementById('settingsPanel');
       const closeInfoButton = document.getElementById('closeInfoButton');
       const closeSettingsButton = document.getElementById('closeSettingsButton');
+
+      infoButton?.setAttribute('aria-expanded', 'false');
+      settingsButton?.setAttribute('aria-expanded', 'false');
       const particleCountSlider = document.getElementById('particleCount');
       const particleCountValue = document.getElementById('particleCountValue');
       const shapeDetailSlider = document.getElementById('shapeDetail');
@@ -485,6 +488,16 @@
         fullscreenButton.addEventListener('click', toggleFullscreen);
         closeInfoButton?.addEventListener('click', toggleInfoPanel);
         closeSettingsButton?.addEventListener('click', toggleSettingsPanel);
+
+        document.addEventListener('keydown', (event) => {
+          if (event.key !== 'Escape') return;
+          if (infoPanel.style.display !== 'none') {
+            toggleInfoPanel(false);
+          }
+          if (settingsPanel.style.display !== 'none') {
+            toggleSettingsPanel(false);
+          }
+        });
       }
 
       // Add Lighting to the Scene
@@ -788,15 +801,25 @@
       }
 
       // Toggle Info Panel
-      function toggleInfoPanel() {
-        infoPanel.style.display =
-          infoPanel.style.display === 'none' ? 'block' : 'none';
+      function toggleInfoPanel(forceOpen) {
+        const open =
+          typeof forceOpen === 'boolean'
+            ? forceOpen
+            : infoPanel.style.display === 'none';
+        infoPanel.style.display = open ? 'block' : 'none';
+        infoPanel.setAttribute('aria-hidden', String(!open));
+        infoButton?.setAttribute('aria-expanded', String(open));
       }
 
       // Toggle Settings Panel
-      function toggleSettingsPanel() {
-        settingsPanel.style.display =
-          settingsPanel.style.display === 'none' ? 'block' : 'none';
+      function toggleSettingsPanel(forceOpen) {
+        const open =
+          typeof forceOpen === 'boolean'
+            ? forceOpen
+            : settingsPanel.style.display === 'none';
+        settingsPanel.style.display = open ? 'block' : 'none';
+        settingsPanel.setAttribute('aria-hidden', String(!open));
+        settingsButton?.setAttribute('aria-expanded', String(open));
       }
 
       // Toggle Fullscreen Mode

--- a/toys/multi.html
+++ b/toys/multi.html
@@ -32,6 +32,24 @@
         display: none;
         z-index: 5;
       }
+
+      .capability-banner__content {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .capability-banner__dismiss {
+        border: 1px solid rgba(255, 229, 189, 0.4);
+        background: rgba(0, 0, 0, 0.25);
+        color: #ffe5bd;
+        border-radius: 999px;
+        width: 24px;
+        height: 24px;
+        line-height: 1;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
     </style>
   </head>
   <body>
@@ -41,7 +59,21 @@
       id="capability-banner"
       class="capability-banner"
       aria-live="polite"
-    ></div>
+      role="status"
+    >
+      <div class="capability-banner__content">
+        <span id="capability-banner-text"></span>
+        <button
+          id="capability-banner-dismiss"
+          class="capability-banner__dismiss"
+          type="button"
+          aria-label="Dismiss capability notice"
+          title="Dismiss capability notice"
+        >
+          ×
+        </button>
+      </div>
+    </div>
     <div id="error-message" style="display: none"></div>
     <script type="module">
       import * as THREE from 'three';
@@ -65,19 +97,31 @@
 
       const canvas = document.getElementById('webglCanvas');
       const capabilityBanner = document.getElementById('capability-banner');
+      const capabilityBannerText = document.getElementById(
+        'capability-banner-text'
+      );
+      const capabilityBannerDismiss = document.getElementById(
+        'capability-banner-dismiss'
+      );
       const allowWebGLFallback = true;
       const hasWebGPU = Boolean(navigator.gpu);
       const useWebGLFallback = allowWebGLFallback && !hasWebGPU;
 
-      if (useWebGLFallback && capabilityBanner) {
-        capabilityBanner.textContent =
+      if (useWebGLFallback && capabilityBannerText && capabilityBanner) {
+        capabilityBannerText.textContent =
           'WebGPU is unavailable, so you are seeing the lighter WebGL preset with fewer particles and simpler lighting.';
         capabilityBanner.style.display = 'block';
-      } else if (!hasWebGPU && capabilityBanner) {
-        capabilityBanner.textContent =
+      } else if (!hasWebGPU && capabilityBannerText && capabilityBanner) {
+        capabilityBannerText.textContent =
           'WebGPU is unavailable in this browser. Try a WebGPU-enabled browser for the full visual fidelity.';
         capabilityBanner.style.display = 'block';
       }
+
+      capabilityBannerDismiss?.addEventListener('click', () => {
+        if (capabilityBanner) {
+          capabilityBanner.style.display = 'none';
+        }
+      });
 
       const hintsButtonHost =
         toyNav?.querySelector('.active-toy-nav__actions') ?? null;

--- a/toys/seary.html
+++ b/toys/seary.html
@@ -85,7 +85,7 @@
       const sparkleCtx = sparkleCanvas.getContext('2d');
 
       const sparkles = [];
-      const maxSparkles = 160;
+      let maxSparkles = 160;
       const burstState = { scale: 1, rotation: 0, intensity: 0 };
       let viewWidth = window.innerWidth;
       let viewHeight = window.innerHeight;
@@ -94,6 +94,18 @@
       let peakSensitivity = 0.2;
       let lastRenderTime = 0;
       let renderElapsed = 0;
+
+      function updateSparkleBudget() {
+        const area = Math.max(viewWidth * viewHeight, 1);
+        const budgetFromArea = Math.round(area / 8500);
+        maxSparkles = Math.min(220, Math.max(80, budgetFromArea));
+
+        if (sparkles.length > maxSparkles) {
+          sparkles.splice(0, sparkles.length - maxSparkles);
+        }
+      }
+
+      updateSparkleBudget();
 
       const hintsButtonHost =
         toyNav?.querySelector('.active-toy-nav__actions') ?? null;
@@ -157,6 +169,7 @@
         onResize: ({ width, height, cssWidth, cssHeight, pixelRatio }) => {
           viewWidth = cssWidth;
           viewHeight = cssHeight;
+          updateSparkleBudget();
           sparkleCanvas.width = width;
           sparkleCanvas.height = height;
           sparkleCanvas.style.width = `${cssWidth}px`;


### PR DESCRIPTION
### Motivation
- Reduce runtime load on smaller devices by scaling particle effects to viewport size and improve UX for fallback and control overlays. 
- Make the WebGPU fallback messaging less intrusive and add basic accessibility affordances for on-screen controls so overlays behave predictably for keyboard/screen-reader users.

### Description
- `toys/seary.html`: made the sparkle budget adaptive to viewport area by introducing `updateSparkleBudget()` and calling it on resize so the number of sparkles scales with screen size and trims excess particles when needed. 
- `toys/multi.html`: replaced the single-line fallback message with a structured capability banner (`.capability-banner__content`) containing `#capability-banner-text` and a dismiss button wired to `#capability-banner-dismiss` and added dismiss styling. 
- `toys/holy.html`: improved control accessibility by adding explicit `type`, `aria-label`, and `title` attributes to toolbar buttons, marking panels as dialogs with `role=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940c444a2c8332a661c76249575e3c)