### PR TITLE
Clarify advanced audio labels and preflight handoff

### DIFF
--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -627,12 +627,14 @@ export function attachCapabilityPreflight({
 
   const description = document.createElement('p');
   description.className = 'control-panel__description';
-  description.textContent = 'One short performance check before audio setup.';
+  description.textContent =
+    'Quick performance check so your audio options open with fewer surprises.';
   panel.appendChild(description);
 
   const sequenceHint = document.createElement('p');
   sequenceHint.className = 'control-panel__microcopy';
-  sequenceHint.textContent = 'Tip: demo audio is usually the fastest start.';
+  sequenceHint.textContent =
+    'Tip: demo audio is usually the fastest way to begin.';
   panel.appendChild(sequenceHint);
 
   const statusContainer = document.createElement('div');
@@ -738,7 +740,7 @@ export function attachCapabilityPreflight({
       if (backLink) backLink.hidden = true;
       if (closeButton) {
         closeButton.hidden = false;
-        closeButton.textContent = 'Start audio options';
+        closeButton.textContent = 'Open audio options';
       }
       performanceButton.hidden = !result.performance.lowPower;
       return;

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -148,7 +148,7 @@ export function initAudioControls(
               type="button"
               aria-describedby="tab-audio-info"
             >
-              More info
+              Tab tips
             </button>
             <span id="tab-audio-info" class="control-panel__info-text">
               Capture sound from the current tab. In the picker, choose “This tab” and enable
@@ -173,7 +173,7 @@ export function initAudioControls(
               type="button"
               aria-describedby="youtube-audio-info"
             >
-              More info
+              YouTube tips
             </button>
             <span id="youtube-audio-info" class="control-panel__info-text">
               Paste a link, load it, then capture. In the picker, choose “This tab” and enable


### PR DESCRIPTION
### Motivation
- Reduce repeated "More info" affordances in the advanced audio panel to lower scan cost and soften preflight copy to make the transition into audio setup feel less like a duplicate gating step.

### Description
- Rename advanced audio info buttons in `assets/js/ui/audio-controls.ts` from `More info` to `Tab tips` and `YouTube tips`, and update preflight copy in `assets/js/core/capability-preflight.ts` by changing the description and microcopy and replacing the CTA `Start audio options` with `Open audio options`.

### Testing
- Ran `bun run check` (Biome checks + TypeScript typecheck + test suite) and it completed successfully with the test suite passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996355c5e908332ae93d838679da7e4)