### PR TITLE
Fix five additional audio controls UX issues

### DIFF
--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -115,7 +115,10 @@ export function initAudioControls(
       options.starterTips && options.starterTips.length > 0
         ? `
     <div class="control-panel__quickstart" data-quickstart-panel>
-      <span class="control-panel__label">Quick start tips</span>
+      <div class="control-panel__first-steps-header">
+        <span class="control-panel__label">Quick start tips</span>
+        <button type="button" class="control-panel__dismiss" data-dismiss-quickstart>Dismiss</button>
+      </div>
       <ul class="control-panel__tips">
         ${options.starterTips
           .slice(0, 3)
@@ -156,14 +159,15 @@ export function initAudioControls(
         type="button"
         class="control-panel__advanced-toggle"
         aria-expanded="false"
+        aria-controls="advanced-audio-panel"
         data-advanced-toggle
       >
-        <span class="control-panel__advanced-title">Advanced audio options</span>
+        <span class="control-panel__advanced-title" data-advanced-toggle-label>Show advanced audio options</span>
         <span class="control-panel__advanced-hint">Tab or YouTube capture for media already playing</span>
       </button>
     </div>
-    <p class="control-panel__advanced-helper">Use these when you want visuals to react to music or videos already playing in your browser.</p>
-    <div class="control-panel__advanced" data-advanced-panel hidden>
+    <p class="control-panel__advanced-helper" data-advanced-helper hidden>Use these when you want visuals to react to music or videos already playing in your browser.</p>
+    <div id="advanced-audio-panel" class="control-panel__advanced" data-advanced-panel hidden>
       ${
         options.onRequestTabAudio
           ? `
@@ -221,6 +225,7 @@ export function initAudioControls(
           />
           <button id="load-youtube" class="cta-button" type="button">Load</button>
         </div>
+        <p id="youtube-url-feedback" class="control-panel__microcopy" data-youtube-url-feedback role="status" aria-live="polite">Paste a full YouTube link to enable Load.</p>
         <div id="recent-youtube" class="control-panel__recent" hidden>
           <span class="control-panel__label small">Recent</span>
           <div id="recent-list" class="control-panel__chip-list"></div>
@@ -260,10 +265,17 @@ export function initAudioControls(
   const advancedPanel = container.querySelector(
     '[data-advanced-panel]',
   ) as HTMLElement | null;
+  const advancedHelper = container.querySelector(
+    '[data-advanced-helper]',
+  ) as HTMLElement | null;
+  const advancedToggleLabel = container.querySelector(
+    '[data-advanced-toggle-label]',
+  ) as HTMLElement | null;
   const ADVANCED_KEY = 'stims-audio-advanced-open';
   const FIRST_STEPS_KEY = 'stims-first-steps-dismissed';
   const GESTURE_HINT_KEY = 'stims-gesture-hints-dismissed';
   const QUICK_START_PRESET_KEY = 'stims-quick-start-preset';
+  const QUICKSTART_TIPS_KEY = 'stims-quickstart-tips-dismissed';
 
   const setPrimaryRow = (row: Element | null, isPrimary: boolean): void => {
     row?.classList.toggle('control-panel__row--primary', isPrimary);
@@ -374,6 +386,12 @@ export function initAudioControls(
       );
       emphasizeDemoAudio();
     }
+    if (state === 'unsupported') {
+      updateStatus(
+        'Microphone is unavailable in this browser. Demo audio is ready to start now.',
+      );
+      emphasizeDemoAudio();
+    }
   });
 
   const firstStepsPanel = container.querySelector(
@@ -383,6 +401,7 @@ export function initAudioControls(
     '[data-dismiss-first-steps]',
   ) as HTMLButtonElement | null;
 
+  let hideFirstSteps = () => {};
   if (firstStepsPanel) {
     let isDismissed = false;
     try {
@@ -391,7 +410,7 @@ export function initAudioControls(
       isDismissed = false;
     }
 
-    const hideFirstSteps = () => {
+    hideFirstSteps = () => {
       firstStepsPanel.hidden = true;
       try {
         window.sessionStorage.setItem(FIRST_STEPS_KEY, 'true');
@@ -402,12 +421,6 @@ export function initAudioControls(
 
     if (isDismissed) {
       firstStepsPanel.hidden = true;
-    } else {
-      window.setTimeout(() => {
-        if (!firstStepsPanel.hidden) {
-          hideFirstSteps();
-        }
-      }, 10000);
     }
 
     dismissFirstSteps?.addEventListener('click', hideFirstSteps);
@@ -436,6 +449,36 @@ export function initAudioControls(
     }
     updateStatus(`${starterPresetLabel} applied.`, 'success');
   });
+
+  const quickstartPanel = container.querySelector(
+    '[data-quickstart-panel]',
+  ) as HTMLElement | null;
+  const dismissQuickstart = container.querySelector(
+    '[data-dismiss-quickstart]',
+  ) as HTMLButtonElement | null;
+
+  if (quickstartPanel) {
+    let quickstartDismissed = false;
+    try {
+      quickstartDismissed =
+        window.sessionStorage.getItem(QUICKSTART_TIPS_KEY) === 'true';
+    } catch (_error) {
+      quickstartDismissed = false;
+    }
+
+    if (quickstartDismissed) {
+      quickstartPanel.hidden = true;
+    }
+
+    dismissQuickstart?.addEventListener('click', () => {
+      quickstartPanel.hidden = true;
+      try {
+        window.sessionStorage.setItem(QUICKSTART_TIPS_KEY, 'true');
+      } catch (_error) {
+        // Ignore storage errors.
+      }
+    });
+  }
 
   const gestureHintsPanel = container.querySelector(
     '[data-gesture-hints]',
@@ -494,6 +537,7 @@ export function initAudioControls(
   const handleSuccess = () => {
     options.onSuccess?.();
     showGestureHints();
+    hideFirstSteps();
   };
 
   if (options.initialStatus) {
@@ -510,17 +554,40 @@ export function initAudioControls(
     } catch (_error) {
       isOpen = false;
     }
-    advancedPanel.hidden = !isOpen;
-    advancedToggle.setAttribute('aria-expanded', String(isOpen));
-    advancedToggle.addEventListener('click', () => {
-      const nextState = advancedPanel.hidden;
-      advancedPanel.hidden = !nextState;
-      advancedToggle.setAttribute('aria-expanded', String(nextState));
+    const setAdvancedState = (open: boolean) => {
+      advancedPanel.hidden = !open;
+      if (advancedHelper) {
+        advancedHelper.hidden = !open;
+      }
+      advancedToggle.setAttribute('aria-expanded', String(open));
+      if (advancedToggleLabel) {
+        advancedToggleLabel.textContent = open
+          ? 'Hide advanced audio options'
+          : 'Show advanced audio options';
+      }
+    };
+
+    setAdvancedState(isOpen);
+    const persistAdvancedState = (nextState: boolean) => {
+      setAdvancedState(nextState);
       try {
         window.sessionStorage.setItem(ADVANCED_KEY, String(nextState));
       } catch (_error) {
         // Ignore storage errors.
       }
+    };
+
+    advancedToggle.addEventListener('click', () => {
+      const nextState = advancedPanel.hidden;
+      persistAdvancedState(nextState);
+    });
+
+    advancedToggle.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape') return;
+      if (advancedPanel.hidden) return;
+      event.preventDefault();
+      persistAdvancedState(false);
+      advancedToggle.focus();
     });
   }
 
@@ -559,6 +626,7 @@ export function initAudioControls(
         microphonePermissionState = 'granted';
         setMicrophoneButtonState();
         writeStoredSource('microphone');
+        setPreferredSource('microphone');
       },
       'Microphone access failed.',
       (message) => {
@@ -578,6 +646,7 @@ export function initAudioControls(
       async () => {
         await options.onRequestDemoAudio();
         writeStoredSource('demo');
+        setPreferredSource('demo');
       },
       'Demo audio failed to load.',
       undefined,
@@ -643,8 +712,37 @@ function setupYouTubeLogic(
     '#recent-youtube',
   ) as HTMLElement;
   const recentList = container.querySelector('#recent-list') as HTMLElement;
+  const urlFeedback = container.querySelector(
+    '[data-youtube-url-feedback]',
+  ) as HTMLElement | null;
   const STORAGE_KEY = 'stims-youtube-url';
   let youtubeReady = false;
+
+  const setUseButtonReadyState = () => {
+    if (!useBtn) return;
+    useBtn.disabled = !youtubeReady;
+    useBtn.setAttribute('aria-disabled', String(!youtubeReady));
+  };
+
+  const setLoadButtonValidityState = () => {
+    if (!input || !(loadBtn instanceof HTMLButtonElement)) return;
+    const value = input.value.trim();
+    const videoId = controller.parseVideoId(input.value);
+    const isValid = Boolean(videoId);
+    loadBtn.disabled = !isValid;
+    loadBtn.setAttribute('aria-disabled', String(!isValid));
+    input.setAttribute('aria-invalid', value ? String(!isValid) : 'false');
+    if (urlFeedback) {
+      if (!value) {
+        urlFeedback.textContent = 'Paste a full YouTube link to enable Load.';
+      } else if (!isValid) {
+        urlFeedback.textContent =
+          'That link was not recognized. Try a full youtube.com/watch URL.';
+      } else {
+        urlFeedback.textContent = 'Link looks good. Press Load to continue.';
+      }
+    }
+  };
   const readStoredUrl = () => {
     try {
       return window.sessionStorage.getItem(STORAGE_KEY);
@@ -677,6 +775,8 @@ function setupYouTubeLogic(
       chip.setAttribute('aria-label', `Load video ${v.id}`);
       chip.addEventListener('click', () => {
         input.value = `https://www.youtube.com/watch?v=${v.id}`;
+        writeStoredUrl(input.value);
+        setLoadButtonValidityState();
         loadVideo(v.id);
       });
       recentList.appendChild(chip);
@@ -687,12 +787,14 @@ function setupYouTubeLogic(
     try {
       playerContainer.hidden = false;
       youtubeReady = false;
+      setUseButtonReadyState();
       updateStatus('Loading player…', 'success');
       await controller.loadVideo('youtube-player', id, (state) => {
         if (state === 1) {
           // Playing
           updateStatus('Ready to capture audio.', 'success');
           youtubeReady = true;
+          setUseButtonReadyState();
         }
       });
       updateStatus('Video loaded.', 'success');
@@ -701,19 +803,34 @@ function setupYouTubeLogic(
       updateStatus('Failed to load YouTube player.');
       playerContainer.hidden = true;
       youtubeReady = false;
+      setUseButtonReadyState();
     }
   };
 
+  if (input) {
+    input.setAttribute('aria-describedby', 'youtube-url-feedback');
+  }
+  setUseButtonReadyState();
+  setLoadButtonValidityState();
   updateRecentList();
 
   if (input) {
     const storedUrl = readStoredUrl();
     if (storedUrl) {
       input.value = storedUrl;
+      setLoadButtonValidityState();
     }
     input.addEventListener('input', () => {
       writeStoredUrl(input.value);
       youtubeReady = false;
+      setUseButtonReadyState();
+      setLoadButtonValidityState();
+    });
+    input.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      if (loadBtn instanceof HTMLButtonElement && loadBtn.disabled) return;
+      loadBtn?.dispatchEvent(new Event('click'));
     });
   }
 
@@ -722,6 +839,7 @@ function setupYouTubeLogic(
     if (!videoId) {
       updateStatus('Paste a valid YouTube link.');
       youtubeReady = false;
+      setUseButtonReadyState();
       input.focus();
       return;
     }

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { initAudioControls } from '../assets/js/ui/audio-controls.ts';
+import { YouTubeController } from '../assets/js/ui/youtube-controller.ts';
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -114,6 +115,60 @@ describe('audio controls primary emphasis', () => {
     expect(stageLabels).toContain('Step 2 · Advanced capture (optional)');
   });
 
+  test('keeps advanced helper copy hidden until advanced options are expanded', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestTabAudio: async () => {},
+    });
+
+    const toggle = container.querySelector(
+      '[data-advanced-toggle]',
+    ) as HTMLButtonElement;
+    const helper = container.querySelector(
+      '[data-advanced-helper]',
+    ) as HTMLElement;
+    const toggleLabel = container.querySelector(
+      '[data-advanced-toggle-label]',
+    ) as HTMLElement;
+
+    expect(helper.hidden).toBe(true);
+    expect(toggle.getAttribute('aria-controls')).toBe('advanced-audio-panel');
+    expect(toggleLabel.textContent).toBe('Show advanced audio options');
+
+    toggle.click();
+
+    expect(helper.hidden).toBe(false);
+    expect(toggleLabel.textContent).toBe('Hide advanced audio options');
+  });
+
+  test('closes advanced options when Escape is pressed on toggle', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestTabAudio: async () => {},
+    });
+
+    const toggle = container.querySelector(
+      '[data-advanced-toggle]',
+    ) as HTMLButtonElement;
+    const panel = container.querySelector(
+      '[data-advanced-panel]',
+    ) as HTMLElement;
+
+    toggle.click();
+    expect(panel.hidden).toBe(false);
+
+    toggle.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Escape' }),
+    );
+    expect(panel.hidden).toBe(true);
+  });
+
   test('reveals touch gesture hints after audio starts on touch-capable devices', async () => {
     const container = document.createElement('section');
 
@@ -138,6 +193,29 @@ describe('audio controls primary emphasis', () => {
     expect(hintPanel.textContent).toContain('Touch gestures');
     expect(hintPanel.textContent).toContain('Pinch/rotate gestures');
   });
+  test('does not auto-hide first steps before user dismisses it', () => {
+    const container = document.createElement('section');
+    const originalSetTimeout = window.setTimeout;
+    let timeoutCalls = 0;
+    window.setTimeout = ((...args: Parameters<typeof window.setTimeout>) => {
+      timeoutCalls += 1;
+      return originalSetTimeout(...args);
+    }) as typeof window.setTimeout;
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const firstSteps = container.querySelector(
+      '[data-first-steps]',
+    ) as HTMLElement;
+    expect(firstSteps.hidden).toBe(false);
+    expect(timeoutCalls).toBe(0);
+
+    window.setTimeout = originalSetTimeout;
+  });
+
   test('renders and dismisses the first-steps onboarding strip', () => {
     const container = document.createElement('section');
 
@@ -163,6 +241,31 @@ describe('audio controls primary emphasis', () => {
 
     expect(firstSteps.hidden).toBe(true);
     expect(sessionStorage.getItem('stims-first-steps-dismissed')).toBe('true');
+  });
+
+  test('renders quick-start tips with a dismiss action and persists dismissal', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      starterTips: ['Tip one', 'Tip two'],
+    });
+
+    const quickstart = container.querySelector(
+      '[data-quickstart-panel]',
+    ) as HTMLElement;
+    const dismiss = container.querySelector(
+      '[data-dismiss-quickstart]',
+    ) as HTMLButtonElement;
+
+    expect(quickstart.hidden).toBe(false);
+    dismiss.click();
+
+    expect(quickstart.hidden).toBe(true);
+    expect(sessionStorage.getItem('stims-quickstart-tips-dismissed')).toBe(
+      'true',
+    );
   });
 
   test('applies low-motion starter preset from first-steps quick action', () => {
@@ -262,6 +365,50 @@ describe('audio controls primary emphasis', () => {
     );
   });
 
+  test('falls back to demo recommendation when microphone is unsupported', async () => {
+    const container = document.createElement('section');
+    const originalNavigator = globalThis.navigator;
+
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        ...originalNavigator,
+        mediaDevices: undefined,
+        permissions: undefined,
+      },
+    });
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+    const status = container.querySelector('#audio-status') as HTMLElement;
+    const micButton = container.querySelector(
+      '#start-audio-btn',
+    ) as HTMLButtonElement;
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(micButton.disabled).toBe(true);
+    expect(status.textContent).toContain(
+      'Microphone is unavailable in this browser',
+    );
+
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+
   test('updates onboarding source copy when demo is preferred', () => {
     const container = document.createElement('section');
 
@@ -276,6 +423,221 @@ describe('audio controls primary emphasis', () => {
       'Start with demo for instant sound',
     );
   });
+
+  test('disables YouTube load until a valid link is entered', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+
+    expect(loadButton.disabled).toBe(true);
+
+    input.value = 'not-a-valid-url';
+    input.dispatchEvent(new Event('input'));
+    expect(loadButton.disabled).toBe(true);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    expect(loadButton.disabled).toBe(false);
+    expect(input.getAttribute('aria-invalid')).toBe('false');
+  });
+
+  test('restores stored YouTube URL with ready-to-load state', () => {
+    sessionStorage.setItem(
+      'stims-youtube-url',
+      'https://youtube.com/watch?v=dQw4w9WgXcQ',
+    );
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+    const feedback = container.querySelector(
+      '[data-youtube-url-feedback]',
+    ) as HTMLElement;
+
+    expect(loadButton.disabled).toBe(false);
+    expect(feedback.textContent).toContain('Link looks good');
+  });
+
+  test('pressing Enter in YouTube URL field triggers load action', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+    let clickCount = 0;
+    loadButton.addEventListener('click', () => {
+      clickCount += 1;
+    });
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(clickCount).toBe(1);
+  });
+
+  test('clicking a recent YouTube chip updates stored URL and validity state', () => {
+    const originalGetRecentVideos = YouTubeController.prototype.getRecentVideos;
+    const originalLoadVideo = YouTubeController.prototype.loadVideo;
+
+    YouTubeController.prototype.getRecentVideos = () => [
+      {
+        id: 'dQw4w9WgXcQ',
+        title: 'Never Gonna Give You Up',
+        timestamp: Date.now(),
+      },
+    ];
+    YouTubeController.prototype.loadVideo = async () => {};
+
+    const container = document.createElement('section');
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const recentChip = container.querySelector(
+      '.control-panel__chip',
+    ) as HTMLButtonElement;
+    const loadButton = container.querySelector(
+      '#load-youtube',
+    ) as HTMLButtonElement;
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+
+    recentChip.click();
+
+    expect(input.value).toContain('dQw4w9WgXcQ');
+    expect(loadButton.disabled).toBe(false);
+    expect(sessionStorage.getItem('stims-youtube-url')).toContain(
+      'dQw4w9WgXcQ',
+    );
+
+    YouTubeController.prototype.getRecentVideos = originalGetRecentVideos;
+    YouTubeController.prototype.loadVideo = originalLoadVideo;
+  });
+
+  test('keeps YouTube capture disabled before a video is ready', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const captureButton = container.querySelector(
+      '#use-youtube-audio',
+    ) as HTMLButtonElement;
+
+    expect(captureButton.disabled).toBe(true);
+    expect(captureButton.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  test('switches emphasis to demo row after successful demo start', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+    });
+
+    const demoButton = container.querySelector(
+      '#use-demo-audio',
+    ) as HTMLButtonElement;
+    demoButton.click();
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+    const firstSteps = container.querySelector(
+      '[data-first-steps]',
+    ) as HTMLElement;
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(firstSteps.hidden).toBe(true);
+  });
+
+  test('switches emphasis back to microphone after successful mic start', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      preferDemoAudio: true,
+    });
+
+    const micButton = container.querySelector(
+      '#start-audio-btn',
+    ) as HTMLButtonElement;
+    micButton.click();
+    await flush();
+
+    const micRow = container.querySelector('[data-audio-row="mic"]');
+    const demoRow = container.querySelector('[data-audio-row="demo"]');
+
+    expect(micRow?.classList.contains('control-panel__row--primary')).toBe(
+      true,
+    );
+    expect(demoRow?.classList.contains('control-panel__row--primary')).toBe(
+      false,
+    );
+  });
+
+  test('shows inline YouTube URL feedback copy as validity changes', () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      onRequestYouTubeAudio: async () => {},
+    });
+
+    const input = container.querySelector('#youtube-url') as HTMLInputElement;
+    const feedback = container.querySelector(
+      '[data-youtube-url-feedback]',
+    ) as HTMLElement;
+
+    expect(input.getAttribute('aria-describedby')).toBe('youtube-url-feedback');
+    expect(feedback.textContent).toContain('Paste a full YouTube link');
+
+    input.value = 'bad';
+    input.dispatchEvent(new Event('input'));
+    expect(feedback.textContent).toContain('not recognized');
+
+    input.value = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+    input.dispatchEvent(new Event('input'));
+    expect(feedback.textContent).toContain('Link looks good');
+  });
+
   test('switches emphasis to demo row after microphone failure', async () => {
     const container = document.createElement('section');
 


### PR DESCRIPTION
### Motivation
- Reduce friction and mismatch between UI affordances and actual audio state by improving fallback messaging, accessibility, and keyboard ergonomics in the audio controls panel. 
- Ensure YouTube capture flows have reliable validation/state synchronization so users don’t encounter stale buttons or confusing feedback.

### Description
- Clear unsupported-microphone fallback by surfacing a friendly status and shifting recommendation emphasis to demo audio when the browser lacks microphone support, and call `setPreferredSource` after successful mic/demo starts to keep emphasis in sync (`assets/js/ui/audio-controls.ts`).
- Add keyboard ergonomics and helper affordance for the advanced panel by wiring `aria-controls`, a hidden helper copy that toggles with the panel, a stateful toggle label, and Escape-to-close behavior on the toggle (`assets/js/ui/audio-controls.ts`).
- Improve YouTube capture UX by making the URL helper a polite live status, restoring persisted URLs into a ready-to-load state on init, updating load validity state when recent chips are selected, and keeping the capture action disabled until the player signals readiness (`assets/js/ui/audio-controls.ts`).
- Remove premature auto-hide of the first-steps onboarding strip and add a dismissible Quick-start tips dismiss action persisted to session storage to avoid surprising auto-dismissals (`assets/js/ui/audio-controls.ts`).
- Add and update unit tests that cover unsupported-mic fallback, Escape-to-close advanced behavior, stored-YouTube-URL restore state, recent-chip selection persistence/validation, and live feedback behavior (`tests/audio-controls.test.ts`).

### Testing
- Ran the full quality gate with `bun run check` (format/lint/typecheck + tests), which completed successfully with all automated tests passing: `183 passed, 2 skipped, 0 failed` across the suite.
- No documentation files were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e02d61648332bc5b527378ac8c99)