### PR TITLE
Add static collection and featured toy links to the homepage

### DIFF
--- a/docs/SEO_AUDIT.md
+++ b/docs/SEO_AUDIT.md
@@ -39,6 +39,25 @@ Other foundations remain strong: canonical tags, robots directives, JSON-LD on m
 2. Optionally add image sitemap support if image search becomes a KPI.
 3. Continue periodic production checks for `/index.html` → `/` redirect behavior.
 
+## Follow-up findings: potential search presence constraints (2026-02-21)
+
+The technical SEO baseline is healthy, but these factors may still limit search visibility growth:
+
+1. **Homepage crawl paths rely heavily on JavaScript-rendered cards.**
+   The homepage keeps the primary library container empty in source (`<main id="toy-list" class="webtoy-container"></main>`), and the full toy grid links are injected client-side. Search crawlers that execute limited JavaScript can still discover URLs through the sitemap, but they may see weaker contextual internal-link signals from the most authoritative page (`/`).
+
+2. **Static internal links on the homepage are sparse compared to inventory size.**
+   In raw HTML, only a few direct toy launch links are present (`toy.html?toy=aurora-painter`, `toy.html?toy=holy`, and `toy.html?toy=seary`) while the full catalog lives under generated `/toys/`, `/tags/`, `/moods/`, and `/capabilities/` pages. That can reduce crawl depth reinforcement if bots prioritize HTML-discoverable links.
+
+3. **Discovery pages are generated, but homepage emphasis favors app interaction over crawlable taxonomy hubs.**
+   The generated SEO surfaces (`/toys/`, `/tags/*`, `/moods/*`, `/capabilities/*`) are included in sitemap artifacts and are indexable, but they are not prominently linked in static homepage nav. This may dampen topical clustering signals despite good metadata and structured data.
+
+### Next actions for visibility growth
+
+1. Add persistent static links from homepage chrome/footer to `/toys/`, `/tags/`, `/moods/`, and `/capabilities/`.
+2. Add a minimal server-rendered "top toys" list in homepage HTML (in addition to JS rendering) to strengthen internal links on first crawl.
+3. Track indexing and impressions in Google Search Console/Bing Webmaster Tools per page group (`/toys/`, `/tags/`, `/moods/`) to confirm which section is underperforming.
+
 ## Programmatic growth opportunities (next cycle)
 
 1. **Automate first-party OG image generation per toy page**  

--- a/index.html
+++ b/index.html
@@ -158,6 +158,25 @@
             Select a card to start right away.
           </p>
         </div>
+        <nav class="feature-card" aria-label="Explore static library pages">
+          <h3>Explore collections</h3>
+          <p>Browse index pages that organize every toy by category.</p>
+          <ul>
+            <li><a class="text-link" href="/toys/">All toy pages</a></li>
+            <li><a class="text-link" href="/tags/">Tags index</a></li>
+            <li><a class="text-link" href="/moods/">Moods index</a></li>
+            <li><a class="text-link" href="/capabilities/">Capabilities index</a></li>
+          </ul>
+        </nav>
+        <nav class="feature-card" aria-label="Featured toy detail pages">
+          <h3>Featured toy pages</h3>
+          <ul>
+            <li><a class="text-link" href="/toys/aurora-painter/">Aurora Painter details</a></li>
+            <li><a class="text-link" href="/toys/seary/">Seary details</a></li>
+            <li><a class="text-link" href="/toys/holy/">Halo Pulse details</a></li>
+            <li><a class="text-link" href="/toys/cube-wave/">Grid Visualizer details</a></li>
+          </ul>
+        </nav>
         <search class="library-search">
           <section class="starter-picks" aria-label="Recommended starter picks">
             <div class="starter-picks__grid">


### PR DESCRIPTION
### Motivation

- Improve crawlable internal-link signals from the homepage to generated taxonomy hubs because the library grid is primarily client-rendered and can weaken crawler-discoverable links.
- Surface representative toy detail pages directly in source HTML to strengthen topical/internal linking without requiring JavaScript execution.

### Description

- Add a static `nav.feature-card` block titled "Explore collections" linking to `/toys/`, `/tags/`, `/moods/`, and `/capabilities/` in `index.html` to expose taxonomy hubs in raw HTML.
- Add a static "Featured toy pages" `nav.feature-card` with direct links to selected toy detail pages (`/toys/aurora-painter/`, `/toys/seary/`, `/toys/holy/`, `/toys/cube-wave/`) in `index.html` to provide immediate homepage-to-detail links.
- Run project linters/formatters as part of the commit workflow and commit the updated `index.html` with the message `Add static collection links on the homepage`.

### Testing

- Ran `biome lint` and `biome format` as part of the commit hook and both completed with no fixes required.
- Ran the SEO validation script `bun run check:seo` and it completed successfully (reports canonical tags, OG metadata, sitemap entries, and image sitemap metadata where expected).
- Performed an automated browser smoke test using Playwright to load the dev server and capture a full-page screenshot which completed and produced the artifact for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e27ef6688332bdbec975b1937e17)