### PR TITLE
Add public docs site map and update README intro/learning links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/zz-plant/stims?style=flat-square)](./LICENSE)
 [![Built with Bun](https://img.shields.io/badge/bun-1.3+-14151a?style=flat-square&logo=bun)](https://bun.sh)
 
-Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). This is a collection of interactive web-based toys designed to deliver playful sensory stimulation. They’re built with **Three.js**, **WebGL**, and live **audio interaction** for anyone who enjoys engaging, responsive visuals. These are great for casual play or sensory exploration, especially for neurodiverse folks.
+Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil.fyi). Stims is an interactive, audio-reactive web toy collection built with **Three.js** + **WebGL** (with WebGPU support where available) for playful, sensory-friendly exploration.
 
 **Keywords for discovery:** interactive web toys, audio-reactive visuals, Three.js/WebGL experiments, sensory-friendly play, generative art playground, calming visualizers.
 
@@ -17,6 +17,12 @@ Welcome to the **Stim Webtoys Library**, hosted at [no.toil.fyi](https://no.toil
 - 🧠 **Toy index**: https://no.toil.fyi/toy.html
 - 📘 **Docs hub**: [`docs/README.md`](./docs/README.md)
 - 🧰 **Contribute**: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+
+
+**Learn the basics in order**
+- 1️⃣ Overview + orientation: [`docs/README.md`](./docs/README.md)
+- 2️⃣ Local setup and workflows: [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md)
+- 3️⃣ Runtime and compatibility expectations: [`docs/PAGE_SPECIFICATIONS.md`](./docs/PAGE_SPECIFICATIONS.md) and [`README.md#browser-support-snapshot`](#browser-support-snapshot)
 
 **Discover by theme**
 - 🌈 **Moods**: https://no.toil.fyi/moods/

--- a/docs/PUBLIC_DOCS_SITE_MAP.md
+++ b/docs/PUBLIC_DOCS_SITE_MAP.md
@@ -1,0 +1,70 @@
+# Public docs site map and messaging alignment
+
+This document captures what the public Stims docs communicate, so repository docs and web-facing copy can stay aligned.
+
+## Core product message
+
+Stim Webtoys is positioned as **interactive, audio-reactive web toys built with Three.js/WebGL for sensory-friendly play**, with WebGPU paths for capable browsers.
+
+## Public docs information architecture
+
+### Documentation tab
+
+- **Get Started**
+  - `introduction`
+  - `quickstart`
+  - `browser-support`
+- **Using Stims**
+  - `guides/playing-toys`
+  - `guides/audio-setup`
+  - `guides/accessibility`
+  - `guides/performance`
+- **Toy Catalog**
+  - `toys/overview`
+  - `toys/featured`
+  - `toys/audio-visualizers`
+  - `toys/interactive-tools`
+  - `toys/webgpu-toys`
+
+### Development tab
+
+- **Contributing**
+  - `contributing/getting-started`
+  - `contributing/development-setup`
+  - `contributing/code-quality`
+- **Architecture**
+  - `architecture/overview`
+  - `architecture/toy-lifecycle`
+  - `architecture/audio-system`
+  - `architecture/rendering`
+- **Building Toys**
+  - `development/toy-development`
+  - `development/toy-interface`
+  - `development/testing-toys`
+  - `development/toy-manifest`
+- **Deployment**
+  - `deployment/overview`
+  - `deployment/cloudflare-pages`
+  - `deployment/static-hosting`
+
+## What each public page emphasizes
+
+- **Introduction**: value proposition, key features (audio reactivity, sensory-friendly defaults, performance controls, WebGL/WebGPU support), and quick links.
+- **Quickstart**: prerequisites, installation, local workflows, and troubleshooting.
+- **Browser support**: feature-level compatibility and troubleshooting for WebGL, microphone, and WebGPU.
+- **Playing toys**: browse/launch flow, filters, badges, and discovery utilities.
+- **Audio setup**: microphone, demo audio, and tab-capture paths plus troubleshooting.
+- **Accessibility**: motion comfort defaults, reduced-motion handling, and fallback controls.
+- **Performance**: quality presets, persistent settings, and performance panel details.
+- **Toy overview / category pages**: toy taxonomy by lifecycle, moods, tags, capabilities, and category-specific guidance.
+- **Contributing getting started**: quality checks, commit/PR expectations, and docs consistency guidance.
+
+## Repo alignment checklist
+
+When updating user-facing copy (README, landing copy, docs hubs), keep these themes visible:
+
+1. Audio-reactive + sensory-friendly positioning.
+2. Clear onboarding path (`introduction` -> `quickstart` -> `browser-support`).
+3. Explicit mention of accessibility and performance controls.
+4. Discovery vocabulary (moods, tags, capabilities, featured/audio/interactive/WebGPU).
+5. Contributor expectations (quality gates, commit/PR metadata, docs consistency).

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ If you need to...
 - [`COPYWRITING_AUDIT_2026-02.md`](./COPYWRITING_AUDIT_2026-02.md)
 - [`OUTSTANDING_ISSUES_AUDIT_2026-03.md`](./OUTSTANDING_ISSUES_AUDIT_2026-03.md)
 - [`TECH_STACK_CAPABILITY_RESEARCH_2026-02.md`](./TECH_STACK_CAPABILITY_RESEARCH_2026-02.md)
+- [`PUBLIC_DOCS_SITE_MAP.md`](./PUBLIC_DOCS_SITE_MAP.md)
 - [`LITERATURE.md`](./LITERATURE.md)
 - [`stim-assessment.md`](./stim-assessment.md)
 - [`stim-user-critiques.md`](./stim-user-critiques.md)


### PR DESCRIPTION
### Motivation
- Align repository docs and public-facing copy with a single source of truth for product messaging and documentation structure.
- Make the README intro more accurate about rendering capabilities by calling out WebGPU where available.
- Provide a clear, ordered onboarding path for readers to follow core docs before diving into development details.

### Description
- Add `docs/PUBLIC_DOCS_SITE_MAP.md` to capture the public docs site map, messaging pillars, and a repo alignment checklist. 
- Update `README.md` to refine the product positioning copy and add a "Learn the basics in order" quick path linking to `docs/README.md`, `docs/DEVELOPMENT.md`, and `docs/PAGE_SPECIFICATIONS.md`. 
- Update `docs/README.md` to reference the newly added `PUBLIC_DOCS_SITE_MAP.md` from the docs index.

### Testing
- No automated tests were run because this is a documentation-only change. 
- Documentation build or site deploy was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a167e2f08332966c7b376131eaad)