### PR TITLE
Treat null as cache miss in library DOM cache

### DIFF
--- a/assets/js/library-view/dom-cache.js
+++ b/assets/js/library-view/dom-cache.js
@@ -2,10 +2,16 @@ export function createLibraryDomCache(doc = document) {
   const cache = new Map();
 
   const ensure = (key, resolver) => {
-    if (!cache.has(key)) {
-      cache.set(key, resolver());
+    if (cache.has(key)) {
+      return cache.get(key);
     }
-    return cache.get(key);
+
+    const resolved = resolver();
+    if (resolved !== null) {
+      cache.set(key, resolved);
+    }
+
+    return resolved;
   };
 
   return {

--- a/assets/js/library-view/dom-cache.js.d.ts
+++ b/assets/js/library-view/dom-cache.js.d.ts
@@ -1,0 +1,15 @@
+export type LibraryDomCache = {
+  ensureMetaNode: () => HTMLElement | null;
+  ensureSearchForm: () => HTMLFormElement | null;
+  ensureSearchClearButton: () => HTMLElement | null;
+  ensureFilterResetButton: () => HTMLElement | null;
+  ensureSearchSuggestions: () => HTMLElement | null;
+  ensureActiveFiltersSummary: () => HTMLElement | null;
+  ensureActiveFiltersChips: () => HTMLElement | null;
+  ensureActiveFiltersClear: () => HTMLElement | null;
+  ensureActiveFiltersStatus: () => HTMLElement | null;
+  ensureSearchMetaNote: () => HTMLElement | null;
+  ensureLibraryRefine: () => HTMLElement | null;
+};
+
+export function createLibraryDomCache(doc?: Document): LibraryDomCache;

--- a/tests/library-dom-cache.test.ts
+++ b/tests/library-dom-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createLibraryDomCache } from '../assets/js/library-view/dom-cache.js';
+
+describe('createLibraryDomCache', () => {
+  test('retries lookup when a node was missing on first ensure call', () => {
+    document.body.innerHTML = '<div id="stage"></div>';
+
+    const cache = createLibraryDomCache(document);
+
+    expect(cache.ensureSearchForm()).toBeNull();
+
+    const form = document.createElement('form');
+    form.setAttribute('data-search-form', '');
+    document.getElementById('stage')?.appendChild(form);
+
+    expect(cache.ensureSearchForm()).toBe(form);
+  });
+
+  test('reuses cached node once it exists', () => {
+    document.body.innerHTML = '<form data-search-form></form>';
+
+    const cache = createLibraryDomCache(document);
+    const initial = cache.ensureSearchForm();
+    const replacement = document.createElement('form');
+    replacement.setAttribute('data-search-form', '');
+    initial?.replaceWith(replacement);
+
+    expect(cache.ensureSearchForm()).toBe(initial);
+  });
+});


### PR DESCRIPTION
### Motivation
- The `createLibraryDomCache` helper cached `null` results which permanently hid elements inserted after the first lookup and broke deferred/hydrated UI initialization.
- Prior behavior retried lookups when a cached value was falsy, so we need to preserve that semantics for nodes that may be added later.

### Description
- Update `ensure` in `createLibraryDomCache` to avoid storing `null` results so missing nodes are treated as cache misses and will be retried on subsequent calls (`assets/js/library-view/dom-cache.js`).
- Short-circuit immediately when a non-null cached value exists to keep previously-found nodes memoized.
- Add a declaration file `assets/js/library-view/dom-cache.js.d.ts` to provide types for consumers and tests.
- Add focused unit tests `tests/library-dom-cache.test.ts` verifying (1) a missing node is retried and discovered after insertion and (2) an existing found node is cached.

### Testing
- Ran `bun run typecheck` which succeeded (`tsc --noEmit` passed).
- Ran focused tests with `bun test --preload=./tests/setup.ts --importmap=./tests/importmap.json tests/library-dom-cache.test.ts` which passed (2 tests, 0 failures).
- Ran the full quality gate via `bun run check` and observed two existing, unrelated failing tests in the suite; these failures are not caused by this change and were present while validating the patch.
- No docs were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a488d54fc08332b12784cec80f06ca)