### PR TITLE
Tone down intro copy and remove premium prompt and skip-link

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -1,8 +1,4 @@
-import {
-  dismissPremiumPrompt,
-  getRecentToySlugs,
-  shouldShowPremiumPrompt,
-} from './utils/growth-metrics.ts';
+import { getRecentToySlugs } from './utils/growth-metrics.ts';
 
 const ns = 'http://www.w3.org/2000/svg';
 
@@ -1871,43 +1867,6 @@ export function createLibraryView({
       });
       panel.appendChild(list);
       listElement.appendChild(panel);
-    }
-
-    if (shouldShowPremiumPrompt()) {
-      const premiumPanel = document.createElement('section');
-      premiumPanel.className =
-        'webtoy-growth-panel webtoy-growth-panel--premium';
-
-      const heading = document.createElement('h3');
-      heading.className = 'webtoy-growth-panel__title';
-      heading.textContent = 'Want premium scene packs?';
-
-      const body = document.createElement('p');
-      body.className = 'webtoy-growth-panel__body';
-      body.textContent =
-        'You keep coming back—join the premium waitlist to unlock saved sessions, exclusive presets, and supporter-only drops.';
-
-      const actions = document.createElement('div');
-      actions.className = 'webtoy-card-actions';
-
-      const join = document.createElement('a');
-      join.className = 'cta-button cta-button--accent';
-      join.href =
-        'mailto:hello@no.toil.fyi?subject=Stim%20premium%20waitlist&body=Add%20me%20to%20the%20premium%20waitlist.';
-      join.textContent = 'Join premium waitlist';
-
-      const dismiss = document.createElement('button');
-      dismiss.type = 'button';
-      dismiss.className = 'cta-button';
-      dismiss.textContent = 'Not now';
-      dismiss.addEventListener('click', () => {
-        dismissPremiumPrompt();
-        premiumPanel.remove();
-      });
-
-      actions.append(join, dismiss);
-      premiumPanel.append(heading, body, actions);
-      listElement.appendChild(premiumPanel);
     }
   };
 

--- a/assets/js/toy-view.ts
+++ b/assets/js/toy-view.ts
@@ -108,13 +108,6 @@ function showElement(element: HTMLElement | null) {
   }
 }
 
-function setLibrarySkipLinkVisible(doc: Document | null, visible: boolean) {
-  if (!doc) return;
-  const skipLink = doc.querySelector<HTMLElement>('.skip-link');
-  if (!skipLink) return;
-  skipLink.hidden = !visible;
-}
-
 function clearContainerContent(container: HTMLElement | null) {
   if (!container) return;
 
@@ -386,14 +379,12 @@ export function createToyView({
     if (state.mode === 'library') {
       showElement(toyList);
       hideElement(container);
-      setLibrarySkipLinkVisible(doc, true);
       state.status = null;
       return { container, status: null };
     }
 
     hideElement(toyList);
     showElement(container);
-    setLibrarySkipLinkVisible(doc, false);
 
     buildToyNav({
       container,

--- a/index.html
+++ b/index.html
@@ -128,7 +128,6 @@
     </script>
   </head>
   <body data-page="library">
-    <a class="skip-link" href="#toy-list">Skip to library</a>
     <div class="content">
       <header class="shell-header">
         <div data-top-nav-container></div>
@@ -139,15 +138,15 @@
       </header>
 
       <section class="intro" id="intro" aria-label="Primary quick actions">
-        <p class="eyebrow">Start fast</p>
-        <h1>Find a stim in under 10 seconds</h1>
-        <p class="cta-helper intro-helper">Start instantly with a recommendation, then fine-tune with search and filters below.</p>
+        <p class="eyebrow">Library</p>
+        <h1>Browse stims</h1>
+        <p class="cta-helper intro-helper">Choose a visual, then refine with search and filters below.</p>
         <div class="intro-actions" role="group" aria-label="Start options">
           <a
             href="toy.html?toy=holy"
             class="cta-button primary"
           >
-            Start a recommended visual
+            Open a visual
           </a>
         </div>
       </section>

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -64,7 +64,7 @@ describe('library filter state normalization', () => {
   });
 });
 
-test('renders continue and premium panels when returner signals are present', async () => {
+test('renders continue panel when returner signals are present', async () => {
   const today = new Date().toISOString().slice(0, 10);
   const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
     .toISOString()
@@ -90,9 +90,6 @@ test('renders continue and premium panels when returner signals are present', as
   await view.init();
 
   expect(document.querySelector('.webtoy-growth-panel')).not.toBeNull();
-  expect(
-    document.querySelector('.webtoy-growth-panel--premium'),
-  ).not.toBeNull();
   const openButton = Array.from(document.querySelectorAll('button')).find(
     (button) => button.textContent === 'Open toy',
   );

--- a/tests/toy-view.test.js
+++ b/tests/toy-view.test.js
@@ -3,8 +3,7 @@ import { createToyView } from '../assets/js/toy-view.ts';
 
 describe('toy view helpers', () => {
   beforeEach(() => {
-    document.body.innerHTML =
-      '<a class="skip-link" href="#toy-list">Skip to library</a><div id="toy-list"></div>';
+    document.body.innerHTML = '<div id="toy-list"></div>';
   });
 
   afterEach(() => {
@@ -32,23 +31,6 @@ describe('toy view helpers', () => {
 
     backControl?.dispatchEvent(new Event('click', { bubbles: true }));
     expect(onBack).toHaveBeenCalledTimes(1);
-  });
-
-  test('hides library skip link while a toy is active', () => {
-    const view = createToyView();
-
-    const skipLink = document.querySelector('.skip-link');
-    expect(skipLink?.hidden).toBe(false);
-
-    view.showActiveToyView(mock(), {
-      slug: 'demo',
-      title: 'Demo Toy',
-    });
-
-    expect(skipLink?.hidden).toBe(true);
-
-    view.showLibraryView();
-    expect(skipLink?.hidden).toBe(false);
   });
 
   test('renders capability error with fallback actions', () => {


### PR DESCRIPTION
### Motivation

- Reduce promotional phrasing in the library landing so the product tone is neutral and self-explanatory. 
- Remove the premium waitlist growth prompt and the skip-to-library skip-link to simplify the library UX and related view logic. 

### Description

- Reworded the library intro in `index.html` by replacing the eyebrow, headline, helper copy, and primary CTA label to neutral language (e.g. `Start fast` → `Library`, `Find a stim in under 10 seconds` → `Browse stims`, CTA to `Open a visual`).
- Removed the `.skip-link` anchor from `index.html` and removed the `setLibrarySkipLinkVisible` function and its calls from `assets/js/toy-view.ts` so toy/library transitions no longer toggle a skip-link element.
- Simplified `assets/js/library-view.js` imports to only use `getRecentToySlugs` and removed the premium waitlist panel rendering and its dismissal handler (`shouldShowPremiumPrompt` / `dismissPremiumPrompt`).
- Updated tests to match the new behavior in `tests/library-filter-state.test.ts` and `tests/toy-view.test.js` by removing expectations for the premium panel and the skip-link.

### Testing

- Ran `bun run check` (Biome lint/format + typecheck + tests) which completed successfully and executed the full test suite. 
- Full test suite results: `180 passed, 2 skipped, 0 failed`.
- Ran `bun run dev` for manual visual verification of the landing copy (local dev server started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df1dcff20833289f0c4c17ad8e1b2)