### PR TITLE
Refine mobile toy control visibility and collapse behavior

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -431,6 +431,11 @@ body {
   justify-content: flex-end;
 }
 
+.active-toy-nav__actions-primary,
+.active-toy-nav__actions-secondary {
+  display: contents;
+}
+
 .toy-nav__share-wrapper,
 .toy-nav__pip-wrapper,
 .toy-nav__next-wrapper,
@@ -1705,6 +1710,19 @@ body {
     align-items: start;
   }
 
+  .active-toy-nav__actions-primary,
+  .active-toy-nav__actions-secondary {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .active-toy-nav__actions-secondary {
+    padding-top: 4px;
+    border-top: 1px solid rgba(148, 165, 180, 0.3);
+  }
+
   .active-toy-nav__actions[data-toy-actions-expanded="true"] {
     max-height: min(28svh, 260px);
     overflow-y: auto;
@@ -1757,7 +1775,8 @@ body {
     justify-content: center;
   }
 
-  .active-toy-nav__actions[data-toy-actions-expanded="false"] {
+  .active-toy-nav__actions[data-toy-actions-expanded="false"]
+    .active-toy-nav__actions-secondary {
     display: none;
   }
 
@@ -1972,6 +1991,11 @@ body {
 
 @media (max-width: 380px) {
   .active-toy-nav__actions {
+    grid-template-columns: 1fr;
+  }
+
+  .active-toy-nav__actions-primary,
+  .active-toy-nav__actions-secondary {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -265,17 +265,26 @@ function renderToyNav(
       </div>
     </div>
     <div class="active-toy-nav__actions" id="toy-nav-actions" data-toy-actions-expanded="true">
-      <div class="renderer-status-container"></div>
-      ${
-        options.onNextToy
-          ? `<div class="toy-nav__next-wrapper">
-              <button type="button" class="toy-nav__next" data-next-toy="true">
-                Next stim
-              </button>
-              <span class="toy-nav__next-status" role="status" aria-live="polite"></span>
-            </div>`
-          : ''
-      }
+      <div class="active-toy-nav__actions-primary">
+        <div class="renderer-status-container"></div>
+        ${
+          options.onNextToy
+            ? `<div class="toy-nav__next-wrapper">
+                <button type="button" class="toy-nav__next" data-next-toy="true">
+                  Next stim
+                </button>
+                <span class="toy-nav__next-status" role="status" aria-live="polite"></span>
+              </div>`
+            : ''
+        }
+        <div class="toy-nav__share-wrapper">
+          <button type="button" class="toy-nav__share" data-share-toy="true">
+            Copy share link
+          </button>
+          <span class="toy-nav__share-status" role="status" aria-live="polite"></span>
+        </div>
+      </div>
+      <div class="active-toy-nav__actions-secondary">
       ${
         options.onToggleHaptics && options.hapticsSupported
           ? `<div class="toy-nav__flow-wrapper">
@@ -292,15 +301,10 @@ function renderToyNav(
         </button>
         <span class="toy-nav__pip-status" role="status" aria-live="polite"></span>
       </div>
-      <div class="toy-nav__share-wrapper">
-        <button type="button" class="toy-nav__share" data-share-toy="true">
-          Copy share link
-        </button>
-        <span class="toy-nav__share-status" role="status" aria-live="polite"></span>
-      </div>
       <button type="button" class="toy-nav__back" data-back-to-library="true">
         <span aria-hidden="true">←</span><span>Back to library</span>
       </button>
+      </div>
     </div>
   `;
 
@@ -350,7 +354,9 @@ function renderToyNav(
       expanded ? 'true' : 'false',
     );
     if (actionsToggleBtn) {
-      actionsToggleBtn.textContent = expanded ? 'Hide controls' : 'Controls';
+      actionsToggleBtn.textContent = expanded
+        ? 'Hide extra controls'
+        : 'More controls';
     }
   };
 

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -122,3 +122,39 @@ describe('library navigation interactions', () => {
     expect(getListenerCount()).toBe(1);
   });
 });
+
+describe('toy navigation visibility states', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="nav"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('mobile view keeps primary actions visible while extra controls are collapsed by default', () => {
+    const { matchMedia } = createMatchMediaStub();
+    window.matchMedia = matchMedia;
+
+    const container = document.getElementById('nav') as HTMLElement;
+    initNavigation(container, { mode: 'toy', title: 'Spectrum Bloom' });
+
+    const actions = container.querySelector('#toy-nav-actions') as HTMLElement;
+    const toggle = container.querySelector(
+      '[data-toy-actions-toggle="true"]',
+    ) as HTMLButtonElement;
+    const primary = container.querySelector('.active-toy-nav__actions-primary');
+    const secondary = container.querySelector(
+      '.active-toy-nav__actions-secondary',
+    );
+
+    expect(actions.dataset.toyActionsExpanded).toBe('false');
+    expect(toggle.textContent).toBe('More controls');
+    expect(primary).toBeTruthy();
+    expect(secondary).toBeTruthy();
+    expect(document.documentElement.dataset.toyControlsExpanded).toBe('false');
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce initial control density on toy pages so essential actions remain visible while secondary controls can be minimized on small viewports.
- Make the mobile controls toggle more explicit so users understand there are additional, collapsible actions.

### Description
- Split the toy navigation actions into primary and secondary groups by changing the markup in `assets/js/ui/nav.ts` so essential actions remain visible while extras can collapse.
- Update the toggle label/state text to use `More controls` when collapsed and `Hide extra controls` when expanded in `assets/js/ui/nav.ts`.
- Add responsive CSS in `assets/css/base.css` to layout the new `.active-toy-nav__actions-primary` and `.active-toy-nav__actions-secondary` groups and to hide only the secondary group when `data-toy-actions-expanded="false"` on mobile.
- Add a test in `tests/nav.test.ts` to assert that on mobile the primary actions are present and extra controls are collapsed by default.

### Testing
- Ran `bun run test tests/nav.test.ts` which passed (5 tests, 0 failures). 
- Ran the full quality gate with `bun run check` (Biome format/lint, `tsc --noEmit`, and test suite) which completed successfully (all checks and tests passed).

Files changed
- `assets/js/ui/nav.ts`
- `assets/css/base.css`
- `tests/nav.test.ts`

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e366f49648332a9f935e3f818cb21)