### PR TITLE
Refactor capability and microphone permission probing

### DIFF
--- a/assets/js/core/services/capability-probe-service.ts
+++ b/assets/js/core/services/capability-probe-service.ts
@@ -1,0 +1,175 @@
+import { isMobileDevice } from '../../utils/device-detect';
+import {
+  getRendererCapabilities,
+  getRenderingSupport,
+  type RendererCapabilities,
+} from '../renderer-capabilities.ts';
+import {
+  type MicrophoneCapability,
+  probeMicrophoneCapability,
+} from './microphone-permission-service.ts';
+
+export type CapabilityPreflightResult = {
+  rendering: {
+    hasWebGL: boolean;
+    rendererBackend: 'webgl' | 'webgpu' | null;
+    webgpuFallbackReason: string | null;
+    triedWebGPU: boolean;
+    shouldRetryWebGPU: boolean;
+  };
+  microphone: MicrophoneCapability;
+  environment: {
+    secureContext: boolean;
+    reducedMotion: boolean;
+    hardwareConcurrency: number | null;
+  };
+  performance: {
+    lowPower: boolean;
+    reason: string | null;
+    recommendedMaxPixelRatio: number;
+    recommendedRenderScale: number;
+  };
+  blockingIssues: string[];
+  warnings: string[];
+  canProceed: boolean;
+};
+
+type PerformanceProfile = {
+  lowPower: boolean;
+  reason: string | null;
+  reducedMotion: boolean;
+};
+
+type CapabilityProbeInputs = {
+  renderingSupport: { hasWebGL: boolean };
+  rendererCapabilities: Pick<
+    RendererCapabilities,
+    'preferredBackend' | 'fallbackReason' | 'triedWebGPU' | 'shouldRetryWebGPU'
+  > | null;
+  microphone: MicrophoneCapability;
+  environment: {
+    secureContext: boolean;
+    hardwareConcurrency: number | null;
+  };
+  performanceProfile: PerformanceProfile;
+};
+
+const isMobileUserAgent = isMobileDevice();
+
+export function getPerformanceProfile(): PerformanceProfile {
+  const deviceMemory =
+    typeof navigator !== 'undefined' && 'deviceMemory' in navigator
+      ? ((navigator as Navigator & { deviceMemory?: number }).deviceMemory ??
+        null)
+      : null;
+  const hardwareConcurrency =
+    typeof navigator !== 'undefined'
+      ? (navigator.hardwareConcurrency ?? null)
+      : null;
+  const reducedMotion =
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+
+  const reasons: string[] = [];
+  if (isMobileUserAgent) reasons.push('mobile device detected');
+  if (reducedMotion) reasons.push('reduced motion preference');
+  if (deviceMemory !== null && deviceMemory <= 4) {
+    reasons.push('limited device memory');
+  }
+  if (hardwareConcurrency !== null && hardwareConcurrency <= 4) {
+    reasons.push('limited CPU cores');
+  }
+
+  return {
+    lowPower: reasons.length > 0,
+    reason: reasons.length > 0 ? reasons.join(', ') : null,
+    reducedMotion,
+  };
+}
+
+export function buildCapabilityPreflightResult({
+  renderingSupport,
+  rendererCapabilities,
+  microphone,
+  environment,
+  performanceProfile,
+}: CapabilityProbeInputs): CapabilityPreflightResult {
+  const renderingBackend =
+    rendererCapabilities?.preferredBackend ??
+    (renderingSupport.hasWebGL ? 'webgl' : null);
+  const webgpuFallbackReason = rendererCapabilities?.fallbackReason ?? null;
+
+  const blockingIssues: string[] = [];
+  const warnings: string[] = [];
+
+  if (!renderingBackend) {
+    blockingIssues.push('Graphics acceleration is unavailable (WebGL/WebGPU).');
+  } else if (renderingBackend === 'webgl' && webgpuFallbackReason) {
+    warnings.push(webgpuFallbackReason);
+  }
+
+  if (!microphone.supported) {
+    warnings.push('Microphone APIs are unavailable in this browser.');
+  } else if (microphone.state === 'denied') {
+    warnings.push(
+      'Microphone access is blocked; visuals will fall back to demo audio.',
+    );
+  }
+
+  if (performanceProfile.lowPower) {
+    warnings.push(
+      'Performance mode recommended for smoother visuals on this device.',
+    );
+  }
+
+  return {
+    rendering: {
+      hasWebGL: renderingSupport.hasWebGL,
+      rendererBackend: renderingBackend,
+      webgpuFallbackReason,
+      triedWebGPU: rendererCapabilities?.triedWebGPU ?? false,
+      shouldRetryWebGPU: rendererCapabilities?.shouldRetryWebGPU ?? false,
+    },
+    microphone,
+    environment: {
+      secureContext: environment.secureContext,
+      reducedMotion: performanceProfile.reducedMotion,
+      hardwareConcurrency: environment.hardwareConcurrency,
+    },
+    performance: {
+      lowPower: performanceProfile.lowPower,
+      reason: performanceProfile.reason,
+      recommendedMaxPixelRatio: 1.25,
+      recommendedRenderScale: 0.9,
+    },
+    blockingIssues,
+    warnings,
+    canProceed: blockingIssues.length === 0,
+  };
+}
+
+export async function runCapabilityProbe(): Promise<CapabilityPreflightResult> {
+  const [rendererCapabilities, microphone] = await Promise.all([
+    getRendererCapabilities().catch((error) => {
+      console.warn('Renderer capability probe failed', error);
+      return null;
+    }),
+    probeMicrophoneCapability(),
+  ]);
+
+  return buildCapabilityPreflightResult({
+    renderingSupport: getRenderingSupport(),
+    rendererCapabilities,
+    microphone,
+    environment: {
+      secureContext:
+        typeof window !== 'undefined' ? Boolean(window.isSecureContext) : false,
+      hardwareConcurrency:
+        typeof navigator !== 'undefined'
+          ? (navigator.hardwareConcurrency ?? null)
+          : null,
+    },
+    performanceProfile: getPerformanceProfile(),
+  });
+}

--- a/assets/js/core/services/microphone-permission-service.ts
+++ b/assets/js/core/services/microphone-permission-service.ts
@@ -1,0 +1,73 @@
+export type MicrophonePermissionState =
+  | PermissionState
+  | 'unsupported'
+  | 'unknown';
+
+export async function queryMicrophonePermissionState(): Promise<MicrophonePermissionState> {
+  if (typeof navigator === 'undefined') {
+    return 'unsupported';
+  }
+
+  if (!navigator.mediaDevices?.getUserMedia) {
+    return 'unsupported';
+  }
+
+  if (!navigator.permissions?.query) {
+    return 'unknown';
+  }
+
+  try {
+    const result = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+    return result.state;
+  } catch (_error) {
+    return 'unknown';
+  }
+}
+
+export type MicrophoneCapability = {
+  supported: boolean;
+  state: MicrophonePermissionState;
+  reason: string | null;
+};
+
+export function getMicrophoneCapabilityFromState(
+  state: MicrophonePermissionState,
+): MicrophoneCapability {
+  if (state === 'unsupported') {
+    return {
+      supported: false,
+      state,
+      reason: 'This browser cannot capture microphone audio.',
+    };
+  }
+
+  if (state === 'denied') {
+    return {
+      supported: true,
+      state,
+      reason: 'Microphone access is blocked for this site.',
+    };
+  }
+
+  if (state === 'unknown') {
+    return {
+      supported: true,
+      state,
+      reason:
+        'Unable to read microphone permission state. The browser will still prompt when needed.',
+    };
+  }
+
+  return {
+    supported: true,
+    state,
+    reason: null,
+  };
+}
+
+export async function probeMicrophoneCapability(): Promise<MicrophoneCapability> {
+  const state = await queryMicrophonePermissionState();
+  return getMicrophoneCapabilityFromState(state);
+}

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -1,3 +1,7 @@
+import {
+  type MicrophonePermissionState,
+  queryMicrophonePermissionState,
+} from '../core/services/microphone-permission-service.ts';
 import { setQualityPresetById } from '../core/settings-panel.ts';
 import { YouTubeController } from './youtube-controller';
 
@@ -17,27 +21,6 @@ export interface AudioControlsOptions {
   starterPresetId?: string;
   onApplyStarterPreset?: () => void;
   autoStartMicrophoneWhenGranted?: boolean;
-}
-
-type MicrophonePermissionState = PermissionState | 'unsupported' | 'unknown';
-
-async function getMicrophonePermissionState(): Promise<MicrophonePermissionState> {
-  if (!navigator.mediaDevices?.getUserMedia) {
-    return 'unsupported';
-  }
-
-  if (!navigator.permissions?.query) {
-    return 'unknown';
-  }
-
-  try {
-    const result = await navigator.permissions.query({
-      name: 'microphone' as PermissionName,
-    });
-    return result.state;
-  } catch (_error) {
-    return 'unknown';
-  }
 }
 
 export function initAudioControls(
@@ -381,7 +364,7 @@ export function initAudioControls(
     setPreferredSource('microphone');
   }
 
-  void getMicrophonePermissionState().then((state) => {
+  void queryMicrophonePermissionState().then((state) => {
     microphonePermissionState = state;
     setMicrophoneButtonState();
     if (state === 'denied') {

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { queryMicrophonePermissionState as querySharedMicrophonePermissionState } from '../core/services/microphone-permission-service.ts';
 
 type AudioAccessReason = 'unsupported' | 'denied' | 'unavailable' | 'timeout';
 
@@ -195,19 +196,11 @@ export class FrequencyAnalyser {
 async function queryMicrophonePermissionState(): Promise<
   PermissionState | undefined
 > {
-  if (typeof navigator === 'undefined') return undefined;
-  if (!navigator.permissions?.query) return undefined;
-
-  try {
-    const status = await navigator.permissions.query({
-      name: 'microphone' as PermissionName,
-    });
-
-    return status.state;
-  } catch (error) {
-    console.warn('Unable to query microphone permission status', error);
+  const state = await querySharedMicrophonePermissionState();
+  if (state === 'unsupported' || state === 'unknown') {
     return undefined;
   }
+  return state;
 }
 
 export async function getMicrophonePermissionState() {

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -248,6 +248,13 @@ describe('audio controls primary emphasis', () => {
     const onRequestMicrophone = mock(async () => {});
 
     const permissions = navigator.permissions;
+    const mediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: mock(async () => ({}) as MediaStream),
+      },
+    });
     Object.defineProperty(navigator, 'permissions', {
       configurable: true,
       value: {
@@ -266,6 +273,10 @@ describe('audio controls primary emphasis', () => {
     Object.defineProperty(navigator, 'permissions', {
       configurable: true,
       value: permissions,
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: mediaDevices,
     });
   });
   test('renders quick-start tips with a dismiss action and persists dismissal', () => {

--- a/tests/capability-probe-service.test.ts
+++ b/tests/capability-probe-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { buildCapabilityPreflightResult } from '../assets/js/core/services/capability-probe-service.ts';
+import { getMicrophoneCapabilityFromState } from '../assets/js/core/services/microphone-permission-service.ts';
+
+describe('capability probe service', () => {
+  test('derives blocking issue when rendering backend is unavailable', () => {
+    const result = buildCapabilityPreflightResult({
+      renderingSupport: { hasWebGL: false },
+      rendererCapabilities: null,
+      microphone: getMicrophoneCapabilityFromState('granted'),
+      environment: {
+        secureContext: true,
+        hardwareConcurrency: 8,
+      },
+      performanceProfile: {
+        lowPower: false,
+        reason: null,
+        reducedMotion: false,
+      },
+    });
+
+    expect(result.blockingIssues).toEqual([
+      'Graphics acceleration is unavailable (WebGL/WebGPU).',
+    ]);
+    expect(result.canProceed).toBe(false);
+  });
+
+  test('derives warnings from webgl fallback, denied microphone, and low-power profile', () => {
+    const result = buildCapabilityPreflightResult({
+      renderingSupport: { hasWebGL: true },
+      rendererCapabilities: {
+        preferredBackend: 'webgl',
+        fallbackReason: 'WebGPU unsupported',
+        triedWebGPU: true,
+        shouldRetryWebGPU: false,
+      },
+      microphone: getMicrophoneCapabilityFromState('denied'),
+      environment: {
+        secureContext: true,
+        hardwareConcurrency: 2,
+      },
+      performanceProfile: {
+        lowPower: true,
+        reason: 'limited CPU cores',
+        reducedMotion: false,
+      },
+    });
+
+    expect(result.warnings).toEqual([
+      'WebGPU unsupported',
+      'Microphone access is blocked; visuals will fall back to demo audio.',
+      'Performance mode recommended for smoother visuals on this device.',
+    ]);
+    expect(result.canProceed).toBe(true);
+    expect(result.rendering).toMatchObject({
+      rendererBackend: 'webgl',
+      triedWebGPU: true,
+      shouldRetryWebGPU: false,
+      webgpuFallbackReason: 'WebGPU unsupported',
+    });
+  });
+
+  test('keeps output shape stable for unsupported microphone state', () => {
+    const result = buildCapabilityPreflightResult({
+      renderingSupport: { hasWebGL: true },
+      rendererCapabilities: {
+        preferredBackend: 'webgpu',
+        fallbackReason: null,
+        triedWebGPU: true,
+        shouldRetryWebGPU: false,
+      },
+      microphone: getMicrophoneCapabilityFromState('unsupported'),
+      environment: {
+        secureContext: false,
+        hardwareConcurrency: null,
+      },
+      performanceProfile: {
+        lowPower: false,
+        reason: null,
+        reducedMotion: true,
+      },
+    });
+
+    expect(result).toEqual({
+      rendering: {
+        hasWebGL: true,
+        rendererBackend: 'webgpu',
+        webgpuFallbackReason: null,
+        triedWebGPU: true,
+        shouldRetryWebGPU: false,
+      },
+      microphone: {
+        supported: false,
+        state: 'unsupported',
+        reason: 'This browser cannot capture microphone audio.',
+      },
+      environment: {
+        secureContext: false,
+        reducedMotion: true,
+        hardwareConcurrency: null,
+      },
+      performance: {
+        lowPower: false,
+        reason: null,
+        recommendedMaxPixelRatio: 1.25,
+        recommendedRenderScale: 0.9,
+      },
+      blockingIssues: [],
+      warnings: ['Microphone APIs are unavailable in this browser.'],
+      canProceed: true,
+    });
+  });
+});

--- a/tests/microphone-permission-service.test.ts
+++ b/tests/microphone-permission-service.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import {
+  getMicrophoneCapabilityFromState,
+  queryMicrophonePermissionState,
+} from '../assets/js/core/services/microphone-permission-service.ts';
+
+const originalNavigator = globalThis.navigator;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: originalNavigator,
+  });
+});
+
+describe('microphone permission service', () => {
+  test('returns unsupported when getUserMedia is unavailable', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        ...originalNavigator,
+        mediaDevices: undefined,
+      },
+    });
+
+    await expect(queryMicrophonePermissionState()).resolves.toBe('unsupported');
+  });
+
+  test('returns unknown when permissions API is unavailable', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        ...originalNavigator,
+        mediaDevices: { getUserMedia: mock(async () => new MediaStream()) },
+        permissions: undefined,
+      },
+    });
+
+    await expect(queryMicrophonePermissionState()).resolves.toBe('unknown');
+  });
+
+  test('returns denied/prompt/granted from permissions query', async () => {
+    for (const state of ['denied', 'prompt', 'granted'] as const) {
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: {
+          ...originalNavigator,
+          mediaDevices: { getUserMedia: mock(async () => new MediaStream()) },
+          permissions: {
+            query: mock(async () => ({ state })),
+          },
+        },
+      });
+
+      await expect(queryMicrophonePermissionState()).resolves.toBe(state);
+    }
+  });
+
+  test('maps unknown fallback and denied to reasons', () => {
+    expect(getMicrophoneCapabilityFromState('unknown')).toEqual({
+      supported: true,
+      state: 'unknown',
+      reason:
+        'Unable to read microphone permission state. The browser will still prompt when needed.',
+    });
+
+    expect(getMicrophoneCapabilityFromState('denied')).toEqual({
+      supported: true,
+      state: 'denied',
+      reason: 'Microphone access is blocked for this site.',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Centralize microphone permission querying and capability derivation to remove duplicated logic and make probes testable.
- Separate pure capability probing from UI rendering so the preflight UI only handles DOM/history/focus concerns while the probe returns pure data.
- Reuse the shared microphone probe inside audio utilities to keep runtime behavior consistent across consumers.

### Description

- Added a shared microphone permission service at `assets/js/core/services/microphone-permission-service.ts` that returns `unsupported | unknown | prompt | denied | granted` and maps states to capability metadata (`supported`, `reason`).
- Added a pure capability probe service at `assets/js/core/services/capability-probe-service.ts` that builds the full preflight result shape (rendering, microphone, environment, performance, warnings/blocking, `canProceed`) and exposes `runCapabilityProbe` and `buildCapabilityPreflightResult`.
- Refactored `assets/js/core/capability-preflight.ts` to delegate probe execution to `runCapabilityProbe` and re-export the `CapabilityPreflightResult` type, keeping the panel UI/attach/open/close and focus management intact.
- Replaced local microphone permission implementations with the shared service: `assets/js/ui/audio-controls.ts` now calls `queryMicrophonePermissionState`, and `assets/js/utils/audio-handler.ts` adapts to the shared query (mapping `unsupported`/`unknown` to the previous `undefined` contract).
- Added focused unit tests for the new services in `tests/microphone-permission-service.test.ts` and `tests/capability-probe-service.test.ts`, and adjusted `tests/audio-controls.test.ts` to ensure granted-path auto-start remains covered.

### Testing

- Ran focused tests: `bun run test tests/microphone-permission-service.test.ts tests/capability-probe-service.test.ts tests/audio-controls.test.ts` and all tests in that run passed.
- Ran the project quality gate: `bun run check` (Biome formatting/lint, TypeScript typecheck, and test suite) and the full test suite completed successfully with no failures.
- Verified targeted audio/control behavior via existing `tests/audio-controls.test.ts` which passed after updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4829bccbc8332ad69fbc4e4f39958)