### PR TITLE
Respect visibility and optimize rendering/input/audio/gamepad performance

### DIFF
--- a/assets/js/core/toy-runtime.ts
+++ b/assets/js/core/toy-runtime.ts
@@ -305,6 +305,7 @@ export function createToyRuntime({
   let previewActive = false;
   let previewStart = 0;
   let previewLastFrame = 0;
+  let previewVisibilityCleanup: (() => void) | null = null;
 
   const updatePreviewFrequencyData = (time: number) => {
     for (let i = 0; i < previewFrequencyData.length; i += 1) {
@@ -334,7 +335,13 @@ export function createToyRuntime({
   };
 
   const startPreviewLoop = () => {
-    if (!previewOptions.enabled || previewActive) return;
+    if (
+      !previewOptions.enabled ||
+      previewActive ||
+      (typeof document !== 'undefined' && document.hidden)
+    ) {
+      return;
+    }
     previewActive = true;
     const timeSource = globalThis.performance ?? {
       now: () => Date.now(),
@@ -359,6 +366,28 @@ export function createToyRuntime({
 
     previewAnimationId = requestAnimationFrame(tick);
   };
+
+  if (typeof document !== 'undefined') {
+    const handlePreviewVisibilityChange = () => {
+      if (document.hidden) {
+        stopPreviewLoop();
+        return;
+      }
+      if (!analyser) {
+        startPreviewLoop();
+      }
+    };
+    document.addEventListener(
+      'visibilitychange',
+      handlePreviewVisibilityChange,
+    );
+    previewVisibilityCleanup = () => {
+      document.removeEventListener(
+        'visibilitychange',
+        handlePreviewVisibilityChange,
+      );
+    };
+  }
 
   const startAudio = async (request?: ToyAudioRequest) => {
     stopPreviewLoop();
@@ -426,6 +455,7 @@ export function createToyRuntime({
       pluginManager.dispose();
       inputController.dispose();
       performanceController.dispose();
+      previewVisibilityCleanup?.();
       unregisterGlobals();
       toy.dispose();
     },

--- a/assets/js/hero-canvas.ts
+++ b/assets/js/hero-canvas.ts
@@ -39,6 +39,20 @@ interface HeroCanvasConfig {
   colorScheme?: 'cosmic' | 'aurora' | 'sunset';
 }
 
+type ParticleGrid = Map<string, Particle[]>;
+
+const CONNECTION_NEIGHBOR_OFFSETS = [
+  [-1, -1],
+  [0, -1],
+  [1, -1],
+  [-1, 0],
+  [0, 0],
+  [1, 0],
+  [-1, 1],
+  [0, 1],
+  [1, 1],
+] as const;
+
 const COLOR_SCHEMES = {
   cosmic: { baseHue: 240, hueRange: 60, saturation: 70, lightness: 55 },
   aurora: { baseHue: 160, hueRange: 80, saturation: 75, lightness: 50 },
@@ -63,6 +77,7 @@ export function initHeroCanvas(
   const scheme = COLOR_SCHEMES[colorScheme];
   const particles: Particle[] = [];
   const orbs: GlowOrb[] = [];
+  const particleGrid: ParticleGrid = new Map();
   let animationId: number | null = null;
   let width = 0;
   let height = 0;
@@ -89,6 +104,7 @@ export function initHeroCanvas(
     height = rect.height;
     canvas.width = width * dpr;
     canvas.height = height * dpr;
+    ctx?.setTransform(1, 0, 0, 1, 0, 0);
     ctx?.scale(dpr, dpr);
 
     // Reinitialize particles on resize
@@ -151,6 +167,9 @@ export function initHeroCanvas(
   }
 
   function updateParticles() {
+    const interactionRadius = 150;
+    const interactionRadiusSquared = interactionRadius * interactionRadius;
+
     for (const p of particles) {
       // Move
       p.x += p.vx;
@@ -162,9 +181,13 @@ export function initHeroCanvas(
       // Mouse interaction - gentle push
       const dx = p.x - mouseX;
       const dy = p.y - mouseY;
-      const dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < 150 && dist > 0) {
-        const force = (150 - dist) / 150;
+      const distSquared = dx * dx + dy * dy;
+      if (
+        distSquared < interactionRadiusSquared &&
+        distSquared > Number.EPSILON
+      ) {
+        const dist = Math.sqrt(distSquared);
+        const force = (interactionRadius - dist) / interactionRadius;
         const angle = Math.atan2(dy, dx);
         p.vx += Math.cos(angle) * force * 0.02;
         p.vy += Math.sin(angle) * force * 0.02;
@@ -217,23 +240,54 @@ export function initHeroCanvas(
   function drawConnections() {
     if (!ctx) return;
     ctx.lineWidth = 0.5;
+    const cellSize = connectionDistance;
+    const connectionDistanceSquared = connectionDistance * connectionDistance;
+    particleGrid.clear();
 
-    for (let i = 0; i < particles.length; i++) {
-      for (let j = i + 1; j < particles.length; j++) {
-        const p1 = particles[i];
-        const p2 = particles[j];
-        const dx = p1.x - p2.x;
-        const dy = p1.y - p2.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
+    for (const particle of particles) {
+      const cellX = Math.floor(particle.x / cellSize);
+      const cellY = Math.floor(particle.y / cellSize);
+      const key = `${cellX},${cellY}`;
+      const bucket = particleGrid.get(key);
+      if (bucket) {
+        bucket.push(particle);
+      } else {
+        particleGrid.set(key, [particle]);
+      }
+    }
 
-        if (dist < connectionDistance) {
-          const alpha = (1 - dist / connectionDistance) * 0.15;
-          const hue = (p1.hue + p2.hue) / 2;
-          ctx.strokeStyle = `hsla(${hue}, ${scheme.saturation}%, ${scheme.lightness}%, ${alpha})`;
-          ctx.beginPath();
-          ctx.moveTo(p1.x, p1.y);
-          ctx.lineTo(p2.x, p2.y);
-          ctx.stroke();
+    for (const [key, bucket] of particleGrid) {
+      const [cellX, cellY] = key.split(',').map(Number);
+      for (const particle of bucket) {
+        for (const [offsetX, offsetY] of CONNECTION_NEIGHBOR_OFFSETS) {
+          const neighborBucket = particleGrid.get(
+            `${cellX + offsetX},${cellY + offsetY}`,
+          );
+          if (!neighborBucket) continue;
+
+          for (const neighbor of neighborBucket) {
+            if (neighbor === particle) continue;
+            if (
+              neighbor.x < particle.x ||
+              (neighbor.x === particle.x && neighbor.y <= particle.y)
+            ) {
+              continue;
+            }
+
+            const dx = particle.x - neighbor.x;
+            const dy = particle.y - neighbor.y;
+            const distSquared = dx * dx + dy * dy;
+            if (distSquared >= connectionDistanceSquared) continue;
+
+            const dist = Math.sqrt(distSquared);
+            const alpha = (1 - dist / connectionDistance) * 0.15;
+            const hue = (particle.hue + neighbor.hue) / 2;
+            ctx.strokeStyle = `hsla(${hue}, ${scheme.saturation}%, ${scheme.lightness}%, ${alpha})`;
+            ctx.beginPath();
+            ctx.moveTo(particle.x, particle.y);
+            ctx.lineTo(neighbor.x, neighbor.y);
+            ctx.stroke();
+          }
         }
       }
     }

--- a/assets/js/library-view/three-library-effects.ts
+++ b/assets/js/library-view/three-library-effects.ts
@@ -33,7 +33,8 @@ interface PreviewItem {
   dispose: () => void;
 }
 
-const PREVIEW_LIMIT = 6;
+const BACKGROUND_FRAME_INTERVAL_MS = 1000 / 30;
+const PREVIEW_FRAME_INTERVAL_MS = 1000 / 24;
 
 export function createLibraryThreeEffects() {
   let backgroundRenderer: WebGLRenderer | null = null;
@@ -44,8 +45,11 @@ export function createLibraryThreeEffects() {
   let pulse = 0;
   let resizeHandler: (() => void) | null = null;
   let previewObserver: IntersectionObserver | null = null;
+  let visibilityHandler: (() => void) | null = null;
   const backgroundColor = new Color(0x0b0d16);
   const previews = new Map<string, PreviewItem>();
+  let lastBackgroundRenderAt = 0;
+  let lastPreviewRenderAt = 0;
 
   const canUseWebGL = () => {
     try {
@@ -62,12 +66,29 @@ export function createLibraryThreeEffects() {
     typeof window !== 'undefined' &&
     typeof document !== 'undefined' &&
     canUseWebGL();
+  const isCompactViewport =
+    typeof window !== 'undefined' && window.innerWidth < 960;
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const previewLimit = prefersReducedMotion ? 0 : isCompactViewport ? 2 : 4;
 
-  const animate = () => {
+  const shouldRender = () =>
+    typeof document === 'undefined' ? true : !document.hidden;
+
+  const animate = (now: number) => {
     animationFrame = window.requestAnimationFrame(animate);
+    if (!shouldRender()) return;
 
-    if (backgroundRenderer && backgroundScene && backgroundCamera) {
-      const time = performance.now() * 0.0002;
+    if (
+      backgroundRenderer &&
+      backgroundScene &&
+      backgroundCamera &&
+      now - lastBackgroundRenderAt >= BACKGROUND_FRAME_INTERVAL_MS
+    ) {
+      lastBackgroundRenderAt = now;
+      const time = now * 0.0002;
       if (backgroundParticles) {
         backgroundParticles.rotation.y = time * (0.18 + pulse * 0.6);
         backgroundParticles.rotation.x = Math.sin(time * 2) * 0.07;
@@ -81,12 +102,15 @@ export function createLibraryThreeEffects() {
       backgroundRenderer.render(backgroundScene, backgroundCamera);
     }
 
-    previews.forEach((item) => {
-      if (!item.isVisible) return;
-      item.mesh.rotation.x += 0.004 + pulse * 0.01;
-      item.mesh.rotation.y += 0.007 + pulse * 0.01;
-      item.renderer.render(item.scene, item.camera);
-    });
+    if (now - lastPreviewRenderAt >= PREVIEW_FRAME_INTERVAL_MS) {
+      lastPreviewRenderAt = now;
+      previews.forEach((item) => {
+        if (!item.isVisible) return;
+        item.mesh.rotation.x += 0.004 + pulse * 0.01;
+        item.mesh.rotation.y += 0.007 + pulse * 0.01;
+        item.renderer.render(item.scene, item.camera);
+      });
+    }
 
     pulse = Math.max(0, pulse * 0.93 - 0.003);
   };
@@ -167,7 +191,7 @@ export function createLibraryThreeEffects() {
             item.isVisible = entry.isIntersecting;
           });
         },
-        { root: null, rootMargin: '120px', threshold: 0.01 },
+        { root: null, rootMargin: '80px', threshold: 0.01 },
       );
     }
 
@@ -178,7 +202,7 @@ export function createLibraryThreeEffects() {
 
     let renderer: WebGLRenderer;
     try {
-      renderer = new WebGLRenderer({ alpha: true, antialias: true });
+      renderer = new WebGLRenderer({ alpha: true, antialias: false });
     } catch (_error) {
       previewRoot.remove();
       return;
@@ -238,7 +262,7 @@ export function createLibraryThreeEffects() {
 
   const syncCardPreviews = (cards: HTMLElement[], toys: ToyLike[]) => {
     const nextKeys = new Set<string>();
-    cards.slice(0, PREVIEW_LIMIT).forEach((card, index) => {
+    cards.slice(0, previewLimit).forEach((card, index) => {
       const toy = toys[index];
       if (!toy) return;
       if (!webglAvailable) return;
@@ -257,7 +281,14 @@ export function createLibraryThreeEffects() {
   return {
     init() {
       createAmbientLayer();
-      animate();
+      visibilityHandler = () => {
+        if (!document.hidden) {
+          lastBackgroundRenderAt = 0;
+          lastPreviewRenderAt = 0;
+        }
+      };
+      document.addEventListener('visibilitychange', visibilityHandler);
+      animationFrame = window.requestAnimationFrame(animate);
     },
     syncCardPreviews,
     triggerLaunchTransition() {
@@ -266,6 +297,10 @@ export function createLibraryThreeEffects() {
     dispose() {
       if (animationFrame) {
         window.cancelAnimationFrame(animationFrame);
+      }
+      if (visibilityHandler) {
+        document.removeEventListener('visibilitychange', visibilityHandler);
+        visibilityHandler = null;
       }
       previews.forEach((preview) => preview.dispose());
       previews.clear();

--- a/assets/js/utils/audio-handler.ts
+++ b/assets/js/utils/audio-handler.ts
@@ -14,10 +14,12 @@ export class FrequencyAnalyser {
   private rms = 0;
   private readonly historySize = 64;
   private energyHistory: { bass: number[]; mid: number[]; treble: number[] } = {
-    bass: [],
-    mid: [],
-    treble: [],
+    bass: new Array(this.historySize).fill(0),
+    mid: new Array(this.historySize).fill(0),
+    treble: new Array(this.historySize).fill(0),
   };
+  private historyIndex = 0;
+  private historyCount = 0;
   private readonly sourceNode: MediaStreamAudioSourceNode;
   private readonly silentGain: GainNode;
   private readonly workletNode?: AudioWorkletNode;
@@ -47,7 +49,15 @@ export class FrequencyAnalyser {
       this.workletNode.port.onmessage = (event: MessageEvent) => {
         const { frequencyData, rms } = event.data ?? {};
         if (frequencyData) {
-          this.frequencyData = new Uint8Array(frequencyData);
+          const nextData =
+            frequencyData instanceof Uint8Array
+              ? frequencyData
+              : new Uint8Array(frequencyData);
+          if (this.frequencyData.length !== nextData.length) {
+            this.frequencyData = new Uint8Array(nextData.length);
+            this.frequencyBinCount = nextData.length;
+          }
+          this.frequencyData.set(nextData);
           this.updateEnergyHistory();
         }
         if (typeof rms === 'number') {
@@ -129,16 +139,11 @@ export class FrequencyAnalyser {
 
   private updateEnergyHistory() {
     const { bass, mid, treble } = this.getMultiBandEnergy();
-
-    this.energyHistory.bass.push(bass);
-    this.energyHistory.mid.push(mid);
-    this.energyHistory.treble.push(treble);
-
-    if (this.energyHistory.bass.length > this.historySize) {
-      this.energyHistory.bass.shift();
-      this.energyHistory.mid.shift();
-      this.energyHistory.treble.shift();
-    }
+    this.energyHistory.bass[this.historyIndex] = bass;
+    this.energyHistory.mid[this.historyIndex] = mid;
+    this.energyHistory.treble[this.historyIndex] = treble;
+    this.historyIndex = (this.historyIndex + 1) % this.historySize;
+    this.historyCount = Math.min(this.historyCount + 1, this.historySize);
   }
 
   getMultiBandEnergy() {
@@ -167,8 +172,14 @@ export class FrequencyAnalyser {
   }
 
   getEnergyAverages() {
-    const avg = (arr: number[]) =>
-      arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+    const avg = (arr: number[]) => {
+      if (this.historyCount === 0) return 0;
+      let total = 0;
+      for (let i = 0; i < this.historyCount; i += 1) {
+        total += arr[i] ?? 0;
+      }
+      return total / this.historyCount;
+    };
     return {
       bass: avg(this.energyHistory.bass),
       mid: avg(this.energyHistory.mid),

--- a/assets/js/utils/gamepad-navigation.ts
+++ b/assets/js/utils/gamepad-navigation.ts
@@ -439,6 +439,8 @@ export const initGamepadNavigation = (
   let lastDirection: FocusDirection | null = null;
   let nextMoveTime = 0;
   let rafId: number | null = null;
+  const canRun = () =>
+    typeof document === 'undefined' ? true : !document.hidden;
 
   const setActive = () => {
     if (!body.classList.contains(resolved.activeClass)) {
@@ -548,6 +550,13 @@ export const initGamepadNavigation = (
   };
 
   const tick = (now: number) => {
+    if (!canRun()) {
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      return;
+    }
     const pad = getPrimaryGamepad();
     if (pad) {
       handleDirectional(now, pad);
@@ -557,6 +566,7 @@ export const initGamepadNavigation = (
   };
 
   const handleConnect = () => {
+    if (!canRun()) return;
     if (!doc.activeElement || doc.activeElement === doc.body) {
       if (resolved.restoreFocus) {
         restoreLastFocusedElement(
@@ -570,6 +580,20 @@ export const initGamepadNavigation = (
 
     if (rafId === null) {
       rafId = window.requestAnimationFrame(tick);
+    }
+  };
+
+  const handleVisibilityChange = () => {
+    if (!canRun()) {
+      body.classList.remove(resolved.activeClass);
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      return;
+    }
+    if (getPrimaryGamepad()) {
+      handleConnect();
     }
   };
 
@@ -633,6 +657,7 @@ export const initGamepadNavigation = (
   window.addEventListener('gamepadconnected', handleConnect);
   window.addEventListener('gamepaddisconnected', handleDisconnect);
   window.addEventListener('keydown', handleKeydown);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
   doc.addEventListener('focusin', onDocumentFocusIn);
 
   if (
@@ -658,6 +683,7 @@ export const initGamepadNavigation = (
     window.removeEventListener('gamepadconnected', handleConnect);
     window.removeEventListener('gamepaddisconnected', handleDisconnect);
     window.removeEventListener('keydown', handleKeydown);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
     doc.removeEventListener('focusin', onDocumentFocusIn);
     if (rafId !== null) {
       window.cancelAnimationFrame(rafId);

--- a/assets/js/utils/unified-input.ts
+++ b/assets/js/utils/unified-input.ts
@@ -213,6 +213,11 @@ export function createUnifiedInput({
   const updateBounds = () => {
     bounds = boundsSource.getBoundingClientRect();
   };
+  const canPollGamepad = () =>
+    gamepadEnabled &&
+    typeof document !== 'undefined' &&
+    !document.hidden &&
+    !!getPrimaryGamepad();
 
   let resizeObserver: ResizeObserver | null = null;
   const handleWindowResize = () => updateBounds();
@@ -706,7 +711,12 @@ export function createUnifiedInput({
   };
 
   const scheduleFrame = () => {
-    if (inputFrameId != null) return;
+    if (
+      inputFrameId != null ||
+      (typeof document !== 'undefined' && document.hidden)
+    ) {
+      return;
+    }
     inputFrameId = requestAnimationFrame(emitState);
   };
 
@@ -716,23 +726,67 @@ export function createUnifiedInput({
     return () => subscribers.delete(handler);
   };
 
-  if (gamepadEnabled) {
-    const pollGamepad = () => {
-      if (getPrimaryGamepad()) {
-        scheduleFrame();
-      }
-      gamepadFrameId = requestAnimationFrame(pollGamepad);
-    };
+  const stopGamepadPolling = () => {
+    if (gamepadFrameId != null) {
+      cancelAnimationFrame(gamepadFrameId);
+      gamepadFrameId = null;
+    }
+  };
+
+  const pollGamepad = () => {
+    if (!canPollGamepad()) {
+      stopGamepadPolling();
+      return;
+    }
+    scheduleFrame();
     gamepadFrameId = requestAnimationFrame(pollGamepad);
+  };
+
+  const ensureGamepadPolling = () => {
+    if (!canPollGamepad() || gamepadFrameId != null) return;
+    gamepadFrameId = requestAnimationFrame(pollGamepad);
+  };
+
+  const handleGamepadConnectionChange = () => {
+    if (canPollGamepad()) {
+      ensureGamepadPolling();
+      scheduleFrame();
+      return;
+    }
+    stopGamepadPolling();
+  };
+
+  const handleVisibilityChange = () => {
+    if (typeof document === 'undefined') return;
+    if (document.hidden) {
+      if (inputFrameId != null) {
+        cancelAnimationFrame(inputFrameId);
+        inputFrameId = null;
+      }
+      stopGamepadPolling();
+      return;
+    }
+    scheduleFrame();
+    ensureGamepadPolling();
+  };
+
+  if (gamepadEnabled) {
+    window.addEventListener('gamepadconnected', handleGamepadConnectionChange);
+    window.addEventListener(
+      'gamepaddisconnected',
+      handleGamepadConnectionChange,
+    );
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+    ensureGamepadPolling();
   }
 
   const dispose = () => {
     if (inputFrameId != null) {
       cancelAnimationFrame(inputFrameId);
     }
-    if (gamepadFrameId != null) {
-      cancelAnimationFrame(gamepadFrameId);
-    }
+    stopGamepadPolling();
     resizeObserver?.disconnect();
     if (!resizeObserver) {
       window.removeEventListener('resize', handleWindowResize);
@@ -748,6 +802,22 @@ export function createUnifiedInput({
     target.removeEventListener('wheel', handleWheel);
     target.removeEventListener('keydown', handleKeyDown);
     target.removeEventListener('keyup', handleKeyUp);
+    if (gamepadEnabled) {
+      window.removeEventListener(
+        'gamepadconnected',
+        handleGamepadConnectionChange,
+      );
+      window.removeEventListener(
+        'gamepaddisconnected',
+        handleGamepadConnectionChange,
+      );
+      if (typeof document !== 'undefined') {
+        document.removeEventListener(
+          'visibilitychange',
+          handleVisibilityChange,
+        );
+      }
+    }
     subscribers.clear();
     activePointers.clear();
     hoverPointer = null;


### PR DESCRIPTION
### Motivation
- Reduce wasted CPU work by stopping background/preview rendering and input/gamepad polling when the page is not visible.
- Improve hero canvas connection performance for many particles and make particle interactions more robust and stable.
- Make the audio frequency analyser history handling safer and more efficient to provide stable multi-band energy averages.

### Description
- Added visibility checks and `visibilitychange` listeners to pause/resume the preview loop in `createToyRuntime` and to remove the listener on `dispose` via `previewVisibilityCleanup`.
- Implemented spatial hashing for particle connections in `initHeroCanvas` by introducing a `ParticleGrid`, neighbor offsets, squared-distance checks, and minor physics fixes for interaction forces and wrapping, and reset canvas transform on resize.
- Throttled three.js rendering in `three-library-effects.ts` by separating background and preview frame intervals, respecting `document.hidden`, making preview count adaptive to `prefers-reduced-motion` and viewport width, reduced antialiasing for preview canvases, and added visibility listener cleanup.
- Hardened `FrequencyAnalyser` in `audio-handler.ts` by preallocating energy history arrays, tracking `historyIndex`/`historyCount`, safely handling worklet frequency data types and sizes, and updating `getEnergyAverages` to use the fixed-size circular buffer.
- Improved input/gamepad handling by stopping/starting input frames and gamepad polling based on document visibility in `unified-input.ts` and `gamepad-navigation.ts`, centralizing `canRun` checks, and ensuring proper cleanup of listeners and RAFs on dispose/visibility change.

### Testing
- Type-check and build were run with `tsc --noEmit` and completed successfully.
- Unit and integration tests were executed via `npm test` and all tests passed.
- Automated linting (`npm run lint`) was run and returned no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf71ddd0483328b796171dde5e4ac)