### PR TITLE
Use disclosure panels for advanced audio/rendering and simplify active-filters summary

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1283,6 +1283,29 @@ body {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
+.control-panel__disclosure {
+  margin: 8px 0;
+  border: 1px solid rgba(148, 165, 180, 0.28);
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.25);
+  padding: 8px 10px;
+}
+
+.control-panel__disclosure > summary {
+  cursor: pointer;
+  font-weight: 600;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.control-panel__advanced-content {
+  padding-top: 6px;
+}
+
+.control-panel__advanced-content .control-panel__row:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
 .control-panel__status {
   margin-top: 8px;
   font-size: 0.9rem;

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -158,36 +158,20 @@ export function createLibraryView({
 
     const tokens = Array.from(activeFilters);
     const hasTokens = tokens.length > 0;
+    const visibleLabels = tokens
+      .map((token) => formatTokenLabel(token))
+      .slice(0, 2);
+
     summary.hidden = false;
     summary.setAttribute('aria-hidden', 'false');
     summary.classList.toggle('is-empty', !hasTokens);
     chipsContainer.innerHTML = '';
-
-    const appendChip = ({ label, onClick, ariaLabel }) => {
-      const chip = document.createElement('button');
-      chip.type = 'button';
-      chip.className = 'active-filter-chip';
-      chip.textContent = label;
-      if (ariaLabel) {
-        chip.setAttribute('aria-label', ariaLabel);
-      }
-      chip.addEventListener('click', onClick);
-      chipsContainer.appendChild(chip);
-    };
-
-    tokens.forEach((token) => {
-      const label = formatTokenLabel(token);
-      appendChip({
-        label,
-        ariaLabel: `Remove filter ${label}`,
-        onClick: () => removeFilterToken(token),
-      });
-    });
+    chipsContainer.hidden = true;
 
     const status = ensureActiveFiltersStatus();
     if (status instanceof HTMLElement) {
       status.textContent = hasTokens
-        ? `${tokens.length} active`
+        ? `${tokens.length} active${visibleLabels.length > 0 ? ` · ${visibleLabels.join(' + ')}` : ''}`
         : 'No filters selected';
     }
 
@@ -198,6 +182,7 @@ export function createLibraryView({
     ) {
       clearButton.disabled = !hasTokens;
       clearButton.setAttribute('aria-disabled', String(!hasTokens));
+      clearButton.textContent = 'Clear all';
     }
 
     updateSearchMetaNote();
@@ -969,29 +954,6 @@ export function createLibraryView({
     chips.forEach((chip) => {
       chip.classList.remove('is-active');
       updateFilterChipA11y(chip, false);
-    });
-    emitFilterStateChange();
-    commitState({ replace: false });
-    syncRefineDisclosure();
-    renderToys(applyFilters());
-    updateFilterResetState();
-    updateActiveFiltersSummary();
-  };
-
-  const removeFilterToken = (token) => {
-    const [type, value] = token.split(':');
-    if (!type || !value) return;
-    activeFilters.delete(token);
-    const chips = document.querySelectorAll('[data-filter-chip]');
-    chips.forEach((chip) => {
-      const chipType = chip.getAttribute('data-filter-type');
-      const chipValue = chip.getAttribute('data-filter-value');
-      const chipToken =
-        chipType && chipValue ? createFilterToken(chipType, chipValue) : null;
-      if (chipToken === token) {
-        chip.classList.remove('is-active');
-        updateFilterChipA11y(chip, false);
-      }
     });
     emitFilterStateChange();
     commitState({ replace: false });

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -23,6 +23,118 @@ export interface AudioControlsOptions {
   autoStartMicrophoneWhenGranted?: boolean;
 }
 
+function renderOnboardingHelp({
+  starterPresetLabel,
+  firstRunHint,
+  starterTips,
+}: {
+  starterPresetLabel: string;
+  firstRunHint?: string;
+  starterTips?: string[];
+}) {
+  return `
+    <details class="control-panel__disclosure" data-onboarding-help>
+      <summary>Help me choose</summary>
+      <section class="control-panel__first-steps" data-first-steps role="note" aria-label="First steps">
+        <div class="control-panel__first-steps-header">
+          <span class="control-panel__label">First steps</span>
+          <div class="control-panel__first-steps-actions">
+            <button type="button" class="control-panel__dismiss" data-apply-starter-preset>Try ${starterPresetLabel}</button>
+            <button type="button" class="control-panel__dismiss" data-dismiss-first-steps>Dismiss</button>
+          </div>
+        </div>
+        <ul class="control-panel__tips control-panel__tips--compact">
+          <li data-first-step-source>Start with mic for live input, or demo for instant audio.</li>
+          <li>Use <strong>Low motion</strong> in quality controls for a calmer feel.</li>
+          <li>${firstRunHint ?? 'Tap or drag in the canvas once audio starts to feel the response.'}</li>
+        </ul>
+      </section>
+      ${
+        starterTips && starterTips.length > 0
+          ? `
+      <div class="control-panel__quickstart" data-quickstart-panel>
+        <div class="control-panel__first-steps-header">
+          <span class="control-panel__label">Quick start tips</span>
+          <button type="button" class="control-panel__dismiss" data-dismiss-quickstart>Dismiss</button>
+        </div>
+        <ul class="control-panel__tips">
+          ${starterTips
+            .slice(0, 3)
+            .map((tip) => `<li>${tip}</li>`)
+            .join('')}
+        </ul>
+      </div>
+      `
+          : ''
+      }
+    </details>
+  `;
+}
+
+function renderAdvancedAudioSources(options: AudioControlsOptions) {
+  const hasAdvancedOptions =
+    Boolean(options.onRequestTabAudio) ||
+    Boolean(options.onRequestYouTubeAudio);
+  if (!hasAdvancedOptions) return '';
+
+  return `
+    <details class="control-panel__disclosure" data-advanced-audio-disclosure>
+      <summary>Advanced inputs</summary>
+      <p class="control-panel__advanced-helper">Use these when you want visuals to react to audio already playing in your browser.</p>
+      <div id="advanced-audio-panel" class="control-panel__advanced" data-advanced-panel>
+        ${
+          options.onRequestTabAudio
+            ? `
+        <div class="control-panel__row">
+          <div class="control-panel__text">
+            <span class="control-panel__label">Tab capture</span>
+            <span class="control-panel__microcopy">Capture sound from the current tab. Choose “This tab” and enable “Share audio”.</span>
+          </div>
+          <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
+        </div>
+        `
+            : ''
+        }
+        ${
+          options.onRequestYouTubeAudio
+            ? `
+        <div class="control-panel__row control-panel__row--stacked">
+          <div class="control-panel__text">
+            <span class="control-panel__label">YouTube capture</span>
+            <span class="control-panel__microcopy">Paste a link, load it, then capture from the tab picker.</span>
+          </div>
+          <div class="control-panel__field">
+            <label class="sr-only" for="youtube-url">YouTube URL</label>
+            <input
+              id="youtube-url"
+              class="control-panel__input"
+              type="url"
+              placeholder="https://youtube.com/watch?v=..."
+              autocomplete="off"
+              inputmode="url"
+            />
+            <button id="load-youtube" class="cta-button" type="button">Load</button>
+          </div>
+          <p id="youtube-url-feedback" class="control-panel__microcopy" data-youtube-url-feedback role="status" aria-live="polite">Paste a full YouTube link to enable Load.</p>
+          <div id="recent-youtube" class="control-panel__recent" hidden>
+            <span class="control-panel__label small">Recent</span>
+            <div id="recent-list" class="control-panel__chip-list"></div>
+          </div>
+          <div class="control-panel__actions control-panel__actions--inline">
+            <button id="use-youtube-audio" class="cta-button" type="button">Capture YouTube</button>
+          </div>
+          <div id="youtube-player-container" class="control-panel__embed" hidden>
+            <div id="youtube-player"></div>
+          </div>
+        </div>
+        `
+            : ''
+        }
+      </div>
+    </details>
+  `;
+}
+
 export function initAudioControls(
   container: HTMLElement,
   options: AudioControlsOptions,
@@ -45,9 +157,6 @@ export function initAudioControls(
   };
 
   container.className = 'control-panel';
-  const hasAdvancedOptions =
-    Boolean(options.onRequestTabAudio) ||
-    Boolean(options.onRequestYouTubeAudio);
   const firstRunHint = options.firstRunHint?.trim();
   const gestureHints = (options.gestureHints ?? options.starterTips ?? [])
     .filter((tip) => /touch|drag|pinch|swipe|gesture|tap|rotate/i.test(tip))
@@ -62,23 +171,6 @@ export function initAudioControls(
       Choose how this toy listens.
     </p>
     <p class="control-panel__stage-label">Step 1 · Start audio</p>
-    <section class="control-panel__first-steps" data-first-steps role="note" aria-label="First steps">
-      <div class="control-panel__first-steps-header">
-        <span class="control-panel__label">First steps</span>
-        <div class="control-panel__first-steps-actions">
-          <button type="button" class="control-panel__dismiss" data-apply-starter-preset>Try ${starterPresetLabel}</button>
-          <button type="button" class="control-panel__dismiss" data-dismiss-first-steps>Dismiss</button>
-        </div>
-      </div>
-      <ul class="control-panel__tips control-panel__tips--compact">
-        <li data-first-step-source>Start with mic for live input, or demo for instant audio.</li>
-        <li>Then open quality controls and pick <strong>Low motion</strong> if you want a calmer feel.</li>
-        <li>${firstRunHint ?? 'Tap or drag in the canvas once audio starts to quickly feel the response.'}</li>
-      </ul>
-    </section>
-    <p class="control-panel__comparison" data-audio-comparison>
-      Mic reacts to your space right now. Demo starts instantly with no permissions.
-    </p>
     ${
       gestureHints.length > 0
         ? `
@@ -92,24 +184,6 @@ export function initAudioControls(
         ${gestureHints.map((tip) => `<li>${tip}</li>`).join('')}
       </ul>
     </section>
-    `
-        : ''
-    }
-    ${
-      options.starterTips && options.starterTips.length > 0
-        ? `
-    <div class="control-panel__quickstart" data-quickstart-panel>
-      <div class="control-panel__first-steps-header">
-        <span class="control-panel__label">Quick start tips</span>
-        <button type="button" class="control-panel__dismiss" data-dismiss-quickstart>Dismiss</button>
-      </div>
-      <ul class="control-panel__tips">
-        ${options.starterTips
-          .slice(0, 3)
-          .map((tip) => `<li>${tip}</li>`)
-          .join('')}
-      </ul>
-    </div>
     `
         : ''
     }
@@ -133,103 +207,12 @@ export function initAudioControls(
       </div>
       <button id="use-demo-audio" class="cta-button primary" type="button">Preview instantly with demo audio</button>
     </div>
-
-    ${
-      hasAdvancedOptions
-        ? `
-    <p class="control-panel__stage-label">Step 2 · Advanced capture (optional)</p>
-    <div class="control-panel__row control-panel__row--advanced-toggle">
-      <button
-        type="button"
-        class="control-panel__advanced-toggle"
-        aria-expanded="false"
-        aria-controls="advanced-audio-panel"
-        data-advanced-toggle
-      >
-        <span class="control-panel__advanced-title" data-advanced-toggle-label>Show advanced audio options</span>
-        <span class="control-panel__advanced-hint">Tab or YouTube capture for media already playing</span>
-      </button>
-    </div>
-    <p class="control-panel__advanced-helper" data-advanced-helper hidden>Use these when you want visuals to react to music or videos already playing in your browser.</p>
-    <div id="advanced-audio-panel" class="control-panel__advanced" data-advanced-panel hidden>
-      ${
-        options.onRequestTabAudio
-          ? `
-      <div class="control-panel__row">
-        <div class="control-panel__text">
-          <span class="control-panel__label">Tab capture</span>
-          <span class="control-panel__info-wrap">
-            <button
-              class="control-panel__info"
-              type="button"
-              aria-describedby="tab-audio-info"
-            >
-              Tab tips
-            </button>
-            <span id="tab-audio-info" class="control-panel__info-text">
-              Capture sound from the current tab. In the picker, choose “This tab” and enable
-              Share audio.
-            </span>
-          </span>
-        </div>
-        <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
-      </div>
-      `
-          : ''
-      }
-      ${
-        options.onRequestYouTubeAudio
-          ? `
-      <div class="control-panel__row control-panel__row--stacked">
-        <div class="control-panel__text">
-          <span class="control-panel__label">YouTube capture</span>
-          <span class="control-panel__info-wrap">
-            <button
-              class="control-panel__info"
-              type="button"
-              aria-describedby="youtube-audio-info"
-            >
-              YouTube tips
-            </button>
-            <span id="youtube-audio-info" class="control-panel__info-text">
-              Paste a link, load it, then capture. In the picker, choose “This tab” and enable
-              Share audio.
-            </span>
-          </span>
-        </div>
-        <div class="control-panel__field">
-          <label class="sr-only" for="youtube-url">YouTube URL</label>
-          <input
-            id="youtube-url"
-            class="control-panel__input"
-            type="url"
-            placeholder="https://youtube.com/watch?v=..."
-            autocomplete="off"
-            inputmode="url"
-          />
-          <button id="load-youtube" class="cta-button" type="button">Load</button>
-        </div>
-        <p id="youtube-url-feedback" class="control-panel__microcopy" data-youtube-url-feedback role="status" aria-live="polite">Paste a full YouTube link to enable Load.</p>
-        <div id="recent-youtube" class="control-panel__recent" hidden>
-          <span class="control-panel__label small">Recent</span>
-          <div id="recent-list" class="control-panel__chip-list"></div>
-        </div>
-        <div class="control-panel__actions control-panel__actions--inline">
-          <button id="use-youtube-audio" class="cta-button" type="button">
-            Capture YouTube
-          </button>
-        </div>
-        <div id="youtube-player-container" class="control-panel__embed" hidden>
-          <div id="youtube-player"></div>
-        </div>
-      </div>
-      `
-          : ''
-      }
-    </div>
-    `
-        : ''
-    }
+    ${renderOnboardingHelp({
+      starterPresetLabel,
+      firstRunHint,
+      starterTips: options.starterTips,
+    })}
+    ${renderAdvancedAudioSources(options)}
 
     <div id="audio-status" class="control-panel__status" role="status" aria-live="polite" hidden></div>
   `;
@@ -243,18 +226,9 @@ export function initAudioControls(
     container.querySelector('#audio-status')) as HTMLElement;
   const requestTabAudio = options.onRequestTabAudio;
   let microphonePermissionState: MicrophonePermissionState = 'unknown';
-  const advancedToggle = container.querySelector(
-    '[data-advanced-toggle]',
-  ) as HTMLButtonElement | null;
-  const advancedPanel = container.querySelector(
-    '[data-advanced-panel]',
-  ) as HTMLElement | null;
-  const advancedHelper = container.querySelector(
-    '[data-advanced-helper]',
-  ) as HTMLElement | null;
-  const advancedToggleLabel = container.querySelector(
-    '[data-advanced-toggle-label]',
-  ) as HTMLElement | null;
+  const advancedDisclosure = container.querySelector(
+    '[data-advanced-audio-disclosure]',
+  ) as HTMLDetailsElement | null;
   const ADVANCED_KEY = 'stims-audio-advanced-open';
   const FIRST_STEPS_KEY = 'stims-first-steps-dismissed';
   const GESTURE_HINT_KEY = 'stims-gesture-hints-dismissed';
@@ -537,47 +511,23 @@ export function initAudioControls(
     );
   }
 
-  if (advancedToggle && advancedPanel) {
-    let isOpen = false;
+  if (advancedDisclosure) {
     try {
-      isOpen = window.sessionStorage.getItem(ADVANCED_KEY) === 'true';
+      advancedDisclosure.open =
+        window.sessionStorage.getItem(ADVANCED_KEY) === 'true';
     } catch (_error) {
-      isOpen = false;
+      advancedDisclosure.open = false;
     }
-    const setAdvancedState = (open: boolean) => {
-      advancedPanel.hidden = !open;
-      if (advancedHelper) {
-        advancedHelper.hidden = !open;
-      }
-      advancedToggle.setAttribute('aria-expanded', String(open));
-      if (advancedToggleLabel) {
-        advancedToggleLabel.textContent = open
-          ? 'Hide advanced audio options'
-          : 'Show advanced audio options';
-      }
-    };
 
-    setAdvancedState(isOpen);
-    const persistAdvancedState = (nextState: boolean) => {
-      setAdvancedState(nextState);
+    advancedDisclosure.addEventListener('toggle', () => {
       try {
-        window.sessionStorage.setItem(ADVANCED_KEY, String(nextState));
+        window.sessionStorage.setItem(
+          ADVANCED_KEY,
+          String(advancedDisclosure.open),
+        );
       } catch (_error) {
         // Ignore storage errors.
       }
-    };
-
-    advancedToggle.addEventListener('click', () => {
-      const nextState = advancedPanel.hidden;
-      persistAdvancedState(nextState);
-    });
-
-    advancedToggle.addEventListener('keydown', (event) => {
-      if (event.key !== 'Escape') return;
-      if (advancedPanel.hidden) return;
-      event.preventDefault();
-      persistAdvancedState(false);
-      advancedToggle.focus();
     });
   }
 

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -64,6 +64,20 @@ function createValueLabel(label: string) {
   return value;
 }
 
+function createAdvancedControlsSection() {
+  const section = document.createElement('details');
+  section.className = 'control-panel__disclosure';
+  const summary = document.createElement('summary');
+  summary.textContent = 'Advanced rendering';
+  section.appendChild(summary);
+
+  const content = document.createElement('div');
+  content.className = 'control-panel__advanced-content';
+  section.appendChild(content);
+
+  return { section, content };
+}
+
 function resolveDefaultPresetId(defaultPresetId?: string) {
   if (defaultPresetId) return defaultPresetId;
   return isSmartTvDevice() ? 'tv' : 'balanced';
@@ -152,10 +166,54 @@ export function initSystemControls(
   });
 
   if (includeAdvancedControls) {
-    const resolutionRow = panel.addSection(
-      'Resolution scale',
-      'Lower values ease GPU load; higher values sharpen detail.',
+    const advancedContainerRow = panel.addSection(
+      'Fine tuning',
+      'Optional controls for render sharpness and GPU load.',
     );
+    const { section: advancedSection, content: advancedSectionContent } =
+      createAdvancedControlsSection();
+    advancedContainerRow.appendChild(advancedSection);
+
+    const resolutionRow = document.createElement('div');
+    resolutionRow.className = 'control-panel__row';
+    advancedSectionContent.appendChild(resolutionRow);
+    const resolutionText = document.createElement('div');
+    resolutionText.className = 'control-panel__text';
+    resolutionText.innerHTML = `
+      <span class="control-panel__label">Resolution scale</span>
+      <span class="control-panel__microcopy">Lower values ease GPU load; higher values sharpen detail.</span>
+    `;
+    resolutionRow.appendChild(resolutionText);
+
+    const resolutionControl = document.createElement('div');
+    resolutionControl.className =
+      'control-panel__actions control-panel__actions--inline';
+    resolutionRow.appendChild(resolutionControl);
+
+    const pixelRatioRow = document.createElement('div');
+    pixelRatioRow.className = 'control-panel__row';
+    advancedSectionContent.appendChild(pixelRatioRow);
+    const pixelText = document.createElement('div');
+    pixelText.className = 'control-panel__text';
+    pixelText.innerHTML = `
+      <span class="control-panel__label">Pixel ratio cap</span>
+      <span class="control-panel__microcopy">Caps effective DPI to balance clarity and thermal load.</span>
+    `;
+    pixelRatioRow.appendChild(pixelText);
+    const pixelControl = document.createElement('div');
+    pixelControl.className =
+      'control-panel__actions control-panel__actions--inline';
+    pixelRatioRow.appendChild(pixelControl);
+
+    const resetRow = document.createElement('div');
+    resetRow.className = 'control-panel__row';
+    advancedSectionContent.appendChild(resetRow);
+    const resetText = document.createElement('div');
+    resetText.className = 'control-panel__text';
+    resetText.innerHTML =
+      '<span class="control-panel__label">Custom overrides</span>';
+    resetRow.appendChild(resetText);
+
     const resolutionValue = createValueLabel('');
     const resolutionSlider = document.createElement('input');
     resolutionSlider.type = 'range';
@@ -176,12 +234,8 @@ export function initSystemControls(
       updateResolutionValue(value);
       setRenderPreferences({ renderScale: value });
     });
-    resolutionRow.append(resolutionSlider, resolutionValue);
+    resolutionControl.append(resolutionSlider, resolutionValue);
 
-    const pixelRatioRow = panel.addSection(
-      'Pixel ratio cap',
-      'Caps effective DPI to balance clarity and thermal load.',
-    );
     const pixelRatioValue = createValueLabel('');
     const pixelRatioSlider = document.createElement('input');
     pixelRatioSlider.type = 'range';
@@ -202,9 +256,8 @@ export function initSystemControls(
       updatePixelRatioValue(value);
       setRenderPreferences({ maxPixelRatio: value });
     });
-    pixelRatioRow.append(pixelRatioSlider, pixelRatioValue);
+    pixelControl.append(pixelRatioSlider, pixelRatioValue);
 
-    const resetRow = panel.addSection('Custom overrides', undefined);
     const resetButton = document.createElement('button');
     resetButton.type = 'button';
     resetButton.className = 'cta-button ghost';

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -79,17 +79,13 @@ describe('audio controls primary emphasis', () => {
     );
   });
 
-  test('shows comparison guidance and recommended source badge', () => {
+  test('highlights recommended source badge for primary action', () => {
     const container = document.createElement('section');
 
     initAudioControls(container, {
       onRequestMicrophone: async () => {},
       onRequestDemoAudio: async () => {},
     });
-
-    expect(container.textContent).toContain(
-      'Mic reacts to your space right now. Demo starts instantly with no permissions.',
-    );
 
     const micBadge = container.querySelector('[data-recommended-for="mic"]');
     const demoBadge = container.querySelector('[data-recommended-for="demo"]');
@@ -98,7 +94,7 @@ describe('audio controls primary emphasis', () => {
     expect((demoBadge as HTMLElement | null)?.hidden).toBe(true);
   });
 
-  test('shows a two-step sequence with advanced options labeled optional', () => {
+  test('keeps start audio as the only top-level stage label', () => {
     const container = document.createElement('section');
 
     initAudioControls(container, {
@@ -111,11 +107,10 @@ describe('audio controls primary emphasis', () => {
       container.querySelectorAll('.control-panel__stage-label'),
     ).map((node) => node.textContent?.trim());
 
-    expect(stageLabels).toContain('Step 1 · Start audio');
-    expect(stageLabels).toContain('Step 2 · Advanced capture (optional)');
+    expect(stageLabels).toEqual(['Step 1 · Start audio']);
   });
 
-  test('keeps advanced helper copy hidden until advanced options are expanded', () => {
+  test('renders advanced options inside a collapsed disclosure', () => {
     const container = document.createElement('section');
 
     initAudioControls(container, {
@@ -124,28 +119,20 @@ describe('audio controls primary emphasis', () => {
       onRequestTabAudio: async () => {},
     });
 
-    const toggle = container.querySelector(
-      '[data-advanced-toggle]',
-    ) as HTMLButtonElement;
-    const helper = container.querySelector(
-      '[data-advanced-helper]',
-    ) as HTMLElement;
-    const toggleLabel = container.querySelector(
-      '[data-advanced-toggle-label]',
-    ) as HTMLElement;
+    const disclosure = container.querySelector(
+      '[data-advanced-audio-disclosure]',
+    ) as HTMLDetailsElement;
+    expect(disclosure.open).toBe(false);
 
-    expect(helper.hidden).toBe(true);
-    expect(toggle.getAttribute('aria-controls')).toBe('advanced-audio-panel');
-    expect(toggleLabel.textContent).toBe('Show advanced audio options');
+    disclosure.open = true;
+    disclosure.dispatchEvent(new Event('toggle'));
 
-    toggle.click();
-
-    expect(helper.hidden).toBe(false);
-    expect(toggleLabel.textContent).toBe('Hide advanced audio options');
+    expect(sessionStorage.getItem('stims-audio-advanced-open')).toBe('true');
   });
 
-  test('closes advanced options when Escape is pressed on toggle', () => {
+  test('restores advanced disclosure state from session storage', () => {
     const container = document.createElement('section');
+    sessionStorage.setItem('stims-audio-advanced-open', 'true');
 
     initAudioControls(container, {
       onRequestMicrophone: async () => {},
@@ -153,20 +140,10 @@ describe('audio controls primary emphasis', () => {
       onRequestTabAudio: async () => {},
     });
 
-    const toggle = container.querySelector(
-      '[data-advanced-toggle]',
-    ) as HTMLButtonElement;
-    const panel = container.querySelector(
-      '[data-advanced-panel]',
-    ) as HTMLElement;
-
-    toggle.click();
-    expect(panel.hidden).toBe(false);
-
-    toggle.dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Escape' }),
-    );
-    expect(panel.hidden).toBe(true);
+    const disclosure = container.querySelector(
+      '[data-advanced-audio-disclosure]',
+    ) as HTMLDetailsElement;
+    expect(disclosure.open).toBe(true);
   });
 
   test('reveals touch gesture hints after audio starts on touch-capable devices', async () => {


### PR DESCRIPTION
### Motivation
- Improve discoverability and semantics of advanced controls by replacing custom toggles with native disclosure panels. 
- Simplify the active filters UI to show a concise status and avoid duplicative chip rendering logic.
- Group fine-tuning system controls into an optional, collapsible block for less visual clutter.

### Description
- Added CSS for `.control-panel__disclosure` and related styles to support compact `<details>` disclosure panels. 
- Refactored audio controls to render onboarding and advanced inputs via `renderOnboardingHelp` and `renderAdvancedAudioSources`, replacing the previous custom advanced toggle with a `<details>` disclosure that persists open state to `sessionStorage`. 
- Simplified active filters summary in `library-view.js` to hide the chips container, show a concise status with up to two visible labels, and set the clear button text to `Clear all`, and removed the now-unused `removeFilterToken` chip removal flow. 
- Reworked system controls to create an `Advanced rendering` disclosure via `createAdvancedControlsSection` and moved resolution/pixel-ratio/reset controls inside that disclosure while keeping existing slider behavior and event handling.
- Updated unit tests in `tests/audio-controls.test.ts` to reflect disclosure-based behavior and restored session storage restoration checks.

### Testing
- Ran unit tests with `npm test` and the updated `tests/audio-controls.test.ts` suite, which passed after updating expectations for disclosure semantics. 
- Verified interactive behavior in the audio controls by exercising the disclosure `toggle` event and ensuring `sessionStorage` state is written as expected (covered by the updated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85c0458548332a026604a75c88846)