### PR TITLE
Lower default pixel ratio and caps; reduce preview rendering; optimize FFT and Milkdrop transform/cache

### DIFF
--- a/assets/js/core/performance-panel.ts
+++ b/assets/js/core/performance-panel.ts
@@ -13,14 +13,14 @@ export type PerformancePanelOptions = {
 };
 
 const DEFAULT_SETTINGS: PerformanceSettings = {
-  maxPixelRatio: 2,
+  maxPixelRatio: 1.75,
   particleBudget: 1,
   shaderQuality: 'balanced',
 };
 
 const STORAGE_KEY = 'stims:performance-settings';
 const MIN_PIXEL_RATIO = 1;
-const MAX_PIXEL_RATIO = 3;
+const MAX_PIXEL_RATIO = 2.5;
 const MIN_PARTICLE_BUDGET = 0.4;
 const MAX_PARTICLE_BUDGET = 1.6;
 

--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -25,7 +25,7 @@ export type RendererViewport = {
 };
 
 const BASE_RENDERER_SETTINGS: Required<RendererInitConfig> = {
-  maxPixelRatio: 2,
+  maxPixelRatio: 1.75,
   renderScale: 1,
   exposure: 1,
   antialias: true,

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -51,7 +51,7 @@ export async function initRenderer(
   config: RendererInitConfig = {
     antialias: true,
     exposure: 1,
-    maxPixelRatio: isMobileUserAgent ? 1.25 : 2,
+    maxPixelRatio: isMobileUserAgent ? 1.15 : 1.75,
     alpha: false,
     renderScale: 1,
   },
@@ -63,7 +63,7 @@ export async function initRenderer(
   const {
     antialias = true,
     exposure = 1,
-    maxPixelRatio = isMobileUserAgent ? 1.25 : 2,
+    maxPixelRatio = isMobileUserAgent ? 1.15 : 1.75,
     alpha = false,
     renderScale = 1,
   } = config;

--- a/assets/js/library-view/three-library-effects.ts
+++ b/assets/js/library-view/three-library-effects.ts
@@ -90,8 +90,8 @@ type AmbientShardState = {
   scale: number;
 };
 
-const BACKGROUND_FRAME_INTERVAL_MS = 1000 / 20;
-const PREVIEW_FRAME_INTERVAL_MS = 1000 / 16;
+const BACKGROUND_FRAME_INTERVAL_MS = 1000 / 16;
+const PREVIEW_FRAME_INTERVAL_MS = 1000 / 12;
 const PREVIEW_SURFACE_TEXTURES = [
   'circuit_board_pattern.png',
   'water_caustics.png',
@@ -409,7 +409,7 @@ export function createLibraryThreeEffects() {
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const previewLimit = prefersReducedMotion ? 0 : isCompactViewport ? 1 : 2;
+  const previewLimit = prefersReducedMotion ? 0 : 1;
 
   const shouldRender = () =>
     typeof document === 'undefined' ? true : !document.hidden;
@@ -625,25 +625,41 @@ export function createLibraryThreeEffects() {
 
     if (now - lastPreviewRenderAt >= PREVIEW_FRAME_INTERVAL_MS) {
       lastPreviewRenderAt = now;
-      previews.forEach((item) => {
-        if (!item.isVisible || !item.isActive) return;
-        item.hoverStrength += (1 - item.hoverStrength) * 0.16;
-        item.group.rotation.x =
-          pointerState.currentY * 0.18 + item.hoverStrength * 0.04;
-        item.group.rotation.y = pointerState.currentX * 0.22;
-        item.mesh.rotation.x += item.style.motionX + pulse * 0.008;
-        item.mesh.rotation.y += item.style.motionY + pulse * 0.01;
-        item.overlay.rotation.z -= item.style.motionY * 0.6;
-        item.overlay.position.x = pointerState.currentX * 0.08;
-        item.overlay.position.y = -pointerState.currentY * 0.06;
-        item.camera.position.x +=
-          (pointerState.currentX * 0.18 - item.camera.position.x) * 0.12;
-        item.camera.position.y +=
-          (-pointerState.currentY * 0.12 - item.camera.position.y) * 0.12;
-        item.camera.lookAt(0, 0, 0);
-        if (item.composer) item.composer.render();
-        else item.renderer.render(item.scene, item.camera);
-      });
+      const visiblePreviews = Array.from(previews.values()).filter(
+        (item) => item.isVisible,
+      );
+      const previewToRender =
+        visiblePreviews.find((item) => item.isActive) ??
+        visiblePreviews[0] ??
+        null;
+      if (previewToRender) {
+        previewToRender.hoverStrength +=
+          (1 - previewToRender.hoverStrength) * 0.16;
+        previewToRender.group.rotation.x =
+          pointerState.currentY * 0.18 + previewToRender.hoverStrength * 0.04;
+        previewToRender.group.rotation.y = pointerState.currentX * 0.22;
+        previewToRender.mesh.rotation.x +=
+          previewToRender.style.motionX + pulse * 0.008;
+        previewToRender.mesh.rotation.y +=
+          previewToRender.style.motionY + pulse * 0.01;
+        previewToRender.overlay.rotation.z -=
+          previewToRender.style.motionY * 0.6;
+        previewToRender.overlay.position.x = pointerState.currentX * 0.08;
+        previewToRender.overlay.position.y = -pointerState.currentY * 0.06;
+        previewToRender.camera.position.x +=
+          (pointerState.currentX * 0.18 - previewToRender.camera.position.x) *
+          0.12;
+        previewToRender.camera.position.y +=
+          (-pointerState.currentY * 0.12 - previewToRender.camera.position.y) *
+          0.12;
+        previewToRender.camera.lookAt(0, 0, 0);
+        if (previewToRender.composer) previewToRender.composer.render();
+        else
+          previewToRender.renderer.render(
+            previewToRender.scene,
+            previewToRender.camera,
+          );
+      }
     }
 
     pulse = Math.max(0, pulse * 0.93 - 0.003);

--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -185,6 +185,7 @@ export class MilkdropOverlay {
   private suppressEditorChange = false;
   private editorDebounceId: number | null = null;
   private lastInspectorSignature = '';
+  private lastInspectorRenderAt = 0;
   private activeTab: 'browse' | 'editor' | 'inspector' = 'browse';
 
   constructor({
@@ -1330,7 +1331,7 @@ export class MilkdropOverlay {
             ),
           ].join(', ')
         : 'None';
-    this.inspectorMetrics.innerHTML = `
+    const metricsMarkup = `
       <div><strong>Backend:</strong> ${backend}</div>
       <div><strong>Transport support:</strong> ${supportLabel(support.status)}</div>
       <div><strong>Fidelity:</strong> ${fidelityLabel(parity.fidelityClass)}</div>
@@ -1350,6 +1351,17 @@ export class MilkdropOverlay {
       <div><strong>Register pressure:</strong> q${compiled.ir.compatibility.featureAnalysis.registerUsage.q} / t${compiled.ir.compatibility.featureAnalysis.registerUsage.t}</div>
       <div><strong>Primary note:</strong> ${primaryReason ? `${compatibilityCategoryLabel(primaryReason.category)}: ${primaryReason.message}` : (support.reasons[0] ?? parity.visualFallbacks[0] ?? 'Validated for the active backend.')}</div>
     `;
+    const now =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (
+      metricsMarkup === this.lastInspectorSignature &&
+      now - this.lastInspectorRenderAt < 240
+    ) {
+      return;
+    }
+    this.lastInspectorSignature = metricsMarkup;
+    this.lastInspectorRenderAt = now;
+    this.inspectorMetrics.innerHTML = metricsMarkup;
   }
 
   setStatus(message: string) {

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -238,7 +238,7 @@ class MilkdropPresetVM implements MilkdropVM {
     smoothedSamples: [],
   };
   private readonly frameTransformCache = new Map<
-    string,
+    number,
     { x: number; y: number }
   >();
 
@@ -481,6 +481,12 @@ class MilkdropPresetVM implements MilkdropVM {
       env[statement.target] = value;
       scopedEnv[statement.target] = value;
     });
+  }
+
+  private getTransformCacheKey(x: number, y: number) {
+    const quantizedX = Math.round((x + 1) * 2048);
+    const quantizedY = Math.round((y + 1) * 2048);
+    return quantizedX * 4096 + quantizedY;
   }
 
   private buildMainWave(signals: MilkdropRuntimeSignals) {
@@ -782,7 +788,7 @@ class MilkdropPresetVM implements MilkdropVM {
     gridX: number,
     gridY: number,
   ) {
-    const cacheKey = `${gridX},${gridY}`;
+    const cacheKey = this.getTransformCacheKey(gridX, gridY);
     const cached = this.frameTransformCache.get(cacheKey);
     if (cached) {
       return cached;

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -303,7 +303,7 @@ export function initSystemControls(
     const pixelRatioSlider = document.createElement('input');
     pixelRatioSlider.type = 'range';
     pixelRatioSlider.min = '0.75';
-    pixelRatioSlider.max = '3';
+    pixelRatioSlider.max = '2.5';
     pixelRatioSlider.step = '0.05';
     pixelRatioSlider.value = String(
       renderPreferences.maxPixelRatio ?? activeQuality.maxPixelRatio,

--- a/assets/js/utils/frequency-analyser-processor.ts
+++ b/assets/js/utils/frequency-analyser-processor.ts
@@ -18,7 +18,22 @@ function reverseBits(value: number, bits: number): number {
   return reversed;
 }
 
-function fft(real: Float32Array, imag: Float32Array): void {
+function buildTwiddleTable(length: number) {
+  const cos = new Float32Array(length / 2);
+  const sin = new Float32Array(length / 2);
+  for (let index = 0; index < length / 2; index += 1) {
+    const phase = (-TWO_PI * index) / length;
+    cos[index] = Math.cos(phase);
+    sin[index] = Math.sin(phase);
+  }
+  return { cos, sin };
+}
+
+function fft(
+  real: Float32Array,
+  imag: Float32Array,
+  twiddles: ReturnType<typeof buildTwiddleTable>,
+): void {
   const n = real.length;
   const bits = Math.log2(n);
 
@@ -32,13 +47,13 @@ function fft(real: Float32Array, imag: Float32Array): void {
 
   for (let size = 2; size <= n; size <<= 1) {
     const halfSize = size >> 1;
-    const phaseStep = -TWO_PI / size;
+    const tableStep = n / size;
 
     for (let start = 0; start < n; start += size) {
       for (let i = 0; i < halfSize; i += 1) {
-        const phase = phaseStep * i;
-        const cos = Math.cos(phase);
-        const sin = Math.sin(phase);
+        const twiddleIndex = i * tableStep;
+        const cos = twiddles.cos[twiddleIndex] ?? 1;
+        const sin = twiddles.sin[twiddleIndex] ?? 0;
 
         const evenReal = real[start + i];
         const evenImag = imag[start + i];
@@ -65,6 +80,8 @@ class FrequencyAnalyserProcessor extends AudioWorkletProcessor {
   private bufferIndex = 0;
   private readonly outputReal: Float32Array;
   private readonly outputImag: Float32Array;
+  private readonly frequencyData: Uint8Array;
+  private readonly twiddles: ReturnType<typeof buildTwiddleTable>;
 
   constructor(options?: AudioWorkletNodeOptions) {
     super();
@@ -75,6 +92,8 @@ class FrequencyAnalyserProcessor extends AudioWorkletProcessor {
     this.buffer = new Float32Array(this.fftSize);
     this.outputReal = new Float32Array(this.fftSize);
     this.outputImag = new Float32Array(this.fftSize);
+    this.frequencyData = new Uint8Array(this.frequencyBinCount);
+    this.twiddles = buildTwiddleTable(this.fftSize);
   }
 
   private analyse() {
@@ -90,22 +109,21 @@ class FrequencyAnalyserProcessor extends AudioWorkletProcessor {
     }
     const rms = Math.sqrt(sumSquares / this.fftSize);
 
-    fft(this.outputReal, this.outputImag);
+    fft(this.outputReal, this.outputImag, this.twiddles);
 
-    const frequencyData = new Uint8Array(this.frequencyBinCount);
     for (let i = 0; i < this.frequencyBinCount; i += 1) {
       const magnitude =
         Math.sqrt(
           this.outputReal[i] * this.outputReal[i] +
             this.outputImag[i] * this.outputImag[i],
         ) / this.frequencyBinCount;
-      frequencyData[i] = Math.min(
+      this.frequencyData[i] = Math.min(
         255,
         Math.max(0, Math.round(magnitude * 255)),
       );
     }
 
-    this.port.postMessage({ frequencyData, rms }, [frequencyData.buffer]);
+    this.port.postMessage({ frequencyData: this.frequencyData.slice(), rms });
   }
 
   process(inputs: Float32Array[][], outputs: Float32Array[][]) {


### PR DESCRIPTION
### Motivation

- Reduce GPU and thermal load by lowering default and maximum pixel ratio values across renderer and UI settings.
- Reduce CPU/GPU work from library previews by rendering fewer previews less frequently and only updating the active/first visible preview.
- Improve audio analysis and Milkdrop performance by eliminating per-frame allocations and expensive string keys, and throttle inspector DOM updates.

### Description

- Lowered default `maxPixelRatio` from `2` to `1.75` in `DEFAULT_SETTINGS` and `BASE_RENDERER_SETTINGS`, adjusted `initRenderer` defaults to `isMobile ? 1.15 : 1.75`, and reduced the UI/storage `MAX_PIXEL_RATIO` and pixel ratio slider max to `2.5`.
- Reduced preview/work frequency by changing `BACKGROUND_FRAME_INTERVAL_MS` and `PREVIEW_FRAME_INTERVAL_MS`, set `previewLimit` to `prefersReducedMotion ? 0 : 1`, and changed preview loop to render a single visible preview (the active one or the first visible).
- Optimized FFT in `frequency-analyser-processor.ts` by adding `buildTwiddleTable` and reusing precomputed twiddles in `fft`, reusing a `frequencyData` buffer to avoid per-frame allocations, and adjusted `postMessage` to send a copy of the data.
- Improved Milkdrop VM and overlay performance by switching `frameTransformCache` keys from strings to numeric keys via `getTransformCacheKey` (quantizing coordinates), and added inspector update throttling/deduping using `lastInspectorSignature` and `lastInspectorRenderAt` to avoid redundant DOM updates.

### Testing

- Built the project with `npm run build` and verified the TypeScript compilation, which completed successfully.
- Ran the automated test suite with `npm test`, and all tests passed.
- Ran lint/type checks (`eslint`/`tsc`) as part of CI, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdaf4f9e9c8332b51e3f0ff918910b)