### PR TITLE
Keep 3D toy system controls outside active toy container

### DIFF
--- a/assets/js/toys/three-d-toy.ts
+++ b/assets/js/toys/three-d-toy.ts
@@ -38,6 +38,7 @@ export function start({ container }: ToyStartOptions = {}) {
     paletteCycle: true,
     mobilePreset: false,
   };
+  let systemControls: ReturnType<typeof initSystemControls> | null = null;
   const idleDetector = createIdleDetector();
   const clock = new THREE.Clock();
 
@@ -350,7 +351,9 @@ export function start({ container }: ToyStartOptions = {}) {
   }
 
   function setupSettingsPanel() {
-    const panel = initSystemControls(container ?? document.body, {
+    const controlHost = container?.ownerDocument?.body ?? document.body;
+    systemControls?.element.remove();
+    systemControls = initSystemControls(controlHost, {
       title: '3D soundscape',
       description: 'Pick visual behavior and performance for this toy.',
       includeVisualBehaviorControls: true,
@@ -363,8 +366,8 @@ export function start({ container }: ToyStartOptions = {}) {
         rebuildSceneContents();
       },
     });
-    controlState = panel.getVisualBehaviorState();
-    panel.onVisualBehaviorChange((state) => {
+    controlState = systemControls.getVisualBehaviorState();
+    systemControls.onVisualBehaviorChange((state) => {
       controlState = state;
     });
   }
@@ -405,6 +408,8 @@ export function start({ container }: ToyStartOptions = {}) {
         dispose: () => {
           errorElement?.remove();
           postprocessing?.dispose();
+          systemControls?.element.remove();
+          systemControls = null;
         },
       },
     ],


### PR DESCRIPTION
### Motivation
- Prevent the new system-controls panel from being removed by the active toy container cleanup path in `toy-view` (the view removes `.control-panel` children whenever the audio prompt is inactive). 
- Ensure the 3D toy can expose visual behavior and quality toggles reliably and clean up its controls when the toy is disposed.

### Description
- Mount the system controls on the document body (via `container?.ownerDocument?.body`) instead of the active toy container when calling `initSystemControls`. 
- Track the `systemControls` handle in the toy runtime and remove any existing panel before re-initializing to avoid duplicate panels. 
- Remove the system controls during the toy `dispose` lifecycle so controls do not linger after leaving the toy. 

### Testing
- Ran `bun run check`, which reports a failing test in this branch due to an unrelated flaky test: `audio controls primary emphasis > switches emphasis to demo row after successful demo start`. 
- Ran targeted suites which passed: `bun run test tests/audio-controls.test.ts` (passed) and `bun run test tests/control-panel.test.js tests/toy-view.test.js` (passed). 
- Observed that the targeted assertions around `toy-view` and control-panel behavior succeed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86057e1f48332a7dd68520a1ef057)