### PR TITLE
Trim homepage copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,19 +145,18 @@
         <div class="hero-grid">
           <div class="hero-copy">
             <p class="eyebrow">Flagship visualizer</p>
-            <h1>Open the setup once, then settle into the visuals.</h1>
+            <h1>Start fast, then stay with the visuals.</h1>
             <p class="tagline">
-              Stims checks your device quickly, nudges first runs toward demo
-              audio, and lets you switch to mic input once you are ready for a
-              more reactive session.
+              Run a quick check, start with demo audio, and switch to mic input
+              when you want live response.
             </p>
             <div class="intro-highlights" aria-label="What you can do here">
               <article class="intro-highlight-card">
                 <p class="intro-highlight-card__label">Start fast</p>
                 <p class="intro-highlight-card__value">Quick check, then demo</p>
                 <p class="intro-highlight-card__copy">
-                  The first run is guided so you can confirm compatibility and
-                  start visuals without a permission prompt.
+                  Confirm compatibility and get to visuals without a permission
+                  prompt.
                 </p>
               </article>
               <article class="intro-highlight-card">
@@ -171,7 +170,7 @@
                 <p class="intro-highlight-card__label">Low pressure</p>
                 <p class="intro-highlight-card__value">No sign-in required</p>
                 <p class="intro-highlight-card__copy">
-                  You can check compatibility first and keep the setup lightweight.
+                  Check compatibility first and keep the setup lightweight.
                 </p>
               </article>
             </div>
@@ -194,34 +193,32 @@
               </a>
             </div>
             <p class="cta-helper intro-helper">
-              First run path: open the visualizer, pass the quick check, start
-              with demo audio, then switch to mic if you want live input. Built
-              with clear credit to Ryan Geiss's MilkDrop, preset authors, and
-              the broader ecosystem.
+              Open the visualizer, pass the quick check, start with demo audio,
+              then switch to mic if you want live input.
             </p>
             <div class="launch-steps" aria-label="What happens after you start">
               <article class="launch-step">
                 <p class="launch-step__number">1</p>
                 <p class="launch-step__title">Open the player shell</p>
                 <p class="launch-step__copy">
-                  Launch into the dedicated player shell, where the back path
-                  stays visible and the quick check runs first.
+                  Launch into the player shell, where the quick check runs
+                  first.
                 </p>
               </article>
               <article class="launch-step">
                 <p class="launch-step__number">2</p>
                 <p class="launch-step__title">Start with demo audio</p>
                 <p class="launch-step__copy">
-                  Use the built-in track for the easiest first run, then move to
-                  microphone input when you want live response.
+                  Use the built-in track first, then move to microphone input
+                  when you want live response.
                 </p>
               </article>
               <article class="launch-step">
                 <p class="launch-step__number">3</p>
                 <p class="launch-step__title">Adjust as you go</p>
                 <p class="launch-step__copy">
-                  Keep exploring presets, then edit, export, or change inputs
-                  once you find a look you like.
+                  Explore presets, then edit, export, or change inputs once you
+                  find a look you like.
                 </p>
               </article>
             </div>
@@ -278,8 +275,8 @@
                   <article class="callout-card">
                     <p class="callout-title">Good first session</p>
                     <p class="callout-copy">
-                      Start with demo audio, switch presets for a minute, then
-                      open live editing once the basics feel comfortable.
+                      Start with demo audio, switch presets, then open live
+                      editing when you want more control.
                     </p>
                   </article>
                 </div>
@@ -294,9 +291,8 @@
           <p class="eyebrow">Why Stims leads with MilkDrop</p>
           <h2>MilkDrop is the fastest way to understand what Stims does.</h2>
           <p class="section-description">
-            It gives you a familiar visualizer workflow with presets, playback,
-            and live control. The surrounding library stays useful as a way to
-            browse preset variants without leaving that core flow.
+            Presets, playback, and live controls are all in one place. The
+            library helps you browse variants without leaving that core flow.
           </p>
         </div>
         <div class="experience-grid">
@@ -304,8 +300,8 @@
             <p class="experience-card__eyebrow">Preset engine</p>
             <h3>Curated looks ship with the site</h3>
             <p>
-              The homepage takes you straight to bundled presets, smooth
-              transitions, and playback controls that are ready to use.
+              Open bundled presets with smooth transitions and ready-to-use
+              playback controls.
             </p>
           </article>
           <article class="experience-card">
@@ -313,7 +309,7 @@
             <h3>Change the look without breaking playback</h3>
             <p>
               Edit presets in the browser, use diagnostics when something
-              breaks, and roll back to the last working version if needed.
+              breaks, and roll back if needed.
             </p>
           </article>
           <article class="experience-card">
@@ -341,7 +337,8 @@
           <p class="eyebrow">High-utility tools</p>
           <h2 id="system-check-title">Make the first launch smoother.</h2>
           <p class="section-description">
-            Use the quick check if you want a quick compatibility read, lighter settings, or a little more confidence before starting.
+            Use the quick check for compatibility, lighter settings, or a bit
+            more confidence before starting.
           </p>
         </div>
         <div class="system-grid">
@@ -349,7 +346,8 @@
             <div class="readiness-header">
               <p class="readiness-title">Quick device check</p>
               <p class="readiness-subtitle">
-                Check graphics, microphone, motion, and low-motion support. Open details only when you want the extra context.
+                Check graphics, microphone, motion, and low-motion support.
+                Open details only when you want extra context.
               </p>
             </div>
             <ul class="readiness-list">


### PR DESCRIPTION
### Motivation
- Reduce verbose, repetitive homepage copy in the hero, supporting proof band, and system-check area to make the page quicker to scan while preserving the existing CTA structure and onboarding flow. 
- Keep messaging aligned with the repo's MilkDrop-led positioning without changing layout, links, or behavior.

### Description
- Shortened the hero headline and tagline and tightened helper text and the three launch-step descriptions in `index.html` to remove filler while preserving copy intent. 
- Condensed the MilkDrop proof section copy and the “Good first session” callout in `index.html` for more direct supporting messaging. 
- Slimmed the system-check intro and readiness subtitle in `index.html`; no structural, script, or styling changes were made.

### Testing
- Ran formatting/lint and type checks with `bun run check` steps for Biome and `tsc --noEmit`, which passed through lint/format and typecheck phases but the full `bun run check` exited non-zero due to a preexisting failing test. 
- Executed the targeted homepage sanity test with `bun test tests/app-shell.test.js`, which passed. 
- Ran the full test suite (`bun run test`) as part of the quality gate and observed one unrelated failing test: `tests/webgl-check.test.js` (`ensureWebGL overlay > shows capability overlay when neither WebGL nor WebGPU are available`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc34bdb8cc83329d99a77e5bc0c31a)