### PR TITLE
Redesign capability and permission flows

### DIFF
--- a/assets/js/ui/youtube-controller.ts
+++ b/assets/js/ui/youtube-controller.ts
@@ -70,7 +70,9 @@ export class YouTubeController {
     }
 
     const apiUrl = 'https://www.youtube.com/iframe_api';
-    const existingScript = document.querySelector(`script[src="${apiUrl}"]`);
+    const existingScript = Array.from(
+      document.getElementsByTagName('script'),
+    ).find((script) => script.src === apiUrl);
     if (!existingScript) {
       const tag = document.createElement('script');
       tag.src = apiUrl;


### PR DESCRIPTION
### Motivation
- Make capability and microphone permission status clearer to users and reduce friction when granting audio access. 
- Surface an explicit step-by-step audio permission flow in the preflight panel so users understand next actions (grant, browser settings, or demo audio fallback).
- Adapt the audio control CTA and status messaging to reflect real permission states (granted, denied, prompt, unsupported).
- Avoid brittle DOM selector logic when bootstrapping the YouTube iframe API to reduce runtime selector errors in some DOM runtimes.

### Description
- Added a microphone permission probe helper and adaptive CTA copy to `assets/js/ui/audio-controls.ts` so the mic button updates for `granted`, `denied`, `prompt/unknown`, and `unsupported` states and shows clearer pending messages when requesting access.
- Updated `assets/js/core/capability-preflight.ts` to change audio-summary wording (blocked/pending/granted) and added an `updatePermissionFlow` UI section that renders a stepwise checklist and a one-click `Grant microphone access` action which calls `getUserMedia`, stops tracks, and reruns checks to refresh state.
- Hardened YouTube API detection in `assets/js/ui/youtube-controller.ts` by replacing an attribute `querySelector` with iterating script tags and matching `script.src` to avoid selector parsing issues in some test DOM runtimes.
- Small UX fixes: clearer status notes and button copy to help users pick demo audio or retry granting permissions; changes are restricted to the three files above and do not alter public docs.

### Testing
- Ran `bunx biome check assets/js/core/capability-preflight.ts assets/js/ui/audio-controls.ts assets/js/ui/youtube-controller.ts` which passed for the modified files.
- Ran `bun run typecheck` (i.e. `tsc --noEmit`) which completed successfully.
- Ran full quality gate `bun run check` (Biome + typecheck + tests); Biome and TypeScript checks passed, but the test phase failed in this environment due to broad existing `happy-dom` selector/runtime failures across many suites (not specific to these changes).
- Ran targeted unit tests `bun run test tests/audio-controls.test.ts` which exercised the updated audio controls but failed in the current test environment due to a `happy-dom` `window.SyntaxError` constructor/selector parsing problem; the changes themselves were lint/format/type-checked.

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a2255e188332bca1973e6fd13415)