### PR TITLE
Reuse buffers and caches in VM, add line visual rendering, and make WebGL check testable

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -27,6 +27,7 @@ import {
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import type {
   MilkdropBorderVisual,
+  MilkdropColor,
   MilkdropCompiledPreset,
   MilkdropFeedbackCompositeState,
   MilkdropFeedbackManager,
@@ -1443,6 +1444,61 @@ function syncWaveObject(
   return existing;
 }
 
+function createLineObject(
+  positions: number[],
+  color: MilkdropColor,
+  alpha: number,
+  additive: boolean,
+) {
+  const object = new Line(
+    new BufferGeometry(),
+    new LineBasicMaterial({
+      transparent: true,
+      opacity: alpha,
+      ...(additive ? { blending: AdditiveBlending } : {}),
+    }),
+  );
+  ensureGeometryPositions(object.geometry, positions);
+  setMaterialColor(object.material, color, alpha);
+  object.position.z = 0.24;
+  return object;
+}
+
+function syncLineObject(
+  existing: Line | undefined,
+  {
+    positions,
+    color,
+    alpha,
+    additive,
+  }: {
+    positions: number[];
+    color: MilkdropColor;
+    alpha: number;
+    additive: boolean;
+  },
+  alphaMultiplier: number,
+) {
+  if (!(existing instanceof Line) || existing instanceof LineLoop) {
+    if (existing) {
+      disposeObject(existing);
+    }
+    return createLineObject(
+      positions,
+      color,
+      alpha * alphaMultiplier,
+      additive,
+    );
+  }
+
+  ensureGeometryPositions(existing.geometry, positions);
+  const material = existing.material as LineBasicMaterial;
+  material.blending = additive ? AdditiveBlending : NormalBlending;
+  setMaterialColor(material, color, alpha * alphaMultiplier);
+  existing.position.z = 0.24;
+  return existing;
+}
+
 function updateBorderLine(
   object: Line | LineLoop,
   border: MilkdropBorderVisual,
@@ -1815,6 +1871,41 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     });
   }
 
+  private renderLineVisualGroup(
+    group: Group,
+    lines: Array<{
+      positions: number[];
+      color: MilkdropColor;
+      alpha: number;
+      additive?: boolean;
+    }>,
+    alphaMultiplier = 1,
+  ) {
+    lines.forEach((line, index) => {
+      const existing = group.children[index] as Line | undefined;
+      const synced = syncLineObject(
+        existing,
+        {
+          positions: line.positions,
+          color: line.color,
+          alpha: line.alpha,
+          additive: line.additive ?? false,
+        },
+        alphaMultiplier,
+      );
+      if (!existing) {
+        group.add(synced);
+      } else if (synced !== existing) {
+        group.remove(existing);
+        group.add(synced);
+      }
+    });
+    group.children.slice(lines.length).forEach((child) => {
+      disposeObject(child as { children?: unknown[] });
+      group.remove(child);
+    });
+  }
+
   private renderMesh(
     mesh: MilkdropRenderPayload['frameState']['mesh'],
     gpuGeometry: MilkdropGpuGeometryHints,
@@ -1900,13 +1991,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     }
 
     this.proceduralMotionVectors.visible = false;
-    this.renderWaveGroup(
+    this.renderLineVisualGroup(
       this.motionVectorCpuGroup,
-      payload.motionVectors.map((vector) => ({
-        ...vector,
-        drawMode: 'line',
-        pointSize: 1,
-      })),
+      payload.motionVectors,
       alphaMultiplier,
     );
   }
@@ -2024,15 +2111,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         payload.frameState.gpuGeometry.trailWaves,
       );
     } else {
-      this.renderWaveGroup(
-        this.trailGroup,
-        payload.frameState.trails.map((trail) => ({
-          ...trail,
-          drawMode: 'line',
-          additive: false,
-          pointSize: 2,
-        })),
-      );
+      this.renderLineVisualGroup(this.trailGroup, payload.frameState.trails);
     }
     this.renderShapeGroup(this.shapesGroup, payload.frameState.shapes);
     this.renderBorderGroup(this.borderGroup, payload.frameState.borders);
@@ -2059,13 +2138,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       blend?.borders ?? [],
       blend?.alpha ?? 0,
     );
-    this.renderWaveGroup(
+    this.renderLineVisualGroup(
       this.blendMotionVectorGroup,
-      (blend?.motionVectors ?? []).map((vector) => ({
-        ...vector,
-        drawMode: 'line',
-        pointSize: 1,
-      })),
+      blend?.motionVectors ?? [],
       blend?.alpha ?? 0,
     );
 

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -314,7 +314,7 @@ function cloneBlendState(
     color: { ...frameState.mainWave.color },
   };
   return {
-    background: { ...frameState.background },
+    background: frameState.background,
     waveform,
     mainWave: waveform,
     customWaves: frameState.customWaves.map((wave) => ({
@@ -322,11 +322,7 @@ function cloneBlendState(
       positions: [...wave.positions],
       color: { ...wave.color },
     })),
-    trails: frameState.trails.map((trail) => ({
-      ...trail,
-      positions: [...trail.positions],
-      color: { ...trail.color },
-    })),
+    trails: frameState.trails,
     shapes: frameState.shapes.map((shape) => ({
       ...shape,
       color: { ...shape.color },
@@ -342,7 +338,7 @@ function cloneBlendState(
       positions: [...vector.positions],
       color: { ...vector.color },
     })),
-    post: { ...frameState.post },
+    post: frameState.post,
     alpha: 1,
   };
 }

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -48,14 +48,6 @@ function hashSeed(input: string) {
   return hash >>> 0;
 }
 
-function clonePolyline(polyline: MilkdropPolyline): MilkdropPolyline {
-  return {
-    ...polyline,
-    positions: [...polyline.positions],
-    color: { ...polyline.color },
-  };
-}
-
 function defaultSignalEnv(): MilkdropRuntimeSignals {
   const frequencyData = new Uint8Array(64);
   return {
@@ -224,6 +216,11 @@ type MeshField = {
   points: MeshFieldPoint[];
 };
 
+type WaveFrameBuffers = {
+  liveSamples: number[];
+  smoothedSamples: number[];
+};
+
 class MilkdropPresetVM implements MilkdropVM {
   private preset: MilkdropCompiledPreset;
   private state: MutableState = {};
@@ -236,6 +233,14 @@ class MilkdropPresetVM implements MilkdropVM {
   private customWaveState: MutableState[] = [];
   private customShapeState: MutableState[] = [];
   private lastMeshField: MeshField | null = null;
+  private readonly waveBuffers: WaveFrameBuffers = {
+    liveSamples: [],
+    smoothedSamples: [],
+  };
+  private readonly frameTransformCache = new Map<
+    string,
+    { x: number; y: number }
+  >();
 
   constructor(preset: MilkdropCompiledPreset) {
     this.preset = preset;
@@ -276,6 +281,9 @@ class MilkdropPresetVM implements MilkdropVM {
       this.seedCustomShapeState(shape),
     );
     this.lastMeshField = null;
+    this.waveBuffers.liveSamples.length = 0;
+    this.waveBuffers.smoothedSamples.length = 0;
+    this.frameTransformCache.clear();
 
     const zeroSignals = defaultSignalEnv();
     this.runProgram(this.preset.ir.programs.init, this.createEnv(zeroSignals));
@@ -455,13 +463,13 @@ class MilkdropPresetVM implements MilkdropVM {
     env: MutableState,
     locals: MutableState | null = null,
   ) {
+    const scopedEnv = {
+      ...env,
+      ...this.state,
+      ...this.registers,
+      ...(locals ?? {}),
+    };
     block.statements.forEach((statement) => {
-      const scopedEnv = {
-        ...env,
-        ...this.state,
-        ...this.registers,
-        ...(locals ?? {}),
-      };
       const value = evaluateMilkdropExpression(
         statement.expression,
         scopedEnv,
@@ -471,6 +479,7 @@ class MilkdropPresetVM implements MilkdropVM {
       );
       this.setValue(statement.target, value, locals);
       env[statement.target] = value;
+      scopedEnv[statement.target] = value;
     });
   }
 
@@ -480,7 +489,7 @@ class MilkdropPresetVM implements MilkdropVM {
       24,
       192,
     );
-    const positions: number[] = [];
+    const positions = new Array<number>(samples * 3);
     const mode = normalizeWaveMode(this.state.wave_mode ?? 0);
     const centerX = ((this.state.wave_x ?? 0.5) - 0.5) * 2;
     const centerY = (0.5 - (this.state.wave_y ?? 0.5)) * 2;
@@ -497,19 +506,29 @@ class MilkdropPresetVM implements MilkdropVM {
       0,
       1,
     );
-    const liveSamples = Array.from({ length: samples }, (_, index) =>
-      sampleFrequencyData(signals, index / Math.max(1, samples - 1)),
-    );
+    const liveSamples = this.waveBuffers.liveSamples;
+    const smoothedSamples = this.waveBuffers.smoothedSamples;
+    liveSamples.length = samples;
+    smoothedSamples.length = samples;
     const previousSamples = this.lastWaveSamples;
     const historyBlend = clamp(
       0.26 + signals.beatPulse * 0.48 + signals.deltaMs / 120,
       0.24,
       0.92,
     );
-    const smoothedSamples = liveSamples.map((value, index) =>
-      mix(previousSamples[index] ?? value, value, historyBlend),
-    );
-    this.lastWaveSamples = [...smoothedSamples];
+    for (let index = 0; index < samples; index += 1) {
+      const value = sampleFrequencyData(
+        signals,
+        index / Math.max(1, samples - 1),
+      );
+      liveSamples[index] = value;
+      smoothedSamples[index] = mix(
+        previousSamples[index] ?? value,
+        value,
+        historyBlend,
+      );
+    }
+    this.lastWaveSamples = smoothedSamples.slice(0, samples);
 
     for (let index = 0; index < samples; index += 1) {
       const t = index / Math.max(1, samples - 1);
@@ -614,7 +633,10 @@ class MilkdropPresetVM implements MilkdropVM {
             velocity * 0.12;
       }
 
-      positions.push(x, y, 0.22 + velocity * 0.08);
+      const writeIndex = index * 3;
+      positions[writeIndex] = x;
+      positions[writeIndex + 1] = y;
+      positions[writeIndex + 2] = 0.22 + velocity * 0.08;
     }
 
     const waveColor = color(
@@ -760,6 +782,11 @@ class MilkdropPresetVM implements MilkdropVM {
     gridX: number,
     gridY: number,
   ) {
+    const cacheKey = `${gridX},${gridY}`;
+    const cached = this.frameTransformCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
     const local: MutableState = {
       x: gridX,
       y: gridY,
@@ -802,10 +829,12 @@ class MilkdropPresetVM implements MilkdropVM {
     const py = (transformedY + Math.sin(angle * 4) * ripple) * local.zoom;
     const cos = Math.cos(local.rot);
     const sin = Math.sin(local.rot);
-    return {
+    const transformed = {
       x: px * cos - py * sin,
       y: px * sin + py * cos,
     };
+    this.frameTransformCache.set(cacheKey, transformed);
+    return transformed;
   }
 
   private buildMeshField(signals: MilkdropRuntimeSignals): MeshField {
@@ -1133,30 +1162,22 @@ class MilkdropPresetVM implements MilkdropVM {
   }
 
   step(signals: MilkdropRuntimeSignals): MilkdropFrameState {
+    this.frameTransformCache.clear();
     this.runProgram(this.preset.ir.programs.perFrame, this.createEnv(signals));
 
     const { visual: mainWave } = this.buildMainWave(signals);
     const gpuGeometry = this.buildGpuGeometryHints();
     const customWaves = this.buildCustomWaves(signals);
     if (this.lastWaveform) {
-      this.trails.unshift(clonePolyline(this.lastWaveform));
+      this.trails.unshift(this.lastWaveform);
       this.trails = this.trails.slice(0, MAX_TRAILS);
     }
-    this.lastWaveform = {
-      ...mainWave,
-      positions: [...mainWave.positions],
-      color: { ...mainWave.color },
-    };
+    this.lastWaveform = mainWave;
 
     const meshField = this.buildMeshField(signals);
     const mesh = this.buildMesh(meshField);
     const motionVectors = this.buildMotionVectors(signals, meshField);
-    this.lastMeshField = meshField
-      ? {
-          density: meshField.density,
-          points: meshField.points.map((point) => ({ ...point })),
-        }
-      : null;
+    this.lastMeshField = meshField;
 
     const frameState: MilkdropFrameState = {
       presetId: this.preset.source.id,
@@ -1181,6 +1202,7 @@ class MilkdropPresetVM implements MilkdropVM {
       gpuGeometry,
     };
     gpuGeometry.customWaves = customWaves.procedural;
+    this.frameTransformCache.clear();
 
     return frameState;
   }

--- a/assets/js/utils/webgl-check.ts
+++ b/assets/js/utils/webgl-check.ts
@@ -1,3 +1,4 @@
+import type { RenderingSupport } from '../core/renderer-capabilities.ts';
 import { getRenderingSupport } from '../core/renderer-capabilities.ts';
 
 const OVERLAY_ID = 'rendering-capability-overlay';
@@ -8,6 +9,7 @@ const FOCUSABLE_SELECTOR =
 
 let restoreFocusTarget: HTMLElement | null = null;
 let overlayCleanup: (() => void) | null = null;
+let renderingSupportResolver: () => RenderingSupport = getRenderingSupport;
 
 function getFocusableElements(container: HTMLElement) {
   return Array.from(
@@ -278,7 +280,7 @@ export function ensureWebGL(options: EnsureOptions = {}) {
     return false;
   }
 
-  const { hasWebGPU, hasWebGL } = getRenderingSupport();
+  const { hasWebGPU, hasWebGL } = renderingSupportResolver();
 
   if (hasWebGPU || hasWebGL) {
     removeExistingOverlay();
@@ -287,4 +289,10 @@ export function ensureWebGL(options: EnsureOptions = {}) {
 
   addCapabilityOverlay(content);
   return false;
+}
+
+export function setRenderingSupportResolverForTests(
+  resolver: (() => RenderingSupport) | null,
+) {
+  renderingSupportResolver = resolver ?? getRenderingSupport;
 }

--- a/tests/webgl-check.test.js
+++ b/tests/webgl-check.test.js
@@ -26,20 +26,25 @@ describe('ensureWebGL overlay', () => {
   });
 
   test('shows capability overlay when neither WebGL nor WebGPU are available', async () => {
-    mock.module('three/examples/jsm/capabilities/WebGL.js', () => ({
-      default: { isWebGLAvailable: () => false },
-    }));
+    const { ensureWebGL, setRenderingSupportResolverForTests } =
+      await freshImport();
+    try {
+      setRenderingSupportResolverForTests(() => ({
+        hasWebGPU: false,
+        hasWebGL: false,
+      }));
 
-    const { ensureWebGL } = await freshImport();
+      const supported = ensureWebGL({ previewLabel: 'Static check' });
 
-    const supported = ensureWebGL({ previewLabel: 'Static check' });
-
-    expect(supported).toBe(false);
-    const overlay = document.getElementById('rendering-capability-overlay');
-    expect(overlay).toBeTruthy();
-    expect(overlay?.textContent).toContain('WebGL');
-    expect(
-      overlay?.querySelector('.rendering-overlay__preview-pane'),
-    ).not.toBeNull();
+      expect(supported).toBe(false);
+      const overlay = document.getElementById('rendering-capability-overlay');
+      expect(overlay).toBeTruthy();
+      expect(overlay?.textContent).toContain('WebGL');
+      expect(
+        overlay?.querySelector('.rendering-overlay__preview-pane'),
+      ).not.toBeNull();
+    } finally {
+      setRenderingSupportResolverForTests(null);
+    }
   });
 });


### PR DESCRIPTION
### Motivation

- Reduce CPU and GC overhead in the Milkdrop VM and renderer by reusing arrays/objects and avoiding unnecessary deep clones.
- Add a lightweight line rendering path for simple line visuals (trails / motion vectors / blend motion vectors) to avoid constructing full wave objects.
- Make the runtime WebGL/WebGPU capability check injectable so it can be reliably unit-tested.

### Description

- Introduced `WaveFrameBuffers` and reused `liveSamples` / `smoothedSamples` and a preallocated `positions` buffer in `MilkdropPresetVM.buildMainWave` to avoid per-frame allocations, and updated logic to write into these buffers in-place.
- Added `frameTransformCache` to `MilkdropPresetVM` and cached `transformMeshPoint` results per-frame, clearing the cache at frame start/end to avoid redundant per-point computations.
- Changed `runProgram` to reuse a single `scopedEnv` object across statements and update it incrementally to reduce repeated object allocations.
- Stopped deep-cloning several large frame-state fields (like `trails`, `background`, and `post`) in `cloneBlendState` to reduce copying overhead when creating blend snapshots.
- Added dedicated line object creation and synchronization functions (`createLineObject`, `syncLineObject`) and a `renderLineVisualGroup` renderer method in `renderer-adapter.ts`, and switched motion vectors, trails, and blend motion vectors rendering to use the new lightweight line path.
- Made rendering capability detection testable by introducing a `renderingSupportResolver` indirection and exporting `setRenderingSupportResolverForTests` in `utils/webgl-check.ts`.
- Updated the WebGL overlay unit test `tests/webgl-check.test.js` to use the new resolver injection API and restore the resolver after the test.

### Testing

- Ran the updated unit test `tests/webgl-check.test.js` under the test harness and it passed.
- Ran the test suite (`jest`) for the changed modules during development; the modified overlay test was exercised and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd91acd2f48332ad1a7ca9f4fc26b0)