### PR TITLE
Simplify and redesign performance checking flow

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2088,16 +2088,9 @@ body {
 
 .preflight-panel__statuses {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: 1fr;
   gap: 10px;
-  margin: 8px 0;
-}
-
-.preflight-panel__secondary-note {
-  grid-column: 1 / -1;
-  margin: 2px 0 0;
-  font-size: 0.82rem;
-  color: rgba(233, 251, 255, 0.72);
+  margin: 10px 0;
 }
 
 .preflight-status {
@@ -2110,6 +2103,19 @@ body {
     rgba(255, 255, 255, 0.01)
   );
   box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);
+}
+
+.preflight-status--primary {
+  border-width: 1px;
+  background: linear-gradient(
+    145deg,
+    rgba(125, 211, 252, 0.14),
+    rgba(15, 23, 42, 0.55)
+  );
+}
+
+.preflight-status--secondary {
+  background: rgba(8, 14, 28, 0.5);
 }
 
 .preflight-dialog .control-panel__actions {

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2089,13 +2089,13 @@ body {
 .preflight-panel__statuses {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 10px;
-  margin: 10px 0;
+  gap: 8px;
+  margin: 8px 0;
 }
 
 .preflight-status {
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(
     135deg,
@@ -2106,15 +2106,16 @@ body {
 }
 
 .preflight-status--primary {
-  border-width: 1px;
+  border-color: rgba(125, 211, 252, 0.46);
   background: linear-gradient(
     145deg,
-    rgba(125, 211, 252, 0.14),
-    rgba(15, 23, 42, 0.55)
+    rgba(125, 211, 252, 0.16),
+    rgba(15, 23, 42, 0.58)
   );
 }
 
-.preflight-status--secondary {
+.preflight-status--supporting {
+  border-color: rgba(255, 255, 255, 0.12);
   background: rgba(8, 14, 28, 0.5);
 }
 


### PR DESCRIPTION
### Motivation
- Make the preflight/system-check experience clearer by consolidating multiple status messages into a single, prominent performance summary plus a secondary audio card so users can quickly understand readiness and next actions.
- Surface a simpler, action-focused copy and visual hierarchy so the retry and continue flows are more discoverable on constrained devices.

### Description
- Add a helper `getPerformanceCheckSummary` to centralize logic that derives a single performance status from rendering capabilities and device heuristics and use it to render the UI in `assets/js/core/capability-preflight.ts`.
- Replace the previous multi-message rendering status with a primary "Performance check" card and rename the microphone card to "Audio input" (logic and labels updated in `assets/js/core/capability-preflight.ts`).
- Add presentation classes `.preflight-status--primary` and `.preflight-status--secondary` and switch the status layout to a top-to-bottom stack in `assets/css/base.css` to emphasize the performance card.
- Update preflight copy and controls for clarity: panel intro, details summary label (now "What we checked"), issue heading text, and retry button text (now "Re-check performance").

### Testing
- Ran `bun run check` (Biome checks + TypeScript typecheck + test suite) and it completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fa9a988883329b05432e77d0a61a)