### PR TITLE
Move growth lab UI to dedicated internal page

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1798,6 +1798,79 @@ h1 {
   pointer-events: none;
 }
 
+.growth-tracks {
+  margin: 0.6rem 0 0;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--surface-border);
+  background: color-mix(in srgb, var(--card-bg) 88%, var(--accent-color));
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.growth-tracks .system-legend {
+  margin-top: 0.2rem;
+}
+
+.growth-tracks .system-legend__item {
+  align-items: flex-start;
+}
+
+.growth-tracks__form {
+  margin-top: 0.45rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.growth-tracks__label {
+  font-size: 0.92rem;
+  color: var(--text-muted);
+}
+
+.growth-tracks__form-row {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.growth-tracks__form-row select {
+  min-height: 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--surface-border);
+  background: var(--card-bg);
+  color: var(--text-color);
+  padding: 0.35rem 0.6rem;
+}
+
+.growth-tracks__form-row .cta-button {
+  min-height: 36px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
+}
+
+.growth-tracks__form-row .cta-button[data-signal-state="recorded"] {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-color) 62%,
+    var(--surface-border)
+  );
+  background: color-mix(in srgb, var(--accent-color) 20%, transparent);
+}
+
+.growth-tracks__segment-note {
+  margin: 0.15rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.growth-tracks .repo-status__title {
+  font-size: 1.02rem;
+}
+
 .repo-status {
   margin: 1.25rem 0 0.25rem;
   padding: 1.1rem 1.2rem;

--- a/assets/js/growth-lab-entry.ts
+++ b/assets/js/growth-lab-entry.ts
@@ -1,0 +1,11 @@
+import { initOpportunitySignals } from './utils/init-opportunity-signals.ts';
+
+if (typeof window !== 'undefined') {
+  try {
+    window.localStorage.setItem('stims:growth-lab-enabled', '1');
+  } catch (_error) {
+    // Ignore storage access issues.
+  }
+}
+
+initOpportunitySignals();

--- a/assets/js/utils/init-opportunity-signals.ts
+++ b/assets/js/utils/init-opportunity-signals.ts
@@ -1,0 +1,247 @@
+import {
+  isValidMarketSegment,
+  isValidOpportunityTrack,
+  type MarketSegment,
+  type OpportunityTrack,
+  recordOpportunityContact,
+  recordOpportunityInterest,
+  recordSegmentPlanContact,
+  recordSegmentPlanViewed,
+} from './growth-metrics.ts';
+
+const trackLabels: Record<OpportunityTrack, string> = {
+  'creator-mode': 'Creator mode',
+  'partnership-licensing': 'Partnership licensing',
+  'facilitator-toolkit': 'Facilitator toolkit',
+  'community-support': 'Community support',
+};
+
+type SegmentPlan = {
+  label: string;
+  topPriority: string;
+  unlocks: string;
+  pilotMetric: string;
+  roadmap: string[];
+};
+
+const segmentPlans: Record<MarketSegment, SegmentPlan> = {
+  'experiential-installations': {
+    label: 'Experiential installations / activations',
+    topPriority:
+      'P1: Add kiosk defaults (auto demo-audio, fullscreen prompt, idle reset).',
+    unlocks: 'Unlocks reliable unattended operation at events and popups.',
+    pilotMetric:
+      'Pilot KPI: average dwell time per attendee and repeat interactions per session.',
+    roadmap: [
+      'P1: Add kiosk defaults (auto demo-audio, fullscreen prompt, idle reset).',
+      'P2: Publish a stable event setlist with fixed quality profiles for venue hardware.',
+      'P3: Ship an operator runbook for setup, fallback, and live recovery.',
+    ],
+  },
+  'wellness-focus-environments': {
+    label: 'Wellness / focus environments',
+    topPriority:
+      'P1: Create low-stimulation preset bundles with calmer visuals and guided defaults.',
+    unlocks:
+      'Unlocks immediate fit for low-arousal spaces and comfort-sensitive sessions.',
+    pilotMetric:
+      'Pilot KPI: weekly returning sessions and completion rate for short guided sessions.',
+    roadmap: [
+      'P1: Create low-stimulation preset bundles with calmer visuals and guided defaults.',
+      'P2: Introduce timed session modes (2/5/10 min) with gentle end cues.',
+      'P3: Provide facilitator notes for mood-based toy selection and comfort settings.',
+    ],
+  },
+  'education-enrichment': {
+    label: 'Education enrichment',
+    topPriority:
+      'P1: Add classroom mode with simplified controls and larger touch targets.',
+    unlocks:
+      'Unlocks faster classroom starts with fewer teacher-side interventions.',
+    pilotMetric:
+      'Pilot KPI: teacher reuse across classes and successful classroom launches per week.',
+    roadmap: [
+      'P1: Add classroom mode with simplified controls and larger touch targets.',
+      'P2: Bundle lesson prompts per toy (pattern, rhythm, color, interaction outcomes).',
+      'P3: Offer admin-safe defaults (demo-audio first, no-mic required, quick class reset).',
+    ],
+  },
+};
+
+const validationSummary =
+  'Growth-lab signals are sent to the configured server endpoint when enabled.';
+
+const createDiscussionDraftUrl = (track: OpportunityTrack) => {
+  const title = `Interest: ${trackLabels[track]}`;
+  const body = [
+    '## What I am interested in',
+    `- Track: ${trackLabels[track]}`,
+    '- Intended audience/context:',
+    '- Expected outcomes:',
+    '- Timeline or urgency:',
+    '',
+    '## Contact (optional)',
+    '- Name/org:',
+    '- Preferred follow-up channel:',
+  ].join('\n');
+
+  const params = new URLSearchParams({ category: 'ideas', title, body });
+  return `https://github.com/zz-plant/stims/discussions/new?${params.toString()}`;
+};
+
+const createSegmentDiscussionUrl = (segment: MarketSegment) => {
+  const plan = segmentPlans[segment];
+  const title = `Pilot interest: ${plan.label}`;
+  const body = [
+    '## Segment pilot request',
+    `- Segment: ${plan.label}`,
+    '- Organization/environment:',
+    '- Expected audience size:',
+    '- Desired timeline:',
+    '',
+    '## Prioritized roadmap',
+    ...plan.roadmap.map((step) => `- ${step}`),
+    '',
+    `## Unlock focus\n- ${plan.unlocks}`,
+  ].join('\n');
+
+  const params = new URLSearchParams({ category: 'ideas', title, body });
+  return `https://github.com/zz-plant/stims/discussions/new?${params.toString()}`;
+};
+
+const setButtonActivatedState = (button: HTMLButtonElement, text: string) => {
+  button.dataset.signalState = 'recorded';
+  button.textContent = text;
+  button.setAttribute('aria-pressed', 'true');
+};
+
+const isGrowthLabEnabled = () => {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('growth-lab') === '1') return true;
+  try {
+    return window.localStorage.getItem('stims:growth-lab-enabled') === '1';
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const initOpportunitySignals = () => {
+  const container = document.querySelector<HTMLElement>(
+    '[data-opportunity-signals]',
+  );
+  if (!container) return;
+
+  if (!isGrowthLabEnabled()) {
+    container.setAttribute('hidden', '');
+    return;
+  }
+
+  container.removeAttribute('hidden');
+
+  const summary = container.querySelector<HTMLElement>(
+    '[data-opportunity-summary]',
+  );
+  if (summary) summary.textContent = validationSummary;
+
+  const prioritySelect = container.querySelector<HTMLSelectElement>(
+    '[data-opportunity-priority-select]',
+  );
+  const interestButton = container.querySelector<HTMLButtonElement>(
+    '[data-opportunity-action="interest"]',
+  );
+  const contactLink = container.querySelector<HTMLAnchorElement>(
+    '[data-opportunity-action="contact"]',
+  );
+
+  const segmentSelect = container.querySelector<HTMLSelectElement>(
+    '[data-segment-select]',
+  );
+  const segmentPriorityButton = container.querySelector<HTMLButtonElement>(
+    '[data-segment-action="preview"]',
+  );
+  const segmentContactLink = container.querySelector<HTMLAnchorElement>(
+    '[data-segment-action="contact"]',
+  );
+  const segmentOutcome = container.querySelector<HTMLElement>(
+    '[data-segment-outcome]',
+  );
+
+  const getSelectedTrack = (): OpportunityTrack | null => {
+    const selectedValue = prioritySelect?.value;
+    return selectedValue && isValidOpportunityTrack(selectedValue)
+      ? selectedValue
+      : null;
+  };
+
+  const getSelectedSegment = (): MarketSegment | null => {
+    const selectedValue = segmentSelect?.value;
+    return selectedValue && isValidMarketSegment(selectedValue)
+      ? selectedValue
+      : null;
+  };
+
+  const syncTrackContactLink = () => {
+    const selectedTrack = getSelectedTrack();
+    if (contactLink && selectedTrack) {
+      contactLink.href = createDiscussionDraftUrl(selectedTrack);
+    }
+  };
+
+  const syncSegmentPresentation = (segment: MarketSegment) => {
+    const plan = segmentPlans[segment];
+    if (segmentOutcome) {
+      segmentOutcome.textContent = `${plan.topPriority} ${plan.unlocks} ${plan.pilotMetric}`;
+    }
+    if (segmentContactLink) {
+      segmentContactLink.href = createSegmentDiscussionUrl(segment);
+    }
+  };
+
+  syncTrackContactLink();
+  prioritySelect?.addEventListener('change', syncTrackContactLink);
+
+  interestButton?.addEventListener('click', () => {
+    const selectedTrack = getSelectedTrack();
+    if (!selectedTrack) return;
+    recordOpportunityInterest(selectedTrack);
+    setButtonActivatedState(interestButton, 'Vote recorded ✓');
+    if (summary) summary.textContent = validationSummary;
+  });
+
+  contactLink?.addEventListener('click', () => {
+    const selectedTrack = getSelectedTrack();
+    if (!selectedTrack) return;
+    recordOpportunityContact(selectedTrack);
+    if (summary) summary.textContent = validationSummary;
+  });
+
+  const initialSegment = getSelectedSegment();
+  if (initialSegment) syncSegmentPresentation(initialSegment);
+
+  segmentPriorityButton?.addEventListener('click', () => {
+    const segment = getSelectedSegment();
+    if (!segment) return;
+    syncSegmentPresentation(segment);
+    recordSegmentPlanViewed(segment);
+    setButtonActivatedState(segmentPriorityButton, 'Priority recorded ✓');
+    if (summary) summary.textContent = validationSummary;
+  });
+
+  segmentSelect?.addEventListener('change', () => {
+    const segment = getSelectedSegment();
+    if (!segment) return;
+    syncSegmentPresentation(segment);
+    if (segmentPriorityButton) {
+      segmentPriorityButton.dataset.signalState = '';
+      segmentPriorityButton.textContent = 'Mark segment priority';
+    }
+  });
+
+  segmentContactLink?.addEventListener('click', () => {
+    const segment = getSelectedSegment();
+    if (!segment) return;
+    recordSegmentPlanContact(segment);
+    if (summary) summary.textContent = validationSummary;
+  });
+};

--- a/growth-lab.html
+++ b/growth-lab.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stim growth lab</title>
+    <meta name="robots" content="noindex,nofollow" />
+    <meta name="stims-growth-signal-endpoint" content="" />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/index.css" />
+  </head>
+  <body data-page="growth-lab">
+    <main class="wrapper">
+      <section class="github" id="growth-lab">
+        <div class="section-heading">
+          <p class="eyebrow">Internal</p>
+          <h1>Growth lab</h1>
+          <p class="section-description">
+            Internal validation controls for opportunity and segment experiments.
+          </p>
+        </div>
+
+        <div class="growth-tracks" id="growth-tracks" data-opportunity-signals>
+          <p class="repo-status__title">Opportunity tracks under consideration</p>
+          <ul class="system-legend" aria-label="Growth opportunities under consideration">
+            <li class="system-legend__item">
+              🎛️ <strong>Creator mode:</strong> optional premium controls,
+              presets, and export workflows for power users.
+            </li>
+            <li class="system-legend__item">
+              🤝 <strong>Partnership licensing:</strong> event, education, and
+              wellness deployments with curated toy bundles.
+            </li>
+            <li class="system-legend__item">
+              🧰 <strong>Facilitator toolkit:</strong> guided session packs for
+              classrooms, studios, and community spaces.
+            </li>
+            <li class="system-legend__item">
+              💖 <strong>Community support:</strong> donation and membership
+              options for people who want to back development.
+            </li>
+          </ul>
+          <form class="growth-tracks__form" data-opportunity-priority-form>
+            <label for="opportunity-priority" class="growth-tracks__label"
+              >Help us prioritize what to build next</label
+            >
+            <div class="growth-tracks__form-row">
+              <select id="opportunity-priority" data-opportunity-priority-select>
+                <option value="creator-mode">Creator mode</option>
+                <option value="partnership-licensing">Partnership licensing</option>
+                <option value="facilitator-toolkit">Facilitator toolkit</option>
+                <option value="community-support">Community support</option>
+              </select>
+              <button
+                type="button"
+                class="cta-button ghost"
+                data-opportunity-action="interest"
+              >
+                Cast priority vote
+              </button>
+              <a
+                class="text-link"
+                href="https://github.com/zz-plant/stims/discussions/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-opportunity-action="contact"
+                >Share your use case</a
+              >
+            </div>
+          </form>
+          <form class="growth-tracks__form" data-segment-plan-form>
+            <label for="segment-plan" class="growth-tracks__label"
+              >Choose your environment</label
+            >
+            <div class="growth-tracks__form-row">
+              <select id="segment-plan" data-segment-select>
+                <option value="experiential-installations">
+                  Experiential installations / activations
+                </option>
+                <option value="wellness-focus-environments">
+                  Wellness / focus environments
+                </option>
+                <option value="education-enrichment">Education enrichment</option>
+              </select>
+              <button
+                type="button"
+                class="cta-button ghost"
+                data-segment-action="preview"
+              >
+                Mark segment priority
+              </button>
+              <a
+                class="text-link"
+                href="https://github.com/zz-plant/stims/discussions/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-segment-action="contact"
+                >Discuss a pilot</a
+              >
+            </div>
+            <p class="growth-tracks__segment-note" data-segment-outcome aria-live="polite"></p>
+          </form>
+          <p class="repo-status__message" data-opportunity-summary>
+            Growth-lab signals are sent to the configured server endpoint when
+            enabled.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="assets/js/growth-lab-entry.ts"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -451,7 +451,12 @@
             changelog, and ongoing experiments. Follow the repo, drop feedback,
             or help ship the next wave of toys.
           </p>
+          <p class="section-description">
+            We are actively exploring sustainability paths that keep the core
+            library open while funding new work.
+          </p>
         </div>
+        
         <div class="repo-status">
           <div class="repo-status__header">
             <p class="repo-status__title">
@@ -547,6 +552,13 @@
               rel="noopener noreferrer"
               class="cta-button ghost"
               >Suggest a toy</a
+            >
+            <a
+              href="https://github.com/zz-plant/stims/discussions"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="cta-button ghost"
+              >Talk partnerships</a
             >
             <a
               href="https://github.com/zz-plant/stims/blob/main/CHANGELOG.md"

--- a/tests/growth-metrics.test.ts
+++ b/tests/growth-metrics.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 import {
   getGrowthSnapshot,
   recordLibraryVisit,
+  recordOpportunityContact,
+  recordOpportunityInterest,
+  recordSegmentPlanContact,
+  recordSegmentPlanViewed,
   recordToyOpen,
 } from '../assets/js/utils/growth-metrics.ts';
 
@@ -19,5 +23,43 @@ describe('growth metrics', () => {
     expect(snapshot.weeklyActiveDays).toBeGreaterThanOrEqual(1);
     expect(snapshot.toyOpens).toBe(1);
     expect(snapshot.recentToySlugs).toEqual(['aurora-painter']);
+  });
+
+  test('emits non-persistent opportunity signals', () => {
+    let opportunityEvents = 0;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ name: string }>).detail;
+      if (detail?.name === 'opportunity_interest') {
+        opportunityEvents += 1;
+      }
+    };
+
+    window.addEventListener('stims:growth-event', handler as EventListener);
+    recordOpportunityInterest('creator-mode');
+    recordOpportunityContact('creator-mode');
+    window.removeEventListener('stims:growth-event', handler as EventListener);
+
+    expect(opportunityEvents).toBe(1);
+    const raw = window.localStorage.getItem('stims-growth-metrics-v1') ?? '';
+    expect(raw).not.toContain('opportunitySignals');
+  });
+
+  test('emits non-persistent segment signals', () => {
+    let segmentEvents = 0;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ name: string }>).detail;
+      if (detail?.name === 'segment_plan_viewed') {
+        segmentEvents += 1;
+      }
+    };
+
+    window.addEventListener('stims:growth-event', handler as EventListener);
+    recordSegmentPlanViewed('education-enrichment');
+    recordSegmentPlanContact('education-enrichment');
+    window.removeEventListener('stims:growth-event', handler as EventListener);
+
+    expect(segmentEvents).toBe(1);
+    const raw = window.localStorage.getItem('stims-growth-metrics-v1') ?? '';
+    expect(raw).not.toContain('segmentSignals');
   });
 });

--- a/tests/init-opportunity-signals.test.ts
+++ b/tests/init-opportunity-signals.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { initOpportunitySignals } from '../assets/js/utils/init-opportunity-signals.ts';
+
+describe('opportunity signal interactions', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('stims:growth-lab-enabled', '1');
+    document.body.innerHTML = `
+      <div data-opportunity-signals>
+        <select data-opportunity-priority-select>
+          <option value="creator-mode" selected>Creator mode</option>
+          <option value="partnership-licensing">Partnership licensing</option>
+        </select>
+        <button type="button" data-opportunity-action="interest">Cast priority vote</button>
+        <a href="https://github.com/zz-plant/stims/discussions/new" data-opportunity-action="contact">Share your use case</a>
+
+        <select data-segment-select>
+          <option value="experiential-installations" selected>Experiential</option>
+          <option value="wellness-focus-environments">Wellness</option>
+        </select>
+        <button type="button" data-segment-action="preview">Mark segment priority</button>
+        <a href="https://github.com/zz-plant/stims/discussions/new" data-segment-action="contact">Discuss a pilot</a>
+        <p data-segment-outcome></p>
+
+        <p data-opportunity-summary></p>
+      </div>
+    `;
+  });
+
+  test('records selected priority vote and updates summary copy', () => {
+    initOpportunitySignals();
+
+    const button = document.querySelector<HTMLButtonElement>(
+      '[data-opportunity-action="interest"]',
+    );
+    const summary = document.querySelector<HTMLElement>(
+      '[data-opportunity-summary]',
+    );
+
+    expect(button).not.toBeNull();
+    button?.click();
+
+    expect(button?.textContent).toContain('Vote recorded');
+    expect(summary?.textContent).toContain('server endpoint');
+  });
+
+  test('keeps panel hidden when growth lab mode is disabled', () => {
+    window.localStorage.removeItem('stims:growth-lab-enabled');
+    const panel = document.querySelector<HTMLElement>(
+      '[data-opportunity-signals]',
+    );
+
+    initOpportunitySignals();
+
+    expect(panel?.hasAttribute('hidden')).toBe(true);
+  });
+
+  test('updates discussion draft URL to match selected track', () => {
+    initOpportunitySignals();
+
+    const select = document.querySelector<HTMLSelectElement>(
+      '[data-opportunity-priority-select]',
+    );
+    const link = document.querySelector<HTMLAnchorElement>(
+      '[data-opportunity-action="contact"]',
+    );
+
+    expect(link).not.toBeNull();
+    if (select) select.value = 'partnership-licensing';
+    select?.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    const href = link?.getAttribute('href') ?? '';
+    expect(href).toContain('Interest%3A+Partnership+licensing');
+  });
+
+  test('shows concise prioritized outcome for selected segment and segment draft URL', () => {
+    initOpportunitySignals();
+
+    const preview = document.querySelector<HTMLButtonElement>(
+      '[data-segment-action="preview"]',
+    );
+    const link = document.querySelector<HTMLAnchorElement>(
+      '[data-segment-action="contact"]',
+    );
+    const outcome = document.querySelector<HTMLElement>(
+      '[data-segment-outcome]',
+    );
+    const segmentSelect = document.querySelector<HTMLSelectElement>(
+      '[data-segment-select]',
+    );
+
+    if (segmentSelect) segmentSelect.value = 'wellness-focus-environments';
+    segmentSelect?.dispatchEvent(new window.Event('change', { bubbles: true }));
+    preview?.click();
+
+    expect(outcome?.textContent).toContain('P1:');
+    expect(outcome?.textContent).toContain('Unlocks');
+    expect(link?.href ?? '').toContain(
+      'Pilot+interest%3A+Wellness+%2F+focus+environments',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Remove growth-lab validation controls from the public homepage and make internal validation tooling opt-in on a separate page, while keeping non-sensitive local metrics intact and routing validation events to an optional server endpoint.

### Description
- Stop initializing opportunity signals from the main app shell by removing the `initOpportunitySignals` boot from `assets/js/app.ts` and keep homepage boot light.
- Add a dedicated internal entry module `assets/js/growth-lab-entry.ts` and page `growth-lab.html` that enable growth-lab mode and mount the existing opportunity/segment controls only on that internal page.
- Introduce `assets/js/utils/init-opportunity-signals.ts` to gate and wire the growth-lab UI based on a `stims:growth-lab-enabled` flag or `?growth-lab=1` URL param, preserving UI interactions and discussion-draft links.
- Extend `assets/js/utils/growth-metrics.ts` with non-persistent opportunity/segment APIs and optional server-side signaling (`navigator.sendBeacon` with a `fetch(..., { keepalive: true })` fallback), while keeping the persisted `GrowthState` limited to non-sensitive metrics.
- Add `.growth-tracks` styles to `assets/css/index.css` and update/add tests (`tests/growth-metrics.test.ts`, `tests/init-opportunity-signals.test.ts`).

### Testing
- Ran the quality gate with `bun run check`; most tests passed but the run failed in this environment due to unrelated Three.js module export/resolution errors causing a few toy-module tests to fail (4 failed, 1 error); the growth-related tests passed.
- Launched the dev server with `bun run dev:host` successfully and captured Playwright screenshots of the public homepage (growth panel removed) and the dedicated `growth-lab.html` page.
- Executed unit tests for growth tooling and initializers; `tests/init-opportunity-signals.test.ts` and the extended growth assertions in `tests/growth-metrics.test.ts` passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699550194b108332a44b05c858ce9eda)