### PR TITLE
Reduce mobile overlay clutter

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1844,6 +1844,15 @@ body {
     display: none;
   }
 
+  :root[data-preflight-open="true"] .active-toy-nav {
+    display: none;
+  }
+
+  :root[data-preflight-open="true"] .control-panel--floating,
+  :root[data-preflight-open="true"] .milkdrop-overlay__toggle {
+    display: none;
+  }
+
   .renderer-status-container,
   .renderer-status,
   .renderer-pill,

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1848,7 +1848,8 @@ body {
     display: none;
   }
 
-  :root[data-preflight-open="true"] .control-panel--floating,
+  :root[data-preflight-open="true"]
+    .control-panel--floating:not(.preflight-panel),
   :root[data-preflight-open="true"] .milkdrop-overlay__toggle {
     display: none;
   }

--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -537,6 +537,14 @@ export function attachCapabilityPreflight({
   };
 
   const isPanelOpen = () => panel.open || panel.hasAttribute('open');
+  const setPreflightOpenState = (open: boolean) => {
+    if (open) {
+      document.documentElement.dataset.preflightOpen = 'true';
+    } else {
+      delete document.documentElement.dataset.preflightOpen;
+    }
+  };
+
   const openPanel = () => {
     if (isPanelOpen()) return;
     rememberToggle.checked = readRememberPreference();
@@ -545,6 +553,7 @@ export function attachCapabilityPreflight({
     } else {
       panel.setAttribute('open', 'true');
     }
+    setPreflightOpenState(true);
     focusCleanup?.();
     focusCleanup = trapFocus(panel);
     const focusables = getFocusableElements(panel);
@@ -561,6 +570,7 @@ export function attachCapabilityPreflight({
     } else {
       panel.removeAttribute('open');
     }
+    setPreflightOpenState(false);
     focusCleanup?.();
     focusCleanup = null;
   };
@@ -957,6 +967,7 @@ export function attachCapabilityPreflight({
       window.removeEventListener('popstate', handlePopState);
       closingFromHistory = true;
       closePanel();
+      setPreflightOpenState(false);
       panel.remove();
       const params = new URLSearchParams(window.location.search);
       if (params.get(MODAL_PARAM) === MODAL_VALUE) {

--- a/assets/js/ui/nav.ts
+++ b/assets/js/ui/nav.ts
@@ -343,7 +343,7 @@ function renderToyNav(
   const mobileActionsMediaQuery = getMediaQueryList(
     maxWidthQuery(BREAKPOINTS.md),
   );
-  let actionsExpanded = true;
+  let actionsExpanded = !isBelowBreakpoint(BREAKPOINTS.md);
 
   const applyActionsState = (expanded: boolean) => {
     actionsContainer?.setAttribute(
@@ -379,7 +379,7 @@ function renderToyNav(
   };
 
   const syncActionsForViewport = () => {
-    actionsExpanded = true;
+    actionsExpanded = !isBelowBreakpoint(BREAKPOINTS.md);
     applyActionsState(actionsExpanded);
   };
 

--- a/tests/capability-preflight.test.ts
+++ b/tests/capability-preflight.test.ts
@@ -106,4 +106,36 @@ describe('capability preflight launch flow', () => {
 
     preflight.destroy();
   });
+
+  test('tracks preflight open state on the document root', async () => {
+    setTestUrl();
+
+    const preflight = attachCapabilityPreflight({
+      host: document.body,
+      openOnAttach: false,
+      showCloseButton: true,
+      runPreflight: async () => readyResult,
+    });
+
+    expect(document.documentElement.dataset.preflightOpen).toBeUndefined();
+
+    preflight.open();
+    await flush();
+    await flush();
+
+    expect(document.documentElement.dataset.preflightOpen).toBe('true');
+
+    const closeButton = Array.from(
+      document.querySelectorAll('dialog .cta-button.ghost'),
+    ).find((button) => button.textContent?.includes('Close')) as
+      | HTMLButtonElement
+      | undefined;
+
+    closeButton?.click();
+    await flush();
+
+    expect(document.documentElement.dataset.preflightOpen).toBeUndefined();
+
+    preflight.destroy();
+  });
 });

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -154,7 +154,7 @@ describe('toy navigation visibility states', () => {
     window.matchMedia = originalMatchMedia;
   });
 
-  test('mobile view keeps the toy action drawer visible by default', () => {
+  test('mobile view starts with the toy action drawer collapsed', () => {
     const { matchMedia } = createMatchMediaStub();
     window.matchMedia = matchMedia;
 
@@ -170,20 +170,20 @@ describe('toy navigation visibility states', () => {
     ) as HTMLButtonElement;
     const primary = container.querySelector('.active-toy-nav__actions-primary');
 
-    expect(actions.dataset.toyActionsExpanded).toBe('true');
+    expect(actions.dataset.toyActionsExpanded).toBe('false');
     expect(actions.hidden).toBe(false);
     expect(actions.getAttribute('aria-hidden')).toBeNull();
     expect(actions.hasAttribute('inert')).toBe(false);
-    expect(secondary.hidden).toBe(false);
-    expect(secondary.getAttribute('aria-hidden')).toBe('false');
-    expect(secondary.hasAttribute('inert')).toBe(false);
-    expect(toggle.textContent).toBe('Hide audio & settings');
+    expect(secondary.hidden).toBe(true);
+    expect(secondary.getAttribute('aria-hidden')).toBe('true');
+    expect(secondary.hasAttribute('inert')).toBe(true);
+    expect(toggle.textContent).toBe('Audio & settings');
     expect(primary).toBeTruthy();
     expect(secondary).toBeTruthy();
-    expect(document.documentElement.dataset.toyControlsExpanded).toBe('true');
+    expect(document.documentElement.dataset.toyControlsExpanded).toBe('false');
   });
 
-  test('mobile toy nav toggle updates its tools label as the drawer closes', () => {
+  test('mobile toy nav toggle updates its tools label as the drawer opens', () => {
     const { matchMedia } = createMatchMediaStub();
     window.matchMedia = matchMedia;
 
@@ -196,14 +196,14 @@ describe('toy navigation visibility states', () => {
 
     toggle.click();
 
-    expect(toggle.textContent).toBe('Audio & settings');
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.textContent).toBe('Hide audio & settings');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(toggle.getAttribute('aria-controls')).toBe(
       'toy-nav-secondary-actions',
     );
     expect(
       (container.querySelector('#toy-nav-secondary-actions') as HTMLElement)
         .hidden,
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/tests/preflight-mobile-visibility.test.ts
+++ b/tests/preflight-mobile-visibility.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('Preflight mobile visibility regression', () => {
+  test('does not hide the preflight dialog when preflight-open rules hide floating chrome', () => {
+    const css = readFileSync(
+      join(import.meta.dir, '..', 'assets', 'css', 'base.css'),
+      'utf8',
+    );
+
+    expect(css).toMatch(
+      /:root\[data-preflight-open="true"\]\s+\.control-panel--floating:not\(\.preflight-panel\),/,
+    );
+    expect(css).toMatch(
+      /\.preflight-panel\.control-panel--floating\s*\{\s*left:\s*50%;/,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- On small screens multiple floating controls (toy action drawer, floating control panels, and the MilkDrop overlay toggle) stack and obscure the visualizer on first open. The change aims to make the mobile experience calmer by default while preserving access to controls.

### Description
- Collapse the toy action drawer on mobile by default by initializing `actionsExpanded` to `!isBelowBreakpoint(BREAKPOINTS.md)` and syncing viewport state accordingly in `assets/js/ui/nav.ts`.
- Track preflight dialog open state on the document root via a `data-preflight-open` flag and set/clear it when opening, closing, and destroying the preflight dialog in `assets/js/core/capability-preflight.ts`.
- Hide the floating toy nav, floating control panels, and the MilkDrop presets toggle while the preflight dialog is open by adding `:root[data-preflight-open="true"]` rules in `assets/css/base.css`.
- Add regression tests: update `tests/nav.test.ts` to assert the collapsed mobile-drawer behavior and add `tests/capability-preflight.test.ts` coverage to verify the preflight open-state flag lifecycle.

### Testing
- Ran targeted tests: `bun test tests/nav.test.ts tests/capability-preflight.test.ts tests/system-controls-tv-mode.test.ts`, and all listed tests passed.
- Ran the full quality gate: `bun run check`, which completed successfully in the final verification run.
- Docs touched: `None`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcf852bc8c8332b8163ae7d06250dd)