### PR TITLE
Fix five audio control UX pain points

### DIFF
--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -167,6 +167,29 @@ describe('audio controls primary emphasis', () => {
     expect(hintPanel.textContent).toContain('Touch gestures');
     expect(hintPanel.textContent).toContain('Pinch/rotate gestures');
   });
+  test('does not auto-hide first steps before user dismisses it', () => {
+    const container = document.createElement('section');
+    const originalSetTimeout = window.setTimeout;
+    let timeoutCalls = 0;
+    window.setTimeout = ((...args: Parameters<typeof window.setTimeout>) => {
+      timeoutCalls += 1;
+      return originalSetTimeout(...args);
+    }) as typeof window.setTimeout;
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const firstSteps = container.querySelector(
+      '[data-first-steps]',
+    ) as HTMLElement;
+    expect(firstSteps.hidden).toBe(false);
+    expect(timeoutCalls).toBe(0);
+
+    window.setTimeout = originalSetTimeout;
+  });
+
   test('renders and dismisses the first-steps onboarding strip', () => {
     const container = document.createElement('section');
 
@@ -192,6 +215,31 @@ describe('audio controls primary emphasis', () => {
 
     expect(firstSteps.hidden).toBe(true);
     expect(sessionStorage.getItem('stims-first-steps-dismissed')).toBe('true');
+  });
+
+  test('renders quick-start tips with a dismiss action and persists dismissal', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      starterTips: ['Tip one', 'Tip two'],
+    });
+
+    const quickstart = container.querySelector(
+      '[data-quickstart-panel]',
+    ) as HTMLElement;
+    const dismiss = container.querySelector(
+      '[data-dismiss-quickstart]',
+    ) as HTMLButtonElement;
+
+    expect(quickstart.hidden).toBe(false);
+    dismiss.click();
+
+    expect(quickstart.hidden).toBe(true);
+    expect(sessionStorage.getItem('stims-quickstart-tips-dismissed')).toBe(
+      'true',
+    );
   });
 
   test('applies low-motion starter preset from first-steps quick action', () => {
@@ -373,6 +421,87 @@ describe('audio controls primary emphasis', () => {
 
     expect(captureButton.disabled).toBe(true);
     expect(captureButton.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  test('switches emphasis to demo row after successful demo start', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const demoButton = container.querySelector(
+      '#use-demo-audio',
+    ) as HTMLButtonElement;
+    demoButton.click();
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+    const firstSteps = container.querySelector(
+      '[data-first-steps]',
+    ) as HTMLElement;
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(firstSteps.hidden).toBe(true);
+  });
+
+  test('switches emphasis back to microphone after successful mic start', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      preferDemoAudio: true,
+    });
+
+    const micButton = container.querySelector(
+      '#start-audio-btn',
+    ) as HTMLButtonElement;
+    micButton.click();
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+  });
+
+  test('shows inline YouTube URL feedback copy as validity changes', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const feedback = container.querySelector(
+      '[data-youtube-url-feedback]',
+    ) as HTMLElement;
+
+    expect(input.getAttribute('aria-describedby')).toBe('youtube-url-feedback');
+    expect(feedback.textContent).toContain('Paste a full YouTube link');
+
+    input.value = 'bad';
+    input.dispatchEvent(new Event('input'));
+    expect(feedback.textContent).toContain('not recognized');
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    expect(feedback.textContent).toContain('Link looks good');
   });
 
   test('switches emphasis to demo row after microphone failure', async () => {

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -114,6 +114,35 @@ describe('audio controls primary emphasis', () => {
     expect(stageLabels).toContain('Step 2 · Advanced capture (optional)');
   });
 
+  test('keeps advanced helper copy hidden until advanced options are expanded', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestTabAudio: async () => {},
+    });
+
+    const toggle = container.querySelector(
+      '[data-advanced-toggle]',
+    ) as HTMLButtonElement;
+    const helper = container.querySelector(
+      '[data-advanced-helper]',
+    ) as HTMLElement;
+    const toggleLabel = container.querySelector(
+      '[data-advanced-toggle-label]',
+    ) as HTMLElement;
+
+    expect(helper.hidden).toBe(true);
+    expect(toggle.getAttribute('aria-controls')).toBe('advanced-audio-panel');
+    expect(toggleLabel.textContent).toBe('Show advanced audio options');
+
+    toggle.click();
+
+    expect(helper.hidden).toBe(false);
+    expect(toggleLabel.textContent).toBe('Hide advanced audio options');
+  });
+
   test('reveals touch gesture hints after audio starts on touch-capable devices', async () => {
     const container = document.createElement('section');
 
@@ -276,6 +305,76 @@ describe('audio controls primary emphasis', () => {
       'Start with demo for instant sound',
     );
   });
+
+  test('disables YouTube load until a valid link is entered', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+
+    expect(loadButton.disabled).toBe(true);
+
+    input.value = 'not-a-valid-url';
+    input.dispatchEvent(new Event('input'));
+    expect(loadButton.disabled).toBe(true);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    expect(loadButton.disabled).toBe(false);
+    expect(input.getAttribute('aria-invalid')).toBe('false');
+  });
+
+  test('pressing Enter in YouTube URL field triggers load action', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+    let clickCount = 0;
+    loadButton.addEventListener('click', () => {
+      clickCount += 1;
+    });
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(clickCount).toBe(1);
+  });
+
+  test('keeps YouTube capture disabled before a video is ready', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const captureButton = container.querySelector(
+      '#use-youtube-audio',
+    ) as HTMLButtonElement;
+
+    expect(captureButton.disabled).toBe(true);
+    expect(captureButton.getAttribute('aria-disabled')).toBe('true');
+  });
+
   test('switches emphasis to demo row after microphone failure', async () => {
     const container = document.createElement('section');
 


### PR DESCRIPTION
### Motivation
- Reduce user friction in the audio controls panel by clarifying advanced option affordances, preventing dead-end actions for YouTube capture, and improving keyboard and assistive interactions.
- Surface clear validation and readiness states so users do not attempt actions that will fail and can discover advanced options intentionally.

### Description
- Added an accessible advanced-panel toggle with `aria-controls`, a hidden helper copy (`data-advanced-helper`) and a stateful toggle label (`data-advanced-toggle-label`) so the advanced control is explicit and uncluttered when closed (`assets/js/ui/audio-controls.ts`).
- Persisted and restored the advanced panel state and toggle text, and hid/show the helper copy when the panel is opened or closed (`assets/js/ui/audio-controls.ts`).
- Validated the YouTube URL input inline and disabled the `Load` button until a parsable YouTube id is present, and exposed input validity via `aria-invalid` (`assets/js/ui/audio-controls.ts`).
- Disabled the `Capture YouTube` action until a loaded video is actually ready and updated UI attributes (`disabled` / `aria-disabled`) to prevent premature capture attempts (`assets/js/ui/audio-controls.ts`).
- Added keyboard support for the YouTube URL field so pressing Enter triggers the same `Load` action as clicking the `Load` button, and added automated tests to cover the new behaviors (`tests/audio-controls.test.ts`).

### Testing
- Ran the full quality gate with `bun run check`, which performs formatting/lint/typecheck and the test suite, and it completed successfully (all tests passed).
- Executed the updated unit tests and new test cases in `tests/audio-controls.test.ts`, and they passed under `bun test` as part of the `check` run.
- Performed a manual visual smoke check by running the dev server (`bun run dev`) and capturing a screenshot of `toy.html?toy=geom` for verification (screenshot recorded in artifacts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e02d61648332bc5b527378ac8c99)