### PR TITLE
Refactor shared library styles with CSS variables

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,8 +1,23 @@
+:root {
+  --color-page-bg: #1c2026;
+  --color-surface: #262c34;
+  --color-surface-alt: #242a33;
+  --color-surface-hover: #2c3340;
+  --color-border: #3a424d;
+  --color-text-primary: #f2f4f7;
+  --color-text-secondary: #9aa3ad;
+  --color-link: #9ab0c6;
+  --color-link-hover: #c1cfdf;
+  --color-accent: #7a8fa5;
+  --color-button: #6f8195;
+  --color-button-hover: #7f8f9f;
+}
+
 /* General Styles */
 body {
   font-family: "Arial", sans-serif;
-  background-color: #1c2026;
-  color: #f2f4f7;
+  background-color: var(--color-page-bg);
+  color: var(--color-text-primary);
   margin: 0;
   padding: 0;
   display: flex;
@@ -12,11 +27,15 @@ body {
   transition: background-color 0.5s ease;
 }
 
+header,
+footer {
+  background-color: var(--color-surface);
+  width: 100%;
+}
+
 header {
   padding: 20px;
-  background-color: #262c34;
-  color: #f2f4f7;
-  width: 100%;
+  color: var(--color-text-primary);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
@@ -28,10 +47,10 @@ header {
   padding: 10px;
   width: 80%;
   max-width: 500px;
-  border: 1px solid #3a424d;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  background-color: #262c34;
-  color: #f2f4f7;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
   transition: all 0.3s;
   font-size: 1rem;
   min-height: 44px;
@@ -39,7 +58,7 @@ header {
 
 #search-bar:focus,
 #search-bar:focus-visible {
-  border-color: #7a8fa5;
+  border-color: var(--color-accent);
   outline: 2px solid rgba(122, 143, 165, 0.9);
   outline-offset: 2px;
   box-shadow: 0 0 0 3px rgba(122, 143, 165, 0.35);
@@ -57,7 +76,7 @@ header {
 }
 
 .webtoy-card {
-  background-color: #242a33;
+  background-color: var(--color-surface-alt);
   margin: 10px;
   padding: 20px;
   border-radius: 8px;
@@ -76,7 +95,7 @@ header {
 
 .webtoy-card:hover {
   transform: scale(1.05);
-  background-color: #2c3340;
+  background-color: var(--color-surface-hover);
 }
 
 .webtoy-card h3 {
@@ -84,42 +103,35 @@ header {
   font-size: 1.4em;
 }
 
-.webtoy-card a {
-  color: #9ab0c6;
+.webtoy-card a,
+footer a {
+  color: var(--color-link);
   text-decoration: none;
   transition: color 0.3s;
 }
 
+.webtoy-card a:hover,
+footer a:hover {
+  color: var(--color-link-hover);
+}
+
 .webtoy-card a:hover {
-  color: #c1cfdf;
   text-decoration: underline;
 }
 
 /* Footer */
 footer {
   padding: 10px;
-  background-color: #262c34;
-  color: #9aa3ad;
-  width: 100%;
+  color: var(--color-text-secondary);
   position: fixed;
   bottom: 0;
   text-align: center;
   font-size: 0.9em;
 }
 
-footer a {
-  color: #9ab0c6;
-  text-decoration: none;
-  transition: color 0.3s;
-}
-
-footer a:hover {
-  color: #c1cfdf;
-}
-
 /* Button Styling */
 button {
-  background-color: #6f8195;
+  background-color: var(--color-button);
   color: #fdfdfd;
   border: none;
   padding: 10px 20px;
@@ -133,7 +145,7 @@ button {
 }
 
 button:hover {
-  background-color: #7f8f9f;
+  background-color: var(--color-button-hover);
 }
 
 button:focus,


### PR DESCRIPTION
### Motivation
- Centralize repeated color values into theme tokens to make future theming and maintenance easier.
- Remove duplicated header/footer and link rules to reduce CSS surface area while preserving existing visuals.

### Description
- Introduced a `:root` block with CSS custom properties for page, surface, text, link, accent, and button colors and swapped literal color values to use these variables throughout `assets/css/styles.css`.
- Consolidated `header`/`footer` background rules and merged link rules so `footer a` and `.webtoy-card a` share the same color variables.
- Replaced an invalid color-expression attempt with stable `rgba(...)` focus outlines to retain the original accent appearance across browsers.

### Testing
- Ran `bun run check`, which completed linting and typechecks successfully but overall failed due to unrelated test failures in `tests/audio-handler.test.js` (multiple failures stemming from a readonly `navigator` property error); style changes did not introduce type or lint errors.
- Ran `biome lint` and `biome format --write` which passed with no fixes applied.
- Docs: None changed or added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c1779de08332a03cbcef5cc3decd)