### PR TITLE
Improve mobile homepage onboarding and tap affordances

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1726,7 +1726,7 @@ body {
       calc(env(safe-area-inset-top) + 84px)
     );
     max-height: min(
-      30svh,
+      44svh,
       calc(
         100dvh -
         var(--toy-nav-floating-offset, 108px) -
@@ -1743,7 +1743,7 @@ body {
   :root[data-toy-controls-expanded="true"] .control-panel--floating {
     display: block;
     max-height: min(
-      24svh,
+      56svh,
       calc(
         100dvh -
         var(--toy-nav-floating-offset, 108px) -
@@ -1758,10 +1758,11 @@ body {
     right: max(6px, env(safe-area-inset-right));
     width: auto;
     padding: 8px;
+    padding-bottom: max(10px, env(safe-area-inset-bottom));
     clip-path: none;
     border-radius: 18px;
     max-height: min(
-      36svh,
+      52svh,
       calc(
         100dvh -
         12px -

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -235,6 +235,10 @@ footer {
   scroll-margin-top: 6rem;
 }
 
+#toy-list {
+  scroll-margin-top: clamp(7.5rem, 17vh, 9.5rem);
+}
+
 .content {
   position: relative;
   z-index: 1;
@@ -3327,14 +3331,13 @@ footer {
   }
 
   .system-legend {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 0.25rem;
-    -webkit-overflow-scrolling: touch;
+    flex-wrap: wrap;
+    overflow: visible;
+    padding-bottom: 0;
   }
 
   .system-legend__item {
-    white-space: nowrap;
+    white-space: normal;
   }
 
   .search-row {
@@ -3537,6 +3540,10 @@ footer {
 }
 
 @media (max-width: 520px) {
+  #toy-list {
+    scroll-margin-top: 10rem;
+  }
+
   h1 {
     font-size: clamp(1.6rem, 7vw, 1.8rem);
   }

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -198,6 +198,12 @@ html.light .hero-background-canvas {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .skip-link {
+    display: none;
+  }
+}
+
 body,
 html {
   padding: 0;
@@ -362,6 +368,9 @@ footer {
   border-radius: 999px;
   font-weight: 600;
   letter-spacing: 0.01em;
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease,
@@ -1861,8 +1870,12 @@ html.light .repo-status__metric {
 .repo-status__badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   border-radius: 999px;
   overflow: hidden;
+  min-height: 44px;
+  min-width: 44px;
+  padding-inline: 0.35rem;
   transition: transform 0.2s ease;
 }
 
@@ -2876,10 +2889,16 @@ html.light .cta-button.primary {
 
 .webtoy-card-bestfor {
   margin-top: -0.15rem;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.15rem;
   font-size: 0.76rem;
   font-weight: 600;
   color: color-mix(in srgb, var(--accent-color) 62%, var(--text-color) 38%);
+}
+
+.webtoy-card-hint {
+  margin: 0;
+  font-size: 0.74rem;
+  color: var(--text-muted);
 }
 
 .webtoy-card-match {
@@ -2918,16 +2937,19 @@ html.light .cta-button.primary {
 
 .webtoy-card-actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-start;
+  gap: 0.5rem;
   margin-top: 0.3rem;
   position: relative;
   z-index: 2;
 }
 
 .webtoy-card-actions .cta-button {
-  min-height: 36px;
-  padding: 0.45rem 0.8rem;
-  font-size: 0.78rem;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.58rem 0.9rem;
+  font-size: 0.82rem;
 }
 
 .webtoy-card-meta::before {

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1860,6 +1860,11 @@ export function createLibraryView({
     bestFor.textContent = getBestForLabel(toy);
     card.appendChild(bestFor);
 
+    const tapHint = document.createElement('p');
+    tapHint.className = 'webtoy-card-hint';
+    tapHint.textContent = 'Tap anywhere on this card to open.';
+    card.appendChild(tapHint);
+
     const matchedFields = getMatchedFields(toy, getQueryTokens(searchQuery));
     if (matchedFields.length > 0) {
       const matches = document.createElement('p');
@@ -1977,6 +1982,22 @@ export function createLibraryView({
     if (toy.type === 'module') {
       const actions = document.createElement('div');
       actions.className = 'webtoy-card-actions';
+
+      const open = document.createElement('button');
+      open.type = 'button';
+      open.className = 'cta-button cta-button--accent';
+      open.textContent = 'Open toy';
+      open.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openToy(toy);
+      });
+      open.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.stopPropagation();
+        }
+      });
+      actions.appendChild(open);
 
       const play = document.createElement('button');
       play.type = 'button';

--- a/index.html
+++ b/index.html
@@ -141,13 +141,13 @@
       <section class="intro" id="intro" aria-label="Primary quick actions">
         <div class="intro-actions" role="group" aria-label="Start options">
           <a
-            href="toy.html?toy=holy"
+            href="#system-check"
             class="cta-button primary"
           >
-            Start now
+            Run quick system check
           </a>
         </div>
-        <p class="cta-helper intro-helper">Quick system check opens first.</p>
+        <p class="cta-helper intro-helper">Then jump into the library with one tap.</p>
       </section>
 
       <section class="library" id="library">

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -96,8 +96,10 @@ describe('app shell user journeys', () => {
   test('demo button keyboard activation keeps demo-audio launch path', async () => {
     await loadAppShell();
 
-    const playDemo = document.querySelector('.webtoy-card-actions button');
-    expect(playDemo).not.toBeNull();
+    const playDemo = Array.from(
+      document.querySelectorAll('.webtoy-card-actions button'),
+    ).find((button) => button.textContent?.toLowerCase().includes('preview'));
+    expect(playDemo).not.toBeUndefined();
 
     playDemo?.dispatchEvent(
       new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),


### PR DESCRIPTION
### Motivation
- Align the homepage first-step flow and mobile ergonomics so new users see the expected system-check path and interactive controls meet mobile touch-target guidance.
- Surface clearer card-level affordances so tapping a card feels discoverable and users still have an explicit demo-preview action.

### Description
- Update the hero CTA to point to the system-check section and change copy from `Start now` to `Run quick system check` with clarified helper text in `index.html`.
- Add a lightweight tap hint and an explicit `Open toy` action to module cards while preserving the existing demo-audio `Preview` action in `assets/js/library-view.js`.
- Improve mobile touch ergonomics in `assets/css/index.css` by hiding the skip link on coarse-pointer devices, increasing `nav-toggle` and `.repo-status__badge` minimum touch sizes, and enlarging card action buttons and spacing to target ~44px.
- Update the unit test in `tests/app-shell.test.js` to target the preview/demo action text so keyboard activation for demo preview remains covered after adding the new open action.

### Testing
- Ran the full quality gate with `bun run check` (Biome lint/format, `tsc`, and the test suite) and it completed successfully with all tests passing; final run reported 157 tests across the suite with 0 failures and 2 skipped.
- Performed a Playwright mobile traversal using an iPhone 12 device profile to validate the CTA flow, navigation to the system-check anchor, card actions, and touch-target sizes; screenshots were captured and a script confirmed `Small interactive elements: 0` (no visible interactive elements under 44px).
- No docs were modified beyond the copy changes in the page templates (Docs: None).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953a68f6948332bddc07567ee661fa)