### PR TITLE
Use manifest-backed page toy starters and fix page URL origin handling

### DIFF
--- a/assets/js/toys/evol.ts
+++ b/assets/js/toys/evol.ts
@@ -1,6 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/evol.html',
-  title: 'Evolutionary Weirdcore',
-});
+export const start = createManifestBackedPageToyStarter('evol');

--- a/assets/js/toys/geom.ts
+++ b/assets/js/toys/geom.ts
@@ -1,7 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/geom.html',
-  title: 'Microphone Geometry Visualizer',
-  description: 'Cap resolution or boost fidelity for the 2D particle grid.',
-});
+export const start = createManifestBackedPageToyStarter('geom');

--- a/assets/js/toys/holy.ts
+++ b/assets/js/toys/holy.ts
@@ -1,7 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/holy.html',
-  title: 'Ultimate Satisfying Visualizer',
-  description: 'Adjust render scale for halo layers and particle bursts.',
-});
+export const start = createManifestBackedPageToyStarter('holy');

--- a/assets/js/toys/legible.ts
+++ b/assets/js/toys/legible.ts
@@ -1,6 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/legible.html',
-  title: 'Terminal Word Grid',
-});
+export const start = createManifestBackedPageToyStarter('legible');

--- a/assets/js/toys/multi.ts
+++ b/assets/js/toys/multi.ts
@@ -1,8 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/multi.html',
-  title: 'Multi-Capability Visualizer',
-  description:
-    'Balance performance with render scale before joining the multi-mode scene.',
-});
+export const start = createManifestBackedPageToyStarter('multi');

--- a/assets/js/toys/page-toy.ts
+++ b/assets/js/toys/page-toy.ts
@@ -5,6 +5,7 @@ import {
 } from '../core/settings-panel';
 import type { ToyStartOptions } from '../core/toy-interface';
 import { defaultToyLifecycle } from '../core/toy-lifecycle.ts';
+import toyManifest from '../data/toy-manifest.ts';
 
 type PageToyStartOptions = ToyStartOptions & {
   preferDemoAudio?: boolean;
@@ -41,7 +42,14 @@ function resolveEmbeddedStarter(targetWindow: EmbeddedToyWindow | null) {
 
 function resolvePageSrc(path: string) {
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
-  return new URL(path, window.location.origin).toString();
+
+  const origin =
+    typeof window.location.origin === 'string' &&
+    window.location.origin !== 'null'
+      ? window.location.origin
+      : 'http://localhost/';
+
+  return new URL(path, origin).toString();
 }
 
 export function startPageToy({
@@ -171,4 +179,17 @@ export function createPageToyStarter(config: PageToyConfig) {
       ...config,
     });
   };
+}
+
+export function createManifestBackedPageToyStarter(slug: string) {
+  const manifestEntry = toyManifest.find((toy) => toy.slug === slug);
+  if (!manifestEntry) {
+    throw new Error(`Unknown toy slug for page-backed starter: ${slug}`);
+  }
+
+  return createPageToyStarter({
+    path: `./toys/${slug}.html`,
+    title: manifestEntry.title,
+    description: manifestEntry.description,
+  });
 }

--- a/assets/js/toys/seary.ts
+++ b/assets/js/toys/seary.ts
@@ -1,7 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/seary.html',
-  title: 'Trippy Synesthetic Visualizer',
-  description: 'Tune pixel ratio and density for sparkles and bursts.',
-});
+export const start = createManifestBackedPageToyStarter('seary');

--- a/assets/js/toys/symph.ts
+++ b/assets/js/toys/symph.ts
@@ -1,8 +1,3 @@
-import { createPageToyStarter } from './page-toy';
+import { createManifestBackedPageToyStarter } from './page-toy';
 
-export const start = createPageToyStarter({
-  path: './toys/symph.html',
-  title: 'Dreamy Spectrograph',
-  description:
-    'Adjust render quality for the flowing spectrograph and sparkles.',
-});
+export const start = createManifestBackedPageToyStarter('symph');

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -280,6 +280,10 @@ if (import.meta.main) {
   await startServer();
 }
 
-export { startServer };
 export * from './mcp-shared.ts';
-export { defaultQualityGateTimeoutMs, resolveQualityGateCommand, runCommand };
+export {
+  defaultQualityGateTimeoutMs,
+  resolveQualityGateCommand,
+  runCommand,
+  startServer,
+};

--- a/tests/manual/persona-click-routes-2026-03-02.md
+++ b/tests/manual/persona-click-routes-2026-03-02.md
@@ -8,7 +8,7 @@
 
 1. Land on `https://no.toil.fyi`.
 2. Click `/toys/` from the hero/primary nav.
-3. Click first toy card (`3dtoy`) and land on capability-check modal.
+3. Click the first featured toy card and land on capability-check modal.
 
 ### Observed friction
 

--- a/tests/page-toy.test.ts
+++ b/tests/page-toy.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import toyManifest from '../assets/js/data/toy-manifest.ts';
+import {
+  createManifestBackedPageToyStarter,
+  startPageToy,
+} from '../assets/js/toys/page-toy.ts';
+
+const pageBackedSlugs = [
+  'evol',
+  'geom',
+  'holy',
+  'legible',
+  'multi',
+  'seary',
+  'symph',
+];
+
+describe('page-toy starters', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="active-toy-container"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  for (const slug of pageBackedSlugs) {
+    test(`manifest-backed starter creates iframe with manifest title for ${slug}`, () => {
+      const start = createManifestBackedPageToyStarter(slug);
+      const activeToy = start();
+      const manifestEntry = toyManifest.find((toy) => toy.slug === slug);
+
+      const iframe = document.querySelector(
+        'iframe.toy-frame',
+      ) as HTMLIFrameElement | null;
+      expect(iframe).toBeTruthy();
+      expect(iframe?.title).toBe(manifestEntry?.title);
+
+      activeToy?.dispose?.();
+    });
+  }
+
+  test('manifest-backed starter throws for unknown slug', () => {
+    expect(() => createManifestBackedPageToyStarter('not-a-toy')).toThrow(
+      'Unknown toy slug for page-backed starter: not-a-toy',
+    );
+  });
+
+  test('startPageToy supports explicit path and title', () => {
+    const activeToy = startPageToy({
+      path: './toys/evol.html',
+      title: 'Custom title',
+      description: 'Custom description',
+    });
+
+    const iframe = document.querySelector(
+      'iframe.toy-frame',
+    ) as HTMLIFrameElement | null;
+    expect(iframe?.title).toBe('Custom title');
+
+    activeToy.dispose();
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce duplication of toy metadata and centralize title/description by wiring page-backed starters to the toy manifest.  
- Make `startPageToy` robust when `window.location.origin` is unavailable (e.g. some test or embedded environments).  
- Export `startServer` from the MCP server module so it can be reused by scripts/tests.

### Description
- Replace many per-toy `createPageToyStarter` usages with `createManifestBackedPageToyStarter('<slug>')` in `assets/js/toys/*.ts` to derive title/description from the manifest.  
- Add `toyManifest` import and implement `createManifestBackedPageToyStarter` in `assets/js/toys/page-toy.ts`.  
- Adjust `resolvePageSrc` to fall back to `'http://localhost/'` when `window.location.origin` is not a usable string.  
- Re-export `startServer` along with existing exports from `scripts/mcp-server.ts`.  
- Add unit tests in `tests/page-toy.test.ts` to validate manifest-backed starters, unknown slug handling, and explicit `startPageToy` behavior.

### Testing
- Added `tests/page-toy.test.ts` which exercises `createManifestBackedPageToyStarter`, `startPageToy`, and unknown-slug error handling.  
- Ran the automated test suite with `bun:test` for the new tests and they completed successfully.  
- No other automated test failures were observed when running the local test run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48e3e35fc8332b7d0685a2121d0ae)