### PR TITLE
Improve interactivity for five stims

### DIFF
--- a/assets/js/toys/spiral-burst.ts
+++ b/assets/js/toys/spiral-burst.ts
@@ -670,6 +670,10 @@ export function start({ container }: ToyStartOptions = {}) {
               ? 'bloom'
               : 'burst',
       );
+    } else if (event.key.toLowerCase() === 'w') {
+      targetPulseBoost = THREE.MathUtils.clamp(targetPulseBoost + 0.1, 0.6, 2);
+    } else if (event.key.toLowerCase() === 's') {
+      targetPulseBoost = THREE.MathUtils.clamp(targetPulseBoost - 0.1, 0.6, 2);
     }
   }
 

--- a/assets/js/toys/star-field.ts
+++ b/assets/js/toys/star-field.ts
@@ -361,6 +361,10 @@ export function start({ container }: ToyStartOptions = {}) {
       targetDrift = THREE.MathUtils.clamp(targetDrift + 0.1, 0.6, 1.8);
     } else if (event.key === 'ArrowDown') {
       targetDrift = THREE.MathUtils.clamp(targetDrift - 0.1, 0.6, 1.8);
+    } else if (event.key.toLowerCase() === 'w') {
+      targetSparkle = THREE.MathUtils.clamp(targetSparkle + 0.1, 0.6, 2);
+    } else if (event.key.toLowerCase() === 's') {
+      targetSparkle = THREE.MathUtils.clamp(targetSparkle - 0.1, 0.6, 2);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Make a random sample of five toys more interactive so they can be exercised during manual and automated play-testing. 
- Surface simple gesture and keyboard controls so users can steer motion, color drift, and preset/mode switches in real time.
- Preserve existing quality/performance panels and avoid changing metadata or docs.

### Description
- Added lightweight per-toy `controls` state, `target*` smoothing values, `handleInput` gesture adapter, and keyboard handlers wired into the runtime for `rainbow-tunnel`, `cube-wave`, `cosmic-particles`, `star-field`, and `spiral-burst` so pointer gestures and keys adjust speed, wobble, energy, color drift, presets, and modes at runtime. 
- Wired `input` option on the toy starters to call `handleInput` and added `window` `keydown` listeners in plugin `setup` and cleanup in `dispose`. 
- Tuned each toy's animation loop to lerp toward control targets and apply control multipliers (for camera motion, particle sizes/opacity, rotation speeds, hue shifts, etc.).
- Files changed: `assets/js/toys/rainbow-tunnel.ts`, `assets/js/toys/cube-wave.ts`, `assets/js/toys/cosmic-particles.ts`, `assets/js/toys/star-field.ts`, `assets/js/toys/spiral-burst.ts`.

### Testing
- Ran `bun run check` (Biome format/lint, TypeScript `tsc --noEmit`, and the test suite), and the checks completed successfully (all automated checks passed; tests passed with skips observed during run). 
- Formatted files with `biome format --write` as part of the check and fixed formatting issues. 
- Attempted automated Playwright screenshots to capture the five toys, but headless Chromium crashed in this environment so screenshots were not produced (Playwright run failed due to browser SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994184e44c08332832d388661884537)