### PR TITLE
Improve performance and accessibility: resize throttling, low-power canvas, search indexing, and rendering scale reductions

### DIFF
--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -50,7 +50,7 @@ export async function initRenderer(
   config: RendererInitConfig = {
     antialias: true,
     exposure: 1,
-    maxPixelRatio: 2,
+    maxPixelRatio: isMobileUserAgent ? 1.25 : 1.5,
     alpha: false,
     renderScale: 1,
   },
@@ -62,7 +62,7 @@ export async function initRenderer(
   const {
     antialias = true,
     exposure = 1,
-    maxPixelRatio = 2,
+    maxPixelRatio = isMobileUserAgent ? 1.25 : 1.5,
     alpha = false,
     renderScale = 1,
   } = config;
@@ -77,6 +77,7 @@ export async function initRenderer(
     const effectivePixelRatio = Math.min(
       (window.devicePixelRatio || 1) * renderScale,
       adaptiveMaxPixelRatio,
+      isMobileUserAgent ? 1.25 : 1.5,
     );
     renderer.setPixelRatio(effectivePixelRatio);
     renderer.setSize(window.innerWidth, window.innerHeight);

--- a/assets/js/core/web-toy.ts
+++ b/assets/js/core/web-toy.ts
@@ -62,6 +62,9 @@ export default class WebToy {
   viewportResizeHandler: (() => void) | null;
   viewportWidth: number;
   viewportHeight: number;
+  viewportCssWidth: number;
+  viewportCssHeight: number;
+  resizeFrameId: number | null;
 
   constructor({
     cameraOptions = {},
@@ -128,19 +131,22 @@ export default class WebToy {
     this.viewportResizeHandler = null;
     this.viewportWidth = window.innerWidth;
     this.viewportHeight = window.innerHeight;
+    this.viewportCssWidth = window.innerWidth;
+    this.viewportCssHeight = window.innerHeight;
+    this.resizeFrameId = null;
 
     if (typeof ResizeObserver !== 'undefined' && this.container) {
       this.resizeObserver = new ResizeObserver(() => {
-        this.handleResize();
+        this.scheduleResize();
       });
       this.resizeObserver.observe(this.container);
     } else {
-      this.resizeHandler = () => this.handleResize();
+      this.resizeHandler = () => this.scheduleResize();
       window.addEventListener('resize', this.resizeHandler);
     }
 
     if (window.visualViewport) {
-      this.viewportResizeHandler = () => this.handleResize();
+      this.viewportResizeHandler = () => this.scheduleResize();
       window.visualViewport.addEventListener(
         'resize',
         this.viewportResizeHandler,
@@ -154,26 +160,51 @@ export default class WebToy {
     defaultToyLifecycle.adoptActiveToy(this);
   }
 
+  scheduleResize() {
+    if (this.resizeFrameId !== null) return;
+    this.resizeFrameId = window.requestAnimationFrame(() => {
+      this.resizeFrameId = null;
+      this.handleResize();
+    });
+  }
+
   handleResize() {
     const visualViewport = window.visualViewport;
-    const viewportWidth = visualViewport?.width ?? window.innerWidth;
-    const viewportHeight = visualViewport?.height ?? window.innerHeight;
+    const viewportWidth = Math.max(
+      1,
+      Math.round(visualViewport?.width ?? window.innerWidth),
+    );
+    const viewportHeight = Math.max(
+      1,
+      Math.round(visualViewport?.height ?? window.innerHeight),
+    );
     let width = viewportWidth;
     let height = viewportHeight;
 
     if (this.container && this.container !== document.body) {
-      width = this.container.clientWidth;
-      height = this.container.clientHeight;
+      width = Math.max(1, this.container.clientWidth);
+      height = Math.max(1, this.container.clientHeight);
     }
 
-    document.documentElement.style.setProperty(
-      '--app-height',
-      `${viewportHeight}px`,
-    );
-    document.documentElement.style.setProperty(
-      '--app-width',
-      `${viewportWidth}px`,
-    );
+    const viewportChanged =
+      viewportWidth !== this.viewportCssWidth ||
+      viewportHeight !== this.viewportCssHeight;
+    if (viewportChanged) {
+      this.viewportCssWidth = viewportWidth;
+      this.viewportCssHeight = viewportHeight;
+      document.documentElement.style.setProperty(
+        '--app-height',
+        `${viewportHeight}px`,
+      );
+      document.documentElement.style.setProperty(
+        '--app-width',
+        `${viewportWidth}px`,
+      );
+    }
+
+    if (width === this.viewportWidth && height === this.viewportHeight) {
+      return;
+    }
 
     this.viewportWidth = width;
     this.viewportHeight = height;
@@ -227,6 +258,11 @@ export default class WebToy {
     if (this.resizeHandler) {
       window.removeEventListener('resize', this.resizeHandler);
       this.resizeHandler = null;
+    }
+
+    if (this.resizeFrameId !== null) {
+      window.cancelAnimationFrame(this.resizeFrameId);
+      this.resizeFrameId = null;
     }
 
     if (this.viewportResizeHandler && window.visualViewport) {

--- a/assets/js/hero-canvas.ts
+++ b/assets/js/hero-canvas.ts
@@ -74,6 +74,19 @@ export function initHeroCanvas(
     colorScheme = 'cosmic',
   } = config;
 
+  const hardwareConcurrency =
+    typeof navigator !== 'undefined' ? (navigator.hardwareConcurrency ?? 4) : 4;
+  const lowPowerMode = hardwareConcurrency <= 4;
+  const effectiveParticleCount = lowPowerMode
+    ? Math.max(32, Math.round(particleCount * 0.65))
+    : particleCount;
+  const effectiveOrbCount = lowPowerMode
+    ? Math.max(2, Math.round(orbCount * 0.75))
+    : orbCount;
+  const effectiveConnectionDistance = lowPowerMode
+    ? connectionDistance * 0.8
+    : connectionDistance;
+  const maxConnectionsPerFrame = lowPowerMode ? 90 : 180;
   const scheme = COLOR_SCHEMES[colorScheme];
   const particles: Particle[] = [];
   const orbs: GlowOrb[] = [];
@@ -98,7 +111,7 @@ export function initHeroCanvas(
   }
 
   function resize() {
-    const dpr = Math.min(window.devicePixelRatio, 2);
+    const dpr = Math.min(window.devicePixelRatio || 1, lowPowerMode ? 1 : 1.5);
     const rect = canvas.getBoundingClientRect();
     width = rect.width;
     height = rect.height;
@@ -114,7 +127,7 @@ export function initHeroCanvas(
 
   function initParticles() {
     particles.length = 0;
-    for (let i = 0; i < particleCount; i++) {
+    for (let i = 0; i < effectiveParticleCount; i++) {
       particles.push({
         x: Math.random() * width,
         y: Math.random() * height,
@@ -133,7 +146,7 @@ export function initHeroCanvas(
 
   function initOrbs() {
     orbs.length = 0;
-    for (let i = 0; i < orbCount; i++) {
+    for (let i = 0; i < effectiveOrbCount; i++) {
       const x = Math.random() * width;
       const y = Math.random() * height;
       orbs.push({
@@ -142,7 +155,9 @@ export function initHeroCanvas(
         targetX: x,
         targetY: y,
         radius: 150 + Math.random() * 200,
-        hue: scheme.baseHue + (i / orbCount) * scheme.hueRange * 2,
+        hue:
+          scheme.baseHue +
+          (i / Math.max(effectiveOrbCount, 1)) * scheme.hueRange * 2,
         alpha: 0.08 + Math.random() * 0.08,
         speed: 0.001 + Math.random() * 0.002,
       });
@@ -212,6 +227,14 @@ export function initHeroCanvas(
   function drawOrbs() {
     if (!ctx) return;
     for (const orb of orbs) {
+      if (lowPowerMode) {
+        ctx.beginPath();
+        ctx.arc(orb.x, orb.y, orb.radius * 0.65, 0, Math.PI * 2);
+        ctx.fillStyle = `hsla(${orb.hue}, 75%, 56%, ${orb.alpha * 0.45})`;
+        ctx.fill();
+        continue;
+      }
+
       const gradient = ctx.createRadialGradient(
         orb.x,
         orb.y,
@@ -240,8 +263,9 @@ export function initHeroCanvas(
   function drawConnections() {
     if (!ctx) return;
     ctx.lineWidth = 0.5;
-    const cellSize = connectionDistance;
-    const connectionDistanceSquared = connectionDistance * connectionDistance;
+    const cellSize = effectiveConnectionDistance;
+    const connectionDistanceSquared =
+      effectiveConnectionDistance * effectiveConnectionDistance;
     particleGrid.clear();
 
     for (const particle of particles) {
@@ -256,6 +280,7 @@ export function initHeroCanvas(
       }
     }
 
+    let renderedConnections = 0;
     for (const [key, bucket] of particleGrid) {
       const [cellX, cellY] = key.split(',').map(Number);
       for (const particle of bucket) {
@@ -266,6 +291,9 @@ export function initHeroCanvas(
           if (!neighborBucket) continue;
 
           for (const neighbor of neighborBucket) {
+            if (renderedConnections >= maxConnectionsPerFrame) {
+              return;
+            }
             if (neighbor === particle) continue;
             if (
               neighbor.x < particle.x ||
@@ -280,13 +308,14 @@ export function initHeroCanvas(
             if (distSquared >= connectionDistanceSquared) continue;
 
             const dist = Math.sqrt(distSquared);
-            const alpha = (1 - dist / connectionDistance) * 0.15;
+            const alpha = (1 - dist / effectiveConnectionDistance) * 0.15;
             const hue = (particle.hue + neighbor.hue) / 2;
             ctx.strokeStyle = `hsla(${hue}, ${scheme.saturation}%, ${scheme.lightness}%, ${alpha})`;
             ctx.beginPath();
             ctx.moveTo(particle.x, particle.y);
             ctx.lineTo(neighbor.x, neighbor.y);
             ctx.stroke();
+            renderedConnections += 1;
           }
         }
       }
@@ -300,34 +329,34 @@ export function initHeroCanvas(
       const radius = p.radius * pulse;
       const alpha = p.alpha * (0.7 + pulse * 0.3);
 
-      // Glow effect
-      const gradient = ctx.createRadialGradient(
-        p.x,
-        p.y,
-        0,
-        p.x,
-        p.y,
-        radius * 3,
-      );
-      gradient.addColorStop(
-        0,
-        `hsla(${p.hue}, ${p.saturation}%, ${p.lightness}%, ${alpha})`,
-      );
-      gradient.addColorStop(
-        0.4,
-        `hsla(${p.hue}, ${p.saturation}%, ${p.lightness}%, ${alpha * 0.4})`,
-      );
-      gradient.addColorStop(1, 'transparent');
+      if (!lowPowerMode) {
+        const gradient = ctx.createRadialGradient(
+          p.x,
+          p.y,
+          0,
+          p.x,
+          p.y,
+          radius * 3,
+        );
+        gradient.addColorStop(
+          0,
+          `hsla(${p.hue}, ${p.saturation}%, ${p.lightness}%, ${alpha})`,
+        );
+        gradient.addColorStop(
+          0.4,
+          `hsla(${p.hue}, ${p.saturation}%, ${p.lightness}%, ${alpha * 0.4})`,
+        );
+        gradient.addColorStop(1, 'transparent');
 
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, radius * 3, 0, Math.PI * 2);
-      ctx.fillStyle = gradient;
-      ctx.fill();
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, radius * 3, 0, Math.PI * 2);
+        ctx.fillStyle = gradient;
+        ctx.fill();
+      }
 
-      // Core
       ctx.beginPath();
       ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
-      ctx.fillStyle = `hsla(${p.hue}, ${p.saturation}%, ${p.lightness + 20}%, ${alpha + 0.2})`;
+      ctx.fillStyle = `hsla(${p.hue}, ${p.saturation}%, ${p.lightness + 20}%, ${lowPowerMode ? alpha * 0.85 : alpha + 0.2})`;
       ctx.fill();
     }
   }
@@ -346,7 +375,9 @@ export function initHeroCanvas(
     }
 
     drawOrbs();
-    drawConnections();
+    if (!lowPowerMode || time % 2 === 0) {
+      drawConnections();
+    }
     drawParticles();
   }
 

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -43,6 +43,8 @@ export function createLibraryView({
   let lastRenderedQuery = '';
   let suggestionSignature = '';
   let renderedCardMap = new Map();
+  let toyBySlug = new Map();
+  let toySearchMetadata = new Map();
   const filterLabelCache = new Map();
   const activeFilters = new Set();
   const threeEffects = createLibraryThreeEffects();
@@ -63,6 +65,41 @@ export function createLibraryView({
   } = createLibraryDomCache(document);
 
   const getToyList = () => document.getElementById(targetId);
+  const getToyKey = (toy, index = 0) => toy?.slug ?? `toy-${index}`;
+
+  const buildToySearchMetadata = (toy) => {
+    const tags = (toy.tags ?? []).map((tag) => tag.toLowerCase());
+    const moods = (toy.moods ?? []).map((mood) => mood.toLowerCase());
+    const flags = [
+      toy.requiresWebGPU ? 'webgpu webgl gpu' : '',
+      toy.capabilities?.microphone ? 'microphone mic live audio' : '',
+      toy.capabilities?.demoAudio ? 'demo audio preview starter' : '',
+      toy.capabilities?.motion ? 'motion tilt gyro mobile' : '',
+    ]
+      .filter(Boolean)
+      .map((value) => value.toLowerCase());
+
+    const fields = {
+      title: toy.title?.toLowerCase() ?? '',
+      slug: toy.slug?.toLowerCase() ?? '',
+      description: toy.description?.toLowerCase() ?? '',
+      tags,
+      moods,
+      flags,
+    };
+
+    return {
+      fields,
+      searchHaystacks: [
+        fields.title,
+        fields.slug,
+        fields.description,
+        ...tags,
+        ...moods,
+        ...flags,
+      ].filter(Boolean),
+    };
+  };
 
   const syncRefineDisclosure = () => {
     const refine = ensureLibraryRefine();
@@ -95,7 +132,7 @@ export function createLibraryView({
     }
   };
 
-  const getOriginalIndex = (toy) => originalOrder.get(toy.slug) ?? 0;
+  const getOriginalIndex = (toy) => originalOrder.get(getToyKey(toy)) ?? 0;
   const getFeaturedRank = (toy) =>
     Number.isFinite(toy.featuredRank)
       ? toy.featuredRank
@@ -508,19 +545,21 @@ export function createLibraryView({
   const getMatchedFields = (toy, queryTokens) => {
     if (!queryTokens.length) return [];
 
+    const metadata = toySearchMetadata.get(getToyKey(toy));
+    const fields = metadata?.fields;
+    if (!fields) return [];
+
     const matchedSources = new Set();
     queryTokens.forEach((token) => {
-      if (toy.title?.toLowerCase().includes(token)) matchedSources.add('Title');
-      if (toy.slug?.toLowerCase().includes(token)) matchedSources.add('Slug');
-      if (toy.description?.toLowerCase().includes(token)) {
+      if (fields.title.includes(token)) matchedSources.add('Title');
+      if (fields.slug.includes(token)) matchedSources.add('Slug');
+      if (fields.description.includes(token)) {
         matchedSources.add('Description');
       }
-      if ((toy.tags ?? []).some((tag) => tag.toLowerCase().includes(token))) {
+      if (fields.tags.some((tag) => tag.includes(token))) {
         matchedSources.add('Tags');
       }
-      if (
-        (toy.moods ?? []).some((mood) => mood.toLowerCase().includes(token))
-      ) {
+      if (fields.moods.some((mood) => mood.includes(token))) {
         matchedSources.add('Moods');
       }
       if (toy.requiresWebGPU && 'webgpu'.includes(token)) {
@@ -540,23 +579,10 @@ export function createLibraryView({
     return Array.from(matchedSources).slice(0, 3);
   };
 
-  const matchesSearchQuery = (toy, query) => {
-    const queryTokens = getQueryTokens(query);
+  const matchesSearchQuery = (toy, queryTokens) => {
     if (queryTokens.length === 0) return true;
-
-    const searchHaystacks = [
-      toy.title,
-      toy.slug,
-      toy.description,
-      ...(toy.tags ?? []),
-      ...(toy.moods ?? []),
-      toy.requiresWebGPU ? 'webgpu webgl gpu' : '',
-      toy.capabilities?.microphone ? 'microphone mic live audio' : '',
-      toy.capabilities?.demoAudio ? 'demo audio preview starter' : '',
-      toy.capabilities?.motion ? 'motion tilt gyro mobile' : '',
-    ]
-      .filter(Boolean)
-      .map((value) => value.toLowerCase());
+    const metadata = toySearchMetadata.get(getToyKey(toy));
+    const searchHaystacks = metadata?.searchHaystacks ?? [];
 
     return queryTokens.every((token) =>
       searchHaystacks.some((field) => field.includes(token)),
@@ -564,11 +590,13 @@ export function createLibraryView({
   };
 
   const computeFilteredToys = () => {
+    const queryTokens = getQueryTokens(searchQuery);
+    const filterTokens = Array.from(activeFilters);
     const filtered = allToys.filter((toy) => {
       const matchesChips =
-        activeFilters.size === 0 ||
-        Array.from(activeFilters).every((token) => matchesFilter(toy, token));
-      return matchesChips && matchesSearchQuery(toy, searchQuery);
+        filterTokens.length === 0 ||
+        filterTokens.every((token) => matchesFilter(toy, token));
+      return matchesChips && matchesSearchQuery(toy, queryTokens);
     });
 
     return sortList(filtered);
@@ -584,7 +612,16 @@ export function createLibraryView({
   const setToys = (nextToys = []) => {
     allToys = nextToys;
     originalOrder = new Map(
-      nextToys.map((toy, index) => [toy.slug ?? `toy-${index}`, index]),
+      nextToys.map((toy, index) => [getToyKey(toy, index), index]),
+    );
+    toyBySlug = new Map(
+      nextToys.filter((toy) => toy.slug).map((toy) => [toy.slug, toy]),
+    );
+    toySearchMetadata = new Map(
+      nextToys.map((toy, index) => [
+        getToyKey(toy, index),
+        buildToySearchMetadata(toy),
+      ]),
     );
     populateSearchSuggestions();
   };
@@ -810,7 +847,7 @@ export function createLibraryView({
 
     const recentSlugs = getRecentToySlugs(3);
     const recentToys = recentSlugs
-      .map((slug) => allToys.find((toy) => toy.slug === slug))
+      .map((slug) => toyBySlug.get(slug))
       .filter(Boolean);
 
     if (recentToys.length > 0) {
@@ -837,7 +874,7 @@ export function createLibraryView({
     }
   };
 
-  const createCard = (toy) => {
+  const createCard = (toy, queryTokens = []) => {
     const card = document.createElement(cardElement);
     card.className = 'webtoy-card';
     if (toy.slug) {
@@ -896,7 +933,7 @@ export function createLibraryView({
       card.appendChild(guidanceNode);
     }
 
-    const matchedFields = getMatchedFields(toy, getQueryTokens(searchQuery));
+    const matchedFields = getMatchedFields(toy, queryTokens);
     if (matchedFields.length > 0) {
       const matches = document.createElement('p');
       matches.className = 'webtoy-card-match';
@@ -973,20 +1010,6 @@ export function createLibraryView({
       card.appendChild(actions);
     }
 
-    card.addEventListener('click', (event) => {
-      event.stopPropagation();
-      handleOpenToy(toy, event);
-    });
-
-    if (enableKeyboardHandlers) {
-      card.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          handleOpenToy(toy, event);
-        }
-      });
-    }
-
     return card;
   };
 
@@ -1014,10 +1037,37 @@ export function createLibraryView({
       if (!(card instanceof HTMLElement)) return;
       const slug = card.dataset.toySlug;
       if (!slug) return;
-      const toy = allToys.find((entry) => entry.slug === slug);
+      const toy = toyBySlug.get(slug);
       if (!toy) return;
       handleOpenToy(toy, event);
     });
+    if (enableKeyboardHandlers) {
+      list.addEventListener('keydown', (event) => {
+        const target =
+          event.target && typeof event.target === 'object'
+            ? event.target
+            : null;
+        const card =
+          target && 'closest' in target
+            ? target.closest?.('.webtoy-card')
+            : null;
+        if (!(card instanceof HTMLElement)) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        if (
+          target instanceof HTMLElement &&
+          target !== card &&
+          target.closest('button, a, input, select, textarea, summary')
+        ) {
+          return;
+        }
+        const slug = card.dataset.toySlug;
+        if (!slug) return;
+        const toy = toyBySlug.get(slug);
+        if (!toy) return;
+        event.preventDefault();
+        handleOpenToy(toy, event);
+      });
+    }
   };
 
   const createEmptyState = () => {
@@ -1132,9 +1182,10 @@ export function createLibraryView({
     renderGrowthPanels(fragment);
     const nextCardMap = new Map();
     const cards = [];
+    const queryTokens = getQueryTokens(searchQuery);
     listToRender.forEach((toy, index) => {
-      const key = toy.slug ?? `toy-${index}`;
-      const card = renderedCardMap.get(key) ?? createCard(toy);
+      const key = getToyKey(toy, index);
+      const card = renderedCardMap.get(key) ?? createCard(toy, queryTokens);
       applyCardMotionVariant(card, index);
       nextCardMap.set(key, card);
       cards.push(card);

--- a/assets/js/library-view/three-library-effects.ts
+++ b/assets/js/library-view/three-library-effects.ts
@@ -30,11 +30,12 @@ interface PreviewItem {
   camera: PerspectiveCamera;
   mesh: Mesh;
   isVisible: boolean;
+  isActive: boolean;
   dispose: () => void;
 }
 
-const BACKGROUND_FRAME_INTERVAL_MS = 1000 / 30;
-const PREVIEW_FRAME_INTERVAL_MS = 1000 / 24;
+const BACKGROUND_FRAME_INTERVAL_MS = 1000 / 20;
+const PREVIEW_FRAME_INTERVAL_MS = 1000 / 12;
 
 export function createLibraryThreeEffects() {
   let backgroundRenderer: WebGLRenderer | null = null;
@@ -72,7 +73,7 @@ export function createLibraryThreeEffects() {
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const previewLimit = prefersReducedMotion ? 0 : isCompactViewport ? 2 : 4;
+  const previewLimit = prefersReducedMotion ? 0 : isCompactViewport ? 1 : 2;
 
   const shouldRender = () =>
     typeof document === 'undefined' ? true : !document.hidden;
@@ -105,7 +106,7 @@ export function createLibraryThreeEffects() {
     if (now - lastPreviewRenderAt >= PREVIEW_FRAME_INTERVAL_MS) {
       lastPreviewRenderAt = now;
       previews.forEach((item) => {
-        if (!item.isVisible) return;
+        if (!item.isVisible || !item.isActive) return;
         item.mesh.rotation.x += 0.004 + pulse * 0.01;
         item.mesh.rotation.y += 0.007 + pulse * 0.01;
         item.renderer.render(item.scene, item.camera);
@@ -116,10 +117,10 @@ export function createLibraryThreeEffects() {
   };
 
   const createAmbientLayer = () => {
-    if (!webglAvailable) return;
+    if (!webglAvailable || prefersReducedMotion || isCompactViewport) return;
     try {
       const renderer = new WebGLRenderer({ alpha: true, antialias: false });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+      renderer.setPixelRatio(1);
       renderer.setSize(window.innerWidth, window.innerHeight);
       renderer.domElement.className = 'library-three-ambient';
 
@@ -200,6 +201,22 @@ export function createLibraryThreeEffects() {
     previewRoot.dataset.previewKey = key;
     host.prepend(previewRoot);
 
+    let isActive = index === 0;
+    const activate = () => {
+      isActive = true;
+      const item = previews.get(key);
+      if (item) item.isActive = true;
+    };
+    const deactivate = () => {
+      isActive = false;
+      const item = previews.get(key);
+      if (item) item.isActive = false;
+    };
+    previewRoot.addEventListener('pointerenter', activate);
+    previewRoot.addEventListener('focusin', activate);
+    previewRoot.addEventListener('pointerleave', deactivate);
+    previewRoot.addEventListener('focusout', deactivate);
+
     let renderer: WebGLRenderer;
     try {
       renderer = new WebGLRenderer({ alpha: true, antialias: false });
@@ -238,9 +255,14 @@ export function createLibraryThreeEffects() {
     const light = new DirectionalLight(0xffffff, 1.1);
     light.position.copy(new Vector3(2, 3, 3));
     scene.add(light);
+    renderer.render(scene, camera);
 
     const dispose = () => {
       previewObserver?.unobserve(previewRoot);
+      previewRoot.removeEventListener('pointerenter', activate);
+      previewRoot.removeEventListener('focusin', activate);
+      previewRoot.removeEventListener('pointerleave', deactivate);
+      previewRoot.removeEventListener('focusout', deactivate);
       (mesh.geometry as BufferGeometry).dispose();
       (mesh.material as Material).dispose();
       renderer.dispose();
@@ -256,6 +278,7 @@ export function createLibraryThreeEffects() {
       camera,
       mesh,
       isVisible: true,
+      isActive,
       dispose,
     });
   };

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -163,7 +163,7 @@ function createFeedbackRenderTarget(
   height: number,
   backend: 'webgl' | 'webgpu',
 ) {
-  const resolutionScale = backend === 'webgpu' ? 1.5 : 1.1;
+  const resolutionScale = backend === 'webgpu' ? 1 : 0.85;
   const scaledWidth = Math.max(1, Math.round(width * resolutionScale));
   const scaledHeight = Math.max(1, Math.round(height * resolutionScale));
   const target = new WebGLRenderTarget(scaledWidth, scaledHeight, {
@@ -175,7 +175,7 @@ function createFeedbackRenderTarget(
         }
       : {}),
   });
-  target.samples = backend === 'webgpu' ? 4 : 2;
+  target.samples = backend === 'webgpu' ? 2 : 0;
   return target;
 }
 
@@ -597,7 +597,7 @@ class FeedbackManager {
 
   constructor(width: number, height: number, backend: 'webgl' | 'webgpu') {
     this.camera.position.z = 1;
-    this.resolutionScale = backend === 'webgpu' ? 1.5 : 1.1;
+    this.resolutionScale = backend === 'webgpu' ? 1 : 0.85;
     this.sceneTarget = createFeedbackRenderTarget(width, height, backend);
     this.targets = [
       createFeedbackRenderTarget(width, height, backend),
@@ -816,6 +816,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
   private readonly blendBorderGroup = new Group();
   private readonly blendMotionVectorGroup = new Group();
   private readonly feedback: FeedbackManager | null;
+  private readonly colorScaleScratch = new Color(1, 1, 1);
+  private readonly tintScratch = new Color(1, 1, 1);
 
   constructor({
     scene,
@@ -1067,11 +1069,13 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       payload.frameState.post.shaderControls.saturation;
     this.feedback.compositeMaterial.uniforms.contrast.value =
       payload.frameState.post.shaderControls.contrast;
-    this.feedback.compositeMaterial.uniforms.colorScale.value = new Color(
+    this.colorScaleScratch.setRGB(
       payload.frameState.post.shaderControls.colorScale.r,
       payload.frameState.post.shaderControls.colorScale.g,
       payload.frameState.post.shaderControls.colorScale.b,
     );
+    this.feedback.compositeMaterial.uniforms.colorScale.value =
+      this.colorScaleScratch;
     this.feedback.compositeMaterial.uniforms.hueShift.value =
       payload.frameState.post.shaderControls.hueShift;
     this.feedback.compositeMaterial.uniforms.brightenBoost.value =
@@ -1080,11 +1084,12 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       payload.frameState.post.shaderControls.invertBoost;
     this.feedback.compositeMaterial.uniforms.solarizeBoost.value =
       payload.frameState.post.shaderControls.solarizeBoost;
-    this.feedback.compositeMaterial.uniforms.tint.value = new Color(
+    this.tintScratch.setRGB(
       payload.frameState.post.shaderControls.tint.r,
       payload.frameState.post.shaderControls.tint.g,
       payload.frameState.post.shaderControls.tint.b,
     );
+    this.feedback.compositeMaterial.uniforms.tint.value = this.tintScratch;
 
     this.renderer.setRenderTarget(this.feedback.sceneTarget);
     this.renderer.render(this.scene, this.camera);

--- a/assets/js/utils/unified-input.ts
+++ b/assets/js/utils/unified-input.ts
@@ -179,7 +179,6 @@ export function createUnifiedInput({
   let lastPrimary: UnifiedPointer | null = null;
   let isPressed = false;
   let inputFrameId: number | null = null;
-  let gamepadFrameId: number | null = null;
   let lastSource: InputSource = 'none';
   let lastGamepadConnected = false;
   let wheelDelta = 0;
@@ -699,7 +698,7 @@ export function createUnifiedInput({
     if (
       keyState.size > 0 ||
       activePointers.size > 0 ||
-      (gamepadEnabled && getPrimaryGamepad()) ||
+      canPollGamepad() ||
       Math.abs(wheelDelta) > PERFORMANCE_WHEEL_MIN ||
       Math.abs(wheelAccum) > PERFORMANCE_WHEEL_MIN ||
       Object.values(actionLastTriggeredAt).some(
@@ -726,34 +725,10 @@ export function createUnifiedInput({
     return () => subscribers.delete(handler);
   };
 
-  const stopGamepadPolling = () => {
-    if (gamepadFrameId != null) {
-      cancelAnimationFrame(gamepadFrameId);
-      gamepadFrameId = null;
-    }
-  };
-
-  const pollGamepad = () => {
-    if (!canPollGamepad()) {
-      stopGamepadPolling();
-      return;
-    }
-    scheduleFrame();
-    gamepadFrameId = requestAnimationFrame(pollGamepad);
-  };
-
-  const ensureGamepadPolling = () => {
-    if (!canPollGamepad() || gamepadFrameId != null) return;
-    gamepadFrameId = requestAnimationFrame(pollGamepad);
-  };
-
   const handleGamepadConnectionChange = () => {
     if (canPollGamepad()) {
-      ensureGamepadPolling();
       scheduleFrame();
-      return;
     }
-    stopGamepadPolling();
   };
 
   const handleVisibilityChange = () => {
@@ -763,11 +738,9 @@ export function createUnifiedInput({
         cancelAnimationFrame(inputFrameId);
         inputFrameId = null;
       }
-      stopGamepadPolling();
       return;
     }
     scheduleFrame();
-    ensureGamepadPolling();
   };
 
   if (gamepadEnabled) {
@@ -779,14 +752,12 @@ export function createUnifiedInput({
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', handleVisibilityChange);
     }
-    ensureGamepadPolling();
   }
 
   const dispose = () => {
     if (inputFrameId != null) {
       cancelAnimationFrame(inputFrameId);
     }
-    stopGamepadPolling();
     resizeObserver?.disconnect();
     if (!resizeObserver) {
       window.removeEventListener('resize', handleWindowResize);

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -519,9 +519,9 @@ video_echo=1
     ).feedback;
 
     expect(feedback).not.toBeNull();
-    expect(feedback?.sceneTarget.width).toBe(960);
-    expect(feedback?.sceneTarget.height).toBe(540);
-    expect(feedback?.sceneTarget.samples).toBe(4);
+    expect(feedback?.sceneTarget.width).toBe(640);
+    expect(feedback?.sceneTarget.height).toBe(360);
+    expect(feedback?.sceneTarget.samples).toBe(2);
     expect(feedback?.sceneTarget.texture.type).toBe(HalfFloatType);
   });
 
@@ -570,9 +570,9 @@ video_echo=1
     ).feedback;
 
     expect(feedback).not.toBeNull();
-    expect(feedback?.sceneTarget.width).toBe(704);
-    expect(feedback?.sceneTarget.height).toBe(396);
-    expect(feedback?.sceneTarget.samples).toBe(2);
+    expect(feedback?.sceneTarget.width).toBe(544);
+    expect(feedback?.sceneTarget.height).toBe(306);
+    expect(feedback?.sceneTarget.samples).toBe(0);
     expect(feedback?.sceneTarget.texture.type).not.toBe(HalfFloatType);
     expect(feedback?.sceneTarget.texture.minFilter).toBe(LinearFilter);
     expect(feedback?.sceneTarget.texture.magFilter).toBe(LinearFilter);


### PR DESCRIPTION
### Motivation
- Reduce CPU/GPU work on constrained devices and mobile by lowering render scales, frame rates, and particle complexity.  
- Make viewport resize handling more efficient and avoid redundant DOM updates.  
- Improve search responsiveness and keyboard accessibility in the library view by precomputing metadata and using slug lookups.  
- Simplify gamepad polling to avoid unnecessary animation loops when not needed.

### Description
- Throttle and coalesce resizes in `WebToy` by adding `scheduleResize`, `resizeFrameId`, `viewportCssWidth/Height`, guarded CSS updates, and canceling pending frames in `dispose`.  
- Lower default maximum pixel ratios for mobile in `renderer-setup.ts` and clamp the effective pixel ratio to mobile/desktop caps.  
- Add low-power heuristics to `hero-canvas.ts` using `navigator.hardwareConcurrency` to reduce `particleCount`, `orbCount`, `connectionDistance`, DPR, glow effects, and cap per-frame connections; also make connections draw less frequently on low-power devices.  
- Reduce background and preview render frequencies and preview limits in `three-library-effects.ts`, make ambient layer conditional on viewport/motion, force pixel ratio to `1`, and add `isActive` activation/focus handlers to only render active previews.  
- Tune feedback render target scales and multisampling for milkdrop adapter in `milkdrop/renderer-adapter.ts` and replace per-frame color allocations with reusable `Color` scratch objects for uniform updates.  
- Simplify gamepad handling in `unified-input.ts` by removing a separate gamepad animation loop and relying on `canPollGamepad()` checks and `scheduleFrame`.  
- Improve library search and rendering in `library-view.js` by adding `toyBySlug` and `toySearchMetadata`, precomputing searchable fields with `buildToySearchMetadata`, using tokenized queries for matching, optimizing card rendering keys via `getToyKey`, and adding keyboard click handling for cards.

### Testing
- Ran unit tests in `tests/milkdrop-renderer-adapter.test.ts` which were updated to match new feedback target sizes and sample counts, and those tests passed.  
- Verified library view and hero canvas changes with local smoke tests for search, keyboard navigation, and hero animation under simulated low-power settings, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafcadcb3c83328daacb724e8bafe1)