### PR TITLE
Reduce duplicated first-step actions on home and onboarding

### DIFF
--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -716,17 +716,6 @@ export function attachCapabilityPreflight({
     backLink.hidden = true;
     actions.appendChild(backLink);
   }
-  const continueButton = document.createElement('button');
-  continueButton.className = 'cta-button primary';
-  continueButton.type = 'button';
-  continueButton.textContent = 'Continue to audio setup';
-  continueButton.hidden = true;
-  continueButton.addEventListener('click', () => {
-    setRememberPreference(rememberToggle.checked);
-    closePanel();
-  });
-  actions.appendChild(continueButton);
-
   panel.appendChild(actions);
 
   const retryButton = document.createElement('button');
@@ -740,21 +729,24 @@ export function attachCapabilityPreflight({
   const applyActionPriority = (result: CapabilityPreflightResult | null) => {
     if (!result) {
       if (closeButton) closeButton.hidden = false;
-      continueButton.hidden = true;
       performanceButton.hidden = true;
       if (backLink) backLink.hidden = true;
       return;
     }
 
     if (result.canProceed) {
-      continueButton.hidden = false;
       if (backLink) backLink.hidden = true;
-      if (closeButton) closeButton.hidden = true;
+      if (closeButton) {
+        closeButton.hidden = false;
+        closeButton.textContent = 'Start audio options';
+      }
       performanceButton.hidden = !result.performance.lowPower;
       return;
     }
 
-    continueButton.hidden = true;
+    if (closeButton) {
+      closeButton.textContent = 'Close';
+    }
     performanceButton.hidden = true;
     if (backLink) {
       backLink.hidden = false;

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -2335,31 +2335,6 @@ export function createLibraryView({
     updateActiveFiltersSummary();
   };
 
-  const clearAllFilters = () => {
-    searchQuery = '';
-    activeFilters.clear();
-    const chips = document.querySelectorAll('[data-filter-chip].is-active');
-    chips.forEach((chip) => {
-      chip.classList.remove('is-active');
-      updateFilterChipA11y(chip, false);
-    });
-    emitFilterStateChange();
-
-    if (searchInputId) {
-      const search = document.getElementById(searchInputId);
-      if (search && 'value' in search) {
-        search.value = '';
-      }
-    }
-
-    commitState({ replace: false });
-    syncRefineDisclosure();
-    renderToys(applyFilters());
-    updateSearchClearState();
-    updateFilterResetState();
-    updateActiveFiltersSummary();
-  };
-
   const removeFilterToken = (token) => {
     const [type, value] = token.split(':');
     if (!type || !value) return;
@@ -2456,7 +2431,7 @@ export function createLibraryView({
       clearButton instanceof HTMLElement &&
       clearButton.tagName === 'BUTTON'
     ) {
-      clearButton.addEventListener('click', () => clearAllFilters());
+      clearButton.addEventListener('click', () => clearFilters());
     }
   };
 

--- a/index.html
+++ b/index.html
@@ -162,9 +162,9 @@
         <search class="library-search">
           <section class="starter-picks" aria-label="Recommended starter picks">
             <div class="starter-picks__grid">
-              <a href="toy.html?toy=holy" class="starter-pick" data-quickstart-slug="holy">
-                <strong>Halo Flow</strong>
-                <span>Balanced and calm-friendly</span>
+              <a href="toy.html?toy=seary" class="starter-pick" data-quickstart-slug="seary">
+                <strong>Seary</strong>
+                <span>Ambient and low-pressure</span>
               </a>
               <a
                 href="toy.html?toy=aurora-painter"


### PR DESCRIPTION
### Motivation
- Remove duplicated first-step entry points so the intro CTA and starter picks do not launch the same toy immediately. 
- Unify filter-reset language and behavior so the active-filters clear control only clears filters (not search), avoiding competing reset affordances. 
- Simplify the preflight/onboarding action surface to avoid multiple progression controls in the same first-run step.

### Description
- Swapped the first starter pick in the library from `holy` to `seary` and updated its label and helper copy in `index.html` so it no longer duplicates the hero CTA. 
- Replaced the previous `clearAllFilters` path with a single `clearFilters()` flow and wired the active-filters clear button to `clearFilters()` in `assets/js/library-view.js`, removing the code path that also cleared search. 
- Simplified capability preflight controls in `assets/js/core/capability-preflight.ts` by removing the separate “Continue to audio setup” button and reusing the existing close/start button, switching its label to `Start audio options` when the preflight result allows proceeding.

### Testing
- Ran the full quality gate with `bun run check`, which completed successfully and reported the test run as passing (automated test suite: all tests passed with 167 passing and 2 skipped, 0 failed). 
- Linted/format checks (Biome) and TypeScript typecheck ran as part of `bun run check` and reported no issues. 
- No docs changed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699632631b048332a1b371ef5c349def)