### PR TITLE
Validate WebGPU capability claims and update docs/copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ All JavaScript dependencies are installed via Bun and bundled locally with Vite,
 
 - A WebGPU fallback warning means the browser lacked a compatible adapter or device at startup; toys will fall back to WebGL when possible.
 - To force a retry (for example, after toggling a browser flag or switching GPUs), refresh the page—WebGPU detection resets and will attempt the adapter/device handshake again.
-- WebGPU-only toys (like [`multi`](./multi.html)) won’t run without WebGPU; expect them to stay idle or prompt you to pick another toy until the capability probe succeeds. The renderer capability probe and fallback reasons live in [`assets/js/core/renderer-capabilities.ts`](./assets/js/core/renderer-capabilities.ts) if you need to trace the gating logic.
+- Toys that disable WebGL fallback won’t run without WebGPU; expect those entries to stay idle or prompt you to pick another toy until the capability probe succeeds. Most current toys can still fall back to WebGL when WebGPU is unavailable. The renderer capability probe and fallback reasons live in [`assets/js/core/renderer-capabilities.ts`](./assets/js/core/renderer-capabilities.ts) if you need to trace the gating logic.
 
 #### Dev-server hosting
 
@@ -374,7 +374,7 @@ If private reporting is unavailable for any reason, open a regular issue with mi
 
 Feature availability varies by browser and device, but this table is a practical baseline:
 
-| Browser | WebGL toys | Microphone input | WebGPU-only toys |
+| Browser | WebGL toys | Microphone input | WebGPU-optimized toys |
 | --- | --- | --- | --- |
 | Chrome (desktop/mobile) | ✅ | ✅ | ✅ (supported hardware/drivers) |
 | Edge (desktop) | ✅ | ✅ | ✅ (supported hardware/drivers) |

--- a/docs/stim-assessment.md
+++ b/docs/stim-assessment.md
@@ -2,13 +2,18 @@
 
 ## Findings
 
-- **Multi-Capability Visualizer (`multi`)**
-  - The library manifest lists `multi` as a standalone page that requires WebGPU, but the toy metadata leaves `requiresWebGPU` set to `false`, so the loader never shows the capability warning or aborts on unsupported devices.
-  - Result: users on browsers without WebGPU attempt to load `multi` with no notice about degraded visuals.
+- **Manifest truth has changed; docs lag remains**
+  - `assets/data/toys.json` now marks `multi` and the rest of the catalog with `requiresWebGPU: true`, and the entries include `allowWebGLFallback: true`.
+  - Some long-lived docs/copy still use older “WebGPU-only” language that implies hard gating where fallback is available.
+  - Result: contributor and user-facing guidance can drift from runtime behavior.
 
 ## Fix plan
 
-- **Multi-Capability Visualizer (`multi`)**
-  - Align toy metadata with the documented requirement by marking the toy as `requiresWebGPU` so the loader surfaces the WebGPU capability screen instead of failing silently.
-  - Expand the standalone page entry (`multi.html`) to present a friendlier WebGPU warning plus a tuned WebGL fallback preset (reduced particles/light bounces) for unsupported browsers.
-  - Add a lightweight telemetry hook in the loader to track WebGPU support rates so we can tune defaults before forcing WebGPU-only paths.
+- **Keep docs aligned with metadata reality**
+  - Treat `assets/data/toys.json` as the source of truth for capability claims.
+  - Remove or rephrase copy that implies specific toys are WebGPU-only unless `allowWebGLFallback` is explicitly false.
+  - Enforce this with automated checks in `bun run check:toys` so stale claims are caught in CI.
+
+- **Follow-up product validation**
+  - Add lightweight loader telemetry to track WebGPU support rates and fallback frequency.
+  - Use telemetry to decide whether any toys should become truly WebGPU-only in the future.

--- a/scripts/check-toys.ts
+++ b/scripts/check-toys.ts
@@ -59,6 +59,7 @@ export async function runToyChecks(root = repoRoot) {
     validateSlugEntrypointConsistency(entries, issues);
     await detectUnregisteredToyFiles(entries, issues, root);
     await validateGeneratedArtifactParity(entries, issues, root);
+    await validateCapabilityClaims(entries, issues, root);
   } catch (error) {
     issues.push(error instanceof Error ? error.message : String(error));
   }
@@ -233,6 +234,32 @@ async function detectUnregisteredToyFiles(
 
     issues.push(
       `Unregistered toy module detected: ${modulePath}\nEither register it in assets/data/toys.json or remove the file, then run: ${REGENERATE_COMMAND}`,
+    );
+  }
+}
+
+async function validateCapabilityClaims(
+  entries: ToyManifest,
+  issues: string[],
+  root = repoRoot,
+) {
+  const hasWebGpuOnlyToy = entries.some(
+    (entry) => entry.requiresWebGPU && !entry.allowWebGLFallback,
+  );
+
+  if (hasWebGpuOnlyToy) return;
+
+  const readmePath = path.join(root, 'README.md');
+  const readme = await fs.readFile(readmePath, 'utf8');
+  const staleClaims = [
+    'WebGPU-only toys (like [`multi`](./multi.html))',
+    '| Browser | WebGL toys | Microphone input | WebGPU-only toys |',
+  ];
+
+  for (const claim of staleClaims) {
+    if (!readme.includes(claim)) continue;
+    issues.push(
+      `README contains stale WebGPU-only wording ("${claim}") but assets/data/toys.json currently exposes fallback for all toys. Update README copy or metadata to match.`,
     );
   }
 }

--- a/tests/check-toys.test.ts
+++ b/tests/check-toys.test.ts
@@ -27,6 +27,7 @@ async function createTempRepo() {
     'export const toyManifest = [];\n',
   );
   await fs.writeFile(path.join(root, 'public/toys.json'), '[]\n');
+  await fs.writeFile(path.join(root, 'README.md'), '# temp repo\n');
   return root;
 }
 


### PR DESCRIPTION
### Motivation

- Keep human-facing documentation aligned with the toy metadata which now expresses `allowWebGLFallback` and prevents stale "WebGPU-only" language from misleading contributors and users.
- Add an automated guard so README/content drift is detected in CI when no toys are truly WebGPU-only.

### Description

- Add `validateCapabilityClaims` to `scripts/check-toys.ts` and wire it into `runToyChecks` to scan `README.md` for stale WebGPU-only phrasing when no entries have `requiresWebGPU && !allowWebGLFallback`.
- Teach the checker to look for specific stale strings and to emit a helpful issue when the README disagrees with `assets/data/toys.json`.
- Update `README.md` and `docs/stim-assessment.md` to reflect the new metadata model and rephrase WebGPU guidance to mention `allowWebGLFallback` and WebGPU-optimized wording.
- Update `tests/check-toys.test.ts` to create a minimal `README.md` in the temporary repo so the new capability-claim check can run in tests.

### Testing

- Ran the repository test suite via `bun run test`, including `tests/check-toys.test.ts`, and the modified test passed.
- Exercised `runToyChecks` to confirm `validateCapabilityClaims` runs and reports an issue when README contains the stale strings in a repo with only fallbacks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7dee30ec88332a25220f0de315a91)