### PR TITLE
Add robust Codex setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dev": "vite",
     "dev:host": "vite --host",
     "dev:check": "bun scripts/dev-check.mjs || node scripts/dev-check.mjs",
+    "setup:codex": "bash scripts/codex-setup.sh",
     "check": "biome check assets scripts tests && bun run typecheck && bun run test",
     "check:quick": "biome check assets scripts tests && bun run typecheck",
     "check:toys": "bun run scripts/check-toys.ts",

--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/codex-setup.sh [options]
+
+Bootstrap this repository for Codex or local contributor sessions.
+
+Options:
+  --frozen-lockfile   Use bun install --frozen-lockfile.
+  --skip-install      Skip dependency installation.
+  --skip-check        Skip all quality checks.
+  --quick-check       Run bun run check:quick (default).
+  --full-check        Run bun run check.
+  -h, --help          Show this help message.
+USAGE
+}
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but not installed or not on PATH." >&2
+    exit 1
+  fi
+}
+
+ensure_repo_root() {
+  if [[ ! -f "package.json" || ! -f "bun.lock" ]]; then
+    echo "Error: run this script from the repository root (missing package.json or bun.lock)." >&2
+    exit 1
+  fi
+}
+
+INSTALL_MODE="normal"
+DO_INSTALL=1
+DO_CHECK=1
+CHECK_MODE="quick"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --frozen-lockfile)
+      INSTALL_MODE="frozen"
+      shift
+      ;;
+    --skip-install)
+      DO_INSTALL=0
+      shift
+      ;;
+    --skip-check)
+      DO_CHECK=0
+      shift
+      ;;
+    --quick-check)
+      CHECK_MODE="quick"
+      shift
+      ;;
+    --full-check)
+      CHECK_MODE="full"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+ensure_repo_root
+require_command bun
+
+log "Starting Codex setup for stims"
+log "Bun version: $(bun --version)"
+
+if [[ "$DO_INSTALL" -eq 1 ]]; then
+  if [[ "$INSTALL_MODE" == "frozen" ]]; then
+    log "Installing dependencies with frozen lockfile"
+    bun install --frozen-lockfile
+  else
+    log "Installing dependencies"
+    bun install
+  fi
+else
+  log "Skipping dependency installation"
+fi
+
+if [[ "$DO_CHECK" -eq 1 ]]; then
+  if [[ "$CHECK_MODE" == "full" ]]; then
+    log "Running full quality gate (bun run check)"
+    bun run check
+  else
+    log "Running quick quality gate (bun run check:quick)"
+    bun run check:quick
+  fi
+else
+  log "Skipping quality checks"
+fi
+
+log "Codex setup complete"


### PR DESCRIPTION
### Motivation
- Provide a simple, discoverable bootstrap for Codex and local contributor sessions so environments can be prepared consistently.
- Make the setup flow safe and configurable with clear defaults and toggles for install and quality-check steps.

### Description
- Add an executable bootstrap script `scripts/codex-setup.sh` that uses `set -euo pipefail`, timestamped logging, argument parsing, repo-root validation, and a `require_command` check for `bun`.
- The script supports `--frozen-lockfile`, `--skip-install`, `--skip-check`, `--quick-check`, and `--full-check` modes and runs `bun install` and/or `bun run check`/`bun run check:quick` accordingly.
- Add a `setup:codex` npm script entry in `package.json` mapped to `bash scripts/codex-setup.sh` for easy discovery and invocation.
- The script file is added executable (`chmod +x`) and the package change was inserted near existing `dev:check` script to keep the scripts group logical.

### Testing
- Ran `bash scripts/codex-setup.sh --help` which printed usage successfully.
- Ran `bash scripts/codex-setup.sh --skip-install --skip-check` which executed and exited successfully with logging output.
- Ran `bun run check:quick` to validate quick quality gate and typecheck, which completed without errors.
- Commit hooks/lint/format were exercised during commit and `biome` checks/reporting succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e37268438833288f24e0af721d9b0)