### PR TITLE
Boost instant motion and color in two random stims

### DIFF
--- a/assets/js/toys/mobile-ripples.ts
+++ b/assets/js/toys/mobile-ripples.ts
@@ -64,7 +64,7 @@ export function start({ container }: ToyStartOptions = {}) {
   const palette = {
     background: new THREE.Color('#04020b'),
     baseHue: 0.58,
-    saturation: 0.7,
+    saturation: 0.82,
   };
 
   function getRingConfig() {
@@ -135,7 +135,8 @@ export function start({ container }: ToyStartOptions = {}) {
     const mids = getBandAverage(data, 0.28, 0.7) / 255;
     const treble = getBandAverage(data, 0.7, 1) / 255;
 
-    const pulse = 0.8 + bass * 0.9;
+    const idlePulse = 0.24 + Math.sin(time * 1.35) * 0.11;
+    const pulse = 0.95 + idlePulse + bass * 0.85;
     const driftX = (input?.normalizedCentroid.x ?? 0) * 2.2;
     const driftY = (input?.normalizedCentroid.y ?? 0) * 1.6;
 
@@ -144,15 +145,18 @@ export function start({ container }: ToyStartOptions = {}) {
     group.rotation.z = time * (0.08 + mids * 0.1);
 
     rings.forEach(({ mesh, baseScale, pulseOffset }) => {
-      const ripple = Math.sin(time * 0.9 + pulseOffset) * (0.12 + treble * 0.2);
+      const ripple =
+        Math.sin(time * (0.9 + mids * 0.28) + pulseOffset) *
+        (0.2 + treble * 0.3);
       const scale = baseScale * (pulse + ripple);
       mesh.scale.setScalar(scale);
-      mesh.rotation.z += 0.002 + treble * 0.004;
+      mesh.rotation.z += 0.003 + mids * 0.002 + treble * 0.004;
     });
 
-    const hue = (palette.baseHue + avg * 0.25 + time * 0.02) % 1;
-    material.color.setHSL(hue, palette.saturation, 0.52 + avg * 0.25);
-    material.opacity = 0.45 + avg * 0.4;
+    const hue =
+      (palette.baseHue + 0.06 * Math.sin(time * 0.6) + avg * 0.28) % 1;
+    material.color.setHSL(hue, palette.saturation, 0.56 + avg * 0.24);
+    material.opacity = 0.6 + avg * 0.25;
   }
 
   function setupSettingsPanel() {

--- a/assets/js/toys/rainbow-tunnel.ts
+++ b/assets/js/toys/rainbow-tunnel.ts
@@ -40,7 +40,7 @@ export function start({ container }: ToyStartOptions = {}) {
     const ringCount = Math.max(8, Math.round(20 * scale));
     const ringSpacing = 30;
     const tunnelLength = ringCount * ringSpacing;
-    const particleCount = Math.max(250, Math.floor(500 * scale));
+    const particleCount = Math.max(320, Math.floor(680 * scale));
     const torusDetail = Math.max(24, Math.round(64 * Math.sqrt(scale)));
     return { ringCount, ringSpacing, tunnelLength, particleCount, torusDetail };
   }
@@ -130,9 +130,9 @@ export function start({ container }: ToyStartOptions = {}) {
     );
     particleMaterial = new THREE.PointsMaterial({
       color: 0xffffff,
-      size: 0.5,
+      size: 0.75,
       transparent: true,
-      opacity: 0.6,
+      opacity: 0.75,
     });
     particleTrail = new THREE.Points(particleGeometry, particleMaterial);
     runtime.toy.scene.add(particleTrail);
@@ -161,7 +161,9 @@ export function start({ container }: ToyStartOptions = {}) {
       const normalizedValue = value / 255;
 
       // Rotate rings at varying speeds
-      const rotationSpeed = 0.01 + normalizedValue * 0.05;
+      const idleEnergy = 0.18 + 0.16 * (Math.sin(time * 0.9 + idx * 0.24) + 1);
+      const energy = Math.max(normalizedValue, idleEnergy);
+      const rotationSpeed = 0.018 + energy * 0.06;
       ringData.outer.rotation.x += rotationSpeed;
       ringData.outer.rotation.z += rotationSpeed * 0.5;
       if (ringData.inner) {
@@ -170,18 +172,18 @@ export function start({ container }: ToyStartOptions = {}) {
       }
 
       // Pulsing scale based on audio
-      const scale = 1 + normalizedValue * 0.4;
+      const scale = 1.04 + energy * 0.45;
       ringData.outer.scale.set(scale, scale, 1);
       if (ringData.inner) {
         ringData.inner.scale.set(scale * 0.9, scale * 0.9, 1);
       }
 
       // Dynamic color shift
-      const hueShift = (ringData.hue + normalizedAvg * 0.3 + time * 0.05) % 1;
+      const hueShift = (ringData.hue + normalizedAvg * 0.4 + time * 0.08) % 1;
       const outerMaterial = ringData.outer
         .material as THREE.MeshStandardMaterial;
-      outerMaterial.color.setHSL(hueShift, 0.8, 0.5 + normalizedValue * 0.2);
-      outerMaterial.emissive.setHSL(hueShift, 0.6, normalizedValue * 0.4);
+      outerMaterial.color.setHSL(hueShift, 0.85, 0.55 + energy * 0.2);
+      outerMaterial.emissive.setHSL(hueShift, 0.72, 0.18 + energy * 0.45);
 
       if (ringData.inner) {
         const innerMaterial = ringData.inner
@@ -189,24 +191,24 @@ export function start({ container }: ToyStartOptions = {}) {
         innerMaterial.color.setHSL(
           (hueShift + 0.1) % 1,
           0.9,
-          0.6 + normalizedValue * 0.2,
+          0.64 + energy * 0.2,
         );
         innerMaterial.emissive.setHSL(
           (hueShift + 0.1) % 1,
-          0.8,
-          normalizedValue * 0.5,
+          0.86,
+          0.2 + energy * 0.5,
         );
-        innerMaterial.opacity = 0.5 + normalizedValue * 0.4;
+        innerMaterial.opacity = 0.62 + energy * 0.3;
       }
     });
 
     // Smooth camera fly-through
-    const flySpeed = 0.8 + normalizedAvg * 2;
+    const flySpeed = 1.55 + normalizedAvg * 2.8;
     runtime.toy.camera.position.z -= flySpeed;
 
     // Add slight camera wobble
-    runtime.toy.camera.position.x = Math.sin(time * 2) * 2;
-    runtime.toy.camera.position.y = Math.cos(time * 1.5) * 2;
+    runtime.toy.camera.position.x = Math.sin(time * 2.4) * 2.4;
+    runtime.toy.camera.position.y = Math.cos(time * 1.85) * 2.2;
 
     // Reset camera when it reaches the end
     if (runtime.toy.camera.position.z < -tunnelLength + 50) {


### PR DESCRIPTION
### Motivation
- Make two randomly selected toys feel more immediately lively on load so they are enjoyable without requiring loud audio or long wait time.
- Ensure motion, color, and particle visibility provide instant visual payoff while preserving audio-reactive behavior.

### Description
- `assets/js/toys/mobile-ripples.ts`: increased base saturation, added a small sinusoidal `idlePulse` to provide continuous motion, amplified ripple amplitude and tied ripple frequency to mids, and brightened hue/opacity response to average frequency.
- `assets/js/toys/rainbow-tunnel.ts`: increased particle density and point size/opacity for better visibility, added per-ring `idleEnergy` so rings animate during quiet audio, used `energy = max(normalizedValue, idleEnergy)` to drive rotation/scale/color/emissive, and sped up camera fly-through and wobble for quicker momentum.
- Both toys keep their existing audio-reactive mappings but now include an ambient baseline so they feel alive immediately; code was formatted to project standards after changes.

### Testing
- Ran `bun run check` (Biome lint/format, `tsc` typecheck, and test suite) and the full test suite passed with no failures.
- Launched the dev server and ran a Playwright capture against `/?toy=mobile-ripples` and `/?toy=rainbow-tunnel` to produce screenshots of the improved toys (artifacts saved).
- No documentation files were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699410633ac083328c25b240c384dd57)