### PR TITLE
Refactor haptics into shared engine and integrate haptics in clay toy

### DIFF
--- a/assets/js/loader/haptics.ts
+++ b/assets/js/loader/haptics.ts
@@ -1,73 +1,16 @@
-import { WebHaptics } from 'web-haptics';
+import {
+  createHapticsEngine,
+  type HapticEngine,
+  supportsHaptics,
+} from '../utils/haptics-engine';
 
 export const HAPTICS_STORAGE_KEY = 'stims:haptics-enabled';
-
-type HapticPatternStep = {
-  delay?: number;
-  duration: number;
-  intensity?: number;
-};
-
-type HapticEngine = {
-  isSupported: boolean;
-  trigger: (input?: number | number[] | HapticPatternStep[]) => Promise<void>;
-  cancel: () => void;
-};
-
-function createDefaultHapticEngine(
-  navigatorRef: () => Navigator | null,
-): HapticEngine {
-  const webHaptics = new WebHaptics();
-
-  const triggerWithNavigatorFallback = (
-    input: number | number[] | HapticPatternStep[] = [
-      { duration: 25, intensity: 0.7 },
-    ],
-  ) => {
-    if (WebHaptics.isSupported) {
-      return webHaptics.trigger(input);
-    }
-
-    const nav = navigatorRef();
-    if (!nav?.vibrate) {
-      return Promise.resolve();
-    }
-
-    if (typeof input === 'number') {
-      nav.vibrate(input);
-      return Promise.resolve();
-    }
-
-    if (Array.isArray(input) && typeof input[0] === 'number') {
-      nav.vibrate(input as number[]);
-      return Promise.resolve();
-    }
-
-    const steps = (input as HapticPatternStep[]) ?? [];
-    const pattern = steps.flatMap((entry) =>
-      entry.delay ? [entry.delay, entry.duration] : [entry.duration],
-    );
-    nav.vibrate(pattern);
-    return Promise.resolve();
-  };
-
-  return {
-    isSupported: WebHaptics.isSupported,
-    trigger: triggerWithNavigatorFallback,
-    cancel: () => {
-      webHaptics.cancel();
-      const nav = navigatorRef();
-      nav?.vibrate?.(0);
-    },
-  };
-}
 
 export function canUseHaptics() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return false;
   }
-  const supportsVibration =
-    WebHaptics.isSupported || typeof navigator.vibrate === 'function';
+  const supportsVibration = supportsHaptics(() => navigator);
   return (
     supportsVibration && /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent)
   );
@@ -79,7 +22,7 @@ export function createHapticsController({
   windowRef = () => (typeof window !== 'undefined' ? window : null),
   navigatorRef = () => (typeof navigator !== 'undefined' ? navigator : null),
   documentRef = () => (typeof document !== 'undefined' ? document : null),
-  hapticEngine = createDefaultHapticEngine(navigatorRef),
+  hapticEngine = createHapticsEngine(navigatorRef),
 }: {
   view?: { setHapticsState?: (active: boolean) => void };
   isPartyModeActive: () => boolean;
@@ -96,7 +39,7 @@ export function createHapticsController({
     const nav = navigatorRef();
     if (!win || !nav) return false;
     const supportsVibration =
-      hapticEngine.isSupported || typeof nav.vibrate === 'function';
+      hapticEngine.isSupported || supportsHaptics(() => nav);
     return supportsVibration && /Mobi|Android|iPhone|iPad/i.test(nav.userAgent);
   };
 

--- a/assets/js/toys/clay-toy.ts
+++ b/assets/js/toys/clay-toy.ts
@@ -12,6 +12,7 @@ import {
   SpotLight,
   Vector2,
 } from 'three';
+import { createHapticsEngine, supportsHaptics } from '../utils/haptics-engine';
 import { createUnifiedInput } from '../utils/unified-input';
 import { ensureWebGL } from '../utils/webgl-check';
 import { createWebGLRenderer } from '../utils/webgl-renderer';
@@ -100,6 +101,35 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
   const height = 12;
   const segments = 100;
   let potteryMesh!: Mesh<LatheGeometry, MeshStandardMaterial>;
+  const haptics = createHapticsEngine(() => navigator);
+  const hapticsSupported = supportsHaptics(() => navigator);
+  let lastDragPulseAt = 0;
+
+  const triggerSculptHaptic = (deltaY: number) => {
+    if (!hapticsSupported) {
+      return;
+    }
+
+    const now = performance.now();
+    if (now - lastDragPulseAt < 80) {
+      return;
+    }
+    lastDragPulseAt = now;
+
+    const energy = Math.min(Math.abs(deltaY), 100) / 100;
+    const duration = Math.round(8 + energy * 18);
+    const intensity = MathUtils.clamp(0.18 + energy * 0.72, 0.18, 0.9);
+
+    void haptics.trigger([{ duration, intensity }]);
+  };
+
+  const triggerContactHaptic = () => {
+    if (!hapticsSupported) {
+      return;
+    }
+
+    void haptics.trigger([{ duration: 45, intensity: 0.55 }]);
+  };
 
   function createClay() {
     const profilePoints: Vector2[] = [];
@@ -200,9 +230,7 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
           clientY: state.primary.clientY,
           normalizedY: state.primary.normalizedY,
         };
-        if (navigator.vibrate) {
-          navigator.vibrate(50);
-        }
+        triggerContactHaptic();
       }
 
       if (state.justReleased) {
@@ -213,11 +241,7 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
       if (isInteracting && state.primary && previousPointer) {
         const deltaY = state.primary.clientY - previousPointer.clientY;
         deformClay(deltaY, state.primary.normalizedY);
-
-        if (navigator.vibrate) {
-          const intensity = Math.min(Math.abs(deltaY), 100);
-          navigator.vibrate(intensity);
-        }
+        triggerSculptHaptic(deltaY);
 
         previousPointer = {
           clientY: state.primary.clientY,
@@ -275,6 +299,7 @@ export function startClayToy({ container }: ClayStartOptions = {}) {
       unifiedInput.dispose();
       resetButton?.removeEventListener('click', createClay);
       renderer.dispose();
+      haptics.cancel();
       scene.clear();
       firstSculptOverlay.remove();
       renderer.domElement.remove();

--- a/assets/js/utils/haptics-engine.ts
+++ b/assets/js/utils/haptics-engine.ts
@@ -1,0 +1,71 @@
+import { WebHaptics } from 'web-haptics';
+
+export type HapticPatternStep = {
+  delay?: number;
+  duration: number;
+  intensity?: number;
+};
+
+export type HapticInput = number | number[] | HapticPatternStep[];
+
+export type HapticEngine = {
+  isSupported: boolean;
+  trigger: (input?: HapticInput) => Promise<void>;
+  cancel: () => void;
+};
+
+export function supportsHaptics(navigatorRef: () => Navigator | null) {
+  return (
+    WebHaptics.isSupported || typeof navigatorRef()?.vibrate === 'function'
+  );
+}
+
+export function createHapticsEngine(
+  navigatorRef: () => Navigator | null,
+): HapticEngine {
+  const webHaptics = new WebHaptics();
+
+  const trigger = (
+    input: HapticInput = [
+      {
+        duration: 25,
+        intensity: 0.7,
+      },
+    ],
+  ) => {
+    if (WebHaptics.isSupported) {
+      return webHaptics.trigger(input);
+    }
+
+    const nav = navigatorRef();
+    if (!nav?.vibrate) {
+      return Promise.resolve();
+    }
+
+    if (typeof input === 'number') {
+      nav.vibrate(input);
+      return Promise.resolve();
+    }
+
+    if (Array.isArray(input) && typeof input[0] === 'number') {
+      nav.vibrate(input as number[]);
+      return Promise.resolve();
+    }
+
+    const steps = (input as HapticPatternStep[]) ?? [];
+    const pattern = steps.flatMap((entry) =>
+      entry.delay ? [entry.delay, entry.duration] : [entry.duration],
+    );
+    nav.vibrate(pattern);
+    return Promise.resolve();
+  };
+
+  return {
+    isSupported: WebHaptics.isSupported,
+    trigger,
+    cancel: () => {
+      webHaptics.cancel();
+      navigatorRef()?.vibrate?.(0);
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Centralize the WebHaptics + `navigator.vibrate` fallback into a single reusable engine to remove duplicated logic and unify haptics feature detection.
- Replace ad-hoc `navigator.vibrate` calls in the clay toy with the shared engine to provide intensity/duration control, throttling, and proper cancellation.

### Description
- Add `assets/js/utils/haptics-engine.ts` which exports `createHapticsEngine`, `supportsHaptics`, and related types, implementing `web-haptics` with a `navigator.vibrate` fallback.
- Update `assets/js/loader/haptics.ts` to use `createHapticsEngine` and `supportsHaptics` and remove the previous inline engine implementation and `web-haptics` import.
- Update `assets/js/toys/clay-toy.ts` to import `createHapticsEngine` and `supportsHaptics`, add `triggerSculptHaptic` and `triggerContactHaptic` helpers that compute duration/intensity and throttle pulses, replace direct `navigator.vibrate` usage with `haptics.trigger`, and call `haptics.cancel()` during disposal.

### Testing
- Ran a TypeScript build/typecheck with `tsc`, and it completed successfully.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d5f16a4883329c8c6959ba3d2e83)