### PR TITLE
Add generated OG images and update SEO/OG/meta across site; WebGPU annotations

### DIFF
--- a/public/capabilities/demo-audio/index.html
+++ b/public/capabilities/demo-audio/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 24 toys with demo audio available support." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/demo-audio/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/capability-demo-audio.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Demo audio available capability page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Demo audio available toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 24 toys with demo audio available support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-demo-audio.svg" />
+    <meta name="twitter:image:alt" content="Demo audio available capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/demo-audio/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/capabilities/demo-audio/index.html
+++ b/public/capabilities/demo-audio/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Demo audio available toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 24 toys with demo audio available support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-demo-audio.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Demo audio available capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/demo-audio/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/capabilities/index.html
+++ b/public/capabilities/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Capabilities | Stim Webtoys Library" />
     <meta name="twitter:description" content="Find toys by microphone support, demo audio, device motion, and WebGPU so you can play with the setup you have." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/capabilities.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys capabilities page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/capabilities/index.html
+++ b/public/capabilities/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Find toys by microphone support, demo audio, device motion, and WebGPU so you can play with the setup you have." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/capabilities.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Stim Webtoys capabilities page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Capabilities | Stim Webtoys Library" />
     <meta name="twitter:description" content="Find toys by microphone support, demo audio, device motion, and WebGPU so you can play with the setup you have." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/capabilities.svg" />
+    <meta name="twitter:image:alt" content="Stim Webtoys capabilities page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
@@ -64,7 +64,7 @@
       
         <li class="feature-card">
           <h3>WebGPU enhanced</h3>
-          <p>1 toys</p>
+          <p>24 toys</p>
           <a class="cta-button ghost" href="/capabilities/webgpu/">View toys</a>
         </li>
       </ul>

--- a/public/capabilities/microphone/index.html
+++ b/public/capabilities/microphone/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 24 toys with microphone ready support." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/microphone/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/capability-microphone.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Microphone ready capability page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Microphone ready toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 24 toys with microphone ready support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-microphone.svg" />
+    <meta name="twitter:image:alt" content="Microphone ready capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/microphone/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/capabilities/microphone/index.html
+++ b/public/capabilities/microphone/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Microphone ready toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 24 toys with microphone ready support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-microphone.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Microphone ready capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/microphone/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/capabilities/motion/index.html
+++ b/public/capabilities/motion/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Device motion support toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with device motion support support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-motion.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Device motion support capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/motion/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/capabilities/motion/index.html
+++ b/public/capabilities/motion/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with device motion support support." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/motion/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/capability-motion.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Device motion support capability page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Device motion support toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with device motion support support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-motion.svg" />
+    <meta name="twitter:image:alt" content="Device motion support capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/motion/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/capabilities/webgpu/index.html
+++ b/public/capabilities/webgpu/index.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Explore 1 toys with webgpu enhanced support." />
+    <meta name="description" content="Explore 24 toys with webgpu enhanced support." />
     <meta name="robots" content="index,follow" />
     <meta name="keywords" content="WebGPU enhanced toys, WebGPU enhanced support, audio-reactive web toys" />
     <meta property="og:title" content="WebGPU enhanced toys | Stim Webtoys" />
-    <meta property="og:description" content="Explore 1 toys with webgpu enhanced support." />
+    <meta property="og:description" content="Explore 24 toys with webgpu enhanced support." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/capabilities/webgpu/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/capability-webgpu.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="WebGPU enhanced capability page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="WebGPU enhanced toys | Stim Webtoys" />
-    <meta name="twitter:description" content="Explore 1 toys with webgpu enhanced support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:description" content="Explore 24 toys with webgpu enhanced support." />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-webgpu.svg" />
+    <meta name="twitter:image:alt" content="WebGPU enhanced capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/webgpu/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
@@ -31,7 +31,7 @@
     <title>WebGPU enhanced toys | Stim Webtoys</title>
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"Capabilities","item":"https://no.toil.fyi/capabilities/"},{"@type":"ListItem","position":3,"name":"WebGPU enhanced","item":"https://no.toil.fyi/capabilities/webgpu/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","name":"WebGPU enhanced toys | Stim Webtoys","description":"Explore 1 toys with webgpu enhanced support.","url":"https://no.toil.fyi/capabilities/webgpu/","isPartOf":{"@type":"WebSite","name":"Stim Webtoys Library","url":"https://no.toil.fyi"},"mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","position":1,"name":"Multi-Capability Visualizer","url":"https://no.toil.fyi/toys/multi/"}]}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","name":"WebGPU enhanced toys | Stim Webtoys","description":"Explore 24 toys with webgpu enhanced support.","url":"https://no.toil.fyi/capabilities/webgpu/","isPartOf":{"@type":"WebSite","name":"Stim Webtoys Library","url":"https://no.toil.fyi"},"mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","position":1,"name":"3D Toy","url":"https://no.toil.fyi/toys/3dtoy/"},{"@type":"ListItem","position":2,"name":"Aurora Painter","url":"https://no.toil.fyi/toys/aurora-painter/"},{"@type":"ListItem","position":3,"name":"Pottery Wheel Sculptor","url":"https://no.toil.fyi/toys/clay/"},{"@type":"ListItem","position":4,"name":"Evolutionary Weirdcore","url":"https://no.toil.fyi/toys/evol/"},{"@type":"ListItem","position":5,"name":"Microphone Geometry Visualizer","url":"https://no.toil.fyi/toys/geom/"},{"@type":"ListItem","position":6,"name":"Halo Visualizer","url":"https://no.toil.fyi/toys/holy/"},{"@type":"ListItem","position":7,"name":"Multi-Capability Visualizer","url":"https://no.toil.fyi/toys/multi/"},{"@type":"ListItem","position":8,"name":"Synesthetic Visualizer","url":"https://no.toil.fyi/toys/seary/"},{"@type":"ListItem","position":9,"name":"Terminal Word Grid","url":"https://no.toil.fyi/toys/legible/"},{"@type":"ListItem","position":10,"name":"Spectrograph","url":"https://no.toil.fyi/toys/symph/"},{"@type":"ListItem","position":11,"name":"Grid Visualizer","url":"https://no.toil.fyi/toys/cube-wave/"},{"@type":"ListItem","position":12,"name":"Bubble Harmonics","url":"https://no.toil.fyi/toys/bubble-harmonics/"},{"@type":"ListItem","position":13,"name":"Pocket Pulse","url":"https://no.toil.fyi/toys/pocket-pulse/"},{"@type":"ListItem","position":14,"name":"Mobile Ripples","url":"https://no.toil.fyi/toys/mobile-ripples/"},{"@type":"ListItem","position":15,"name":"Cosmic Particles","url":"https://no.toil.fyi/toys/cosmic-particles/"},{"@type":"ListItem","position":16,"name":"Audio Light Show","url":"https://no.toil.fyi/toys/lights/"},{"@type":"ListItem","position":17,"name":"Spiral Burst","url":"https://no.toil.fyi/toys/spiral-burst/"},{"@type":"ListItem","position":18,"name":"Rainbow Tunnel","url":"https://no.toil.fyi/toys/rainbow-tunnel/"},{"@type":"ListItem","position":19,"name":"Star Field","url":"https://no.toil.fyi/toys/star-field/"},{"@type":"ListItem","position":20,"name":"Fractal Kite Garden","url":"https://no.toil.fyi/toys/fractal-kite-garden/"},{"@type":"ListItem","position":21,"name":"Tactile Sand Table","url":"https://no.toil.fyi/toys/tactile-sand-table/"},{"@type":"ListItem","position":22,"name":"Bioluminescent Tidepools","url":"https://no.toil.fyi/toys/bioluminescent-tidepools/"},{"@type":"ListItem","position":23,"name":"Neon Wave","url":"https://no.toil.fyi/toys/neon-wave/"},{"@type":"ListItem","position":24,"name":"MilkDrop Proto","url":"https://no.toil.fyi/toys/milkdrop/"}]}}</script>
 
   </head>
   <body>
@@ -46,17 +46,178 @@
         <div class="section-heading">
           <p class="eyebrow">Capability</p>
           <h1>WebGPU enhanced</h1>
-          <p class="section-description">1 toys support this capability.</p>
+          <p class="section-description">24 toys support this capability.</p>
           <a class="text-link" href="/capabilities/">All capabilities</a>
         </div>
       </section>
       <section>
         <ul class="feature-card-grid">
         <li class="feature-card">
+          <h3>3D Toy</h3>
+          <p>A twisting 3D tunnel that responds to sound.</p>
+          <a class="cta-button ghost" href="/toys/3dtoy/">View details</a>
+          <a class="text-link" href="/toy.html?toy=3dtoy">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Aurora Painter</h3>
+          <p>Paint flowing aurora ribbons that react to your microphone in layered waves.</p>
+          <a class="cta-button ghost" href="/toys/aurora-painter/">View details</a>
+          <a class="text-link" href="/toy.html?toy=aurora-painter">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Pottery Wheel Sculptor</h3>
+          <p>Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.</p>
+          <a class="cta-button ghost" href="/toys/clay/">View details</a>
+          <a class="text-link" href="/toy.html?toy=clay">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Evolutionary Weirdcore</h3>
+          <p>Watch surreal landscapes evolve with fractals and glitches that react to music.</p>
+          <a class="cta-button ghost" href="/toys/evol/">View details</a>
+          <a class="text-link" href="/toy.html?toy=evol">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Microphone Geometry Visualizer</h3>
+          <p>Push shifting geometric forms directly from live mic input with responsive controls.</p>
+          <a class="cta-button ghost" href="/toys/geom/">View details</a>
+          <a class="text-link" href="/toy.html?toy=geom">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Halo Visualizer</h3>
+          <p>Layered halos, particles, and shapes that respond to your music.</p>
+          <a class="cta-button ghost" href="/toys/holy/">View details</a>
+          <a class="text-link" href="/toy.html?toy=holy">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
           <h3>Multi-Capability Visualizer</h3>
           <p>Shapes and lights move with both sound and device motion.</p>
           <a class="cta-button ghost" href="/toys/multi/">View details</a>
           <a class="text-link" href="/toy.html?toy=multi">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Synesthetic Visualizer</h3>
+          <p>Blend audio and visuals into linked patterns.</p>
+          <a class="cta-button ghost" href="/toys/seary/">View details</a>
+          <a class="text-link" href="/toy.html?toy=seary">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Terminal Word Grid</h3>
+          <p>A retro green text grid that pulses to audio and surfaces fresh words as you play.</p>
+          <a class="cta-button ghost" href="/toys/legible/">View details</a>
+          <a class="text-link" href="/toy.html?toy=legible">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Spectrograph</h3>
+          <p>A spectrograph that moves gently with your audio.</p>
+          <a class="cta-button ghost" href="/toys/symph/">View details</a>
+          <a class="text-link" href="/toy.html?toy=symph">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Grid Visualizer</h3>
+          <p>Swap between cube waves and bouncing spheres without stopping the music.</p>
+          <a class="cta-button ghost" href="/toys/cube-wave/">View details</a>
+          <a class="text-link" href="/toy.html?toy=cube-wave">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Bubble Harmonics</h3>
+          <p>Translucent, audio-inflated bubbles that split into harmonics on high frequencies.</p>
+          <a class="cta-button ghost" href="/toys/bubble-harmonics/">View details</a>
+          <a class="text-link" href="/toy.html?toy=bubble-harmonics">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Pocket Pulse</h3>
+          <p>A mobile-optimized pulse field that responds to audio and touch gestures.</p>
+          <a class="cta-button ghost" href="/toys/pocket-pulse/">View details</a>
+          <a class="text-link" href="/toy.html?toy=pocket-pulse">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Mobile Ripples</h3>
+          <p>Low-power neon ripples tuned for touch-first screens and pocket GPUs.</p>
+          <a class="cta-button ghost" href="/toys/mobile-ripples/">View details</a>
+          <a class="text-link" href="/toy.html?toy=mobile-ripples">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Cosmic Particles</h3>
+          <p>Jump between orbiting swirls and nebula fly-throughs with a single toggle.</p>
+          <a class="cta-button ghost" href="/toys/cosmic-particles/">View details</a>
+          <a class="text-link" href="/toy.html?toy=cosmic-particles">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Audio Light Show</h3>
+          <p>Swap shader styles and color palettes while lights ripple with your microphone input.</p>
+          <a class="cta-button ghost" href="/toys/lights/">View details</a>
+          <a class="text-link" href="/toy.html?toy=lights">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Spiral Burst</h3>
+          <p>Colorful spirals rotate and expand with every beat.</p>
+          <a class="cta-button ghost" href="/toys/spiral-burst/">View details</a>
+          <a class="text-link" href="/toy.html?toy=spiral-burst">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Rainbow Tunnel</h3>
+          <p>Fly through colorful rings that spin to your music.</p>
+          <a class="cta-button ghost" href="/toys/rainbow-tunnel/">View details</a>
+          <a class="text-link" href="/toy.html?toy=rainbow-tunnel">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Star Field</h3>
+          <p>A field of shimmering stars reacts to the beat.</p>
+          <a class="cta-button ghost" href="/toys/star-field/">View details</a>
+          <a class="text-link" href="/toy.html?toy=star-field">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Fractal Kite Garden</h3>
+          <p>Grow branching kite fractals that sway with mids and shimmer with crisp highs.</p>
+          <a class="cta-button ghost" href="/toys/fractal-kite-garden/">View details</a>
+          <a class="text-link" href="/toy.html?toy=fractal-kite-garden">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Tactile Sand Table</h3>
+          <p>Heightfield sand ripples that respond to bass, mids, and device tilt.</p>
+          <a class="cta-button ghost" href="/toys/tactile-sand-table/">View details</a>
+          <a class="text-link" href="/toy.html?toy=tactile-sand-table">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Bioluminescent Tidepools</h3>
+          <p>Sketch glowing currents that bloom with high-frequency sparkle from your music.</p>
+          <a class="cta-button ghost" href="/toys/bioluminescent-tidepools/">View details</a>
+          <a class="text-link" href="/toy.html?toy=bioluminescent-tidepools">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>Neon Wave</h3>
+          <p>Retro-wave visualizer with bloom effects, custom shaders, and four color themes.</p>
+          <a class="cta-button ghost" href="/toys/neon-wave/">View details</a>
+          <a class="text-link" href="/toy.html?toy=neon-wave">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
+          <h3>MilkDrop Proto</h3>
+          <p>A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system.</p>
+          <a class="cta-button ghost" href="/toys/milkdrop/">View details</a>
+          <a class="text-link" href="/toy.html?toy=milkdrop">Launch toy</a>
         </li>
       </ul>
       </section>

--- a/public/capabilities/webgpu/index.html
+++ b/public/capabilities/webgpu/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="WebGPU enhanced toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 24 toys with webgpu enhanced support." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/capability-webgpu.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="WebGPU enhanced capability page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/capabilities/webgpu/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/calming/index.html
+++ b/public/moods/calming/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="calming mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 toys with a calming vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-calming.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="calming mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/calming/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/calming/index.html
+++ b/public/moods/calming/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 3 toys with a calming vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/calming/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-calming.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="calming mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="calming mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 toys with a calming vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-calming.svg" />
+    <meta name="twitter:image:alt" content="calming mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/calming/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/celestial/index.html
+++ b/public/moods/celestial/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="celestial mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a celestial vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-celestial.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="celestial mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/celestial/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/celestial/index.html
+++ b/public/moods/celestial/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a celestial vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/celestial/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-celestial.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="celestial mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="celestial mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a celestial vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-celestial.svg" />
+    <meta name="twitter:image:alt" content="celestial mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/celestial/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/cosmic/index.html
+++ b/public/moods/cosmic/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="cosmic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 5 toys with a cosmic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-cosmic.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="cosmic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/cosmic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/cosmic/index.html
+++ b/public/moods/cosmic/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 5 toys with a cosmic vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/cosmic/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-cosmic.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="cosmic mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="cosmic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 5 toys with a cosmic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-cosmic.svg" />
+    <meta name="twitter:image:alt" content="cosmic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/cosmic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/dreamy/index.html
+++ b/public/moods/dreamy/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 4 toys with a dreamy vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/dreamy/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-dreamy.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="dreamy mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="dreamy mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 toys with a dreamy vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-dreamy.svg" />
+    <meta name="twitter:image:alt" content="dreamy mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/dreamy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/dreamy/index.html
+++ b/public/moods/dreamy/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="dreamy mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 toys with a dreamy vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-dreamy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="dreamy mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/dreamy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/drifting/index.html
+++ b/public/moods/drifting/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="drifting mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a drifting vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-drifting.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="drifting mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/drifting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/drifting/index.html
+++ b/public/moods/drifting/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a drifting vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/drifting/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-drifting.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="drifting mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="drifting mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a drifting vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-drifting.svg" />
+    <meta name="twitter:image:alt" content="drifting mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/drifting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/energetic/index.html
+++ b/public/moods/energetic/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 7 toys with a energetic vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/energetic/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-energetic.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="energetic mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="energetic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 7 toys with a energetic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-energetic.svg" />
+    <meta name="twitter:image:alt" content="energetic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/energetic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/energetic/index.html
+++ b/public/moods/energetic/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="energetic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 7 toys with a energetic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-energetic.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="energetic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/energetic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/ethereal/index.html
+++ b/public/moods/ethereal/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ethereal mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 toys with a ethereal vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-ethereal.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="ethereal mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/ethereal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/ethereal/index.html
+++ b/public/moods/ethereal/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 3 toys with a ethereal vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/ethereal/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-ethereal.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="ethereal mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ethereal mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 toys with a ethereal vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-ethereal.svg" />
+    <meta name="twitter:image:alt" content="ethereal mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/ethereal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/fiery/index.html
+++ b/public/moods/fiery/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a fiery vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/fiery/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-fiery.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="fiery mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="fiery mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a fiery vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-fiery.svg" />
+    <meta name="twitter:image:alt" content="fiery mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/fiery/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/fiery/index.html
+++ b/public/moods/fiery/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="fiery mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a fiery vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-fiery.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="fiery mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/fiery/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/focus/index.html
+++ b/public/moods/focus/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="focus mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 toys with a focus vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-focus.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="focus mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/focus/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/focus/index.html
+++ b/public/moods/focus/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 4 toys with a focus vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/focus/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-focus.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="focus mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="focus mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 toys with a focus vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-focus.svg" />
+    <meta name="twitter:image:alt" content="focus mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/focus/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/glow/index.html
+++ b/public/moods/glow/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="glow mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a glow vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-glow.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="glow mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/glow/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/glow/index.html
+++ b/public/moods/glow/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a glow vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/glow/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-glow.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="glow mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="glow mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a glow vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-glow.svg" />
+    <meta name="twitter:image:alt" content="glow mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/glow/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/grounded/index.html
+++ b/public/moods/grounded/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="grounded mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a grounded vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-grounded.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="grounded mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/grounded/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/grounded/index.html
+++ b/public/moods/grounded/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a grounded vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/grounded/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-grounded.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="grounded mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="grounded mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a grounded vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-grounded.svg" />
+    <meta name="twitter:image:alt" content="grounded mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/grounded/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/immersive/index.html
+++ b/public/moods/immersive/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="immersive mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 6 toys with a immersive vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-immersive.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="immersive mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/immersive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/immersive/index.html
+++ b/public/moods/immersive/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 6 toys with a immersive vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/immersive/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-immersive.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="immersive mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="immersive mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 6 toys with a immersive vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-immersive.svg" />
+    <meta name="twitter:image:alt" content="immersive mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/immersive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/index.html
+++ b/public/moods/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Moods | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse toys by mood and sensory vibe, from calming visuals to playful, energetic stims." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/moods.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys moods page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/index.html
+++ b/public/moods/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Browse toys by mood and sensory vibe, from calming visuals to playful, energetic stims." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/moods.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Stim Webtoys moods page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Moods | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse toys by mood and sensory vibe, from calming visuals to playful, energetic stims." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/moods.svg" />
+    <meta name="twitter:image:alt" content="Stim Webtoys moods page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/luminous/index.html
+++ b/public/moods/luminous/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a luminous vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/luminous/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-luminous.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="luminous mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="luminous mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a luminous vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-luminous.svg" />
+    <meta name="twitter:image:alt" content="luminous mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/luminous/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/luminous/index.html
+++ b/public/moods/luminous/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="luminous mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a luminous vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-luminous.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="luminous mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/luminous/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/minimal/index.html
+++ b/public/moods/minimal/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a minimal vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/minimal/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-minimal.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="minimal mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="minimal mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a minimal vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-minimal.svg" />
+    <meta name="twitter:image:alt" content="minimal mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/minimal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/minimal/index.html
+++ b/public/moods/minimal/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="minimal mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a minimal vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-minimal.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="minimal mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/minimal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/playful/index.html
+++ b/public/moods/playful/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="playful mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a playful vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-playful.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="playful mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/playful/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/playful/index.html
+++ b/public/moods/playful/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a playful vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/playful/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-playful.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="playful mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="playful mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a playful vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-playful.svg" />
+    <meta name="twitter:image:alt" content="playful mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/playful/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/psychedelic/index.html
+++ b/public/moods/psychedelic/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="psychedelic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a psychedelic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-psychedelic.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="psychedelic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/psychedelic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/psychedelic/index.html
+++ b/public/moods/psychedelic/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a psychedelic vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/psychedelic/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-psychedelic.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="psychedelic mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="psychedelic mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a psychedelic vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-psychedelic.svg" />
+    <meta name="twitter:image:alt" content="psychedelic mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/psychedelic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/pulsing/index.html
+++ b/public/moods/pulsing/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a pulsing vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/pulsing/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-pulsing.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="pulsing mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pulsing mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a pulsing vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-pulsing.svg" />
+    <meta name="twitter:image:alt" content="pulsing mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/pulsing/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/pulsing/index.html
+++ b/public/moods/pulsing/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pulsing mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a pulsing vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-pulsing.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="pulsing mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/pulsing/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/serene/index.html
+++ b/public/moods/serene/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 5 toys with a serene vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/serene/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-serene.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="serene mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="serene mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 5 toys with a serene vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-serene.svg" />
+    <meta name="twitter:image:alt" content="serene mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/serene/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/serene/index.html
+++ b/public/moods/serene/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="serene mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 5 toys with a serene vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-serene.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="serene mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/serene/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/tactile/index.html
+++ b/public/moods/tactile/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tactile mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a tactile vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-tactile.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="tactile mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/tactile/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/tactile/index.html
+++ b/public/moods/tactile/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 toys with a tactile vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/tactile/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-tactile.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="tactile mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tactile mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 toys with a tactile vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-tactile.svg" />
+    <meta name="twitter:image:alt" content="tactile mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/tactile/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/moods/uplifting/index.html
+++ b/public/moods/uplifting/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="uplifting mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a uplifting vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-uplifting.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="uplifting mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/uplifting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/moods/uplifting/index.html
+++ b/public/moods/uplifting/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 toys with a uplifting vibe." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/moods/uplifting/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/mood-uplifting.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="uplifting mood page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="uplifting mood toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 toys with a uplifting vibe." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/mood-uplifting.svg" />
+    <meta name="twitter:image:alt" content="uplifting mood page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/moods/uplifting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/og/3dtoy.svg
+++ b/public/og/3dtoy.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="3D Toy">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">3D Toy</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">3D Toy</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/aurora-painter.svg
+++ b/public/og/aurora-painter.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Aurora Painter">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Aurora Painter</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Aurora Painter</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/bioluminescent-tidepools.svg
+++ b/public/og/bioluminescent-tidepools.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Bioluminescent Tidepools">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Bioluminescent Tidepools</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Bioluminescent Tidepools</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/bubble-harmonics.svg
+++ b/public/og/bubble-harmonics.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Bubble Harmonics">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Bubble Harmonics</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Bubble Harmonics</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/capabilities.svg
+++ b/public/og/capabilities.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Capabilities">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="300" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Browse by capability</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys discovery</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Capabilities</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Filter toys by microphone, motion, audio, and WebGPU</text>
+</svg>

--- a/public/og/capability-demo-audio.svg
+++ b/public/og/capability-demo-audio.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Demo audio available toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="480" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Capability: Demo audio available</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys capability collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Demo audio available toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">24 toys support this</text>
+</svg>

--- a/public/og/capability-microphone.svg
+++ b/public/og/capability-microphone.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Microphone ready toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="420" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Capability: Microphone ready</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys capability collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Microphone ready toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">24 toys support this</text>
+</svg>

--- a/public/og/capability-motion.svg
+++ b/public/og/capability-motion.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Device motion support toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="495" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Capability: Device motion support</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys capability collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Device motion support toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys support this</text>
+</svg>

--- a/public/og/capability-webgpu.svg
+++ b/public/og/capability-webgpu.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="WebGPU enhanced toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="405" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Capability: WebGPU enhanced</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys capability collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">WebGPU enhanced toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">24 toys support this</text>
+</svg>

--- a/public/og/clay.svg
+++ b/public/og/clay.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Pottery Wheel Sculptor">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Pottery Wheel Sculptor</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Pottery Wheel Sculptor</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/cosmic-particles.svg
+++ b/public/og/cosmic-particles.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Cosmic Particles">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Cosmic Particles</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Cosmic Particles</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/cube-wave.svg
+++ b/public/og/cube-wave.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Grid Visualizer">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Grid Visualizer</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Grid Visualizer</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/default.svg
+++ b/public/og/default.svg
@@ -4,11 +4,17 @@
       <stop offset="0%" stop-color="#0b1024" />
       <stop offset="100%" stop-color="#26377f" />
     </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Stim Webtoys</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Audio-reactive sensory visual play</text>
+  
+  <text x="90" y="170" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
+  <text x="90" y="272" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Stim Webtoys</text>
+  <text x="90" y="342" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Audio-reactive sensory visual play</text>
 </svg>

--- a/public/og/evol.svg
+++ b/public/og/evol.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Evolutionary Weirdcore">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Evolutionary Weirdcore</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Evolutionary Weirdcore</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/fractal-kite-garden.svg
+++ b/public/og/fractal-kite-garden.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Fractal Kite Garden">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Fractal Kite Garden</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Fractal Kite Garden</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/geom.svg
+++ b/public/og/geom.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Microphone Geometry Visualizer">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Microphone Geometry Visualizer</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Microphone Geometry Visualizer</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/holy.svg
+++ b/public/og/holy.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Halo Visualizer">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Halo Visualizer</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Halo Visualizer</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/legible.svg
+++ b/public/og/legible.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Terminal Word Grid">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Terminal Word Grid</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Terminal Word Grid</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/lights.svg
+++ b/public/og/lights.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Audio Light Show">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Audio Light Show</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Audio Light Show</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/milkdrop.svg
+++ b/public/og/milkdrop.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="MilkDrop Proto">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">MilkDrop Proto</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">MilkDrop Proto</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/mobile-ripples.svg
+++ b/public/og/mobile-ripples.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Mobile Ripples">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Mobile Ripples</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Mobile Ripples</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/mood-calming.svg
+++ b/public/og/mood-calming.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="calming mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: calming</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">calming mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">3 toys with this vibe</text>
+</svg>

--- a/public/og/mood-celestial.svg
+++ b/public/og/mood-celestial.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="celestial mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: celestial</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">celestial mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-cosmic.svg
+++ b/public/og/mood-cosmic.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="cosmic mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: cosmic</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">cosmic mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">5 toys with this vibe</text>
+</svg>

--- a/public/og/mood-dreamy.svg
+++ b/public/og/mood-dreamy.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="dreamy mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: dreamy</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">dreamy mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">4 toys with this vibe</text>
+</svg>

--- a/public/og/mood-drifting.svg
+++ b/public/og/mood-drifting.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="drifting mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: drifting</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">drifting mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/mood-energetic.svg
+++ b/public/og/mood-energetic.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="energetic mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: energetic</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">energetic mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">7 toys with this vibe</text>
+</svg>

--- a/public/og/mood-ethereal.svg
+++ b/public/og/mood-ethereal.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="ethereal mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: ethereal</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">ethereal mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">3 toys with this vibe</text>
+</svg>

--- a/public/og/mood-fiery.svg
+++ b/public/og/mood-fiery.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="fiery mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: fiery</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">fiery mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-focus.svg
+++ b/public/og/mood-focus.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="focus mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: focus</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">focus mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">4 toys with this vibe</text>
+</svg>

--- a/public/og/mood-glow.svg
+++ b/public/og/mood-glow.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="glow mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: glow</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">glow mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-grounded.svg
+++ b/public/og/mood-grounded.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="grounded mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: grounded</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">grounded mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-immersive.svg
+++ b/public/og/mood-immersive.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="immersive mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: immersive</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">immersive mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">6 toys with this vibe</text>
+</svg>

--- a/public/og/mood-luminous.svg
+++ b/public/og/mood-luminous.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="luminous mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: luminous</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">luminous mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/mood-minimal.svg
+++ b/public/og/mood-minimal.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="minimal mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: minimal</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">minimal mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/mood-playful.svg
+++ b/public/og/mood-playful.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="playful mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: playful</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">playful mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-psychedelic.svg
+++ b/public/og/mood-psychedelic.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="psychedelic mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="255" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: psychedelic</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">psychedelic mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/mood-pulsing.svg
+++ b/public/og/mood-pulsing.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="pulsing mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: pulsing</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">pulsing mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/mood-serene.svg
+++ b/public/og/mood-serene.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="serene mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: serene</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">serene mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">5 toys with this vibe</text>
+</svg>

--- a/public/og/mood-tactile.svg
+++ b/public/og/mood-tactile.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="tactile mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: tactile</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">tactile mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy with this vibe</text>
+</svg>

--- a/public/og/mood-uplifting.svg
+++ b/public/og/mood-uplifting.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="uplifting mood">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3f1239" />
+      <stop offset="100%" stop-color="#c026d3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Mood: uplifting</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys mood collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">uplifting mood</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys with this vibe</text>
+</svg>

--- a/public/og/moods.svg
+++ b/public/og/moods.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Moods">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3b1027" />
+      <stop offset="100%" stop-color="#9333ea" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Browse by mood</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys discovery</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Moods</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Find visuals that match your sensory flow</text>
+</svg>

--- a/public/og/multi.svg
+++ b/public/og/multi.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Multi-Capability Visualizer">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Multi-Capability Visualizer</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Multi-Capability Visualizer</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/neon-wave.svg
+++ b/public/og/neon-wave.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Neon Wave">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Neon Wave</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Neon Wave</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/pocket-pulse.svg
+++ b/public/og/pocket-pulse.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Pocket Pulse">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Pocket Pulse</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Pocket Pulse</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/rainbow-tunnel.svg
+++ b/public/og/rainbow-tunnel.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Rainbow Tunnel">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Rainbow Tunnel</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Rainbow Tunnel</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/seary.svg
+++ b/public/og/seary.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Synesthetic Visualizer">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Synesthetic Visualizer</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Synesthetic Visualizer</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/spiral-burst.svg
+++ b/public/og/spiral-burst.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Spiral Burst">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Spiral Burst</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Spiral Burst</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/star-field.svg
+++ b/public/og/star-field.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Star Field">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Star Field</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Star Field</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/symph.svg
+++ b/public/og/symph.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Spectrograph">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Spectrograph</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Spectrograph</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/tactile-sand-table.svg
+++ b/public/og/tactile-sand-table.svg
@@ -1,14 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Tactile Sand Table">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="#1a0c33" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Tactile Sand Table</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Launch now</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys toy page</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Tactile Sand Table</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Interactive audio-reactive web toy</text>
 </svg>

--- a/public/og/tag-3d.svg
+++ b/public/og/tag-3d.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="3d toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: 3d</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">3d toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-ambient.svg
+++ b/public/og/tag-ambient.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="ambient toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: ambient</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">ambient toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-audio-mapped.svg
+++ b/public/og/tag-audio-mapped.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="audio-mapped toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="255" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: audio-mapped</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">audio-mapped toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-aurora.svg
+++ b/public/og/tag-aurora.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="aurora toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: aurora</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">aurora toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-bioluminescent.svg
+++ b/public/og/tag-bioluminescent.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="bioluminescent toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="285" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: bioluminescent</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">bioluminescent toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-bloom.svg
+++ b/public/og/tag-bloom.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="bloom toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: bloom</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">bloom toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-bubbles.svg
+++ b/public/og/tag-bubbles.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="bubbles toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: bubbles</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">bubbles toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-burst.svg
+++ b/public/og/tag-burst.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="burst toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: burst</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">burst toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-calming.svg
+++ b/public/og/tag-calming.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="calming toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: calming</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">calming toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-caustics.svg
+++ b/public/og/tag-caustics.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="caustics toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: caustics</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">caustics toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-cyberpunk.svg
+++ b/public/og/tag-cyberpunk.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="cyberpunk toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: cyberpunk</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">cyberpunk toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-evolutionary.svg
+++ b/public/og/tag-evolutionary.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="evolutionary toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="255" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: evolutionary</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">evolutionary toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-feedback.svg
+++ b/public/og/tag-feedback.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="feedback toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: feedback</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">feedback toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-fractal.svg
+++ b/public/og/tag-fractal.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="fractal toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: fractal</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">fractal toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-generative.svg
+++ b/public/og/tag-generative.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="generative toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: generative</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">generative toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-geometry.svg
+++ b/public/og/tag-geometry.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="geometry toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: geometry</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">geometry toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-gestural.svg
+++ b/public/og/tag-gestural.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="gestural toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: gestural</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">gestural toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">4 toys in this tag</text>
+</svg>

--- a/public/og/tag-glitch.svg
+++ b/public/og/tag-glitch.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="glitch toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: glitch</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">glitch toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-grid.svg
+++ b/public/og/tag-grid.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="grid toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: grid</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">grid toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-halos.svg
+++ b/public/og/tag-halos.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="halos toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: halos</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">halos toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-haptics.svg
+++ b/public/og/tag-haptics.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="haptics toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: haptics</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">haptics toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-harmonics.svg
+++ b/public/og/tag-harmonics.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="harmonics toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: harmonics</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">harmonics toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-hybrid.svg
+++ b/public/og/tag-hybrid.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="hybrid toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: hybrid</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">hybrid toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-immersive.svg
+++ b/public/og/tag-immersive.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="immersive toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: immersive</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">immersive toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-kite.svg
+++ b/public/og/tag-kite.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="kite toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: kite</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">kite toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-legacy.svg
+++ b/public/og/tag-legacy.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="legacy toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: legacy</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">legacy toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-lights.svg
+++ b/public/og/tag-lights.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="lights toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: lights</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">lights toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-microphone.svg
+++ b/public/og/tag-microphone.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="microphone toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: microphone</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">microphone toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-mobile.svg
+++ b/public/og/tag-mobile.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="mobile toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: mobile</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">mobile toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-mode-switch.svg
+++ b/public/og/tag-mode-switch.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="mode-switch toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="240" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: mode-switch</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">mode-switch toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-motion.svg
+++ b/public/og/tag-motion.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="motion toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: motion</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">motion toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-nebula.svg
+++ b/public/og/tag-nebula.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="nebula toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: nebula</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">nebula toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-ocean.svg
+++ b/public/og/tag-ocean.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="ocean toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: ocean</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">ocean toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-palette.svg
+++ b/public/og/tag-palette.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="palette toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: palette</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">palette toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-particles.svg
+++ b/public/og/tag-particles.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="particles toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: particles</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">particles toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-patterns.svg
+++ b/public/og/tag-patterns.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="patterns toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: patterns</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">patterns toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-pottery.svg
+++ b/public/og/tag-pottery.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="pottery toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: pottery</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">pottery toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-pulses.svg
+++ b/public/og/tag-pulses.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="pulses toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: pulses</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">pulses toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-rainbow.svg
+++ b/public/og/tag-rainbow.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="rainbow toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: rainbow</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">rainbow toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-reactive.svg
+++ b/public/og/tag-reactive.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="reactive toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: reactive</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">reactive toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-retro.svg
+++ b/public/og/tag-retro.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="retro toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: retro</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">retro toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">3 toys in this tag</text>
+</svg>

--- a/public/og/tag-ribbons.svg
+++ b/public/og/tag-ribbons.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="ribbons toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: ribbons</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">ribbons toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-ripples.svg
+++ b/public/og/tag-ripples.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="ripples toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: ripples</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">ripples toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-sand.svg
+++ b/public/og/tag-sand.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="sand toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: sand</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">sand toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-sculpting.svg
+++ b/public/og/tag-sculpting.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="sculpting toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: sculpting</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">sculpting toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-shader.svg
+++ b/public/og/tag-shader.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="shader toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: shader</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">shader toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-spectrograph.svg
+++ b/public/og/tag-spectrograph.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="spectrograph toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="255" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: spectrograph</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">spectrograph toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-spirals.svg
+++ b/public/og/tag-spirals.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="spirals toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: spirals</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">spirals toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-stars.svg
+++ b/public/og/tag-stars.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="stars toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: stars</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">stars toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-swirl.svg
+++ b/public/og/tag-swirl.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="swirl toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: swirl</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">swirl toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-synesthetic.svg
+++ b/public/og/tag-synesthetic.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="synesthetic toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="240" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: synesthetic</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">synesthetic toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-synthwave.svg
+++ b/public/og/tag-synthwave.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="synthwave toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: synthwave</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">synthwave toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-text.svg
+++ b/public/og/tag-text.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="text toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: text</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">text toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-tilt.svg
+++ b/public/og/tag-tilt.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="tilt toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: tilt</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">tilt toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-touch.svg
+++ b/public/og/tag-touch.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="touch toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: touch</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">touch toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-tunnel.svg
+++ b/public/og/tag-tunnel.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="tunnel toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: tunnel</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">tunnel toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-visualizer.svg
+++ b/public/og/tag-visualizer.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="visualizer toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="225" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: visualizer</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">visualizer toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">2 toys in this tag</text>
+</svg>

--- a/public/og/tag-warp.svg
+++ b/public/og/tag-warp.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="warp toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: warp</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">warp toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tag-waves.svg
+++ b/public/og/tag-waves.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="waves toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2f4f" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Tag: waves</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys tag collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">waves toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">1 toy in this tag</text>
+</svg>

--- a/public/og/tags.svg
+++ b/public/og/tags.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Tags">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b3b35" />
+      <stop offset="100%" stop-color="#0ea5a0" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="220" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">Browse by tag</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys discovery</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">Tags</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Explore themes, interactions, and visual styles</text>
+</svg>

--- a/public/og/toys.svg
+++ b/public/og/toys.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="All toys">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22113f" />
+      <stop offset="100%" stop-color="#3b82f6" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="0" y="0" width="1200" height="630" fill="url(#shine)" opacity="0.4" />
+  <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
+  <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
+  <rect x="90" y="92" width="285" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">SEO collection page</text>
+  <text x="90" y="220" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys collection</text>
+  <text x="90" y="322" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">All toys</text>
+  <text x="90" y="392" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">Browse every interactive audio-reactive visual toy</text>
+</svg>

--- a/public/sitemap-1.xml
+++ b/public/sitemap-1.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://no.toil.fyi/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -11,7 +11,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/index.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20,43 +20,43 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/toys.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tags.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/moods.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/capabilities.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/3dtoy/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -65,7 +65,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/aurora-painter/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -74,7 +74,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/clay/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -83,7 +83,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/evol/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -92,7 +92,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/geom/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -101,7 +101,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/holy/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -110,7 +110,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/multi/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -119,7 +119,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/seary/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -128,7 +128,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/legible/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -137,7 +137,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/symph/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -146,7 +146,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cube-wave/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -155,7 +155,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bubble-harmonics/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -164,7 +164,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/pocket-pulse/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -173,7 +173,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/mobile-ripples/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -182,7 +182,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/cosmic-particles/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -191,7 +191,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/lights/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -200,7 +200,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/spiral-burst/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -209,7 +209,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/rainbow-tunnel/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -218,7 +218,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/star-field/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -227,7 +227,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/fractal-kite-garden/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -236,7 +236,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/tactile-sand-table/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -245,7 +245,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/bioluminescent-tidepools/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -254,7 +254,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/neon-wave/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -263,7 +263,7 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/toys/milkdrop/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -272,749 +272,749 @@
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/3d/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-3d.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ambient/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-ambient.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/audio-mapped/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-audio-mapped.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/aurora/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-aurora.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bioluminescent/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-bioluminescent.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bloom/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-bloom.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/bubbles/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-bubbles.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/burst/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-burst.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/calming/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-calming.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/caustics/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-caustics.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/cyberpunk/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-cyberpunk.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/evolutionary/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-evolutionary.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/feedback/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-feedback.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/fractal/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-fractal.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/generative/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-generative.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/geometry/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-geometry.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/gestural/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-gestural.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/glitch/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-glitch.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/grid/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-grid.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/halos/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-halos.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/haptics/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-haptics.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/harmonics/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-harmonics.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/hybrid/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-hybrid.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/immersive/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-immersive.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/kite/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-kite.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/legacy/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-legacy.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/lights/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-lights.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/microphone/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-microphone.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mobile/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-mobile.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/mode-switch/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-mode-switch.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/motion/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-motion.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/nebula/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-nebula.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ocean/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-ocean.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/palette/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-palette.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/particles/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-particles.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/patterns/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-patterns.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pottery/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-pottery.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/pulses/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-pulses.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/rainbow/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-rainbow.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/reactive/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-reactive.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/retro/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-retro.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ribbons/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-ribbons.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/ripples/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-ripples.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sand/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-sand.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/sculpting/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-sculpting.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/shader/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-shader.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spectrograph/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-spectrograph.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/spirals/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-spirals.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/stars/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-stars.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/swirl/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-swirl.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synesthetic/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-synesthetic.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/synthwave/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-synthwave.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/text/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-text.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tilt/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-tilt.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/touch/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-touch.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/tunnel/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-tunnel.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/visualizer/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-visualizer.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/warp/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-warp.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/tags/waves/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/tag-waves.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/calming/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-calming.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/celestial/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-celestial.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/cosmic/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-cosmic.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/dreamy/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-dreamy.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/drifting/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-drifting.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/energetic/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-energetic.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/ethereal/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-ethereal.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/fiery/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-fiery.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/focus/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-focus.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/glow/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-glow.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/grounded/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-grounded.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/immersive/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-immersive.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/luminous/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-luminous.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/minimal/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-minimal.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/playful/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-playful.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/psychedelic/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-psychedelic.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/pulsing/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-pulsing.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/serene/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-serene.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/tactile/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-tactile.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/moods/uplifting/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/mood-uplifting.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/microphone/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/capability-microphone.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/demo-audio/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/capability-demo-audio.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/motion/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/capability-motion.svg</image:loc>
     </image:image>
   </url>
   <url>
     <loc>https://no.toil.fyi/capabilities/webgpu/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
-      <image:loc>https://no.toil.fyi/og/default.svg</image:loc>
+      <image:loc>https://no.toil.fyi/og/capability-webgpu.svg</image:loc>
     </image:image>
   </url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://no.toil.fyi/sitemap-1.xml</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-02-25</lastmod>
   </sitemap>
 </sitemapindex>

--- a/public/tags/3d/index.html
+++ b/public/tags/3d/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="3d toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged 3d." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-3d.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="3d tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/3d/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/3d/index.html
+++ b/public/tags/3d/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged 3d." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/3d/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-3d.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="3d tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="3d toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged 3d." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-3d.svg" />
+    <meta name="twitter:image:alt" content="3d tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/3d/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/ambient/index.html
+++ b/public/tags/ambient/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ambient toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged ambient." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ambient.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="ambient tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ambient/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/ambient/index.html
+++ b/public/tags/ambient/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged ambient." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ambient/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-ambient.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="ambient tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ambient toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged ambient." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ambient.svg" />
+    <meta name="twitter:image:alt" content="ambient tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ambient/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/audio-mapped/index.html
+++ b/public/tags/audio-mapped/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="audio-mapped toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged audio-mapped." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-audio-mapped.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="audio-mapped tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/audio-mapped/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/audio-mapped/index.html
+++ b/public/tags/audio-mapped/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged audio-mapped." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/audio-mapped/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-audio-mapped.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="audio-mapped tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="audio-mapped toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged audio-mapped." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-audio-mapped.svg" />
+    <meta name="twitter:image:alt" content="audio-mapped tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/audio-mapped/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/aurora/index.html
+++ b/public/tags/aurora/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged aurora." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/aurora/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-aurora.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="aurora tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="aurora toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged aurora." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-aurora.svg" />
+    <meta name="twitter:image:alt" content="aurora tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/aurora/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/aurora/index.html
+++ b/public/tags/aurora/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="aurora toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged aurora." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-aurora.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="aurora tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/aurora/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/bioluminescent/index.html
+++ b/public/tags/bioluminescent/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bioluminescent toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bioluminescent." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bioluminescent.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="bioluminescent tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bioluminescent/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/bioluminescent/index.html
+++ b/public/tags/bioluminescent/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged bioluminescent." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bioluminescent/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-bioluminescent.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="bioluminescent tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bioluminescent toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bioluminescent." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bioluminescent.svg" />
+    <meta name="twitter:image:alt" content="bioluminescent tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bioluminescent/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/bloom/index.html
+++ b/public/tags/bloom/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bloom toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bloom." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bloom.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="bloom tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bloom/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/bloom/index.html
+++ b/public/tags/bloom/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged bloom." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bloom/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-bloom.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="bloom tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bloom toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bloom." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bloom.svg" />
+    <meta name="twitter:image:alt" content="bloom tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bloom/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/bubbles/index.html
+++ b/public/tags/bubbles/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged bubbles." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/bubbles/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-bubbles.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="bubbles tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bubbles toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bubbles." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bubbles.svg" />
+    <meta name="twitter:image:alt" content="bubbles tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bubbles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/bubbles/index.html
+++ b/public/tags/bubbles/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="bubbles toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged bubbles." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-bubbles.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="bubbles tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/bubbles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/burst/index.html
+++ b/public/tags/burst/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged burst." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/burst/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-burst.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="burst tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="burst toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged burst." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-burst.svg" />
+    <meta name="twitter:image:alt" content="burst tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/burst/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/burst/index.html
+++ b/public/tags/burst/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="burst toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged burst." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-burst.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="burst tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/burst/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/calming/index.html
+++ b/public/tags/calming/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged calming." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/calming/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-calming.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="calming tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="calming toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged calming." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-calming.svg" />
+    <meta name="twitter:image:alt" content="calming tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/calming/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/calming/index.html
+++ b/public/tags/calming/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="calming toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged calming." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-calming.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="calming tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/calming/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/caustics/index.html
+++ b/public/tags/caustics/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged caustics." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/caustics/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-caustics.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="caustics tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="caustics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged caustics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-caustics.svg" />
+    <meta name="twitter:image:alt" content="caustics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/caustics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/caustics/index.html
+++ b/public/tags/caustics/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="caustics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged caustics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-caustics.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="caustics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/caustics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/cyberpunk/index.html
+++ b/public/tags/cyberpunk/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged cyberpunk." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/cyberpunk/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-cyberpunk.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="cyberpunk tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="cyberpunk toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged cyberpunk." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-cyberpunk.svg" />
+    <meta name="twitter:image:alt" content="cyberpunk tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/cyberpunk/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/cyberpunk/index.html
+++ b/public/tags/cyberpunk/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="cyberpunk toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged cyberpunk." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-cyberpunk.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="cyberpunk tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/cyberpunk/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/evolutionary/index.html
+++ b/public/tags/evolutionary/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged evolutionary." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/evolutionary/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-evolutionary.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="evolutionary tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="evolutionary toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged evolutionary." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-evolutionary.svg" />
+    <meta name="twitter:image:alt" content="evolutionary tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/evolutionary/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/evolutionary/index.html
+++ b/public/tags/evolutionary/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="evolutionary toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged evolutionary." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-evolutionary.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="evolutionary tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/evolutionary/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/feedback/index.html
+++ b/public/tags/feedback/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged feedback." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/feedback/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-feedback.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="feedback tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="feedback toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged feedback." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-feedback.svg" />
+    <meta name="twitter:image:alt" content="feedback tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/feedback/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/feedback/index.html
+++ b/public/tags/feedback/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="feedback toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged feedback." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-feedback.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="feedback tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/feedback/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/fractal/index.html
+++ b/public/tags/fractal/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="fractal toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged fractal." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-fractal.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="fractal tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/fractal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/fractal/index.html
+++ b/public/tags/fractal/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged fractal." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/fractal/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-fractal.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="fractal tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="fractal toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged fractal." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-fractal.svg" />
+    <meta name="twitter:image:alt" content="fractal tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/fractal/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/generative/index.html
+++ b/public/tags/generative/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="generative toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged generative." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-generative.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="generative tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/generative/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/generative/index.html
+++ b/public/tags/generative/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged generative." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/generative/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-generative.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="generative tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="generative toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged generative." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-generative.svg" />
+    <meta name="twitter:image:alt" content="generative tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/generative/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/geometry/index.html
+++ b/public/tags/geometry/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="geometry toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged geometry." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-geometry.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="geometry tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/geometry/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/geometry/index.html
+++ b/public/tags/geometry/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged geometry." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/geometry/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-geometry.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="geometry tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="geometry toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged geometry." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-geometry.svg" />
+    <meta name="twitter:image:alt" content="geometry tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/geometry/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/gestural/index.html
+++ b/public/tags/gestural/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="gestural toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 Stim Webtoys tagged gestural." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-gestural.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="gestural tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/gestural/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/gestural/index.html
+++ b/public/tags/gestural/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 4 Stim Webtoys tagged gestural." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/gestural/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-gestural.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="gestural tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="gestural toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 4 Stim Webtoys tagged gestural." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-gestural.svg" />
+    <meta name="twitter:image:alt" content="gestural tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/gestural/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/glitch/index.html
+++ b/public/tags/glitch/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged glitch." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/glitch/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-glitch.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="glitch tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="glitch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged glitch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-glitch.svg" />
+    <meta name="twitter:image:alt" content="glitch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/glitch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/glitch/index.html
+++ b/public/tags/glitch/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="glitch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged glitch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-glitch.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="glitch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/glitch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/grid/index.html
+++ b/public/tags/grid/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged grid." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/grid/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-grid.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="grid tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="grid toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged grid." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-grid.svg" />
+    <meta name="twitter:image:alt" content="grid tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/grid/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/grid/index.html
+++ b/public/tags/grid/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="grid toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged grid." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-grid.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="grid tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/grid/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/halos/index.html
+++ b/public/tags/halos/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="halos toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged halos." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-halos.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="halos tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/halos/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/halos/index.html
+++ b/public/tags/halos/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged halos." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/halos/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-halos.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="halos tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="halos toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged halos." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-halos.svg" />
+    <meta name="twitter:image:alt" content="halos tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/halos/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/haptics/index.html
+++ b/public/tags/haptics/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="haptics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged haptics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-haptics.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="haptics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/haptics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/haptics/index.html
+++ b/public/tags/haptics/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged haptics." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/haptics/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-haptics.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="haptics tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="haptics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged haptics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-haptics.svg" />
+    <meta name="twitter:image:alt" content="haptics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/haptics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/harmonics/index.html
+++ b/public/tags/harmonics/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="harmonics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged harmonics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-harmonics.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="harmonics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/harmonics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/harmonics/index.html
+++ b/public/tags/harmonics/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged harmonics." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/harmonics/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-harmonics.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="harmonics tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="harmonics toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged harmonics." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-harmonics.svg" />
+    <meta name="twitter:image:alt" content="harmonics tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/harmonics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/hybrid/index.html
+++ b/public/tags/hybrid/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged hybrid." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/hybrid/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-hybrid.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="hybrid tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="hybrid toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged hybrid." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-hybrid.svg" />
+    <meta name="twitter:image:alt" content="hybrid tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/hybrid/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/hybrid/index.html
+++ b/public/tags/hybrid/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="hybrid toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged hybrid." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-hybrid.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="hybrid tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/hybrid/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/immersive/index.html
+++ b/public/tags/immersive/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="immersive toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged immersive." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-immersive.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="immersive tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/immersive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/immersive/index.html
+++ b/public/tags/immersive/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged immersive." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/immersive/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-immersive.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="immersive tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="immersive toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged immersive." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-immersive.svg" />
+    <meta name="twitter:image:alt" content="immersive tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/immersive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Tags | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse audio-reactive toys by visual theme, interaction style, and sensory-friendly tags." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tags.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys tags page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Browse audio-reactive toys by visual theme, interaction style, and sensory-friendly tags." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tags.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Stim Webtoys tags page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Tags | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse audio-reactive toys by visual theme, interaction style, and sensory-friendly tags." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tags.svg" />
+    <meta name="twitter:image:alt" content="Stim Webtoys tags page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/kite/index.html
+++ b/public/tags/kite/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged kite." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/kite/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-kite.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="kite tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="kite toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged kite." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-kite.svg" />
+    <meta name="twitter:image:alt" content="kite tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/kite/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/kite/index.html
+++ b/public/tags/kite/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="kite toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged kite." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-kite.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="kite tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/kite/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/legacy/index.html
+++ b/public/tags/legacy/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="legacy toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged legacy." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-legacy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="legacy tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/legacy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/legacy/index.html
+++ b/public/tags/legacy/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged legacy." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/legacy/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-legacy.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="legacy tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="legacy toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged legacy." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-legacy.svg" />
+    <meta name="twitter:image:alt" content="legacy tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/legacy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/lights/index.html
+++ b/public/tags/lights/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="lights toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged lights." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-lights.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="lights tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/lights/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/lights/index.html
+++ b/public/tags/lights/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged lights." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/lights/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-lights.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="lights tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="lights toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged lights." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-lights.svg" />
+    <meta name="twitter:image:alt" content="lights tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/lights/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/microphone/index.html
+++ b/public/tags/microphone/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged microphone." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/microphone/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-microphone.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="microphone tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="microphone toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged microphone." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-microphone.svg" />
+    <meta name="twitter:image:alt" content="microphone tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/microphone/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/microphone/index.html
+++ b/public/tags/microphone/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="microphone toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged microphone." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-microphone.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="microphone tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/microphone/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/mobile/index.html
+++ b/public/tags/mobile/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="mobile toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged mobile." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-mobile.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="mobile tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/mobile/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/mobile/index.html
+++ b/public/tags/mobile/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged mobile." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mobile/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-mobile.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="mobile tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="mobile toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged mobile." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-mobile.svg" />
+    <meta name="twitter:image:alt" content="mobile tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/mobile/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/mode-switch/index.html
+++ b/public/tags/mode-switch/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="mode-switch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged mode-switch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-mode-switch.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="mode-switch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/mode-switch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/mode-switch/index.html
+++ b/public/tags/mode-switch/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged mode-switch." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/mode-switch/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-mode-switch.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="mode-switch tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="mode-switch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged mode-switch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-mode-switch.svg" />
+    <meta name="twitter:image:alt" content="mode-switch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/mode-switch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/motion/index.html
+++ b/public/tags/motion/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged motion." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/motion/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-motion.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="motion tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="motion toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged motion." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-motion.svg" />
+    <meta name="twitter:image:alt" content="motion tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/motion/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/motion/index.html
+++ b/public/tags/motion/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="motion toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged motion." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-motion.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="motion tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/motion/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/nebula/index.html
+++ b/public/tags/nebula/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged nebula." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/nebula/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-nebula.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="nebula tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="nebula toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged nebula." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-nebula.svg" />
+    <meta name="twitter:image:alt" content="nebula tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/nebula/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/nebula/index.html
+++ b/public/tags/nebula/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="nebula toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged nebula." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-nebula.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="nebula tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/nebula/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/ocean/index.html
+++ b/public/tags/ocean/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged ocean." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ocean/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-ocean.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="ocean tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ocean toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ocean." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ocean.svg" />
+    <meta name="twitter:image:alt" content="ocean tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ocean/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/ocean/index.html
+++ b/public/tags/ocean/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ocean toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ocean." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ocean.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="ocean tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ocean/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/palette/index.html
+++ b/public/tags/palette/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged palette." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/palette/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-palette.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="palette tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="palette toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged palette." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-palette.svg" />
+    <meta name="twitter:image:alt" content="palette tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/palette/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/palette/index.html
+++ b/public/tags/palette/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="palette toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged palette." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-palette.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="palette tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/palette/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/particles/index.html
+++ b/public/tags/particles/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="particles toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged particles." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-particles.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="particles tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/particles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/particles/index.html
+++ b/public/tags/particles/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged particles." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/particles/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-particles.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="particles tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="particles toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged particles." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-particles.svg" />
+    <meta name="twitter:image:alt" content="particles tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/particles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/patterns/index.html
+++ b/public/tags/patterns/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="patterns toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged patterns." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-patterns.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="patterns tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/patterns/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/patterns/index.html
+++ b/public/tags/patterns/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged patterns." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/patterns/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-patterns.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="patterns tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="patterns toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged patterns." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-patterns.svg" />
+    <meta name="twitter:image:alt" content="patterns tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/patterns/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/pottery/index.html
+++ b/public/tags/pottery/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged pottery." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pottery/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-pottery.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="pottery tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pottery toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged pottery." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-pottery.svg" />
+    <meta name="twitter:image:alt" content="pottery tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/pottery/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/pottery/index.html
+++ b/public/tags/pottery/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pottery toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged pottery." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-pottery.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="pottery tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/pottery/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/pulses/index.html
+++ b/public/tags/pulses/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pulses toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged pulses." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-pulses.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="pulses tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/pulses/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/pulses/index.html
+++ b/public/tags/pulses/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged pulses." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/pulses/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-pulses.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="pulses tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="pulses toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged pulses." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-pulses.svg" />
+    <meta name="twitter:image:alt" content="pulses tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/pulses/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/rainbow/index.html
+++ b/public/tags/rainbow/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged rainbow." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/rainbow/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-rainbow.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="rainbow tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="rainbow toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged rainbow." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-rainbow.svg" />
+    <meta name="twitter:image:alt" content="rainbow tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/rainbow/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/rainbow/index.html
+++ b/public/tags/rainbow/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="rainbow toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged rainbow." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-rainbow.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="rainbow tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/rainbow/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/reactive/index.html
+++ b/public/tags/reactive/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged reactive." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/reactive/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-reactive.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="reactive tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="reactive toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged reactive." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-reactive.svg" />
+    <meta name="twitter:image:alt" content="reactive tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/reactive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/reactive/index.html
+++ b/public/tags/reactive/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="reactive toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged reactive." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-reactive.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="reactive tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/reactive/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/retro/index.html
+++ b/public/tags/retro/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 3 Stim Webtoys tagged retro." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/retro/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-retro.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="retro tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="retro toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 Stim Webtoys tagged retro." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-retro.svg" />
+    <meta name="twitter:image:alt" content="retro tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/retro/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/retro/index.html
+++ b/public/tags/retro/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="retro toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 3 Stim Webtoys tagged retro." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-retro.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="retro tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/retro/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/ribbons/index.html
+++ b/public/tags/ribbons/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged ribbons." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ribbons/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-ribbons.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="ribbons tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ribbons toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ribbons." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ribbons.svg" />
+    <meta name="twitter:image:alt" content="ribbons tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ribbons/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/ribbons/index.html
+++ b/public/tags/ribbons/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ribbons toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ribbons." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ribbons.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="ribbons tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ribbons/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/ripples/index.html
+++ b/public/tags/ripples/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ripples toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ripples." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ripples.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="ripples tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ripples/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/ripples/index.html
+++ b/public/tags/ripples/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged ripples." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/ripples/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-ripples.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="ripples tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ripples toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged ripples." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-ripples.svg" />
+    <meta name="twitter:image:alt" content="ripples tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/ripples/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/sand/index.html
+++ b/public/tags/sand/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged sand." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sand/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-sand.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="sand tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="sand toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged sand." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-sand.svg" />
+    <meta name="twitter:image:alt" content="sand tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/sand/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/sand/index.html
+++ b/public/tags/sand/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="sand toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged sand." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-sand.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="sand tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/sand/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/sculpting/index.html
+++ b/public/tags/sculpting/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged sculpting." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/sculpting/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-sculpting.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="sculpting tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="sculpting toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged sculpting." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-sculpting.svg" />
+    <meta name="twitter:image:alt" content="sculpting tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/sculpting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/sculpting/index.html
+++ b/public/tags/sculpting/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="sculpting toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged sculpting." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-sculpting.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="sculpting tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/sculpting/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/shader/index.html
+++ b/public/tags/shader/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="shader toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged shader." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-shader.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="shader tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/shader/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/shader/index.html
+++ b/public/tags/shader/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged shader." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/shader/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-shader.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="shader tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="shader toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged shader." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-shader.svg" />
+    <meta name="twitter:image:alt" content="shader tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/shader/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/spectrograph/index.html
+++ b/public/tags/spectrograph/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged spectrograph." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spectrograph/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-spectrograph.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="spectrograph tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="spectrograph toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged spectrograph." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-spectrograph.svg" />
+    <meta name="twitter:image:alt" content="spectrograph tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/spectrograph/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/spectrograph/index.html
+++ b/public/tags/spectrograph/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="spectrograph toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged spectrograph." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-spectrograph.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="spectrograph tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/spectrograph/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/spirals/index.html
+++ b/public/tags/spirals/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged spirals." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/spirals/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-spirals.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="spirals tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="spirals toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged spirals." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-spirals.svg" />
+    <meta name="twitter:image:alt" content="spirals tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/spirals/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/spirals/index.html
+++ b/public/tags/spirals/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="spirals toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged spirals." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-spirals.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="spirals tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/spirals/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/stars/index.html
+++ b/public/tags/stars/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged stars." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/stars/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-stars.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="stars tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="stars toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged stars." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-stars.svg" />
+    <meta name="twitter:image:alt" content="stars tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/stars/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/stars/index.html
+++ b/public/tags/stars/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="stars toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged stars." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-stars.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="stars tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/stars/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/swirl/index.html
+++ b/public/tags/swirl/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="swirl toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged swirl." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-swirl.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="swirl tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/swirl/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/swirl/index.html
+++ b/public/tags/swirl/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged swirl." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/swirl/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-swirl.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="swirl tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="swirl toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged swirl." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-swirl.svg" />
+    <meta name="twitter:image:alt" content="swirl tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/swirl/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/synesthetic/index.html
+++ b/public/tags/synesthetic/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="synesthetic toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged synesthetic." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-synesthetic.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="synesthetic tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/synesthetic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/synesthetic/index.html
+++ b/public/tags/synesthetic/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged synesthetic." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synesthetic/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-synesthetic.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="synesthetic tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="synesthetic toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged synesthetic." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-synesthetic.svg" />
+    <meta name="twitter:image:alt" content="synesthetic tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/synesthetic/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/synthwave/index.html
+++ b/public/tags/synthwave/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged synthwave." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/synthwave/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-synthwave.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="synthwave tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="synthwave toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged synthwave." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-synthwave.svg" />
+    <meta name="twitter:image:alt" content="synthwave tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/synthwave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/synthwave/index.html
+++ b/public/tags/synthwave/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="synthwave toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged synthwave." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-synthwave.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="synthwave tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/synthwave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/text/index.html
+++ b/public/tags/text/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged text." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/text/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-text.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="text tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="text toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged text." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-text.svg" />
+    <meta name="twitter:image:alt" content="text tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/text/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/text/index.html
+++ b/public/tags/text/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="text toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged text." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-text.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="text tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/text/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/tilt/index.html
+++ b/public/tags/tilt/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged tilt." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tilt/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-tilt.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="tilt tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tilt toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged tilt." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-tilt.svg" />
+    <meta name="twitter:image:alt" content="tilt tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/tilt/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/tilt/index.html
+++ b/public/tags/tilt/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tilt toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged tilt." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-tilt.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="tilt tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/tilt/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/touch/index.html
+++ b/public/tags/touch/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="touch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged touch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-touch.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="touch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/touch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/touch/index.html
+++ b/public/tags/touch/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged touch." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/touch/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-touch.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="touch tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="touch toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged touch." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-touch.svg" />
+    <meta name="twitter:image:alt" content="touch tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/touch/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/tunnel/index.html
+++ b/public/tags/tunnel/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tunnel toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged tunnel." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-tunnel.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="tunnel tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/tunnel/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/tunnel/index.html
+++ b/public/tags/tunnel/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged tunnel." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/tunnel/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-tunnel.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="tunnel tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="tunnel toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged tunnel." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-tunnel.svg" />
+    <meta name="twitter:image:alt" content="tunnel tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/tunnel/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/visualizer/index.html
+++ b/public/tags/visualizer/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="visualizer toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged visualizer." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-visualizer.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="visualizer tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/visualizer/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/visualizer/index.html
+++ b/public/tags/visualizer/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 2 Stim Webtoys tagged visualizer." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/visualizer/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-visualizer.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="visualizer tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="visualizer toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 2 Stim Webtoys tagged visualizer." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-visualizer.svg" />
+    <meta name="twitter:image:alt" content="visualizer tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/visualizer/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/warp/index.html
+++ b/public/tags/warp/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged warp." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/warp/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-warp.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="warp tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="warp toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged warp." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-warp.svg" />
+    <meta name="twitter:image:alt" content="warp tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/warp/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/tags/warp/index.html
+++ b/public/tags/warp/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="warp toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged warp." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-warp.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="warp tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/warp/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/waves/index.html
+++ b/public/tags/waves/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="waves toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged waves." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-waves.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="waves tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/waves/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/tags/waves/index.html
+++ b/public/tags/waves/index.html
@@ -10,18 +10,18 @@
     <meta property="og:description" content="Explore 1 Stim Webtoys tagged waves." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/tags/waves/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
-    <meta property="og:image:alt" content="Stim Webtoys Library icon" />
+    <meta property="og:image" content="https://no.toil.fyi/og/tag-waves.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="waves tag page preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="waves toys | Stim Webtoys" />
     <meta name="twitter:description" content="Explore 1 Stim Webtoys tagged waves." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta name="twitter:image:alt" content="Stim Webtoys Library icon" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/tag-waves.svg" />
+    <meta name="twitter:image:alt" content="waves tag page preview image" />
     <link rel="canonical" href="https://no.toil.fyi/tags/waves/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />

--- a/public/toys/3dtoy/index.html
+++ b/public/toys/3dtoy/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="3D Toy | Stim Webtoys" />
     <meta name="twitter:description" content="A twisting 3D tunnel that responds to sound." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/3dtoy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="3D Toy preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/3dtoy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/3dtoy/index.html
+++ b/public/toys/3dtoy/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"3D Toy","description":"A twisting 3D tunnel that responds to sound.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/3dtoy/","image":"https://no.toil.fyi/og/3dtoy.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["tunnel","3d","legacy","energetic","immersive","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"3D Toy","item":"https://no.toil.fyi/toys/3dtoy/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is 3D Toy?","acceptedAnswer":{"@type":"Answer","text":"A twisting 3D tunnel that responds to sound."}},{"@type":"Question","name":"How do I start 3D Toy?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does 3D Toy support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is 3D Toy?","acceptedAnswer":{"@type":"Answer","text":"A twisting 3D tunnel that responds to sound."}},{"@type":"Question","name":"How do I start 3D Toy?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does 3D Toy support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does 3D Toy support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/aurora-painter/index.html
+++ b/public/toys/aurora-painter/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Aurora Painter","description":"Paint flowing aurora ribbons that react to your microphone in layered waves.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/aurora-painter/","image":"https://no.toil.fyi/og/aurora-painter.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["aurora","ribbons","gestural","dreamy","ethereal","luminous","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Aurora Painter","item":"https://no.toil.fyi/toys/aurora-painter/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Aurora Painter?","acceptedAnswer":{"@type":"Answer","text":"Paint flowing aurora ribbons that react to your microphone in layered waves."}},{"@type":"Question","name":"How do I start Aurora Painter?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Aurora Painter support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Aurora Painter?","acceptedAnswer":{"@type":"Answer","text":"Paint flowing aurora ribbons that react to your microphone in layered waves."}},{"@type":"Question","name":"How do I start Aurora Painter?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Aurora Painter support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Aurora Painter support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/aurora-painter/index.html
+++ b/public/toys/aurora-painter/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Aurora Painter | Stim Webtoys" />
     <meta name="twitter:description" content="Paint flowing aurora ribbons that react to your microphone in layered waves." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/aurora-painter.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Aurora Painter preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/aurora-painter/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/bioluminescent-tidepools/index.html
+++ b/public/toys/bioluminescent-tidepools/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Bioluminescent Tidepools","description":"Sketch glowing currents that bloom with high-frequency sparkle from your music.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/bioluminescent-tidepools/","image":"https://no.toil.fyi/og/bioluminescent-tidepools.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["ocean","bioluminescent","caustics","gestural","serene","ethereal","fiery","dreamy","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Bioluminescent Tidepools","item":"https://no.toil.fyi/toys/bioluminescent-tidepools/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Bioluminescent Tidepools?","acceptedAnswer":{"@type":"Answer","text":"Sketch glowing currents that bloom with high-frequency sparkle from your music."}},{"@type":"Question","name":"How do I start Bioluminescent Tidepools?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Bioluminescent Tidepools support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Bioluminescent Tidepools?","acceptedAnswer":{"@type":"Answer","text":"Sketch glowing currents that bloom with high-frequency sparkle from your music."}},{"@type":"Question","name":"How do I start Bioluminescent Tidepools?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Bioluminescent Tidepools support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Bioluminescent Tidepools support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/bioluminescent-tidepools/index.html
+++ b/public/toys/bioluminescent-tidepools/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bioluminescent Tidepools | Stim Webtoys" />
     <meta name="twitter:description" content="Sketch glowing currents that bloom with high-frequency sparkle from your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/bioluminescent-tidepools.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Bioluminescent Tidepools preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/bioluminescent-tidepools/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/bubble-harmonics/index.html
+++ b/public/toys/bubble-harmonics/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bubble Harmonics | Stim Webtoys" />
     <meta name="twitter:description" content="Translucent, audio-inflated bubbles that split into harmonics on high frequencies." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/bubble-harmonics.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Bubble Harmonics preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/bubble-harmonics/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/bubble-harmonics/index.html
+++ b/public/toys/bubble-harmonics/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Bubble Harmonics","description":"Translucent, audio-inflated bubbles that split into harmonics on high frequencies.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/bubble-harmonics/","image":"https://no.toil.fyi/og/bubble-harmonics.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["bubbles","harmonics","reactive","playful","uplifting","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Bubble Harmonics","item":"https://no.toil.fyi/toys/bubble-harmonics/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Bubble Harmonics?","acceptedAnswer":{"@type":"Answer","text":"Translucent, audio-inflated bubbles that split into harmonics on high frequencies."}},{"@type":"Question","name":"How do I start Bubble Harmonics?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Bubble Harmonics support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Bubble Harmonics?","acceptedAnswer":{"@type":"Answer","text":"Translucent, audio-inflated bubbles that split into harmonics on high frequencies."}},{"@type":"Question","name":"How do I start Bubble Harmonics?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Bubble Harmonics support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Bubble Harmonics support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/clay/index.html
+++ b/public/toys/clay/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Pottery Wheel Sculptor","description":"Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/clay/","image":"https://no.toil.fyi/og/clay.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["sculpting","pottery","3d","focus","tactile","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Pottery Wheel Sculptor","item":"https://no.toil.fyi/toys/clay/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Pottery Wheel Sculptor?","acceptedAnswer":{"@type":"Answer","text":"Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools."}},{"@type":"Question","name":"How do I start Pottery Wheel Sculptor?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Pottery Wheel Sculptor support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Pottery Wheel Sculptor?","acceptedAnswer":{"@type":"Answer","text":"Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools."}},{"@type":"Question","name":"How do I start Pottery Wheel Sculptor?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Pottery Wheel Sculptor support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Pottery Wheel Sculptor support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/clay/index.html
+++ b/public/toys/clay/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Pottery Wheel Sculptor | Stim Webtoys" />
     <meta name="twitter:description" content="Spin and shape a 3D clay vessel with smoothing, carving, and pinching tools." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/clay.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Pottery Wheel Sculptor preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/clay/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/cosmic-particles/index.html
+++ b/public/toys/cosmic-particles/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Cosmic Particles","description":"Jump between orbiting swirls and nebula fly-throughs with a single toggle.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/cosmic-particles/","image":"https://no.toil.fyi/og/cosmic-particles.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["particles","nebula","swirl","cosmic","immersive","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Cosmic Particles","item":"https://no.toil.fyi/toys/cosmic-particles/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Cosmic Particles?","acceptedAnswer":{"@type":"Answer","text":"Jump between orbiting swirls and nebula fly-throughs with a single toggle."}},{"@type":"Question","name":"How do I start Cosmic Particles?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Cosmic Particles support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Cosmic Particles?","acceptedAnswer":{"@type":"Answer","text":"Jump between orbiting swirls and nebula fly-throughs with a single toggle."}},{"@type":"Question","name":"How do I start Cosmic Particles?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Cosmic Particles support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Cosmic Particles support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/cosmic-particles/index.html
+++ b/public/toys/cosmic-particles/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Cosmic Particles | Stim Webtoys" />
     <meta name="twitter:description" content="Jump between orbiting swirls and nebula fly-throughs with a single toggle." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/cosmic-particles.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Cosmic Particles preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/cosmic-particles/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/cube-wave/index.html
+++ b/public/toys/cube-wave/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Grid Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Swap between cube waves and bouncing spheres without stopping the music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/cube-wave.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Grid Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/cube-wave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/cube-wave/index.html
+++ b/public/toys/cube-wave/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Grid Visualizer","description":"Swap between cube waves and bouncing spheres without stopping the music.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/cube-wave/","image":"https://no.toil.fyi/og/cube-wave.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["grid","waves","mode-switch","pulsing","energetic","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Grid Visualizer","item":"https://no.toil.fyi/toys/cube-wave/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Grid Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Swap between cube waves and bouncing spheres without stopping the music."}},{"@type":"Question","name":"How do I start Grid Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Grid Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Grid Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Swap between cube waves and bouncing spheres without stopping the music."}},{"@type":"Question","name":"How do I start Grid Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Grid Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Grid Visualizer support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/evol/index.html
+++ b/public/toys/evol/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Evolutionary Weirdcore | Stim Webtoys" />
     <meta name="twitter:description" content="Watch surreal landscapes evolve with fractals and glitches that react to music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/evol.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Evolutionary Weirdcore preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/evol/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/evol/index.html
+++ b/public/toys/evol/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Evolutionary Weirdcore","description":"Watch surreal landscapes evolve with fractals and glitches that react to music.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/evol/","image":"https://no.toil.fyi/og/evol.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["fractal","glitch","evolutionary","psychedelic","cosmic","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Evolutionary Weirdcore","item":"https://no.toil.fyi/toys/evol/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Evolutionary Weirdcore?","acceptedAnswer":{"@type":"Answer","text":"Watch surreal landscapes evolve with fractals and glitches that react to music."}},{"@type":"Question","name":"How do I start Evolutionary Weirdcore?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Evolutionary Weirdcore support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Evolutionary Weirdcore?","acceptedAnswer":{"@type":"Answer","text":"Watch surreal landscapes evolve with fractals and glitches that react to music."}},{"@type":"Question","name":"How do I start Evolutionary Weirdcore?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Evolutionary Weirdcore support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Evolutionary Weirdcore support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/fractal-kite-garden/index.html
+++ b/public/toys/fractal-kite-garden/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Fractal Kite Garden","description":"Grow branching kite fractals that sway with mids and shimmer with crisp highs.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/fractal-kite-garden/","image":"https://no.toil.fyi/og/fractal-kite-garden.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["fractal","kite","generative","dreamy","serene","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Fractal Kite Garden","item":"https://no.toil.fyi/toys/fractal-kite-garden/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Fractal Kite Garden?","acceptedAnswer":{"@type":"Answer","text":"Grow branching kite fractals that sway with mids and shimmer with crisp highs."}},{"@type":"Question","name":"How do I start Fractal Kite Garden?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Fractal Kite Garden support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Fractal Kite Garden?","acceptedAnswer":{"@type":"Answer","text":"Grow branching kite fractals that sway with mids and shimmer with crisp highs."}},{"@type":"Question","name":"How do I start Fractal Kite Garden?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Fractal Kite Garden support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Fractal Kite Garden support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/fractal-kite-garden/index.html
+++ b/public/toys/fractal-kite-garden/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Fractal Kite Garden | Stim Webtoys" />
     <meta name="twitter:description" content="Grow branching kite fractals that sway with mids and shimmer with crisp highs." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/fractal-kite-garden.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Fractal Kite Garden preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/fractal-kite-garden/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/geom/index.html
+++ b/public/toys/geom/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Microphone Geometry Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Push shifting geometric forms directly from live mic input with responsive controls." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/geom.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Microphone Geometry Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/geom/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/geom/index.html
+++ b/public/toys/geom/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Microphone Geometry Visualizer","description":"Push shifting geometric forms directly from live mic input with responsive controls.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/geom/","image":"https://no.toil.fyi/og/geom.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["geometry","microphone","reactive","energetic","immersive","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Microphone Geometry Visualizer","item":"https://no.toil.fyi/toys/geom/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Microphone Geometry Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Push shifting geometric forms directly from live mic input with responsive controls."}},{"@type":"Question","name":"How do I start Microphone Geometry Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Microphone Geometry Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Microphone Geometry Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Push shifting geometric forms directly from live mic input with responsive controls."}},{"@type":"Question","name":"How do I start Microphone Geometry Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Microphone Geometry Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Microphone Geometry Visualizer support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/holy/index.html
+++ b/public/toys/holy/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Halo Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Layered halos, particles, and shapes that respond to your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/holy.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Halo Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/holy/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/holy/index.html
+++ b/public/toys/holy/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Halo Visualizer","description":"Layered halos, particles, and shapes that respond to your music.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/holy/","image":"https://no.toil.fyi/og/holy.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["halos","particles","ambient","serene","ethereal","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Halo Visualizer","item":"https://no.toil.fyi/toys/holy/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Halo Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Layered halos, particles, and shapes that respond to your music."}},{"@type":"Question","name":"How do I start Halo Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Halo Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Halo Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Layered halos, particles, and shapes that respond to your music."}},{"@type":"Question","name":"How do I start Halo Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Halo Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Halo Visualizer support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/index.html
+++ b/public/toys/index.html
@@ -10,17 +10,17 @@
     <meta property="og:description" content="Browse every audio-reactive visual toy for sensory play, calming exploration, and responsive creative visuals." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://no.toil.fyi/toys/" />
-    <meta property="og:image" content="https://no.toil.fyi/icons/icon-512.png" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
+    <meta property="og:image" content="https://no.toil.fyi/og/toys.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Stim Webtoys collection preview image" />
     <meta property="og:site_name" content="Stim Webtoys Library" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="All toys | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse every audio-reactive visual toy for sensory play, calming exploration, and responsive creative visuals." />
-    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
+    <meta name="twitter:image" content="https://no.toil.fyi/og/toys.svg" />
     <meta name="twitter:image:alt" content="Stim Webtoys collection preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/index.html
+++ b/public/toys/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="All toys | Stim Webtoys Library" />
     <meta name="twitter:description" content="Browse every audio-reactive visual toy for sensory play, calming exploration, and responsive creative visuals." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/toys.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Stim Webtoys collection preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/legible/index.html
+++ b/public/toys/legible/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Terminal Word Grid","description":"A retro green text grid that pulses to audio and surfaces fresh words as you play.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/legible/","image":"https://no.toil.fyi/og/legible.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["text","retro","grid","focus","minimal","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Terminal Word Grid","item":"https://no.toil.fyi/toys/legible/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Terminal Word Grid?","acceptedAnswer":{"@type":"Answer","text":"A retro green text grid that pulses to audio and surfaces fresh words as you play."}},{"@type":"Question","name":"How do I start Terminal Word Grid?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Terminal Word Grid support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Terminal Word Grid?","acceptedAnswer":{"@type":"Answer","text":"A retro green text grid that pulses to audio and surfaces fresh words as you play."}},{"@type":"Question","name":"How do I start Terminal Word Grid?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Terminal Word Grid support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Terminal Word Grid support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/legible/index.html
+++ b/public/toys/legible/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terminal Word Grid | Stim Webtoys" />
     <meta name="twitter:description" content="A retro green text grid that pulses to audio and surfaces fresh words as you play." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/legible.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Terminal Word Grid preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/legible/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/lights/index.html
+++ b/public/toys/lights/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Audio Light Show | Stim Webtoys" />
     <meta name="twitter:description" content="Swap shader styles and color palettes while lights ripple with your microphone input." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/lights.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Audio Light Show preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/lights/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/lights/index.html
+++ b/public/toys/lights/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Audio Light Show","description":"Swap shader styles and color palettes while lights ripple with your microphone input.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/lights/","image":"https://no.toil.fyi/og/lights.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["lights","shader","palette","energetic","luminous","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Audio Light Show","item":"https://no.toil.fyi/toys/lights/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Audio Light Show?","acceptedAnswer":{"@type":"Answer","text":"Swap shader styles and color palettes while lights ripple with your microphone input."}},{"@type":"Question","name":"How do I start Audio Light Show?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Audio Light Show support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Audio Light Show?","acceptedAnswer":{"@type":"Answer","text":"Swap shader styles and color palettes while lights ripple with your microphone input."}},{"@type":"Question","name":"How do I start Audio Light Show?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Audio Light Show support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Audio Light Show support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/milkdrop/index.html
+++ b/public/toys/milkdrop/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="MilkDrop Proto | Stim Webtoys" />
     <meta name="twitter:description" content="A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/milkdrop.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="MilkDrop Proto preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/milkdrop/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/milkdrop/index.html
+++ b/public/toys/milkdrop/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"MilkDrop Proto","description":"A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/milkdrop/","image":"https://no.toil.fyi/og/milkdrop.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["feedback","warp","visualizer","retro","immersive","psychedelic","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"MilkDrop Proto","item":"https://no.toil.fyi/toys/milkdrop/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is MilkDrop Proto?","acceptedAnswer":{"@type":"Answer","text":"A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system."}},{"@type":"Question","name":"How do I start MilkDrop Proto?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does MilkDrop Proto support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is MilkDrop Proto?","acceptedAnswer":{"@type":"Answer","text":"A hardware-accelerated feedback engine inspired by the MilkDrop visualizer system."}},{"@type":"Question","name":"How do I start MilkDrop Proto?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does MilkDrop Proto support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does MilkDrop Proto support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/mobile-ripples/index.html
+++ b/public/toys/mobile-ripples/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Mobile Ripples | Stim Webtoys" />
     <meta name="twitter:description" content="Low-power neon ripples tuned for touch-first screens and pocket GPUs." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/mobile-ripples.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Mobile Ripples preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/mobile-ripples/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/mobile-ripples/index.html
+++ b/public/toys/mobile-ripples/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Mobile Ripples","description":"Low-power neon ripples tuned for touch-first screens and pocket GPUs.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/mobile-ripples/","image":"https://no.toil.fyi/og/mobile-ripples.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["mobile","ripples","touch","calming","focus","glow","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Mobile Ripples","item":"https://no.toil.fyi/toys/mobile-ripples/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Mobile Ripples?","acceptedAnswer":{"@type":"Answer","text":"Low-power neon ripples tuned for touch-first screens and pocket GPUs."}},{"@type":"Question","name":"How do I start Mobile Ripples?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Mobile Ripples support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Mobile Ripples?","acceptedAnswer":{"@type":"Answer","text":"Low-power neon ripples tuned for touch-first screens and pocket GPUs."}},{"@type":"Question","name":"How do I start Mobile Ripples?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Mobile Ripples support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Mobile Ripples support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/multi/index.html
+++ b/public/toys/multi/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Multi-Capability Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Shapes and lights move with both sound and device motion." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/multi.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Multi-Capability Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/multi/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/neon-wave/index.html
+++ b/public/toys/neon-wave/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Neon Wave","description":"Retro-wave visualizer with bloom effects, custom shaders, and four color themes.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/neon-wave/","image":"https://no.toil.fyi/og/neon-wave.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["synthwave","cyberpunk","retro","visualizer","bloom","energetic","immersive","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Neon Wave","item":"https://no.toil.fyi/toys/neon-wave/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Neon Wave?","acceptedAnswer":{"@type":"Answer","text":"Retro-wave visualizer with bloom effects, custom shaders, and four color themes."}},{"@type":"Question","name":"How do I start Neon Wave?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Neon Wave support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Neon Wave?","acceptedAnswer":{"@type":"Answer","text":"Retro-wave visualizer with bloom effects, custom shaders, and four color themes."}},{"@type":"Question","name":"How do I start Neon Wave?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Neon Wave support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Neon Wave support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/neon-wave/index.html
+++ b/public/toys/neon-wave/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Neon Wave | Stim Webtoys" />
     <meta name="twitter:description" content="Retro-wave visualizer with bloom effects, custom shaders, and four color themes." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/neon-wave.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Neon Wave preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/neon-wave/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/pocket-pulse/index.html
+++ b/public/toys/pocket-pulse/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Pocket Pulse | Stim Webtoys" />
     <meta name="twitter:description" content="A mobile-optimized pulse field that responds to audio and touch gestures." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/pocket-pulse.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Pocket Pulse preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/pocket-pulse/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/pocket-pulse/index.html
+++ b/public/toys/pocket-pulse/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Pocket Pulse","description":"A mobile-optimized pulse field that responds to audio and touch gestures.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/pocket-pulse/","image":"https://no.toil.fyi/og/pocket-pulse.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["mobile","pulses","touch","uplifting","focus","minimal","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Pocket Pulse","item":"https://no.toil.fyi/toys/pocket-pulse/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Pocket Pulse?","acceptedAnswer":{"@type":"Answer","text":"A mobile-optimized pulse field that responds to audio and touch gestures."}},{"@type":"Question","name":"How do I start Pocket Pulse?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Pocket Pulse support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Pocket Pulse?","acceptedAnswer":{"@type":"Answer","text":"A mobile-optimized pulse field that responds to audio and touch gestures."}},{"@type":"Question","name":"How do I start Pocket Pulse?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Pocket Pulse support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Pocket Pulse support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/rainbow-tunnel/index.html
+++ b/public/toys/rainbow-tunnel/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rainbow Tunnel | Stim Webtoys" />
     <meta name="twitter:description" content="Fly through colorful rings that spin to your music." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/rainbow-tunnel.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Rainbow Tunnel preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/rainbow-tunnel/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/rainbow-tunnel/index.html
+++ b/public/toys/rainbow-tunnel/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Rainbow Tunnel","description":"Fly through colorful rings that spin to your music.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/rainbow-tunnel/","image":"https://no.toil.fyi/og/rainbow-tunnel.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["tunnel","rainbow","immersive","cosmic","drifting","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Rainbow Tunnel","item":"https://no.toil.fyi/toys/rainbow-tunnel/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Rainbow Tunnel?","acceptedAnswer":{"@type":"Answer","text":"Fly through colorful rings that spin to your music."}},{"@type":"Question","name":"How do I start Rainbow Tunnel?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Rainbow Tunnel support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Rainbow Tunnel?","acceptedAnswer":{"@type":"Answer","text":"Fly through colorful rings that spin to your music."}},{"@type":"Question","name":"How do I start Rainbow Tunnel?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Rainbow Tunnel support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -91,6 +91,13 @@
         </div>
         <ul class="feature-card-grid">
         <li class="feature-card">
+          <h3>Multi-Capability Visualizer</h3>
+          <p>Shapes and lights move with both sound and device motion.</p>
+          <a class="cta-button ghost" href="/toys/multi/">View details</a>
+          <a class="text-link" href="/toy.html?toy=multi">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
           <h3>3D Toy</h3>
           <p>A twisting 3D tunnel that responds to sound.</p>
           <a class="cta-button ghost" href="/toys/3dtoy/">View details</a>
@@ -102,13 +109,6 @@
           <p>Watch surreal landscapes evolve with fractals and glitches that react to music.</p>
           <a class="cta-button ghost" href="/toys/evol/">View details</a>
           <a class="text-link" href="/toy.html?toy=evol">Launch toy</a>
-        </li>
-      
-        <li class="feature-card">
-          <h3>Multi-Capability Visualizer</h3>
-          <p>Shapes and lights move with both sound and device motion.</p>
-          <a class="cta-button ghost" href="/toys/multi/">View details</a>
-          <a class="text-link" href="/toy.html?toy=multi">Launch toy</a>
         </li>
       
         <li class="feature-card">
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Rainbow Tunnel support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/seary/index.html
+++ b/public/toys/seary/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Synesthetic Visualizer | Stim Webtoys" />
     <meta name="twitter:description" content="Blend audio and visuals into linked patterns." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/seary.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Synesthetic Visualizer preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/seary/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/seary/index.html
+++ b/public/toys/seary/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Synesthetic Visualizer","description":"Blend audio and visuals into linked patterns.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/seary/","image":"https://no.toil.fyi/og/seary.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["synesthetic","patterns","audio-mapped","dreamy","immersive","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Synesthetic Visualizer","item":"https://no.toil.fyi/toys/seary/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Synesthetic Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Blend audio and visuals into linked patterns."}},{"@type":"Question","name":"How do I start Synesthetic Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Synesthetic Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Synesthetic Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Blend audio and visuals into linked patterns."}},{"@type":"Question","name":"How do I start Synesthetic Visualizer?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Synesthetic Visualizer support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Synesthetic Visualizer support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/spiral-burst/index.html
+++ b/public/toys/spiral-burst/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spiral Burst | Stim Webtoys" />
     <meta name="twitter:description" content="Colorful spirals rotate and expand with every beat." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/spiral-burst.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Spiral Burst preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/spiral-burst/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/spiral-burst/index.html
+++ b/public/toys/spiral-burst/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Spiral Burst","description":"Colorful spirals rotate and expand with every beat.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/spiral-burst/","image":"https://no.toil.fyi/og/spiral-burst.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["spirals","burst","gestural","energetic","pulsing","cosmic","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Spiral Burst","item":"https://no.toil.fyi/toys/spiral-burst/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Spiral Burst?","acceptedAnswer":{"@type":"Answer","text":"Colorful spirals rotate and expand with every beat."}},{"@type":"Question","name":"How do I start Spiral Burst?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Spiral Burst support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Spiral Burst?","acceptedAnswer":{"@type":"Answer","text":"Colorful spirals rotate and expand with every beat."}},{"@type":"Question","name":"How do I start Spiral Burst?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Spiral Burst support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -98,6 +98,13 @@
         </li>
       
         <li class="feature-card">
+          <h3>Multi-Capability Visualizer</h3>
+          <p>Shapes and lights move with both sound and device motion.</p>
+          <a class="cta-button ghost" href="/toys/multi/">View details</a>
+          <a class="text-link" href="/toy.html?toy=multi">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
           <h3>3D Toy</h3>
           <p>A twisting 3D tunnel that responds to sound.</p>
           <a class="cta-button ghost" href="/toys/3dtoy/">View details</a>
@@ -109,13 +116,6 @@
           <p>Paint flowing aurora ribbons that react to your microphone in layered waves.</p>
           <a class="cta-button ghost" href="/toys/aurora-painter/">View details</a>
           <a class="text-link" href="/toy.html?toy=aurora-painter">Launch toy</a>
-        </li>
-      
-        <li class="feature-card">
-          <h3>Evolutionary Weirdcore</h3>
-          <p>Watch surreal landscapes evolve with fractals and glitches that react to music.</p>
-          <a class="cta-button ghost" href="/toys/evol/">View details</a>
-          <a class="text-link" href="/toy.html?toy=evol">Launch toy</a>
         </li>
       </ul>
       </section>
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Spiral Burst support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/star-field/index.html
+++ b/public/toys/star-field/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Star Field | Stim Webtoys" />
     <meta name="twitter:description" content="A field of shimmering stars reacts to the beat." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/star-field.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Star Field preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/star-field/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/star-field/index.html
+++ b/public/toys/star-field/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Star Field","description":"A field of shimmering stars reacts to the beat.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/star-field/","image":"https://no.toil.fyi/og/star-field.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["stars","nebula","gestural","serene","drifting","celestial","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Star Field","item":"https://no.toil.fyi/toys/star-field/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Star Field?","acceptedAnswer":{"@type":"Answer","text":"A field of shimmering stars reacts to the beat."}},{"@type":"Question","name":"How do I start Star Field?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Star Field support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Star Field?","acceptedAnswer":{"@type":"Answer","text":"A field of shimmering stars reacts to the beat."}},{"@type":"Question","name":"How do I start Star Field?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Star Field support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Star Field support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/symph/index.html
+++ b/public/toys/symph/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spectrograph | Stim Webtoys" />
     <meta name="twitter:description" content="A spectrograph that moves gently with your audio." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/symph.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Spectrograph preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/symph/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/public/toys/symph/index.html
+++ b/public/toys/symph/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Spectrograph","description":"A spectrograph that moves gently with your audio.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/symph/","image":"https://no.toil.fyi/og/symph.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["spectrograph","ambient","calming","serene","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Spectrograph","item":"https://no.toil.fyi/toys/symph/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Spectrograph?","acceptedAnswer":{"@type":"Answer","text":"A spectrograph that moves gently with your audio."}},{"@type":"Question","name":"How do I start Spectrograph?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Spectrograph support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Spectrograph?","acceptedAnswer":{"@type":"Answer","text":"A spectrograph that moves gently with your audio."}},{"@type":"Question","name":"How do I start Spectrograph?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Spectrograph support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Spectrograph support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. No device motion input required. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/tactile-sand-table/index.html
+++ b/public/toys/tactile-sand-table/index.html
@@ -33,7 +33,7 @@
 
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Tactile Sand Table","description":"Heightfield sand ripples that respond to bass, mids, and device tilt.","applicationCategory":"Game","operatingSystem":"Web","url":"https://no.toil.fyi/toys/tactile-sand-table/","image":"https://no.toil.fyi/og/tactile-sand-table.svg","isAccessibleForFree":true,"audience":{"@type":"Audience","audienceType":"People seeking interactive audio-reactive visuals for sensory-friendly creative play"},"keywords":["sand","tilt","haptics","calming","grounded","audio-reactive"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://no.toil.fyi/"},{"@type":"ListItem","position":2,"name":"All toys","item":"https://no.toil.fyi/toys/"},{"@type":"ListItem","position":3,"name":"Tactile Sand Table","item":"https://no.toil.fyi/toys/tactile-sand-table/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Tactile Sand Table?","acceptedAnswer":{"@type":"Answer","text":"Heightfield sand ripples that respond to bass, mids, and device tilt."}},{"@type":"Question","name":"How do I start Tactile Sand Table?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Tactile Sand Table support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. Supports device motion interactions. Runs without WebGPU requirements."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Tactile Sand Table?","acceptedAnswer":{"@type":"Answer","text":"Heightfield sand ripples that respond to bass, mids, and device tilt."}},{"@type":"Question","name":"How do I start Tactile Sand Table?","acceptedAnswer":{"@type":"Answer","text":"Open the toy and press Launch. Then enable microphone or demo audio options if prompted for the most reactive visuals."}},{"@type":"Question","name":"What capabilities does Tactile Sand Table support?","acceptedAnswer":{"@type":"Answer","text":"Supports live microphone input. Includes demo audio mode. Supports device motion interactions. Uses WebGPU for enhanced effects and needs a compatible browser/device."}}]}</script>
 
 
   </head>
@@ -78,7 +78,7 @@
       <div class="feature-card">
         <h3>Capabilities</h3>
         <ul>
-          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/motion/">Device motion support</a></li>
+          <li><a class="text-link" href="/capabilities/microphone/">Microphone ready</a></li><li><a class="text-link" href="/capabilities/demo-audio/">Demo audio available</a></li><li><a class="text-link" href="/capabilities/motion/">Device motion support</a></li><li><a class="text-link" href="/capabilities/webgpu/">WebGPU enhanced</a></li>
         </ul>
       </div>
     
@@ -105,17 +105,17 @@
         </li>
       
         <li class="feature-card">
+          <h3>Multi-Capability Visualizer</h3>
+          <p>Shapes and lights move with both sound and device motion.</p>
+          <a class="cta-button ghost" href="/toys/multi/">View details</a>
+          <a class="text-link" href="/toy.html?toy=multi">Launch toy</a>
+        </li>
+      
+        <li class="feature-card">
           <h3>3D Toy</h3>
           <p>A twisting 3D tunnel that responds to sound.</p>
           <a class="cta-button ghost" href="/toys/3dtoy/">View details</a>
           <a class="text-link" href="/toy.html?toy=3dtoy">Launch toy</a>
-        </li>
-      
-        <li class="feature-card">
-          <h3>Aurora Painter</h3>
-          <p>Paint flowing aurora ribbons that react to your microphone in layered waves.</p>
-          <a class="cta-button ghost" href="/toys/aurora-painter/">View details</a>
-          <a class="text-link" href="/toy.html?toy=aurora-painter">Launch toy</a>
         </li>
       </ul>
       </section>
@@ -139,7 +139,7 @@
       
         <div class="feature-card">
           <dt><strong>What capabilities does Tactile Sand Table support?</strong></dt>
-          <dd>Supports live microphone input. Includes demo audio mode. Supports device motion interactions. Runs without WebGPU requirements.</dd>
+          <dd>Supports live microphone input. Includes demo audio mode. Supports device motion interactions. Uses WebGPU for enhanced effects and needs a compatible browser/device.</dd>
         </div>
       
     </dl>

--- a/public/toys/tactile-sand-table/index.html
+++ b/public/toys/tactile-sand-table/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Tactile Sand Table | Stim Webtoys" />
     <meta name="twitter:description" content="Heightfield sand ripples that respond to bass, mids, and device tilt." />
-    <meta name="twitter:image" content="https://no.toil.fyi/og/tactile-sand-table.svg" />
+    <meta name="twitter:image" content="https://no.toil.fyi/icons/icon-512.png" />
     <meta name="twitter:image:alt" content="Tactile Sand Table preview image" />
     <link rel="canonical" href="https://no.toil.fyi/toys/tactile-sand-table/" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />

--- a/scripts/generate-seo.ts
+++ b/scripts/generate-seo.ts
@@ -98,6 +98,8 @@ const renderPage = ({
   socialImageType = 'image/png',
   socialImageWidth = 512,
   socialImageHeight = 512,
+  twitterImage,
+  twitterImageAlt,
 }: {
   title: string;
   description: string;
@@ -110,7 +112,15 @@ const renderPage = ({
   socialImageType?: string;
   socialImageWidth?: number;
   socialImageHeight?: number;
-}) => `<!doctype html>
+  twitterImage?: string;
+  twitterImageAlt?: string;
+}) => {
+  const resolvedTwitterImage =
+    twitterImage ??
+    (socialImageType === 'image/svg+xml' ? iconUrl : socialImage);
+  const resolvedTwitterImageAlt = twitterImageAlt ?? socialImageAlt;
+
+  return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -132,8 +142,8 @@ const renderPage = ({
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="${escapeHtml(title)}" />
     <meta name="twitter:description" content="${escapeHtml(description)}" />
-    <meta name="twitter:image" content="${socialImage}" />
-    <meta name="twitter:image:alt" content="${escapeHtml(socialImageAlt)}" />
+    <meta name="twitter:image" content="${resolvedTwitterImage}" />
+    <meta name="twitter:image:alt" content="${escapeHtml(resolvedTwitterImageAlt)}" />
     <link rel="canonical" href="${canonical}" />
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
@@ -150,6 +160,7 @@ ${extraHead}
   </body>
 </html>
 `;
+};
 
 type ToyEntry = {
   slug: string;

--- a/scripts/generate-seo.ts
+++ b/scripts/generate-seo.ts
@@ -33,25 +33,47 @@ const escapeXml = (value: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;');
 
+const truncateOgText = (value: string, maxChars: number) =>
+  value.length > maxChars ? `${value.slice(0, maxChars - 1)}…` : value;
+
 const buildOgSvg = ({
   title,
   subtitle,
+  eyebrow = 'Stim Webtoys Library',
+  accentStart = '#0b1024',
+  accentEnd = '#26377f',
+  chip,
 }: {
   title: string;
   subtitle: string;
+  eyebrow?: string;
+  accentStart?: string;
+  accentEnd?: string;
+  chip?: string;
 }) => `<svg xmlns="http://www.w3.org/2000/svg" width="${ogWidth}" height="${ogHeight}" viewBox="0 0 ${ogWidth} ${ogHeight}" role="img" aria-label="${escapeHtml(title)}">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1024" />
-      <stop offset="100%" stop-color="#26377f" />
+      <stop offset="0%" stop-color="${accentStart}" />
+      <stop offset="100%" stop-color="${accentEnd}" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
   </defs>
   <rect width="${ogWidth}" height="${ogHeight}" fill="url(#bg)" />
+  <rect x="0" y="0" width="${ogWidth}" height="${ogHeight}" fill="url(#shine)" opacity="0.4" />
   <circle cx="1035" cy="540" r="160" fill="rgba(255,255,255,0.12)" />
   <circle cx="160" cy="100" r="120" fill="rgba(255,255,255,0.1)" />
-  <text x="90" y="220" font-size="42" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">Stim Webtoys Library</text>
-  <text x="90" y="320" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">${escapeHtml(title)}</text>
-  <text x="90" y="390" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">${escapeHtml(subtitle)}</text>
+  ${
+    chip
+      ? `<rect x="90" y="92" width="${Math.max(220, Math.min(560, chip.length * 15))}" height="56" rx="28" fill="rgba(255,255,255,0.14)" />
+  <text x="120" y="128" font-size="30" fill="#f7f9ff" font-family="Inter, Arial, sans-serif">${escapeHtml(truncateOgText(chip, 36))}</text>`
+      : ''
+  }
+  <text x="90" y="${chip ? '220' : '170'}" font-size="40" fill="#dbe4ff" font-family="Inter, Arial, sans-serif">${escapeHtml(truncateOgText(eyebrow, 44))}</text>
+  <text x="90" y="${chip ? '322' : '272'}" font-size="72" font-weight="700" fill="#ffffff" font-family="Inter, Arial, sans-serif">${escapeHtml(truncateOgText(title, 30))}</text>
+  <text x="90" y="${chip ? '392' : '342'}" font-size="32" fill="#e2e8ff" font-family="Inter, Arial, sans-serif">${escapeHtml(truncateOgText(subtitle, 56))}</text>
 </svg>`;
 
 const getSitemapMeta = (url: string) => {
@@ -499,8 +521,60 @@ const generateSeo = async () => {
   const defaultOgSvg = buildOgSvg({
     title: 'Stim Webtoys',
     subtitle: 'Audio-reactive sensory visual play',
+    eyebrow: 'Stim Webtoys Library',
+    accentStart: '#0b1024',
+    accentEnd: '#26377f',
   });
   await writeFile(path.join(ogDir, 'default.svg'), defaultOgSvg);
+
+  const toysIndexOgFile = 'toys.svg';
+  const tagsIndexOgFile = 'tags.svg';
+  const moodsIndexOgFile = 'moods.svg';
+  const capabilitiesIndexOgFile = 'capabilities.svg';
+  await writeFile(
+    path.join(ogDir, toysIndexOgFile),
+    buildOgSvg({
+      title: 'All toys',
+      subtitle: 'Browse every interactive audio-reactive visual toy',
+      eyebrow: 'Stim Webtoys collection',
+      accentStart: '#22113f',
+      accentEnd: '#3b82f6',
+      chip: 'SEO collection page',
+    }),
+  );
+  await writeFile(
+    path.join(ogDir, tagsIndexOgFile),
+    buildOgSvg({
+      title: 'Tags',
+      subtitle: 'Explore themes, interactions, and visual styles',
+      eyebrow: 'Stim Webtoys discovery',
+      accentStart: '#0b3b35',
+      accentEnd: '#0ea5a0',
+      chip: 'Browse by tag',
+    }),
+  );
+  await writeFile(
+    path.join(ogDir, moodsIndexOgFile),
+    buildOgSvg({
+      title: 'Moods',
+      subtitle: 'Find visuals that match your sensory flow',
+      eyebrow: 'Stim Webtoys discovery',
+      accentStart: '#3b1027',
+      accentEnd: '#9333ea',
+      chip: 'Browse by mood',
+    }),
+  );
+  await writeFile(
+    path.join(ogDir, capabilitiesIndexOgFile),
+    buildOgSvg({
+      title: 'Capabilities',
+      subtitle: 'Filter toys by microphone, motion, audio, and WebGPU',
+      eyebrow: 'Stim Webtoys discovery',
+      accentStart: '#1f2937',
+      accentEnd: '#2563eb',
+      chip: 'Browse by capability',
+    }),
+  );
 
   const tagEntries = buildTagIndex(toys);
   const moodEntries = buildMoodIndex(toys);
@@ -547,7 +621,11 @@ const generateSeo = async () => {
       }),
     )}</script>
 `,
+      socialImage: `${baseUrl}/og/${toysIndexOgFile}`,
       socialImageAlt: 'Stim Webtoys collection preview image',
+      socialImageType: 'image/svg+xml',
+      socialImageWidth: ogWidth,
+      socialImageHeight: ogHeight,
     }),
   );
 
@@ -566,6 +644,10 @@ const generateSeo = async () => {
     const ogSvg = buildOgSvg({
       title: toy.title,
       subtitle: 'Interactive audio-reactive web toy',
+      eyebrow: 'Stim Webtoys toy page',
+      accentStart: '#1a0c33',
+      accentEnd: '#1d4ed8',
+      chip: 'Launch now',
     });
     await writeFile(path.join(ogDir, `${toy.slug}.svg`), ogSvg);
 
@@ -680,6 +762,11 @@ ${extraHead}
         'audio reactive themes',
         'sensory friendly toys',
       ],
+      socialImage: `${baseUrl}/og/${tagsIndexOgFile}`,
+      socialImageAlt: 'Stim Webtoys tags page preview image',
+      socialImageType: 'image/svg+xml',
+      socialImageWidth: ogWidth,
+      socialImageHeight: ogHeight,
     }),
   );
 
@@ -704,6 +791,18 @@ ${extraHead}
       </section>
     `;
     const tagPath = path.join(tagsDir, entry.slug);
+    const tagOgFile = `tag-${entry.slug}.svg`;
+    await writeFile(
+      path.join(ogDir, tagOgFile),
+      buildOgSvg({
+        title: `${entry.label} toys`,
+        subtitle: `${entry.toys.length} toy${entry.toys.length === 1 ? '' : 's'} in this tag`,
+        eyebrow: 'Stim Webtoys tag collection',
+        accentStart: '#0f2f4f',
+        accentEnd: '#2563eb',
+        chip: `Tag: ${entry.label}`,
+      }),
+    );
     await mkdir(tagPath, { recursive: true });
     await writeFile(
       path.join(tagPath, 'index.html'),
@@ -734,6 +833,11 @@ ${extraHead}
       }),
     )}</script>
 `,
+        socialImage: `${baseUrl}/og/${tagOgFile}`,
+        socialImageAlt: `${entry.label} tag page preview image`,
+        socialImageType: 'image/svg+xml',
+        socialImageWidth: ogWidth,
+        socialImageHeight: ogHeight,
       }),
     );
   }
@@ -760,6 +864,11 @@ ${extraHead}
       canonical: `${baseUrl}/moods/`,
       body: moodsIndexBody,
       keywords: ['mood visualizer', 'calming visuals', 'sensory vibe toys'],
+      socialImage: `${baseUrl}/og/${moodsIndexOgFile}`,
+      socialImageAlt: 'Stim Webtoys moods page preview image',
+      socialImageType: 'image/svg+xml',
+      socialImageWidth: ogWidth,
+      socialImageHeight: ogHeight,
     }),
   );
 
@@ -784,6 +893,18 @@ ${extraHead}
       </section>
     `;
     const moodPath = path.join(moodsDir, entry.slug);
+    const moodOgFile = `mood-${entry.slug}.svg`;
+    await writeFile(
+      path.join(ogDir, moodOgFile),
+      buildOgSvg({
+        title: `${entry.label} mood`,
+        subtitle: `${entry.toys.length} toy${entry.toys.length === 1 ? '' : 's'} with this vibe`,
+        eyebrow: 'Stim Webtoys mood collection',
+        accentStart: '#3f1239',
+        accentEnd: '#c026d3',
+        chip: `Mood: ${entry.label}`,
+      }),
+    );
     await mkdir(moodPath, { recursive: true });
     await writeFile(
       path.join(moodPath, 'index.html'),
@@ -814,6 +935,11 @@ ${extraHead}
       }),
     )}</script>
 `,
+        socialImage: `${baseUrl}/og/${moodOgFile}`,
+        socialImageAlt: `${entry.label} mood page preview image`,
+        socialImageType: 'image/svg+xml',
+        socialImageWidth: ogWidth,
+        socialImageHeight: ogHeight,
       }),
     );
   }
@@ -844,6 +970,11 @@ ${extraHead}
         'demo audio toys',
         'webgpu visual toys',
       ],
+      socialImage: `${baseUrl}/og/${capabilitiesIndexOgFile}`,
+      socialImageAlt: 'Stim Webtoys capabilities page preview image',
+      socialImageType: 'image/svg+xml',
+      socialImageWidth: ogWidth,
+      socialImageHeight: ogHeight,
     }),
   );
 
@@ -868,6 +999,18 @@ ${extraHead}
       </section>
     `;
     const capPath = path.join(capabilitiesDir, entry.slug);
+    const capabilityOgFile = `capability-${entry.slug}.svg`;
+    await writeFile(
+      path.join(ogDir, capabilityOgFile),
+      buildOgSvg({
+        title: `${entry.label} toys`,
+        subtitle: `${entry.toys.length} toy${entry.toys.length === 1 ? '' : 's'} support this`,
+        eyebrow: 'Stim Webtoys capability collection',
+        accentStart: '#1f2937',
+        accentEnd: '#0ea5e9',
+        chip: `Capability: ${entry.label}`,
+      }),
+    );
     await mkdir(capPath, { recursive: true });
     await writeFile(
       path.join(capPath, 'index.html'),
@@ -898,6 +1041,11 @@ ${extraHead}
       }),
     )}</script>
 `,
+        socialImage: `${baseUrl}/og/${capabilityOgFile}`,
+        socialImageAlt: `${entry.label} capability page preview image`,
+        socialImageType: 'image/svg+xml',
+        socialImageWidth: ogWidth,
+        socialImageHeight: ogHeight,
       }),
     );
   }
@@ -906,25 +1054,28 @@ ${extraHead}
   const urls = [
     { loc: `${baseUrl}/`, image: `${baseUrl}/og/default.svg` },
     { loc: `${baseUrl}/index.html`, image: `${baseUrl}/og/default.svg` },
-    { loc: `${baseUrl}/toys/`, image: `${baseUrl}/og/default.svg` },
-    { loc: `${baseUrl}/tags/`, image: `${baseUrl}/og/default.svg` },
-    { loc: `${baseUrl}/moods/`, image: `${baseUrl}/og/default.svg` },
-    { loc: `${baseUrl}/capabilities/`, image: `${baseUrl}/og/default.svg` },
+    { loc: `${baseUrl}/toys/`, image: `${baseUrl}/og/${toysIndexOgFile}` },
+    { loc: `${baseUrl}/tags/`, image: `${baseUrl}/og/${tagsIndexOgFile}` },
+    { loc: `${baseUrl}/moods/`, image: `${baseUrl}/og/${moodsIndexOgFile}` },
+    {
+      loc: `${baseUrl}/capabilities/`,
+      image: `${baseUrl}/og/${capabilitiesIndexOgFile}`,
+    },
     ...toys.map((toy) => ({
       loc: `${baseUrl}/toys/${toy.slug}/`,
       image: `${baseUrl}/og/${toy.slug}.svg`,
     })),
     ...tagEntries.map((entry) => ({
       loc: `${baseUrl}/tags/${entry.slug}/`,
-      image: `${baseUrl}/og/default.svg`,
+      image: `${baseUrl}/og/tag-${entry.slug}.svg`,
     })),
     ...moodEntries.map((entry) => ({
       loc: `${baseUrl}/moods/${entry.slug}/`,
-      image: `${baseUrl}/og/default.svg`,
+      image: `${baseUrl}/og/mood-${entry.slug}.svg`,
     })),
     ...capabilityEntries.map((entry) => ({
       loc: `${baseUrl}/capabilities/${entry.slug}/`,
-      image: `${baseUrl}/og/default.svg`,
+      image: `${baseUrl}/og/capability-${entry.slug}.svg`,
     })),
   ];
 


### PR DESCRIPTION
### Motivation
- Improve SEO and social previews by replacing the generic PNG icon with purpose-built SVG Open Graph images for toys, tags, moods, capabilities, and index pages.
- Centralize OG generation and metadata formatting to ensure consistent previews and trimmed text for social cards.
- Reflect updated capability coverage (WebGPU) across capability pages, toy detail pages, and listings.

### Description
- Added a large set of SVG OG images under `public/og/*` and switched pages to reference these SVGs with proper `image/svg+xml`, `1200x630` sizes and descriptive `alt` text across toys, tags, moods, capabilities, and index pages.
- Enhanced `scripts/generate-seo.ts` to generate customizable OG SVGs (`buildOgSvg`) with eyebrow/chip/accents, text truncation, and to write index/tag/mood/capability OG files and per-toy OG assets; updated sitemap and canonical imagery accordingly.
- Updated many HTML pages (toys, tags, moods, capabilities, index pages) to use the new OG image fields, corrected og/twitter meta types/dimensions/alt text, and adjusted capability counts and listings (notably WebGPU now shown as supported on many pages and linked in toy capability lists).
- Updated page JSON-LD/FAQ and human-facing copy on toy detail pages to mention WebGPU where applicable and to adjust capability/copy consistency.

### Testing
- Ran the SEO generation script `node scripts/generate-seo.ts` to regenerate OG images, pages, and sitemaps, which completed and produced the updated `public/og/` assets and HTML files (succeeded).
- Verified the sitemap files (`public/sitemap-1.xml`, `public/sitemap.xml`) were updated and include the new OG image URLs and current lastmod dates (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6773e3ac833297e134b590ee2fb4)