### PR TITLE
Remove generated PNG binaries and reference shared PNG OG icon

### DIFF
--- a/docs/SEO_AUDIT.md
+++ b/docs/SEO_AUDIT.md
@@ -1,96 +1,52 @@
-# SEO Audit (2026-02-11)
+# SEO Audit (2026-02-18)
 
 ## Scope
 
-This audit reviews the current static SEO surface for the Stim Webtoys Library:
+This audit reviews the production SEO surface for [https://no.toil.fyi](https://no.toil.fyi):
 
-- Core homepage metadata (`index.html`)
-- Programmatically generated landing pages (`public/toys`, `public/tags`, `public/moods`, `public/capabilities`)
-- Discovery assets (`public/robots.txt`, `public/sitemap.xml`, `public/sitemap-1.xml`)
-- SEO generation workflow (`scripts/generate-seo.ts`)
+- Homepage metadata and structured data (`/`)
+- Representative toy landing page (`/toys/cube-wave/`)
+- Discovery assets (`/robots.txt`, `/sitemap.xml`, `/sitemap-1.xml`)
+- Generator/check workflow (`scripts/generate-seo.ts`, `scripts/check-seo.ts`)
 
 ## Executive summary
 
-The project has a **strong SEO baseline** for a static creative site:
+The site now has solid technical SEO defaults and the two highest-priority opportunities from the previous audit are addressed:
 
-- Canonical URLs and social metadata are present on the homepage and generated hub/detail pages.
-- JSON-LD is implemented for `WebSite`, `CollectionPage`, `ItemList`, `FAQPage`, and breadcrumbs.
-- Crawl directives and sitemap discovery are configured via `robots.txt` + sitemap index/chunk files.
-- The SEO page surface is generated from toy metadata, which improves consistency and scale.
+- **P0 complete:** generated SEO pages now use PNG social images (`og:image`) with explicit `image/png` type metadata.
+- **P1 complete:** sitemap chunk entries include per-URL `lastmod` values.
 
-Primary opportunities are around **social preview robustness**, **richer crawl hints**, and **ongoing audit automation**.
+Other foundations remain strong: canonical tags, robots directives, JSON-LD on major pages, and sitemap discovery via `robots.txt`.
 
-## Strengths observed
+## What changed in this cycle
 
-1. **Homepage metadata completeness**
-   - Includes canonical, Open Graph, Twitter, description, robots, and structured data graph.
-2. **Programmatic SEO coverage**
-   - Dedicated index pages exist for toys, tags, moods, and capabilities.
-   - Toy detail pages include FAQs and breadcrumbs in both UI and JSON-LD.
-3. **Crawlability**
-   - `robots.txt` allows crawling and links the sitemap index.
-   - Sitemap index references chunked sitemap files for scale.
-4. **Deterministic SEO generation pipeline**
-   - `bun run generate:seo` can regenerate OG images/pages/sitemaps from metadata.
+### P0 — Improve social share reliability (completed)
 
-## Risks and recommendations
+- `scripts/generate-seo.ts` now publishes generated pages with PNG OG metadata using the existing site icon (`/icons/icon-512.png`).
+- Generated pages now use PNG for OG/Twitter image references and metadata:
+  - `og:image` points to a PNG asset
+  - `og:image:type` is `image/png`
+  - width/height metadata is present
 
-### 1) Use PNG/JPG Open Graph images in addition to SVG
+### P1 — Strengthen crawl freshness hints (completed)
 
-- **Why:** Some social/link unfurlers inconsistently render SVG OG assets.
-- **Current state:** Generated SEO pages frequently point `og:image` to `.svg` assets under `/og/`.
-- **Recommendation:** Generate PNG derivatives for each OG card and set:
-  - `og:image` to PNG,
-  - `og:image:type` to `image/png`,
-  - dimensions (`og:image:width`, `og:image:height`) across generated pages.
-- **Priority:** High (share-preview reliability)
+- `sitemap-*.xml` URL entries include per-URL `lastmod` values.
+- `scripts/check-seo.ts` validates this behavior.
 
-### 2) Add `lastmod` to each URL entry in sitemap chunks
+## Remaining recommendations (lower priority)
 
-- **Why:** Per-URL freshness signals can help crawlers prioritize recrawls.
-- **Current state:** Sitemap index has `lastmod`; chunk entries should also carry `lastmod` where possible.
-- **Recommendation:** Extend `scripts/generate-seo.ts` to emit per-URL `lastmod` values in `sitemap-*.xml`.
-- **Priority:** Medium
-
-### 3) Validate canonical consistency between `/` and `/index.html`
-
-- **Why:** Duplicate home URLs can split equity if canonical behavior diverges across hosts/CDNs.
-- **Current state:** Canonical points to `/`; generated pages mostly link to directory-style canonicals.
-- **Recommendation:** Keep strict redirects from `/index.html` → `/` at edge/server level and periodically verify in production.
-- **Priority:** Medium
-
-### 4) Add a repeatable SEO audit script/check
-
-- **Why:** Prevents regressions as metadata/page templates evolve.
-- **Current state:** SEO generation exists; automated SEO validation is not yet explicit.
-- **Recommendation:** Add a lightweight `seo:check` script to verify:
-  - required meta tags,
-  - canonical presence,
-  - structured-data JSON parseability,
-  - sitemap URL validity,
-  - robots sitemap pointer.
-- **Priority:** Medium
-
-### 5) Optional: Add image sitemap support for OG assets
-
-- **Why:** Can improve image discoverability for rich cards/asset surfaces.
-- **Current state:** Standard sitemap coverage exists.
-- **Recommendation:** Evaluate image sitemap only if image search/referral becomes a KPI.
-- **Priority:** Low
-
-## Suggested implementation plan
-
-1. Update SEO generator to produce PNG OG assets and enriched OG meta fields.
-2. Add per-URL `lastmod` in sitemap chunks.
-3. Add `seo:check` script and include it in CI or scheduled checks.
-4. Run a production crawl sample (e.g., homepage + 3 toy pages + 3 taxonomy pages) after deploy.
+1. Generate dedicated 1200x630 PNG cards per toy instead of the shared 512x512 icon image.
+2. Optionally add image sitemap support if image search becomes a KPI.
+3. Continue periodic production checks for `/index.html` → `/` redirect behavior.
 
 ## Validation commands run for this audit
 
 - `bun run generate:seo`
-- `sed -n '1,120p' index.html`
-- `sed -n '1,220p' public/toys/index.html`
-- `sed -n '1,220p' public/toys/cube-wave/index.html`
-- `cat public/robots.txt`
-- `sed -n '1,220p' public/sitemap.xml`
-- `sed -n '1,260p' scripts/generate-seo.ts`
+- `bun run check:seo`
+- `curl -sS https://no.toil.fyi/ -o /tmp/no_toil_home.html`
+- `curl -sS https://no.toil.fyi/toys/cube-wave/ -o /tmp/no_toil_cube_wave.html`
+- `curl -sS https://no.toil.fyi/robots.txt -o /tmp/no_toil_robots.txt`
+- `curl -sS https://no.toil.fyi/sitemap.xml -o /tmp/no_toil_sitemap.xml`
+- `curl -sS https://no.toil.fyi/sitemap-1.xml -o /tmp/no_toil_sitemap1.xml`
+- `curl -sSI https://no.toil.fyi/`
+- `curl -sSI https://no.toil.fyi/index.html`

--- a/public/capabilities/demo-audio/index.html
+++ b/public/capabilities/demo-audio/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/demo-audio/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/capabilities/index.html
+++ b/public/capabilities/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/capabilities/microphone/index.html
+++ b/public/capabilities/microphone/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/microphone/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/capabilities/motion/index.html
+++ b/public/capabilities/motion/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/motion/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/capabilities/webgpu/index.html
+++ b/public/capabilities/webgpu/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/webgpu/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/calming/index.html
+++ b/public/moods/calming/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/calming/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/celestial/index.html
+++ b/public/moods/celestial/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/celestial/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/cosmic/index.html
+++ b/public/moods/cosmic/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/cosmic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/dreamy/index.html
+++ b/public/moods/dreamy/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/dreamy/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/drifting/index.html
+++ b/public/moods/drifting/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/drifting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/energetic/index.html
+++ b/public/moods/energetic/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/energetic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/ethereal/index.html
+++ b/public/moods/ethereal/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/ethereal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/fiery/index.html
+++ b/public/moods/fiery/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/fiery/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/focus/index.html
+++ b/public/moods/focus/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/focus/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/glow/index.html
+++ b/public/moods/glow/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/glow/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/grounded/index.html
+++ b/public/moods/grounded/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/grounded/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/immersive/index.html
+++ b/public/moods/immersive/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/immersive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/index.html
+++ b/public/moods/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/luminous/index.html
+++ b/public/moods/luminous/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/luminous/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/minimal/index.html
+++ b/public/moods/minimal/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/minimal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/playful/index.html
+++ b/public/moods/playful/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/playful/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/psychedelic/index.html
+++ b/public/moods/psychedelic/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/psychedelic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/pulsing/index.html
+++ b/public/moods/pulsing/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/pulsing/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/serene/index.html
+++ b/public/moods/serene/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/serene/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/tactile/index.html
+++ b/public/moods/tactile/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/tactile/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/moods/uplifting/index.html
+++ b/public/moods/uplifting/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/uplifting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/sitemap-1.xml
+++ b/public/sitemap-1.xml
@@ -2,679 +2,679 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://no.toil.fyi/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/index.html</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/3dtoy/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/aurora-painter/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/clay/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/evol/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/geom/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/holy/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/multi/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/seary/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/legible/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/symph/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cube-wave/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bubble-harmonics/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/pocket-pulse/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/mobile-ripples/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cosmic-particles/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/lights/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/spiral-burst/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/rainbow-tunnel/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/star-field/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/fractal-kite-garden/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/tactile-sand-table/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bioluminescent-tidepools/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/neon-wave/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/milkdrop/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/3d/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ambient/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/audio-mapped/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/aurora/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bioluminescent/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bloom/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bubbles/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/burst/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/calming/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/caustics/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/cyberpunk/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/evolutionary/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/feedback/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/fractal/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/generative/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/geometry/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/gestural/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/glitch/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/grid/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/halos/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/haptics/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/harmonics/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/hybrid/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/immersive/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/kite/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/legacy/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/lights/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/microphone/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mobile/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mode-switch/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/motion/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/nebula/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ocean/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/palette/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/particles/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/patterns/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pottery/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pulses/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/rainbow/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/reactive/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/retro/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ribbons/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ripples/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sand/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sculpting/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/shader/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spectrograph/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spirals/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/stars/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/swirl/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synesthetic/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synthwave/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/text/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tilt/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/touch/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tunnel/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/visualizer/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/warp/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/waves/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/calming/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/celestial/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/cosmic/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/dreamy/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/drifting/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/energetic/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/ethereal/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/fiery/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/focus/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/glow/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/grounded/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/immersive/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/luminous/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/minimal/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/playful/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/psychedelic/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/pulsing/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/serene/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/tactile/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/uplifting/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/microphone/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/demo-audio/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/motion/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/webgpu/</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://no.toil.fyi/sitemap-1.xml</loc>
-    <lastmod>2026-02-11</lastmod>
+    <lastmod>2026-02-18</lastmod>
   </sitemap>
 </sitemapindex>

--- a/public/tags/3d/index.html
+++ b/public/tags/3d/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/3d/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/ambient/index.html
+++ b/public/tags/ambient/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ambient/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/audio-mapped/index.html
+++ b/public/tags/audio-mapped/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/audio-mapped/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/aurora/index.html
+++ b/public/tags/aurora/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/aurora/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/bioluminescent/index.html
+++ b/public/tags/bioluminescent/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bioluminescent/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/bloom/index.html
+++ b/public/tags/bloom/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bloom/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/bubbles/index.html
+++ b/public/tags/bubbles/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bubbles/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/burst/index.html
+++ b/public/tags/burst/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/burst/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/calming/index.html
+++ b/public/tags/calming/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/calming/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/caustics/index.html
+++ b/public/tags/caustics/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/caustics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/cyberpunk/index.html
+++ b/public/tags/cyberpunk/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/cyberpunk/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/evolutionary/index.html
+++ b/public/tags/evolutionary/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/evolutionary/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/feedback/index.html
+++ b/public/tags/feedback/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/feedback/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/fractal/index.html
+++ b/public/tags/fractal/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/fractal/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/generative/index.html
+++ b/public/tags/generative/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/generative/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/geometry/index.html
+++ b/public/tags/geometry/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/geometry/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/gestural/index.html
+++ b/public/tags/gestural/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/gestural/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/glitch/index.html
+++ b/public/tags/glitch/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/glitch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/grid/index.html
+++ b/public/tags/grid/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/grid/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/halos/index.html
+++ b/public/tags/halos/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/halos/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/haptics/index.html
+++ b/public/tags/haptics/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/haptics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/harmonics/index.html
+++ b/public/tags/harmonics/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/harmonics/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/hybrid/index.html
+++ b/public/tags/hybrid/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/hybrid/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/immersive/index.html
+++ b/public/tags/immersive/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/immersive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/kite/index.html
+++ b/public/tags/kite/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/kite/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/legacy/index.html
+++ b/public/tags/legacy/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/legacy/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/lights/index.html
+++ b/public/tags/lights/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/lights/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/microphone/index.html
+++ b/public/tags/microphone/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/microphone/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/mobile/index.html
+++ b/public/tags/mobile/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mobile/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/mode-switch/index.html
+++ b/public/tags/mode-switch/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mode-switch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/motion/index.html
+++ b/public/tags/motion/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/motion/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/nebula/index.html
+++ b/public/tags/nebula/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/nebula/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/ocean/index.html
+++ b/public/tags/ocean/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ocean/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/palette/index.html
+++ b/public/tags/palette/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/palette/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/particles/index.html
+++ b/public/tags/particles/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/particles/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/patterns/index.html
+++ b/public/tags/patterns/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/patterns/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/pottery/index.html
+++ b/public/tags/pottery/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pottery/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/pulses/index.html
+++ b/public/tags/pulses/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pulses/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/rainbow/index.html
+++ b/public/tags/rainbow/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/rainbow/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/reactive/index.html
+++ b/public/tags/reactive/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/reactive/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/retro/index.html
+++ b/public/tags/retro/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/retro/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/ribbons/index.html
+++ b/public/tags/ribbons/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ribbons/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/ripples/index.html
+++ b/public/tags/ripples/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ripples/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/sand/index.html
+++ b/public/tags/sand/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sand/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/sculpting/index.html
+++ b/public/tags/sculpting/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sculpting/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/shader/index.html
+++ b/public/tags/shader/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/shader/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/spectrograph/index.html
+++ b/public/tags/spectrograph/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spectrograph/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/spirals/index.html
+++ b/public/tags/spirals/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spirals/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/stars/index.html
+++ b/public/tags/stars/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/stars/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/swirl/index.html
+++ b/public/tags/swirl/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/swirl/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/synesthetic/index.html
+++ b/public/tags/synesthetic/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synesthetic/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/synthwave/index.html
+++ b/public/tags/synthwave/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synthwave/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/text/index.html
+++ b/public/tags/text/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/text/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/tilt/index.html
+++ b/public/tags/tilt/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tilt/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/touch/index.html
+++ b/public/tags/touch/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/touch/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/tunnel/index.html
+++ b/public/tags/tunnel/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tunnel/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/visualizer/index.html
+++ b/public/tags/visualizer/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/visualizer/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/warp/index.html
+++ b/public/tags/warp/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/warp/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/tags/waves/index.html
+++ b/public/tags/waves/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/waves/" />
     <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys Library icon" />

--- a/public/toys/3dtoy/index.html
+++ b/public/toys/3dtoy/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A twisting 3D tunnel that responds to sound." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/3dtoy/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/3dtoy.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="3D Toy preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="3D Toy | Stim Webtoys" />
     <meta name="twitter:description" content="A twisting 3D tunnel that responds to sound." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/3dtoy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="3D Toy preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/3dtoy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/aurora-painter/index.html
+++ b/public/toys/aurora-painter/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Paint flowing aurora ribbons that react to your microphone in layered waves." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/aurora-painter/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/aurora-painter.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Aurora Painter preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Aurora Painter | Stim Webtoys" />
     <meta name="twitter:description" content="Paint flowing aurora ribbons that react to your microphone in layered waves." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/aurora-painter.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Aurora Painter preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/aurora-painter/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/bioluminescent-tidepools/index.html
+++ b/public/toys/bioluminescent-tidepools/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Sketch glowing currents that bloom with high-frequency sparkle from your music." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/bioluminescent-tidepools/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/bioluminescent-tidepools.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Bioluminescent Tidepools preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bioluminescent Tidepools | Stim Webtoys" />
     <meta name="twitter:description" content="Sketch glowing currents that bloom with high-frequency sparkle from your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/bioluminescent-tidepools.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Bioluminescent Tidepools preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/bioluminescent-tidepools/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/bubble-harmonics/index.html
+++ b/public/toys/bubble-harmonics/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Translucent, audio-inflated bubbles that split into harmonics on high frequencies." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/bubble-harmonics/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/bubble-harmonics.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Bubble Harmonics preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bubble Harmonics | Stim Webtoys" />
     <meta name="twitter:description" content="Translucent, audio-inflated bubbles that split into harmonics on high frequencies." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/bubble-harmonics.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Bubble Harmonics preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/bubble-harmonics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/clay/index.html
+++ b/public/toys/clay/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/clay/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/clay.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Pottery Wheel Sculptor preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Pottery Wheel Sculptor | Stim Webtoys" />
     <meta name="twitter:description" content="Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/clay.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Pottery Wheel Sculptor preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/clay/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/cosmic-particles/index.html
+++ b/public/toys/cosmic-particles/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Jump between orbiting swirls and nebula fly-throughs with a single toggle." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/cosmic-particles/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/cosmic-particles.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Cosmic Particles preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Cosmic Particles | Stim Webtoys" />
     <meta name="twitter:description" content="Jump between orbiting swirls and nebula fly-throughs with a single toggle." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/cosmic-particles.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Cosmic Particles preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/cosmic-particles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/cube-wave/index.html
+++ b/public/toys/cube-wave/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Swap between cube waves and bouncing spheres without stopping the music." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/cube-wave/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/cube-wave.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Grid Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Grid Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Swap between cube waves and bouncing spheres without stopping the music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/cube-wave.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Grid Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/cube-wave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/evol/index.html
+++ b/public/toys/evol/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Watch surreal landscapes evolve with fractals and glitches that react to music." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/evol/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/evol.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Evolutionary Weirdcore preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Evolutionary Weirdcore | Stim Webtoys" />
     <meta name="twitter:description" content="Watch surreal landscapes evolve with fractals and glitches that react to music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/evol.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Evolutionary Weirdcore preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/evol/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/fractal-kite-garden/index.html
+++ b/public/toys/fractal-kite-garden/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Grow branching kite fractals that sway with mids and shimmer with crisp highs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/fractal-kite-garden/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/fractal-kite-garden.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Fractal Kite Garden preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Fractal Kite Garden | Stim Webtoys" />
     <meta name="twitter:description" content="Grow branching kite fractals that sway with mids and shimmer with crisp highs." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/fractal-kite-garden.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Fractal Kite Garden preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/fractal-kite-garden/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/geom/index.html
+++ b/public/toys/geom/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Push shifting geometric forms directly from live mic input with responsive controls." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/geom/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/geom.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Microphone Geometry Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Microphone Geometry Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Push shifting geometric forms directly from live mic input with responsive controls." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/geom.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Microphone Geometry Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/geom/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/holy/index.html
+++ b/public/toys/holy/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Layered halos, particles, and shapes that respond to your music." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/holy/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/holy.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Halo Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Halo Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Layered halos, particles, and shapes that respond to your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/holy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Halo Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/holy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/index.html
+++ b/public/toys/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Browse every audio-reactive visual toy for sensory play, calming exploration, and responsive creative visuals." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/default.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Stim Webtoys collection preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="All toys | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse every audio-reactive visual toy for sensory play, calming exploration, and responsive creative visuals." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/default.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys collection preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/legible/index.html
+++ b/public/toys/legible/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A retro green text grid that pulses to audio and surfaces fresh words as you play." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/legible/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/legible.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Terminal Word Grid preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terminal Word Grid | Stim Webtoys" />
     <meta name="twitter:description" content="A retro green text grid that pulses to audio and surfaces fresh words as you play." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/legible.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Terminal Word Grid preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/legible/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/lights/index.html
+++ b/public/toys/lights/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Swap shader styles and color palettes while lights ripple with your microphone input." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/lights/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/lights.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Audio Light Show preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Audio Light Show | Stim Webtoys" />
     <meta name="twitter:description" content="Swap shader styles and color palettes while lights ripple with your microphone input." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/lights.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Audio Light Show preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/lights/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/milkdrop/index.html
+++ b/public/toys/milkdrop/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/milkdrop/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/milkdrop.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="MilkDrop Proto preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="MilkDrop Proto | Stim Webtoys" />
     <meta name="twitter:description" content="A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/milkdrop.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="MilkDrop Proto preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/milkdrop/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/mobile-ripples/index.html
+++ b/public/toys/mobile-ripples/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Low-power neon ripples tuned for touch-first screens and pocket GPUs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/mobile-ripples/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/mobile-ripples.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Mobile Ripples preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Mobile Ripples | Stim Webtoys" />
     <meta name="twitter:description" content="Low-power neon ripples tuned for touch-first screens and pocket GPUs." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mobile-ripples.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Mobile Ripples preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/mobile-ripples/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/multi/index.html
+++ b/public/toys/multi/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Shapes and lights move with both sound and device motion." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/multi/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/multi.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Multi-Capability Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Multi-Capability Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Shapes and lights move with both sound and device motion." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/multi.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Multi-Capability Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/multi/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/neon-wave/index.html
+++ b/public/toys/neon-wave/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Retro-wave visualizer with bloom effects, custom shaders, and four color themes." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/neon-wave/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/neon-wave.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Neon Wave preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Neon Wave | Stim Webtoys" />
     <meta name="twitter:description" content="Retro-wave visualizer with bloom effects, custom shaders, and four color themes." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/neon-wave.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Neon Wave preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/neon-wave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/pocket-pulse/index.html
+++ b/public/toys/pocket-pulse/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A mobile-optimized pulse field that responds to audio and touch gestures." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/pocket-pulse/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/pocket-pulse.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Pocket Pulse preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Pocket Pulse | Stim Webtoys" />
     <meta name="twitter:description" content="A mobile-optimized pulse field that responds to audio and touch gestures." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/pocket-pulse.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Pocket Pulse preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/pocket-pulse/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/rainbow-tunnel/index.html
+++ b/public/toys/rainbow-tunnel/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Fly through colorful rings that spin to your music." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/rainbow-tunnel/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/rainbow-tunnel.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Rainbow Tunnel preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rainbow Tunnel | Stim Webtoys" />
     <meta name="twitter:description" content="Fly through colorful rings that spin to your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/rainbow-tunnel.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Rainbow Tunnel preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/rainbow-tunnel/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/seary/index.html
+++ b/public/toys/seary/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Blend audio and visuals into linked patterns." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/seary/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/seary.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Synesthetic Visualizer preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Synesthetic Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Blend audio and visuals into linked patterns." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/seary.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Synesthetic Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/seary/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/spiral-burst/index.html
+++ b/public/toys/spiral-burst/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Colorful spirals rotate and expand with every beat." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/spiral-burst/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/spiral-burst.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Spiral Burst preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spiral Burst | Stim Webtoys" />
     <meta name="twitter:description" content="Colorful spirals rotate and expand with every beat." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/spiral-burst.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Spiral Burst preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/spiral-burst/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/star-field/index.html
+++ b/public/toys/star-field/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A field of shimmering stars reacts to the beat." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/star-field/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/star-field.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Star Field preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Star Field | Stim Webtoys" />
     <meta name="twitter:description" content="A field of shimmering stars reacts to the beat." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/star-field.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Star Field preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/star-field/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/symph/index.html
+++ b/public/toys/symph/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="A spectrograph that moves gently with your audio." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/symph/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/symph.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Spectrograph preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spectrograph | Stim Webtoys" />
     <meta name="twitter:description" content="A spectrograph that moves gently with your audio." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/symph.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Spectrograph preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/symph/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/tactile-sand-table/index.html
+++ b/public/toys/tactile-sand-table/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Heightfield sand ripples that respond to bass, mids, and device tilt." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/tactile-sand-table/" />
-    <meta property="og:image" content="https://no.toil.fyi/og/tactile-sand-table.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Tactile Sand Table preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Tactile Sand Table | Stim Webtoys" />
     <meta name="twitter:description" content="Heightfield sand ripples that respond to bass, mids, and device tilt." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tactile-sand-table.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Tactile Sand Table preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/tactile-sand-table/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/scripts/check-seo.ts
+++ b/scripts/check-seo.ts
@@ -19,9 +19,10 @@ const requiredInIndexHtml = [
 ];
 
 const requiredInGeneratedToyPage = [
-  '<meta property="og:image:type" content="image/svg+xml"',
-  '<meta property="og:image:width" content="1200"',
-  '<meta property="og:image:height" content="630"',
+  '<meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png"',
+  '<meta property="og:image:type" content="image/png"',
+  '<meta property="og:image:width" content="512"',
+  '<meta property="og:image:height" content="512"',
   '<link rel="canonical" href="https://no.toil.fyi/toys/cube-wave/" />',
 ];
 

--- a/scripts/generate-seo.ts
+++ b/scripts/generate-seo.ts
@@ -73,7 +73,7 @@ const renderPage = ({
   extraHead = '',
   socialImage = iconUrl,
   socialImageAlt = 'Stim Webtoys Library icon',
-  socialImageType = 'image/svg+xml',
+  socialImageType = 'image/png',
   socialImageWidth = 512,
   socialImageHeight = 512,
 }: {
@@ -547,10 +547,6 @@ const generateSeo = async () => {
       }),
     )}</script>
 `,
-      socialImage: `${baseUrl}/og/default.svg`,
-      socialImageType: 'image/svg+xml',
-      socialImageWidth: ogWidth,
-      socialImageHeight: ogHeight,
       socialImageAlt: 'Stim Webtoys collection preview image',
     }),
   );
@@ -649,10 +645,6 @@ const generateSeo = async () => {
         extraHead: `
 ${extraHead}
 `,
-        socialImage: `${baseUrl}/og/${toy.slug}.svg`,
-        socialImageType: 'image/svg+xml',
-        socialImageWidth: ogWidth,
-        socialImageHeight: ogHeight,
         socialImageAlt: `${toy.title} preview image`,
       }),
     );


### PR DESCRIPTION
### Motivation

- Avoid committing generated binary artifacts by removing per-toy PNGs from the repository and keep SEO metadata binary-free. 
- Preserve the original intent to provide PNG OG metadata (explicit type/size) for better social preview reliability while not generating per-page PNG files.
- Keep sitemap freshness and other SEO improvements (per-URL `lastmod`) intact.

### Description

- Removed generated PNG binaries under `public/og/*.png` and stopped writing per-toy PNG files in `scripts/generate-seo.ts`, switching pages to reference the existing site icon PNG at `/icons/icon-512.png` instead. 
- Updated `scripts/generate-seo.ts` to default OG/Twitter metadata to `image/png` with `512×512` dimensions and to no longer copy or create PNG assets; SVG generation for cards is retained. 
- Updated `scripts/check-seo.ts` to assert the new shared icon PNG expectations for a representative toy page and kept robots/sitemap `lastmod` checks. 
- Regenerated static outputs so many `public/*` pages now reference the shared PNG icon (examples: `public/toys/*`, `public/tags/*`, `public/moods/*`) and updated `docs/SEO_AUDIT.md` to document the binary-free approach and follow-ups.

### Testing

- Ran `bun run generate:seo` and the generation completed successfully. 
- Ran `bun run check:seo` and all assertions passed (homepage OG/canonical, toy page PNG metadata, robots and sitemap checks). 
- Ran the full quality gate `bun run check` and it failed due to pre-existing baseline test issues unrelated to these SEO changes (failures in `mobile-ripples`, `pocket-pulse`, and `lights` toy modules).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69963a568f008332ab658afa18efac0b)