### PR TITLE
Make cube-wave and cosmic-particles more immediately playful

### DIFF
--- a/assets/js/toys/cube-wave.ts
+++ b/assets/js/toys/cube-wave.ts
@@ -78,31 +78,68 @@ export function start({ container }: ToyStartOptions = {}) {
     cubes: {
       label: 'Cubes',
       primitive: 'cubes',
-      grid: { rows: 10, cols: 10, spacingX: 5, spacingZ: 5 },
+      grid: { rows: 12, cols: 12, spacingX: 4.5, spacingZ: 4.5 },
       geometryFactory: () => new THREE.BoxGeometry(4, 4, 4),
       materialFactory: () =>
         new THREE.MeshStandardMaterial({
           color: 0x66ccff,
-          metalness: 0.35,
-          roughness: 0.35,
+          metalness: 0.25,
+          roughness: 0.3,
+          emissive: 0x152844,
+          emissiveIntensity: 0.4,
         }),
       colorFor: () => ({
         baseHue: 0.58,
-        hueRange: -0.45,
+        hueRange: -0.5,
         baseSaturation: 0.8,
         baseLuminance: 0.5,
+        luminanceRange: 0.3,
+        emissive: {
+          baseHue: 0.58,
+          hueRange: -0.25,
+          baseSaturation: 0.55,
+          baseLuminance: 0.06,
+          luminanceRange: 0.22,
+        },
       }),
       animation: {
         heightMode: 'scaleY',
         baseHeight: 0,
         audioHeight: 0,
+        wave: {
+          amplitude: 1.2,
+          frequency: 2.2,
+          phase: (row, col) => row * 0.25 + col * 0.25,
+        },
         baseScale: 1,
-        audioScale: 1.2,
-        rotation: { y: 0.006, audioBoost: 0.02 },
+        audioScale: 1.8,
+        rotation: { y: 0.01, audioBoost: 0.035 },
       },
       camera: {
         position: new THREE.Vector3(0, 30, 80),
-        lookAtY: 0,
+        lookAtY: 2,
+        sway: { amplitude: 3, frequency: 0.18 },
+      },
+      extras: (group) => {
+        const floor = new THREE.Mesh(
+          new THREE.CircleGeometry(56, 48),
+          new THREE.MeshStandardMaterial({
+            color: 0x080b18,
+            roughness: 0.75,
+            metalness: 0.1,
+          }),
+        );
+        floor.rotation.x = -Math.PI / 2;
+        floor.position.y = -2.5;
+        group.add(floor);
+
+        const rimLight = new THREE.PointLight(0x66ccff, 0.7, 120);
+        rimLight.position.set(-36, 26, 32);
+        group.add(rimLight);
+
+        const fillLight = new THREE.PointLight(0xff66aa, 0.55, 110);
+        fillLight.position.set(36, 18, -26);
+        group.add(fillLight);
       },
     },
     spheres: {
@@ -177,7 +214,7 @@ export function start({ container }: ToyStartOptions = {}) {
   };
 
   let currentPreset: GridPreset = presets.cubes;
-  let activeMode: ShapeMode = 'cubes';
+  let activeMode: ShapeMode = 'spheres';
 
   function getGridConfig(preset: GridPreset) {
     const particleScale = quality.activeQuality.particleScale ?? 1;


### PR DESCRIPTION
### Motivation
- Improve first-load engagement by making two randomly chosen stims (`cube-wave` and `cosmic-particles`) feel more dynamic and visually rewarding without extra interaction.
- Surface clearer audio-reactive behavior and motion so toys look lively immediately when demo audio or microphone input starts.
- Keep changes scoped to visual/behavioral tweaks (no API or metadata changes) to reduce risk.

### Description
- `assets/js/toys/cube-wave.ts`: default start mode switched to `spheres` for a livelier initial impression, and the `cubes` preset was enhanced with a denser grid, stronger emissive material settings, added per-grid subtle `wave` motion, higher audio scaling and rotation responsiveness, camera sway, and a simple stage `extras` group (floor + rim/fill lights) for immediate depth.
- `assets/js/toys/cosmic-particles.ts`: reworked the `orbit` preset to produce arm-like particle distributions by computing `baseRadii`, `baseAngles`, and `verticalOffsets`, added per-particle pulsing and orbital animation driven by `time` and audio, added an `ambientGlow` light, made particle size/color and light intensities audio-reactive, and introduced gentle camera drift to increase perceived motion.
- Formatting and linting adjustments applied to touched files to align with project style rules.

### Testing
- Ran `bun run check` which performs Biome formatting/lint, TypeScript typecheck, and the test suite; the command completed successfully with all tests passing.
- Launched a local dev server with `bun run dev --host 0.0.0.0 --port 4173` and captured screenshots of both updated toys to verify visual behavior at runtime.
- No docs were modified (`None`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699410633ac083328c25b240c384dd57)