### PR TITLE
Add scroll offset for toy search anchor

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -246,6 +246,10 @@ footer {
   scroll-margin-top: clamp(7.5rem, 17vh, 9.5rem);
 }
 
+#toy-search {
+  scroll-margin-top: clamp(7.5rem, 17vh, 9.5rem);
+}
+
 .content {
   position: relative;
   z-index: 1;
@@ -3800,6 +3804,10 @@ footer {
 
 @media (max-width: 520px) {
   #toy-list {
+    scroll-margin-top: 10rem;
+  }
+
+  #toy-search {
     scroll-margin-top: 10rem;
   }
 


### PR DESCRIPTION
### Motivation
- The "Browse with filters" CTA targets `#toy-search` but the sticky `.shell-header` can obscure the search input after a hash jump on small viewports, making the action appear to do nothing.

### Description
- Add `scroll-margin-top` rules for `#toy-search` in `assets/css/index.css`, mirroring the existing `#toy-list` values and adding a mobile override so hash navigation keeps the search field visible below the sticky header.

### Testing
- Ran `bun run check` (Biome lint/format + TypeScript typecheck + tests) which completed successfully with `181 pass`, `2 skip`, and `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2a948d288332a682448e50d36dc3)