### PR TITLE
Add growth loops for retention and premium intent

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2962,6 +2962,46 @@ html.light .cta-button.primary {
   font-size: 0.82rem;
 }
 
+.webtoy-growth-panel {
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  border-radius: 0.9rem;
+  background: linear-gradient(
+    155deg,
+    rgba(15, 23, 42, 0.8),
+    rgba(30, 41, 59, 0.7)
+  );
+}
+
+.webtoy-growth-panel--premium {
+  border-color: rgba(196, 132, 252, 0.55);
+}
+
+.webtoy-growth-panel__title {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.webtoy-growth-panel__body {
+  margin: 0 0 0.75rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+html.light .webtoy-growth-panel {
+  background: linear-gradient(
+    155deg,
+    rgba(226, 232, 240, 0.72),
+    rgba(241, 245, 249, 0.94)
+  );
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+html.light .webtoy-growth-panel__body {
+  color: rgba(15, 23, 42, 0.82);
+}
+
 .webtoy-card-meta::before {
   content: "";
   position: absolute;

--- a/assets/js/loader.ts
+++ b/assets/js/loader.ts
@@ -19,6 +19,7 @@ import toyManifest from './data/toy-manifest.ts';
 import type { ToyEntry } from './data/toy-schema.ts';
 import { createRouter, type Route } from './router.ts';
 import { createToyView } from './toy-view.ts';
+import { recordToyOpen } from './utils/growth-metrics.ts';
 import { createManifestClient } from './utils/manifest-client';
 import { applyPartyMode } from './utils/party-mode';
 import { resetToyPictureInPicture } from './utils/picture-in-picture';
@@ -477,6 +478,7 @@ export function createLoader({
       setCurrentToy(toy.slug);
       activeToySlug = toy.slug;
       rememberToy(toy.slug);
+      recordToyOpen(toy.slug, pushState ? 'library' : 'direct');
 
       // Setup audio prompt if startAudio globals are registered by the toy.
       const win = (container?.ownerDocument.defaultView ??

--- a/assets/js/utils/growth-metrics.ts
+++ b/assets/js/utils/growth-metrics.ts
@@ -1,0 +1,181 @@
+type GrowthEventName =
+  | 'library_visit'
+  | 'toy_open'
+  | 'toy_share'
+  | 'premium_prompt_dismissed';
+
+type ToyOpenSource = 'library' | 'direct';
+
+type ToyOpenEntry = {
+  slug: string;
+  openedAt: string;
+  source?: string;
+};
+
+type GrowthState = {
+  activeDays: string[];
+  lastSeenAt?: string;
+  toyOpens: number;
+  toyOpenHistory: ToyOpenEntry[];
+  shares: number;
+  premiumPromptDismissed: boolean;
+};
+
+const STORAGE_KEY = 'stims-growth-metrics-v1';
+
+const createEmptyState = (): GrowthState => ({
+  activeDays: [],
+  toyOpens: 0,
+  toyOpenHistory: [],
+  shares: 0,
+  premiumPromptDismissed: false,
+});
+
+const isoDay = (timestamp = Date.now()) =>
+  new Date(timestamp).toISOString().slice(0, 10);
+
+const readState = (): GrowthState => {
+  if (typeof window === 'undefined') {
+    return createEmptyState();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return createEmptyState();
+    }
+
+    const parsed = JSON.parse(raw) as Partial<GrowthState>;
+    return {
+      activeDays: Array.isArray(parsed.activeDays) ? parsed.activeDays : [],
+      lastSeenAt:
+        typeof parsed.lastSeenAt === 'string' ? parsed.lastSeenAt : undefined,
+      toyOpens:
+        typeof parsed.toyOpens === 'number' && Number.isFinite(parsed.toyOpens)
+          ? parsed.toyOpens
+          : 0,
+      toyOpenHistory: Array.isArray(parsed.toyOpenHistory)
+        ? parsed.toyOpenHistory.filter((entry): entry is ToyOpenEntry =>
+            Boolean(entry && typeof entry.slug === 'string'),
+          )
+        : [],
+      shares:
+        typeof parsed.shares === 'number' && Number.isFinite(parsed.shares)
+          ? parsed.shares
+          : 0,
+      premiumPromptDismissed: Boolean(parsed.premiumPromptDismissed),
+    };
+  } catch (_error) {
+    return createEmptyState();
+  }
+};
+
+const writeState = (state: GrowthState) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (_error) {
+    // Ignore storage write errors.
+  }
+};
+
+const emitMetricEvent = (
+  name: GrowthEventName,
+  detail: Record<string, string | number> = {},
+) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('stims:growth-event', {
+      detail: {
+        name,
+        timestamp: Date.now(),
+        ...detail,
+      },
+    }),
+  );
+};
+
+export const recordLibraryVisit = () => {
+  const state = readState();
+  const today = isoDay();
+  if (!state.activeDays.includes(today)) {
+    state.activeDays.push(today);
+    state.activeDays = state.activeDays.slice(-35);
+  }
+  state.lastSeenAt = new Date().toISOString();
+  writeState(state);
+  emitMetricEvent('library_visit', {
+    weeklyActiveDays: getWeeklyActiveDays(state),
+  });
+  return state;
+};
+
+export const recordToyOpen = (
+  slug: string,
+  source: ToyOpenSource = 'library',
+) => {
+  if (!slug) return;
+  const state = readState();
+  state.toyOpens += 1;
+  state.lastSeenAt = new Date().toISOString();
+  const currentDay = isoDay();
+  if (!state.activeDays.includes(currentDay)) {
+    state.activeDays.push(currentDay);
+    state.activeDays = state.activeDays.slice(-35);
+  }
+
+  const nextHistory: ToyOpenEntry[] = [
+    { slug, openedAt: new Date().toISOString(), source },
+    ...state.toyOpenHistory.filter((entry) => entry.slug !== slug),
+  ];
+  state.toyOpenHistory = nextHistory.slice(0, 8);
+  writeState(state);
+  emitMetricEvent('toy_open', { slug, source, toyOpens: state.toyOpens });
+};
+
+export const recordToyShare = (slug: string) => {
+  const state = readState();
+  state.shares += 1;
+  writeState(state);
+  emitMetricEvent('toy_share', { slug, shares: state.shares });
+};
+
+export const dismissPremiumPrompt = () => {
+  const state = readState();
+  state.premiumPromptDismissed = true;
+  writeState(state);
+  emitMetricEvent('premium_prompt_dismissed');
+};
+
+export const shouldShowPremiumPrompt = () => {
+  const state = readState();
+  if (state.premiumPromptDismissed) return false;
+  return getWeeklyActiveDays(state) >= 2 && state.toyOpens >= 4;
+};
+
+export const getRecentToySlugs = (limit = 3) => {
+  const state = readState();
+  return state.toyOpenHistory.slice(0, limit).map((entry) => entry.slug);
+};
+
+export const getGrowthSnapshot = () => {
+  const state = readState();
+  return {
+    weeklyActiveDays: getWeeklyActiveDays(state),
+    toyOpens: state.toyOpens,
+    shares: state.shares,
+    recentToySlugs: getRecentToySlugs(),
+  };
+};
+
+const getWeeklyActiveDays = (state: GrowthState) => {
+  const lastSevenDays = new Set<string>();
+  for (let index = 0; index < 7; index += 1) {
+    const day = new Date(Date.now() - index * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    lastSevenDays.add(day);
+  }
+
+  return state.activeDays.filter((day) => lastSevenDays.has(day)).length;
+};

--- a/assets/js/utils/init-library.ts
+++ b/assets/js/utils/init-library.ts
@@ -1,6 +1,7 @@
 import toyManifest from '../data/toy-manifest.ts';
 import type { ToyManifest } from '../data/toy-schema.ts';
 import { createLibraryView } from '../library-view.js';
+import { recordLibraryVisit } from './growth-metrics.ts';
 import { parseToyManifest } from './manifest-client.ts';
 
 const resolveToys = async () => {
@@ -104,6 +105,8 @@ export const initLibraryView = async ({
   initNavigation,
   loadFromQuery,
 }: InitLibraryViewOptions) => {
+  recordLibraryVisit();
+
   const libraryView = createLibraryView({
     toys: [],
     loadToy,

--- a/tests/growth-metrics.test.ts
+++ b/tests/growth-metrics.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  getGrowthSnapshot,
+  recordLibraryVisit,
+  recordToyOpen,
+} from '../assets/js/utils/growth-metrics.ts';
+
+describe('growth metrics', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('tracks active days and toy opens', () => {
+    recordLibraryVisit();
+    recordToyOpen('aurora-painter', 'library');
+
+    const snapshot = getGrowthSnapshot();
+    expect(snapshot.weeklyActiveDays).toBeGreaterThanOrEqual(1);
+    expect(snapshot.toyOpens).toBe(1);
+    expect(snapshot.recentToySlugs).toEqual(['aurora-painter']);
+  });
+});

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -63,3 +63,38 @@ describe('library filter state normalization', () => {
     expect(calmChip?.classList.contains('is-active')).toBe(false);
   });
 });
+
+test('renders continue and premium panels when returner signals are present', async () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  window.localStorage.setItem(
+    'stims-growth-metrics-v1',
+    JSON.stringify({
+      activeDays: [yesterday, today],
+      toyOpens: 5,
+      toyOpenHistory: [
+        { slug: 'calm-flow', openedAt: '2026-01-02T00:00:00.000Z' },
+      ],
+      shares: 0,
+      premiumPromptDismissed: false,
+    }),
+  );
+
+  const view = createLibraryView({
+    toys,
+  });
+
+  await view.init();
+
+  expect(document.querySelector('.webtoy-growth-panel')).not.toBeNull();
+  expect(
+    document.querySelector('.webtoy-growth-panel--premium'),
+  ).not.toBeNull();
+  const shareButton = Array.from(document.querySelectorAll('button')).find(
+    (button) => button.textContent === 'Share toy',
+  );
+  expect(shareButton).toBeTruthy();
+});


### PR DESCRIPTION
### Motivation
- Capture simple returner and engagement signals (library visits, toy opens, shares) to enable weekly-active-day and returner UX decisions.
- Surface lightweight growth UI in the library to help returning users resume activity and to surface premium waitlist intent when users demonstrate repeat usage.
- Provide a small viral affordance (copy/share) to measure referral actions and increment share counts.

### Description
- Added a typed growth metrics utility `assets/js/utils/growth-metrics.ts` that persists a compact `GrowthState` in localStorage, emits `stims:growth-event` CustomEvents, and exposes functions: `recordLibraryVisit`, `recordToyOpen`, `recordToyShare`, `getRecentToySlugs`, `shouldShowPremiumPrompt`, and `getGrowthSnapshot`.
- Wired metrics into app flows by calling `recordLibraryVisit()` from `assets/js/utils/init-library.ts` and `recordToyOpen(...)` from `assets/js/loader.ts` when a toy is launched.
- Enhanced the library UI in `assets/js/library-view.js` to render return-user panels ("Continue where you left off" and a premium prompt) and added a `Share toy` button on card actions that copies a toy URL and records a share; also added panel styles to `assets/css/index.css`.
- Added automated tests: `tests/growth-metrics.test.ts` (unit coverage for metrics) and extended `tests/library-filter-state.test.ts` to assert the growth panels and share affordance; updated formatting/lint fixes applied.

### Testing
- Ran `bun run lint:fix` to apply formatting fixes and `bun run check` (Biome formatter/linter, TypeScript `tsc`, and test suite), and the full check completed successfully with no failing checks.
- Ran targeted tests `bun run test tests/growth-metrics.test.ts` and `bun run test tests/library-filter-state.test.ts`, and both passed.
- Ran the full test suite via `bun run check` which executed all tests; the suite completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995500a4edc8332b70609fb9b0b94cd)