### PR TITLE
Fix mobile layout overflow in library UI

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -75,6 +75,12 @@ html {
   color-scheme: dark;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body.tv-mode {
   --tv-scale-multiplier: 1.16;
   --tv-focus-outline-width: 4px;


### PR DESCRIPTION
### Motivation
- Prevent horizontal overflow and right-edge clipping on narrow/mobile screens by ensuring element sizing includes padding and borders.

### Description
- Add a global `box-sizing: border-box` reset (`*`, `*::before`, `*::after`) to `assets/css/index.css` so container and card widths include padding and avoid exceeding the viewport on mobile.

### Testing
- Ran `bun run check` (Biome checks, `tsc`, and test suite) and all automated checks passed.
- Verified on a mobile viewport (`390x844`) with Playwright; DOM audit and screenshot confirmed `document.body.scrollWidth === window.innerWidth` and no overflowing elements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995449fe4188332a44b9beb5561204d)