### PR TITLE
Add three.js ambient background and card preview effects; refactor MilkDrop to use feedback warp effect and postprocessing

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -4299,3 +4299,34 @@ body.tv-mode .content {
   display: inline-flex;
   align-items: center;
 }
+
+.library-three-ambient {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.5;
+}
+
+.library,
+#toy-list {
+  position: relative;
+  z-index: 1;
+}
+
+.webtoy-card-preview {
+  width: 100%;
+  border-radius: 0.85rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  margin-bottom: 0.8rem;
+  background: rgba(4, 6, 16, 0.82);
+}
+
+.webtoy-card-preview canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -11,6 +11,7 @@ import {
 } from './library-view/filter-state.js';
 import { ensureIconSymbol, SVG_NS } from './library-view/icon-sprite.js';
 import { setupDarkModeToggle } from './library-view/theme-toggle.js';
+import { createLibraryThreeEffects } from './library-view/three-library-effects.ts';
 import { getRecentToySlugs } from './utils/growth-metrics.ts';
 
 export function createLibraryView({
@@ -39,6 +40,7 @@ export function createLibraryView({
   let pendingCommit;
   let lastFilteredToys = [];
   const activeFilters = new Set();
+  const threeEffects = createLibraryThreeEffects();
   const {
     ensureMetaNode,
     ensureSearchForm,
@@ -514,6 +516,7 @@ export function createLibraryView({
   };
 
   const openToy = (toy, { preferDemoAudio = false } = {}) => {
+    threeEffects.triggerLaunchTransition();
     if (toy.type === 'module' && typeof loadToy === 'function') {
       loadToy(toy.slug, { pushState: true, preferDemoAudio });
     } else if (toy.module) {
@@ -926,6 +929,10 @@ export function createLibraryView({
 
     renderGrowthPanels(list);
     listToRender.forEach((toy) => list.appendChild(createCard(toy)));
+    const cards = Array.from(list.querySelectorAll('.webtoy-card')).filter(
+      (card) => card instanceof HTMLElement,
+    );
+    threeEffects.syncCardPreviews(cards, listToRender);
     updateResultsMeta(listToRender.length);
     updateActiveFiltersSummary();
   };
@@ -1220,6 +1227,7 @@ export function createLibraryView({
     }
 
     syncRefineDisclosure();
+    threeEffects.init();
     renderToys(applyFilters());
 
     if (enableDarkModeToggle) {

--- a/assets/js/library-view/three-library-effects.ts
+++ b/assets/js/library-view/three-library-effects.ts
@@ -1,0 +1,247 @@
+import {
+  AmbientLight,
+  BoxGeometry,
+  type BufferGeometry,
+  Color,
+  DirectionalLight,
+  Float32BufferAttribute,
+  Group,
+  type Material,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  Points,
+  PointsMaterial,
+  Scene,
+  SphereGeometry,
+  TorusKnotGeometry,
+  Vector3,
+  WebGLRenderer,
+} from 'three';
+
+interface ToyLike {
+  slug?: string;
+}
+
+interface PreviewItem {
+  root: HTMLElement;
+  renderer: WebGLRenderer;
+  scene: Scene;
+  camera: PerspectiveCamera;
+  mesh: Mesh;
+  dispose: () => void;
+}
+
+const PREVIEW_LIMIT = 6;
+
+export function createLibraryThreeEffects() {
+  let backgroundRenderer: WebGLRenderer | null = null;
+  let backgroundScene: Scene | null = null;
+  let backgroundCamera: PerspectiveCamera | null = null;
+  let backgroundParticles: Points | null = null;
+  let animationFrame = 0;
+  let pulse = 0;
+  const previews = new Map<string, PreviewItem>();
+
+  const canUseWebGL = () => {
+    try {
+      const canvas = document.createElement('canvas');
+      const context =
+        canvas.getContext('webgl2') ?? canvas.getContext('webgl') ?? null;
+      return Boolean(context);
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const webglAvailable =
+    typeof window !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    canUseWebGL();
+
+  const animate = () => {
+    animationFrame = window.requestAnimationFrame(animate);
+
+    if (backgroundRenderer && backgroundScene && backgroundCamera) {
+      const time = performance.now() * 0.0002;
+      if (backgroundParticles) {
+        backgroundParticles.rotation.y = time * (0.18 + pulse * 0.6);
+        backgroundParticles.rotation.x = Math.sin(time * 2) * 0.07;
+      }
+      backgroundScene.background = new Color().setHSL(
+        0.68 + Math.sin(time) * 0.05,
+        0.35,
+        0.05 + pulse * 0.02,
+      );
+      backgroundRenderer.render(backgroundScene, backgroundCamera);
+    }
+
+    previews.forEach((item) => {
+      item.mesh.rotation.x += 0.004 + pulse * 0.01;
+      item.mesh.rotation.y += 0.007 + pulse * 0.01;
+      item.renderer.render(item.scene, item.camera);
+    });
+
+    pulse = Math.max(0, pulse * 0.93 - 0.003);
+  };
+
+  const createAmbientLayer = () => {
+    if (!webglAvailable) return;
+    try {
+      const renderer = new WebGLRenderer({ alpha: true, antialias: false });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.domElement.className = 'library-three-ambient';
+
+      const scene = new Scene();
+      const camera = new PerspectiveCamera(
+        65,
+        window.innerWidth / Math.max(window.innerHeight, 1),
+        0.1,
+        100,
+      );
+      camera.position.z = 14;
+
+      const geometry = new SphereGeometry(0.03, 6, 6);
+      const material = new PointsMaterial({
+        size: 0.1,
+        color: 0x88aaff,
+        transparent: true,
+        opacity: 0.4,
+      });
+      const points = new Points(geometry, material);
+      const positions: number[] = [];
+      for (let i = 0; i < 1000; i += 1) {
+        positions.push(
+          (Math.random() - 0.5) * 25,
+          (Math.random() - 0.5) * 16,
+          (Math.random() - 0.5) * 20,
+        );
+      }
+      points.geometry.setAttribute(
+        'position',
+        new Float32BufferAttribute(positions, 3),
+      );
+
+      scene.add(points);
+      scene.add(new AmbientLight(0x8899ff, 0.35));
+
+      document.body.appendChild(renderer.domElement);
+      backgroundRenderer = renderer;
+      backgroundScene = scene;
+      backgroundCamera = camera;
+      backgroundParticles = points;
+
+      const onResize = () => {
+        if (!backgroundRenderer || !backgroundCamera) return;
+        backgroundRenderer.setSize(window.innerWidth, window.innerHeight);
+        backgroundCamera.aspect =
+          window.innerWidth / Math.max(window.innerHeight, 1);
+        backgroundCamera.updateProjectionMatrix();
+      };
+      window.addEventListener('resize', onResize);
+    } catch (_error) {
+      // Gracefully skip when WebGL is unavailable.
+    }
+  };
+
+  const makePreview = (host: HTMLElement, toy: ToyLike, index: number) => {
+    if (!webglAvailable) return;
+    const key = toy.slug ?? `toy-${index}`;
+    if (previews.has(key)) return;
+
+    const previewRoot = document.createElement('div');
+    previewRoot.className = 'webtoy-card-preview';
+    host.prepend(previewRoot);
+
+    let renderer: WebGLRenderer;
+    try {
+      renderer = new WebGLRenderer({ alpha: true, antialias: true });
+    } catch (_error) {
+      previewRoot.remove();
+      return;
+    }
+    renderer.setSize(180, 110, false);
+    renderer.setPixelRatio(1);
+    previewRoot.appendChild(renderer.domElement);
+
+    const scene = new Scene();
+    scene.background = new Color(0x090a16);
+    const camera = new PerspectiveCamera(55, 180 / 110, 0.1, 100);
+    camera.position.z = 2.7;
+
+    const group = new Group();
+    scene.add(group);
+
+    let geometry: BufferGeometry;
+    if (index % 3 === 0) geometry = new TorusKnotGeometry(0.56, 0.18, 92, 12);
+    else if (index % 3 === 1) geometry = new SphereGeometry(0.72, 26, 26);
+    else geometry = new BoxGeometry(1.1, 1.1, 1.1, 5, 5, 5);
+
+    const color = new Color().setHSL(((index * 0.13) % 1) + 0.05, 0.8, 0.6);
+    const material = new MeshStandardMaterial({
+      color,
+      emissive: color.clone().multiplyScalar(0.24),
+      roughness: 0.38,
+      metalness: 0.62,
+    });
+    const mesh = new Mesh(geometry, material);
+    group.add(mesh);
+
+    scene.add(new AmbientLight(0xffffff, 0.4));
+    const light = new DirectionalLight(0xffffff, 1.1);
+    light.position.copy(new Vector3(2, 3, 3));
+    scene.add(light);
+
+    const dispose = () => {
+      (mesh.geometry as BufferGeometry).dispose();
+      (mesh.material as Material).dispose();
+      renderer.dispose();
+      previewRoot.remove();
+    };
+
+    previews.set(key, { root: host, renderer, scene, camera, mesh, dispose });
+  };
+
+  const syncCardPreviews = (cards: HTMLElement[], toys: ToyLike[]) => {
+    const nextKeys = new Set<string>();
+    cards.slice(0, PREVIEW_LIMIT).forEach((card, index) => {
+      const toy = toys[index];
+      if (!toy) return;
+      if (!webglAvailable) return;
+      const key = toy.slug ?? `toy-${index}`;
+      nextKeys.add(key);
+      if (!previews.has(key)) makePreview(card, toy, index);
+    });
+
+    Array.from(previews.entries()).forEach(([key, preview]) => {
+      if (nextKeys.has(key)) return;
+      preview.dispose();
+      previews.delete(key);
+    });
+  };
+
+  return {
+    init() {
+      createAmbientLayer();
+      animate();
+    },
+    syncCardPreviews,
+    triggerLaunchTransition() {
+      pulse = 1;
+    },
+    dispose() {
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+      previews.forEach((preview) => preview.dispose());
+      previews.clear();
+      backgroundRenderer?.dispose();
+      backgroundRenderer?.domElement.remove();
+      backgroundRenderer = null;
+      backgroundScene = null;
+      backgroundCamera = null;
+      backgroundParticles = null;
+    },
+  };
+}

--- a/assets/js/toys/milkdrop-toy.ts
+++ b/assets/js/toys/milkdrop-toy.ts
@@ -1,19 +1,19 @@
 import * as THREE from 'three';
-import { resolveWebGLRenderer } from '../core/postprocessing';
+import {
+  createBloomComposer,
+  type PostprocessingPipeline,
+  resolveWebGLRenderer,
+} from '../core/postprocessing';
 import type { ToyStartOptions } from '../core/toy-interface';
-import FeedbackManager from '../utils/feedback-manager';
+import { createFeedbackWarpEffect } from '../utils/feedback-warp-effect';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import { createToyRuntimeStarter } from '../utils/toy-runtime-starter';
 import { createToyQualityControls } from '../utils/toy-settings';
-import WarpShader from '../utils/warp-shader';
 
 export function start({ container }: ToyStartOptions = {}) {
-  let feedback: FeedbackManager | null = null;
+  let feedbackEffect: ReturnType<typeof createFeedbackWarpEffect> | null = null;
+  let postprocessing: PostprocessingPipeline | null = null;
   let webglRenderer: THREE.WebGLRenderer | null = null;
-  let warpMaterial: THREE.ShaderMaterial | null = null;
-  let warpMesh: THREE.Mesh | null = null;
-  const overlayScene = new THREE.Scene();
-  const overlayCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
   const particleCount = 100;
   const particleGeometry = new THREE.SphereGeometry(0.05, 8, 8);
@@ -54,23 +54,15 @@ export function start({ container }: ToyStartOptions = {}) {
               return;
             }
 
-            feedback = new FeedbackManager({ renderer: webglRenderer });
-
-            warpMaterial = new THREE.ShaderMaterial({
-              ...WarpShader,
-              uniforms: THREE.UniformsUtils.clone(WarpShader.uniforms),
+            feedbackEffect = createFeedbackWarpEffect(webglRenderer);
+            postprocessing = createBloomComposer({
+              renderer: webglRenderer,
+              scene: toy.scene,
+              camera: toy.camera,
+              bloomStrength: 0.95,
+              bloomRadius: 0.5,
+              bloomThreshold: 0.85,
             });
-            warpMaterial.uniforms.tDiffuse.value = feedback.texture;
-            warpMaterial.uniforms.uResolution.value.set(
-              window.innerWidth,
-              window.innerHeight,
-            );
-
-            warpMesh = new THREE.Mesh(
-              new THREE.PlaneGeometry(2, 2),
-              warpMaterial,
-            );
-            overlayScene.add(warpMesh);
           });
         },
         update: ({ time, analyser, toy }) => {
@@ -98,51 +90,24 @@ export function start({ container }: ToyStartOptions = {}) {
           });
 
           // Feedback and Warp
-          if (feedback && warpMaterial && webglRenderer) {
-            const renderer = webglRenderer;
-
-            // 1. Update warp uniforms
-            warpMaterial.uniforms.uTime.value = time;
-            warpMaterial.uniforms.uAudioIntensity.value = energy.bass;
-            warpMaterial.uniforms.uZoom.value =
-              1.0 + Math.sin(time * 0.5) * 0.02;
-            warpMaterial.uniforms.uRotation.value = Math.sin(time * 0.2) * 0.01;
-
-            // 2. Render main scene + feedback into write buffer
-            // In MilkDrop, we render the PREVIOUS frame (distorted) and then overlay new graphics
-            renderer.setRenderTarget(null); // Clear default
-
-            // Actually, we need to render the warped texture BACK into the feedback buffer
-            // or render the scene ON TOP of the warped texture.
-
-            // Sequence:
-            // a. Render overlay (warpMesh showing feedback.texture) into writeBuffer
-            // b. Render main scene (particles) into writeBuffer (no clear)
-            // c. Render writeBuffer to screen
-            // d. Swap
-
-            renderer.setRenderTarget(feedback.writeTarget);
-            renderer.clear();
-            renderer.render(overlayScene, overlayCamera); // Draw the warped previous frame
-            renderer.autoClear = false;
-            renderer.render(toy.scene, toy.camera); // Draw new elements on top
-            renderer.autoClear = true;
-
-            renderer.setRenderTarget(null);
-            renderer.render(overlayScene, overlayCamera); // Final output to screen
-
-            feedback.swap();
-            warpMaterial.uniforms.tDiffuse.value = feedback.texture;
+          if (feedbackEffect && webglRenderer) {
+            feedbackEffect.render({
+              scene: toy.scene,
+              camera: toy.camera,
+              time,
+              intensity: energy.bass,
+            });
+            postprocessing?.updateSize();
           } else {
-            toy.render();
+            postprocessing?.updateSize();
+            postprocessing?.render();
           }
         },
         dispose: () => {
-          feedback?.dispose();
+          feedbackEffect?.dispose();
+          postprocessing?.dispose();
           disposeGeometry(particleGeometry);
           particleMaterials.forEach((material) => disposeMaterial(material));
-          disposeMaterial(warpMaterial);
-          disposeGeometry(warpMesh?.geometry ?? undefined);
         },
       },
     ],

--- a/assets/js/utils/feedback-warp-effect.ts
+++ b/assets/js/utils/feedback-warp-effect.ts
@@ -1,0 +1,65 @@
+import * as THREE from 'three';
+import FeedbackManager from './feedback-manager';
+import WarpShader from './warp-shader';
+
+export function createFeedbackWarpEffect(renderer: THREE.WebGLRenderer) {
+  const feedback = new FeedbackManager({ renderer });
+  const overlayScene = new THREE.Scene();
+  const overlayCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+  const warpMaterial = new THREE.ShaderMaterial({
+    ...WarpShader,
+    uniforms: THREE.UniformsUtils.clone(WarpShader.uniforms),
+  });
+  warpMaterial.uniforms.tDiffuse.value = feedback.texture;
+  warpMaterial.uniforms.uResolution.value.set(
+    window.innerWidth,
+    window.innerHeight,
+  );
+
+  const quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), warpMaterial);
+  overlayScene.add(quad);
+
+  const render = ({
+    scene,
+    camera,
+    time,
+    intensity,
+  }: {
+    scene: THREE.Scene;
+    camera: THREE.Camera;
+    time: number;
+    intensity: number;
+  }) => {
+    warpMaterial.uniforms.uTime.value = time;
+    warpMaterial.uniforms.uAudioIntensity.value = intensity;
+    warpMaterial.uniforms.uZoom.value = 1.0 + Math.sin(time * 0.5) * 0.02;
+    warpMaterial.uniforms.uRotation.value = Math.sin(time * 0.2) * 0.01;
+
+    renderer.setRenderTarget(feedback.writeTarget);
+    renderer.clear();
+    renderer.render(overlayScene, overlayCamera);
+    renderer.autoClear = false;
+    renderer.render(scene, camera);
+    renderer.autoClear = true;
+
+    renderer.setRenderTarget(null);
+    renderer.render(overlayScene, overlayCamera);
+
+    feedback.swap();
+    warpMaterial.uniforms.tDiffuse.value = feedback.texture;
+  };
+
+  const resize = (width: number, height: number) => {
+    feedback.setSize(width, height);
+    warpMaterial.uniforms.uResolution.value.set(width, height);
+  };
+
+  const dispose = () => {
+    feedback.dispose();
+    warpMaterial.dispose();
+    quad.geometry.dispose();
+  };
+
+  return { render, resize, dispose };
+}


### PR DESCRIPTION
### Motivation

- Introduce subtle WebGL-driven ambient visuals and live previews for library cards to improve the visual polish of the toys library.
- Encapsulate feedback/wrap rendering into a reusable effect and move MilkDrop to a modern postprocessing pipeline for clearer separation of concerns and easier reuse.

### Description

- Added a new three.js effects module `createLibraryThreeEffects` in `assets/js/library-view/three-library-effects.ts` that creates a full-screen ambient particle background, manages per-card WebGL preview renderers, and exposes `init`, `syncCardPreviews`, `triggerLaunchTransition`, and `dispose` methods.
- Integrated the three effects into the library view by importing and creating the effects instance in `assets/js/library-view.js`, calling `threeEffects.init()` during initialization, invoking `threeEffects.syncCardPreviews(...)` after rendering cards, and calling `threeEffects.triggerLaunchTransition()` when opening a toy.
- Added CSS classes in `assets/css/index.css` for the ambient canvas and the card preview container (`.library-three-ambient`, `.webtoy-card-preview`, etc.) and adjusted stacking contexts so previews sit above the background.
- Refactored the MilkDrop toy in `assets/js/toys/milkdrop-toy.ts` to use a new `createFeedbackWarpEffect` from `assets/js/utils/feedback-warp-effect.ts` and a `createBloomComposer` postprocessing pipeline, replacing inline feedback/warp/overlay logic with the reusable effect and composer and updating resource disposal accordingly.
- Added `assets/js/utils/feedback-warp-effect.ts` which wraps `FeedbackManager` and the warp shader into a small API providing `render`, `resize`, and `dispose` for the feedback warp pass.

### Testing

- Ran TypeScript type check with `tsc --noEmit` which completed successfully.
- Built the project with `npm run build` which succeeded without errors.
- Executed the test suite with `npm test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af66a3dec08332b8e3b2d5c85f262f)