### PR TITLE
Fix geom microphone error banner layout on mobile

### DIFF
--- a/toys/geom.html
+++ b/toys/geom.html
@@ -41,14 +41,13 @@
         width: 100%;
       }
       #error-message {
-        position: absolute;
-        top: 20px;
-        left: 20px;
-        color: #ff0000;
-        background: rgba(0, 0, 0, 0.7);
+        color: #ff9aa2;
+        background: rgba(38, 5, 10, 0.7);
+        border: 1px solid rgba(255, 154, 162, 0.45);
         padding: 10px;
-        border-radius: 5px;
-        z-index: 10;
+        border-radius: 6px;
+        font-size: 0.95rem;
+        line-height: 1.4;
       }
     </style>
   </head>
@@ -98,8 +97,8 @@
           value="0.25"
         />
       </div>
+      <div id="error-message" style="display: none"></div>
     </div>
-    <div id="error-message" style="display: none"></div>
     <canvas id="gameCanvas" class="toy-canvas"></canvas>
     <script type="module">
       import { getContextFrequencyData } from '../assets/js/core/animation-loop.ts';


### PR DESCRIPTION
### Motivation
- Prevent the microphone error banner from overlaying control labels and sliders on small viewports by making it part of the controls card and improving its readability.

### Description
- Move the `#error-message` element inside the `#controls` container in `toys/geom.html` to avoid it floating over controls on mobile.
- Restyle the banner (soft red text, tinted background, subtle border, slightly larger font and line-height) to improve contrast and legibility while matching the controls card.

### Testing
- Ran the full quality gate with `bun run check` (includes Biome checks, `tsc --noEmit`, and the test suite) which completed successfully (`180 pass`, `2 skip`, `0 fail`).
- Executed an automated Playwright capture of `http://127.0.0.1:5173/toys/geom.html` after a local dev server start to verify the banner layout and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e100bf2b88332943d47a8737508dc)