### PR TITLE
Abstract haptic engine and add WebHaptics integration

### DIFF
--- a/assets/js/loader/haptics.ts
+++ b/assets/js/loader/haptics.ts
@@ -1,10 +1,73 @@
+import { WebHaptics } from 'web-haptics';
+
 export const HAPTICS_STORAGE_KEY = 'stims:haptics-enabled';
+
+type HapticPatternStep = {
+  delay?: number;
+  duration: number;
+  intensity?: number;
+};
+
+type HapticEngine = {
+  isSupported: boolean;
+  trigger: (input?: number | number[] | HapticPatternStep[]) => Promise<void>;
+  cancel: () => void;
+};
+
+function createDefaultHapticEngine(
+  navigatorRef: () => Navigator | null,
+): HapticEngine {
+  const webHaptics = new WebHaptics();
+
+  const triggerWithNavigatorFallback = (
+    input: number | number[] | HapticPatternStep[] = [
+      { duration: 25, intensity: 0.7 },
+    ],
+  ) => {
+    if (WebHaptics.isSupported) {
+      return webHaptics.trigger(input);
+    }
+
+    const nav = navigatorRef();
+    if (!nav?.vibrate) {
+      return Promise.resolve();
+    }
+
+    if (typeof input === 'number') {
+      nav.vibrate(input);
+      return Promise.resolve();
+    }
+
+    if (Array.isArray(input) && typeof input[0] === 'number') {
+      nav.vibrate(input as number[]);
+      return Promise.resolve();
+    }
+
+    const steps = (input as HapticPatternStep[]) ?? [];
+    const pattern = steps.flatMap((entry) =>
+      entry.delay ? [entry.delay, entry.duration] : [entry.duration],
+    );
+    nav.vibrate(pattern);
+    return Promise.resolve();
+  };
+
+  return {
+    isSupported: WebHaptics.isSupported,
+    trigger: triggerWithNavigatorFallback,
+    cancel: () => {
+      webHaptics.cancel();
+      const nav = navigatorRef();
+      nav?.vibrate?.(0);
+    },
+  };
+}
 
 export function canUseHaptics() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return false;
   }
-  const supportsVibration = typeof navigator.vibrate === 'function';
+  const supportsVibration =
+    WebHaptics.isSupported || typeof navigator.vibrate === 'function';
   return (
     supportsVibration && /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent)
   );
@@ -16,12 +79,14 @@ export function createHapticsController({
   windowRef = () => (typeof window !== 'undefined' ? window : null),
   navigatorRef = () => (typeof navigator !== 'undefined' ? navigator : null),
   documentRef = () => (typeof document !== 'undefined' ? document : null),
+  hapticEngine = createDefaultHapticEngine(navigatorRef),
 }: {
   view?: { setHapticsState?: (active: boolean) => void };
   isPartyModeActive: () => boolean;
   windowRef?: () => Window | null;
   navigatorRef?: () => Navigator | null;
   documentRef?: () => Document | null;
+  hapticEngine?: HapticEngine;
 }) {
   let hapticsEnabled = false;
   let beatCleanup: (() => void) | null = null;
@@ -30,7 +95,8 @@ export function createHapticsController({
     const win = windowRef();
     const nav = navigatorRef();
     if (!win || !nav) return false;
-    const supportsVibration = typeof nav.vibrate === 'function';
+    const supportsVibration =
+      hapticEngine.isSupported || typeof nav.vibrate === 'function';
     return supportsVibration && /Mobi|Android|iPhone|iPad/i.test(nav.userAgent);
   };
 
@@ -40,14 +106,15 @@ export function createHapticsController({
   };
 
   const pulseHaptics = (intensity = 0.4) => {
-    const nav = navigatorRef();
-    if (!hapticsEnabled || !canUseLocalHaptics() || !nav?.vibrate) return;
+    if (!hapticsEnabled || !canUseLocalHaptics()) return;
     const doc = documentRef();
     if (doc && doc.body.dataset.audioActive !== 'true') return;
 
     const clampedIntensity = Math.max(0, Math.min(1, intensity));
     const duration = Math.round(10 + clampedIntensity * 18);
-    nav.vibrate(isPartyModeActive() ? [duration, 28, duration] : [duration]);
+    void hapticEngine.trigger(
+      isPartyModeActive() ? [duration, 28, duration] : [duration],
+    );
   };
 
   const syncBeatHapticsListener = () => {
@@ -91,9 +158,8 @@ export function createHapticsController({
     hapticsEnabled = nextEnabled;
     view?.setHapticsState?.(nextEnabled);
     persistHaptics(nextEnabled);
-    const nav = navigatorRef();
-    if (!nextEnabled && nav?.vibrate) {
-      nav.vibrate(0);
+    if (!nextEnabled) {
+      hapticEngine.cancel();
     }
     syncBeatHapticsListener();
   };

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "three": "^0.182.0",
+        "web-haptics": "^0.0.6",
         "yaml": "^2.8.2",
         "zod": "^4.3.6",
       },
@@ -487,6 +488,8 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "web-haptics": ["web-haptics@0.0.6", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "svelte": ">=4", "vue": ">=3" }, "optionalPeers": ["react", "react-dom", "svelte", "vue"] }, "sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "three": "^0.182.0",
+    "web-haptics": "^0.0.6",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   }

--- a/tests/haptics-controller.test.ts
+++ b/tests/haptics-controller.test.ts
@@ -4,11 +4,18 @@ import { createHapticsController } from '../assets/js/loader/haptics.ts';
 describe('haptics controller', () => {
   test('persists and toggles haptics state', () => {
     const setItem = mock((_k: string, _v: string) => {});
-    const vibrate = mock((_pattern: number | number[]) => true);
+    const trigger = mock(
+      (_pattern?: number | number[] | Array<{ duration: number }>) =>
+        Promise.resolve(),
+    );
     const controller = createHapticsController({
       isPartyModeActive: () => false,
-      navigatorRef: () =>
-        ({ userAgent: 'iPhone', vibrate }) as unknown as Navigator,
+      hapticEngine: {
+        isSupported: true,
+        trigger,
+        cancel: mock(() => {}),
+      },
+      navigatorRef: () => ({ userAgent: 'iPhone' }) as unknown as Navigator,
       documentRef: () =>
         ({ body: { dataset: { audioActive: 'true' } } }) as unknown as Document,
       windowRef: () =>
@@ -24,6 +31,6 @@ describe('haptics controller', () => {
     expect(setItem).toHaveBeenCalledWith('stims:haptics-enabled', 'true');
 
     controller.pulseHaptics(0.5);
-    expect(vibrate).toHaveBeenCalled();
+    expect(trigger).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation

- Replace direct `navigator.vibrate` usage with an injectable haptic engine to support the `web-haptics` package and provide a reliable fallback for different environments.
- Allow easier testing and cancellation of haptics by centralizing trigger/cancel behavior behind an interface.

### Description

- Added `web-haptics` dependency and new types `HapticPatternStep` and `HapticEngine` and implemented `createDefaultHapticEngine` which uses `WebHaptics` with a `navigator.vibrate` fallback.
- Updated `canUseHaptics` and internal checks to consider `WebHaptics.isSupported` in addition to `navigator.vibrate`.
- Modified `createHapticsController` to accept an injectable `hapticEngine` and replaced direct `navigator.vibrate` calls with `hapticEngine.trigger` and `hapticEngine.cancel` usage.
- Updated package metadata (`package.json` and `bun.lock`) and adapted `tests/haptics-controller.test.ts` to mock the new `hapticEngine.trigger` API.

### Testing

- Ran the updated unit test `tests/haptics-controller.test.ts` with `bun test` and it succeeded.
- No other automated tests were modified or reported as failing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a739d113cc83329c84524b05bb576e)