### PR TITLE
Add noscript crawlable links for homepage library

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,28 @@
             </details>
           </details>
         </search>
-        <main id="toy-list" class="webtoy-container"></main>
+        <main id="toy-list" class="webtoy-container">
+          <noscript>
+            <section aria-label="Static library links">
+              <h3>Browse toy pages without JavaScript</h3>
+              <p>
+                The interactive library needs JavaScript, but every toy and collection page is available as
+                a regular link.
+              </p>
+              <ul>
+                <li><a class="text-link" href="/toys/">All toy pages</a></li>
+                <li><a class="text-link" href="/tags/">Tags index</a></li>
+                <li><a class="text-link" href="/moods/">Moods index</a></li>
+                <li><a class="text-link" href="/capabilities/">Capabilities index</a></li>
+                <li><a class="text-link" href="/discover/">Discover combinations</a></li>
+                <li><a class="text-link" href="/toys/holy/">Halo Pulse toy page</a></li>
+                <li><a class="text-link" href="/toys/cube-wave/">Grid Visualizer toy page</a></li>
+                <li><a class="text-link" href="/toys/aurora-painter/">Aurora Painter toy page</a></li>
+                <li><a class="text-link" href="/toys/seary/">Seary toy page</a></li>
+              </ul>
+            </section>
+          </noscript>
+        </main>
         <div class="feature-card-grid" aria-label="Library collection shortcuts">
           <nav class="feature-card" aria-label="Explore static library pages">
             <h3>Explore collections</h3>


### PR DESCRIPTION
### Motivation
- The homepage library is populated client-side which can weaken crawl signals for non-JS or limited-JS crawlers, so a static fallback is needed to improve discoverability and internal-linking.

### Description
- Added a `<noscript>` fallback block inside the homepage `<main id="toy-list">` containing direct links to collection hubs and representative toy detail pages in `index.html`.
- The fallback exposes crawlable nav to `/toys/`, `/tags/`, `/moods/`, `/capabilities/`, `/discover/` and several featured toy pages while leaving the JS-driven interactive experience unchanged.

### Testing
- Ran `bun run check:seo` which validated generated SEO artifacts and returned all checks as passing.
- Ran the full quality gate via `bun run check` which executed the Biome checks, TypeScript typecheck, and the test suite (result: 199 passed, 2 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06ee88fc4833293a9b446feb31439)