### PR TITLE
Skip inspector metric updates when inspector tab is hidden and avoid duplicate frame render

### DIFF
--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -185,6 +185,7 @@ export class MilkdropOverlay {
   private suppressEditorChange = false;
   private editorDebounceId: number | null = null;
   private lastInspectorSignature = '';
+  private activeTab: 'browse' | 'editor' | 'inspector' = 'browse';
 
   constructor({
     host = document.body,
@@ -628,7 +629,12 @@ export class MilkdropOverlay {
     this.toggleOpen(true);
   }
 
+  shouldRenderInspectorMetrics() {
+    return this.isOpen() && this.activeTab === 'inspector';
+  }
+
   private setActiveTab(tab: string) {
+    this.activeTab = tab === 'editor' || tab === 'inspector' ? tab : 'browse';
     Object.entries(this.tabPanels).forEach(([id, panel]) => {
       panel.hidden = id !== tab;
     });
@@ -1301,7 +1307,13 @@ export class MilkdropOverlay {
     }
 
     if (!frameState || !compiled) {
-      this.inspectorMetrics.textContent = 'Waiting for preview frames...';
+      if (this.shouldRenderInspectorMetrics()) {
+        this.inspectorMetrics.textContent = 'Waiting for preview frames...';
+      }
+      return;
+    }
+
+    if (!this.shouldRenderInspectorMetrics()) {
       return;
     }
 

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -1201,11 +1201,13 @@ export function createMilkdropExperience({
             }
           : currentFrameState;
 
-      adapter.render({
+      const adapterPresentedFrame = adapter.render({
         frameState: renderFrameState,
         blendState: activeBlendState,
       });
-      runtime.toy.render();
+      if (!adapterPresentedFrame) {
+        runtime.toy.render();
+      }
       overlay.setInspectorState({
         compiled: activeCompiled,
         frameState: currentFrameState,

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -2,6 +2,96 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { DEFAULT_QUALITY_PRESETS } from '../assets/js/core/settings-panel.ts';
 import { MilkdropOverlay } from '../assets/js/milkdrop/overlay.ts';
 
+function createOverlay({
+  onSelectQualityPreset = mock(),
+}: {
+  onSelectQualityPreset?: ReturnType<typeof mock>;
+} = {}) {
+  return new MilkdropOverlay({
+    host: document.body,
+    callbacks: {
+      onSelectPreset: mock(),
+      onSelectQualityPreset,
+      onToggleFavorite: mock(),
+      onSetRating: mock(),
+      onToggleAutoplay: mock(),
+      onTransitionModeChange: mock(),
+      onGoBackPreset: mock(),
+      onNextPreset: mock(),
+      onPreviousPreset: mock(),
+      onRandomize: mock(),
+      onBlendDurationChange: mock(),
+      onImportFiles: mock(),
+      onExport: mock(),
+      onDuplicatePreset: mock(),
+      onDeletePreset: mock(),
+      onEditorSourceChange: mock(),
+      onRevertToActive: mock(),
+      onInspectorFieldChange: mock(),
+    },
+  });
+}
+
+function createInspectorPayload() {
+  return {
+    compiled: {
+      title: 'Signal Bloom',
+      source: {
+        id: 'signal-bloom',
+        origin: 'bundled',
+      },
+      formattedSource: 'zoom=1\n',
+      ir: {
+        numericFields: {
+          zoom: 1,
+          rot: 0,
+          warp: 0,
+          blend_duration: 2.5,
+          mesh_density: 16,
+          wave_scale: 1,
+          ob_size: 0.02,
+          ib_size: 0.01,
+        },
+        customWaves: [],
+        customShapes: [],
+        compatibility: {
+          backends: {
+            webgl: { status: 'supported', reasons: [] },
+            webgpu: { status: 'supported', reasons: [] },
+          },
+          parity: {
+            fidelityClass: 'exact',
+            degradationReasons: [],
+            evidence: { compile: 0, runtime: 0, visual: 0 },
+            backendDivergence: [],
+            visualFallbacks: [],
+          },
+          featureAnalysis: {
+            featuresUsed: [],
+            registerUsage: { q: 0, t: 0 },
+          },
+        },
+      },
+    },
+    frameState: {
+      signals: {
+        frame: 42,
+        bass: 0.2,
+        mid: 0.3,
+        treb: 0.4,
+        beatPulse: 0.5,
+      },
+      mainWave: {
+        positions: new Array(96).fill(0),
+      },
+      customWaves: [],
+      shapes: [],
+      borders: [],
+    },
+    backend: 'webgl' as const,
+  } as unknown as Parameters<MilkdropOverlay['setInspectorState']>[0];
+}
+
 describe('milkdrop overlay quality controls', () => {
   const OriginalMutationObserver = globalThis.MutationObserver;
 
@@ -20,29 +110,7 @@ describe('milkdrop overlay quality controls', () => {
     } as unknown as typeof MutationObserver;
 
     const onSelectQualityPreset = mock();
-    const overlay = new MilkdropOverlay({
-      host: document.body,
-      callbacks: {
-        onSelectPreset: mock(),
-        onSelectQualityPreset,
-        onToggleFavorite: mock(),
-        onSetRating: mock(),
-        onToggleAutoplay: mock(),
-        onTransitionModeChange: mock(),
-        onGoBackPreset: mock(),
-        onNextPreset: mock(),
-        onPreviousPreset: mock(),
-        onRandomize: mock(),
-        onBlendDurationChange: mock(),
-        onImportFiles: mock(),
-        onExport: mock(),
-        onDuplicatePreset: mock(),
-        onDeletePreset: mock(),
-        onEditorSourceChange: mock(),
-        onRevertToActive: mock(),
-        onInspectorFieldChange: mock(),
-      },
-    });
+    const overlay = createOverlay({ onSelectQualityPreset });
 
     overlay.setQualityPresets({
       presets: DEFAULT_QUALITY_PRESETS,
@@ -69,6 +137,42 @@ describe('milkdrop overlay quality controls', () => {
     expect(document.body.textContent).toContain(
       'Comfortable 10-foot visuals with softer density and steadier frame pacing.',
     );
+
+    overlay.dispose();
+  });
+});
+
+describe('milkdrop overlay inspector metrics', () => {
+  const OriginalMutationObserver = globalThis.MutationObserver;
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    globalThis.MutationObserver = OriginalMutationObserver;
+  });
+
+  test('skips inspector metric DOM updates while the inspector tab is hidden', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const payload = createInspectorPayload();
+    const metrics = document.querySelector(
+      '.milkdrop-overlay__inspector-metrics',
+    ) as HTMLElement | null;
+
+    expect(overlay.shouldRenderInspectorMetrics()).toBe(false);
+    overlay.setInspectorState(payload);
+    expect(metrics?.innerHTML).toBe('');
+
+    overlay.openTab('inspector');
+    expect(overlay.shouldRenderInspectorMetrics()).toBe(true);
+    overlay.setInspectorState(payload);
+    expect(metrics?.textContent).toContain('Backend:');
 
     overlay.dispose();
   });


### PR DESCRIPTION
### Motivation
- Reduce unnecessary DOM updates for inspector metrics when the inspector panel is not visible to improve performance.
- Prevent duplicate visual rendering by only calling the fallback `runtime.toy.render()` when the adapter did not present a frame.

### Description
- Added an `activeTab` state and a `shouldRenderInspectorMetrics()` helper to `MilkdropOverlay` to gate inspector metric updates behind the overlay being open and the inspector tab being active.
- Updated `setActiveTab()` to track normalized tab values and updated `setInspectorState()` to skip metric text updates unless `shouldRenderInspectorMetrics()` returns true.
- Changed the render flow in the runtime to capture the result of `adapter.render()` as `adapterPresentedFrame` and call `runtime.toy.render()` only when `adapterPresentedFrame` is falsy.
- Extended `tests/milkdrop-overlay.test.ts` with helpers and a new test that verifies inspector metrics are not updated while the inspector tab is hidden and are rendered once the tab is opened.

### Testing
- Ran the overlay unit tests in `tests/milkdrop-overlay.test.ts` which include the existing quality-control test and the new inspector metrics test; both tests passed.
- The new test asserts `shouldRenderInspectorMetrics()` behavior and DOM updates for `.milkdrop-overlay__inspector-metrics` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd8cd5b1f483329941f28dade1e00a)