### PR TITLE
Use toy starter preset id for quick-start action

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -5,7 +5,6 @@ import {
   PREFLIGHT_SESSION_DISMISS_KEY,
 } from './core/capability-preflight.ts';
 import { setRendererTelemetryHandler } from './core/renderer-capabilities.ts';
-import { setQualityPresetById } from './core/settings-panel.ts';
 import { startToyAudioFromSource } from './core/toy-audio-startup.ts';
 import type { ToyWindow } from './core/toy-globals';
 import toyManifest from './data/toy-manifest.ts';
@@ -232,6 +231,7 @@ const startApp = async () => {
       const gestureHints = starterTips.filter((tip) =>
         /touch|drag|pinch|swipe|gesture|tap|rotate/i.test(tip),
       );
+      const starterPresetId = toyMeta?.starterPreset?.id;
       const starterPresetLabel = toyMeta?.starterPreset?.label;
 
       initAudioControls(audioControlsContainer, {
@@ -260,10 +260,8 @@ const startApp = async () => {
         starterTips,
         firstRunHint,
         gestureHints,
+        starterPresetId,
         starterPresetLabel,
-        onApplyStarterPreset: () => {
-          setQualityPresetById('low-motion');
-        },
         ...buildAudioInitState(result),
       });
     };

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -14,6 +14,7 @@ export interface AudioControlsOptions {
   firstRunHint?: string;
   gestureHints?: string[];
   starterPresetLabel?: string;
+  starterPresetId?: string;
   onApplyStarterPreset?: () => void;
 }
 
@@ -70,6 +71,7 @@ export function initAudioControls(
 
   const starterPresetLabel =
     options.starterPresetLabel?.trim() || 'calm starter preset';
+  const starterPresetId = options.starterPresetId?.trim() || 'low-motion';
 
   container.innerHTML = `
     <p class="control-panel__description">
@@ -421,7 +423,7 @@ export function initAudioControls(
       return;
     }
 
-    const appliedPreset = setQualityPresetById('low-motion');
+    const appliedPreset = setQualityPresetById(starterPresetId);
     if (!appliedPreset) {
       updateStatus('Starter preset unavailable on this toy.', 'error');
       return;

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -185,6 +185,27 @@ describe('audio controls primary emphasis', () => {
     expect(status.textContent).toContain('calm starter preset applied');
   });
 
+  test('applies custom starter preset id when provided', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      starterPresetId: 'performance',
+      starterPresetLabel: 'best-of starter',
+    });
+
+    const starterPresetButton = container.querySelector(
+      '[data-apply-starter-preset]',
+    ) as HTMLButtonElement;
+    starterPresetButton.click();
+
+    expect(localStorage.getItem('stims:quality-preset')).toBe('performance');
+
+    const status = container.querySelector('#audio-status') as HTMLElement;
+    expect(status.textContent).toContain('best-of starter applied');
+  });
+
   test('uses custom starter preset label and callback when provided', () => {
     const container = document.createElement('section');
     let applied = false;


### PR DESCRIPTION
### Motivation
- The first-run quick-start action always applied the hard-coded `low-motion` preset, preventing per-toy `starterPreset` metadata from taking effect and making onboarding guidance inaccurate.

### Description
- Wire the toy metadata `starterPreset.id` into `initAudioControls` so the quick-start action can apply the toy-specific preset.
- Add `starterPresetId` to `AudioControlsOptions` and use it when calling `setQualityPresetById`, falling back to `'low-motion'` when unspecified.
- Remove the now-unnecessary top-level import of `setQualityPresetById` from the app initializer and pass the ID through options instead.
- Add a regression test `tests/audio-controls.test.ts` that verifies a custom `starterPresetId` is persisted and reflected in the status copy.

### Testing
- Ran `bun run check` (Biome checks, TypeScript typecheck, and full test suite) which completed successfully with all tests passing: `169 pass`, `2 skip`, `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699736ef37ec83328f6acf3d1e04768b)