### PR TITLE
Implement toy-page quick wins: starter preset and dismissible gesture hints

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1060,6 +1060,14 @@ body {
   gap: 8px;
 }
 
+.control-panel__first-steps-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .control-panel__dismiss {
   min-height: 44px;
   min-width: 44px;

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ If you need to...
 - [`toys.md`](./toys.md) — per-toy notes and implementation details.
 - [`MCP_SERVER.md`](./MCP_SERVER.md) — MCP stdio server usage.
 - [`FULL_REFACTOR_PLAN.md`](./FULL_REFACTOR_PLAN.md) — staged refactor roadmap.
+- [`TECH_DEBT_REGISTER_2026-02.md`](./TECH_DEBT_REGISTER_2026-02.md) — prioritized technical debt inventory and next steps.
 
 ### Product, UX, and research docs
 

--- a/docs/TECH_DEBT_REGISTER_2026-02.md
+++ b/docs/TECH_DEBT_REGISTER_2026-02.md
@@ -1,0 +1,104 @@
+# Technical debt register (2026-02)
+
+This register captures the highest-impact technical debt observed in the current repository layout and tooling.
+
+## How this was identified
+
+- Reviewed architecture and refactor docs for already-known pain points.
+- Measured large files and generated-page footprint to identify maintenance hotspots.
+- Compared toy implementation inventory to toy-specific tests to find coverage gaps.
+
+## Prioritized debt items
+
+### 1) Oversized runtime modules increase change risk
+
+**Why this is debt**
+
+Several core runtime/UI files are very large (`assets/js/library-view.js` at 2676 lines, `assets/js/core/capability-preflight.ts` at 935 lines, and `assets/js/loader.ts` at 651 lines). Large multipurpose modules are harder to reason about, harder to test in isolation, and increase merge-conflict probability.
+
+**Impact**
+
+- Slower contributor onboarding for runtime changes.
+- Higher regression risk when touching navigation, capability gating, or library rendering.
+- More difficult test targeting because responsibilities are mixed.
+
+**Recommended next step**
+
+Split by responsibility first (state model, DOM rendering, and side-effects), then backfill focused unit tests per extracted module.
+
+---
+
+### 2) SEO/static artifact sprawl in `public/` creates sync overhead
+
+**Why this is debt**
+
+`public/` currently contains 111 checked-in `index.html` pages (including 60 tag pages and 21 mood pages). This improves deploy simplicity but raises maintenance burden and increases the risk of stale generated artifacts if source metadata changes without regeneration.
+
+**Impact**
+
+- Large review diffs for taxonomy/content updates.
+- Potential drift between source metadata and generated output.
+- Longer CI and local verification loops when broad regeneration is needed.
+
+**Recommended next step**
+
+Introduce deterministic generation checks in CI as a required gate for PRs touching toy metadata/taxonomy, and consider reducing committed generated surface where hosting requirements allow.
+
+---
+
+### 3) Toy-level test coverage is uneven versus toy inventory size
+
+**Why this is debt**
+
+There are 26 TypeScript toy modules in `assets/js/toys`, but only a small subset have direct toy-specific test files by slug naming convention. Core/runtime tests are present, but individual toy behavior can regress without focused coverage.
+
+**Impact**
+
+- Higher risk of visual/audio regressions slipping through when editing toy modules.
+- More manual playtesting burden per release.
+
+**Recommended next step**
+
+Set a minimum policy for toy-specific smoke tests (for example: module loads, starts, and disposes cleanly) and apply it incrementally to high-traffic toys first.
+
+---
+
+### 4) Source-of-truth duplication still requires strict discipline
+
+**Why this is debt**
+
+Toy metadata exists in `assets/data/toys.json` while deploy output also includes `public/toys.json`. Even with generation tooling, maintaining dual representations always carries drift risk if process adherence slips.
+
+**Impact**
+
+- Confusing edit surface for new contributors.
+- Risk of stale metadata in deploy artifacts when generation steps are skipped.
+
+**Recommended next step**
+
+Strengthen contributor docs and pre-commit/CI checks to make drift impossible to merge.
+
+---
+
+### 5) Refactor roadmap exists, but execution checkpoints are not yet visible as tracked milestones
+
+**Why this is debt**
+
+A strong staged plan exists in `docs/FULL_REFACTOR_PLAN.md`, including workstreams and exit criteria, but without a linked status tracker contributors cannot quickly see what has been completed versus pending.
+
+**Impact**
+
+- Refactor intent may not consistently translate into day-to-day PR sequencing.
+- Teams can duplicate effort or skip prerequisite work.
+
+**Recommended next step**
+
+Add a lightweight status board (for example, checklist section in the refactor doc or linked issue milestones) and update it with each refactor PR.
+
+## Suggested order of execution
+
+1. Break up oversized runtime modules (highest leverage for maintainability).
+2. Add toy smoke-test baseline for the most-used toys.
+3. Tighten generated-artifact drift checks for metadata/SEO pages.
+4. Establish visible milestone tracking for the existing refactor plan.
+5. Re-assess debt quarterly and refresh this register.

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -7,6 +7,7 @@ describe('audio controls primary emphasis', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
     sessionStorage.clear();
+    localStorage.clear();
     const bootstrapScript = document.createElement('script');
     document.body.appendChild(bootstrapScript);
     globalThis.HTMLButtonElement =
@@ -162,6 +163,57 @@ describe('audio controls primary emphasis', () => {
 
     expect(firstSteps.hidden).toBe(true);
     expect(sessionStorage.getItem('stims-first-steps-dismissed')).toBe('true');
+  });
+
+  test('applies low-motion starter preset from first-steps quick action', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const starterPresetButton = container.querySelector(
+      '[data-apply-starter-preset]',
+    ) as HTMLButtonElement;
+    starterPresetButton.click();
+
+    expect(localStorage.getItem('stims:quality-preset')).toBe('low-motion');
+
+    const status = container.querySelector('#audio-status') as HTMLElement;
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toContain('Starter preset applied');
+  });
+
+  test('hides gesture hints when dismissed by user', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      gestureHints: ['Pinch/rotate gestures', 'Drag to steer'],
+    });
+
+    const demoButton = container.querySelector(
+      '#use-demo-audio',
+    ) as HTMLButtonElement;
+    demoButton.click();
+    await flush();
+
+    const hintPanel = container.querySelector(
+      '[data-gesture-hints]',
+    ) as HTMLElement;
+    expect(hintPanel.hidden).toBe(false);
+
+    const dismiss = hintPanel.querySelector(
+      '[data-dismiss-gesture-hints]',
+    ) as HTMLButtonElement;
+    dismiss.click();
+
+    expect(hintPanel.hidden).toBe(true);
+    expect(sessionStorage.getItem('stims-gesture-hints-dismissed')).toBe(
+      'true',
+    );
   });
 
   test('updates onboarding source copy when demo is preferred', () => {


### PR DESCRIPTION
### Motivation

- Make high-reward, low-effort improvements to the toy audio onboarding so first-time users get an immediate “wow” and touch users see clearer guidance.  
- Provide a safe, reusable way for non-settings UI to apply quality presets and notify runtime subscribers.  

### Description

- Add `setQualityPresetById` to `assets/js/core/settings-panel.ts` to allow external UI to set a quality preset, persist it, and notify `subscribeToQualityPreset` subscribers.  
- Add a one-click starter action in the audio controls first-steps strip that applies the `low-motion` preset and surfaces success/error feedback (`assets/js/ui/audio-controls.ts`).  
- Improve touch onboarding by making gesture hints dismissible with an explicit “Got it” button and by persisting the dismissal in session storage, plus small auto-hide behavior refinements.  
- Add layout CSS for grouped first-step actions (`assets/css/base.css`) and extend `tests/audio-controls.test.ts` to cover the new starter preset action and gesture-hint dismissal.  

### Testing

- Ran the full quality gate with `bun run check`, which completed successfully.  
- Applied automatic lint/format fixes with `bun run lint:fix && bun run format`, which succeeded and was run by the pre-commit hooks.  
- Ran the test suite with `bun test`, which passed (169 tests run, 2 skipped, 0 failed).  
- Launched the dev server with `bun run dev` for a quick visual verification and captured a screenshot of the updated audio controls UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699620e0928883329748c35d8ee92fc7)