### PR TITLE
Debounce overlay browse renders, reuse signal objects, and batch catalog sync

### DIFF
--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -184,6 +184,7 @@ export class MilkdropOverlay {
   private browseQualityStorageKey = QUALITY_STORAGE_KEY;
   private suppressEditorChange = false;
   private editorDebounceId: number | null = null;
+  private browseRenderDebounceId: number | null = null;
   private lastInspectorSignature = '';
   private lastInspectorRenderAt = 0;
   private activeTab: 'browse' | 'editor' | 'inspector' = 'browse';
@@ -432,7 +433,9 @@ export class MilkdropOverlay {
     this.searchInput.className = 'milkdrop-overlay__search';
     this.searchInput.placeholder = 'Search presets';
     this.searchInput.setAttribute('aria-label', 'Search presets');
-    this.searchInput.addEventListener('input', () => this.renderBrowseList());
+    this.searchInput.addEventListener('input', () =>
+      this.scheduleBrowseRender(),
+    );
 
     this.browseModeSelect = document.createElement('select');
     this.browseModeSelect.className = 'milkdrop-overlay__rating-select';
@@ -451,7 +454,7 @@ export class MilkdropOverlay {
     });
     this.browseModeSelect.addEventListener('change', () => {
       this.browseMode = this.browseModeSelect.value as BrowseMode;
-      this.renderBrowseList();
+      this.scheduleBrowseRender(0);
     });
 
     this.browseSupportSelect = document.createElement('select');
@@ -473,7 +476,7 @@ export class MilkdropOverlay {
     this.browseSupportSelect.addEventListener('change', () => {
       this.browseSupportFilter = this.browseSupportSelect
         .value as BrowseFidelityFilter;
-      this.renderBrowseList();
+      this.scheduleBrowseRender(0);
     });
 
     this.browseSortSelect = document.createElement('select');
@@ -493,7 +496,7 @@ export class MilkdropOverlay {
     });
     this.browseSortSelect.addEventListener('change', () => {
       this.browseSort = this.browseSortSelect.value as BrowseSort;
-      this.renderBrowseList();
+      this.scheduleBrowseRender(0);
     });
 
     const browseControls = document.createElement('div');
@@ -903,6 +906,16 @@ export class MilkdropOverlay {
       section.appendChild(this.buildPresetRow(preset));
     });
     this.browseList.appendChild(section);
+  }
+
+  private scheduleBrowseRender(delayMs = 120) {
+    if (this.browseRenderDebounceId !== null) {
+      window.clearTimeout(this.browseRenderDebounceId);
+    }
+    this.browseRenderDebounceId = window.setTimeout(() => {
+      this.browseRenderDebounceId = null;
+      this.renderBrowseList();
+    }, delayMs);
   }
 
   private renderBrowseList() {
@@ -1372,6 +1385,9 @@ export class MilkdropOverlay {
     this.editor.destroy();
     if (this.editorDebounceId !== null) {
       window.clearTimeout(this.editorDebounceId);
+    }
+    if (this.browseRenderDebounceId !== null) {
+      window.clearTimeout(this.browseRenderDebounceId);
     }
     this.root.remove();
   }

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -153,13 +153,18 @@ export function getMilkdropDetailScale({
 
 export function buildMilkdropInputSignalOverrides(
   input: UnifiedInputState | null,
+  target: Partial<MilkdropRuntimeSignals> = {},
 ): Partial<MilkdropRuntimeSignals> {
   const gesture = input?.gesture;
   const performance = input?.performance;
   const sourceFlags = performance?.sourceFlags;
   const actions = performance?.actions;
+  const inputSpeed = Math.hypot(
+    input?.dragDelta.x ?? 0,
+    input?.dragDelta.y ?? 0,
+  );
 
-  return {
+  return Object.assign(target, {
     inputX: input?.normalizedCentroid.x ?? 0,
     inputY: input?.normalizedCentroid.y ?? 0,
     input_x: input?.normalizedCentroid.x ?? 0,
@@ -168,8 +173,8 @@ export function buildMilkdropInputSignalOverrides(
     inputDy: input?.dragDelta.y ?? 0,
     input_dx: input?.dragDelta.x ?? 0,
     input_dy: input?.dragDelta.y ?? 0,
-    inputSpeed: Math.hypot(input?.dragDelta.x ?? 0, input?.dragDelta.y ?? 0),
-    input_speed: Math.hypot(input?.dragDelta.x ?? 0, input?.dragDelta.y ?? 0),
+    inputSpeed: inputSpeed,
+    input_speed: inputSpeed,
     inputPressed: input?.isPressed ? 1 : 0,
     input_pressed: input?.isPressed ? 1 : 0,
     inputJustPressed: input?.justPressed ? 1 : 0,
@@ -232,7 +237,7 @@ export function buildMilkdropInputSignalOverrides(
     input_source_touch: sourceFlags?.touch ? 1 : 0,
     inputSourcePen: sourceFlags?.pen ? 1 : 0,
     input_source_pen: sourceFlags?.pen ? 1 : 0,
-  };
+  });
 }
 
 function buildAgentMilkdropDebugSnapshot({
@@ -464,6 +469,13 @@ export function createMilkdropExperience({
   let keyboardHandler: ((event: KeyboardEvent) => void) | null = null;
   let requestedPresetListener: ((event: Event) => void) | null = null;
   let requestedOverlayTabListener: ((event: Event) => void) | null = null;
+  let catalogSyncPromise: Promise<void> | null = null;
+  let catalogSyncFrameId: number | null = null;
+  const mergedSignals: Partial<MilkdropRuntimeSignals> = {};
+  const lowQualityPostOverride = {
+    shaderEnabled: false,
+    videoEchoEnabled: false,
+  };
 
   const updateAgentDebugSnapshot = () => {
     if (!isAgentMode()) {
@@ -509,6 +521,24 @@ export function createMilkdropExperience({
   const syncCatalog = async () => {
     catalogEntries = await catalogStore.listPresets();
     overlay.setCatalog(catalogEntries, activePresetId, activeBackend);
+  };
+
+  const scheduleCatalogSync = () => {
+    if (catalogSyncPromise || catalogSyncFrameId !== null) {
+      return catalogSyncPromise ?? Promise.resolve();
+    }
+
+    catalogSyncPromise = new Promise((resolve) => {
+      catalogSyncFrameId = window.requestAnimationFrame(() => {
+        catalogSyncFrameId = null;
+        void syncCatalog().finally(() => {
+          catalogSyncPromise = null;
+          resolve();
+        });
+      });
+    });
+
+    return catalogSyncPromise;
   };
 
   const getActiveCatalogEntry = () =>
@@ -609,7 +639,7 @@ export function createMilkdropExperience({
     writeUiPrefs({ lastPresetId: id });
     applyCompiledPreset(nextCompiled);
     setOverlayStatus(`Loaded ${nextCompiled.title}.`);
-    await syncCatalog();
+    await scheduleCatalogSync();
   };
 
   const applyFieldValues = async (updates: Record<string, string | number>) => {
@@ -739,7 +769,7 @@ export function createMilkdropExperience({
         fileName: file.name,
       });
       await catalogStore.saveDraft(saved.id, compiled.formattedSource);
-      await syncCatalog();
+      await scheduleCatalogSync();
       await selectPreset(saved.id);
     }
   };
@@ -753,7 +783,7 @@ export function createMilkdropExperience({
       origin: 'user',
       author: compiled.author,
     });
-    await syncCatalog();
+    await scheduleCatalogSync();
     await selectPreset(saved.id);
   };
 
@@ -764,7 +794,7 @@ export function createMilkdropExperience({
     }
     const deletedId = entry.id;
     await catalogStore.deletePreset(deletedId);
-    await syncCatalog();
+    await scheduleCatalogSync();
     const replacement = catalogEntries.find(
       (candidate) => candidate.id !== deletedId,
     );
@@ -1059,12 +1089,12 @@ export function createMilkdropExperience({
       applyCompiledPreset(nextCompiled);
       void catalogStore.saveDraft(nextCompiled.source.id, state.source);
     }
-    void syncCatalog();
+    void scheduleCatalogSync();
   });
 
   installRequestedPresetListener();
   installRequestedOverlayTabListener();
-  void syncCatalog().then(async () => {
+  void scheduleCatalogSync().then(async () => {
     const requestedOverlayTab = consumeRequestedMilkdropOverlayTab();
     if (requestedOverlayTab) {
       overlay.openTab(requestedOverlayTab);
@@ -1124,7 +1154,7 @@ export function createMilkdropExperience({
           });
           return;
         }
-        void syncCatalog();
+        void scheduleCatalogSync();
       });
     },
 
@@ -1151,12 +1181,16 @@ export function createMilkdropExperience({
         analyser: frame.analyser,
         frequencyData: frame.frequencyData,
       });
-      const inputOverrides = buildMilkdropInputSignalOverrides(frame.input);
-      const signals = {
-        ...baseSignals,
-        ...inputOverrides,
-        ...options.signalOverrides,
-      };
+      const inputOverrides = buildMilkdropInputSignalOverrides(
+        frame.input,
+        mergedSignals,
+      );
+      const signals = Object.assign(
+        mergedSignals,
+        baseSignals,
+        inputOverrides,
+        options.signalOverrides,
+      );
 
       if (
         autoplay &&
@@ -1189,11 +1223,14 @@ export function createMilkdropExperience({
           currentFrameState.post.videoEchoEnabled)
           ? {
               ...currentFrameState,
-              post: {
-                ...currentFrameState.post,
-                shaderEnabled: false,
-                videoEchoEnabled: false,
-              },
+              post: Object.assign(
+                lowQualityPostOverride,
+                currentFrameState.post,
+                {
+                  shaderEnabled: false,
+                  videoEchoEnabled: false,
+                },
+              ),
             }
           : currentFrameState;
 
@@ -1236,6 +1273,11 @@ export function createMilkdropExperience({
         );
         requestedOverlayTabListener = null;
       }
+      if (catalogSyncFrameId !== null) {
+        window.cancelAnimationFrame(catalogSyncFrameId);
+        catalogSyncFrameId = null;
+      }
+      catalogSyncPromise = null;
     },
   };
 }

--- a/docs/FRONTEND_PERFORMANCE_BOTTLENECKS.md
+++ b/docs/FRONTEND_PERFORMANCE_BOTTLENECKS.md
@@ -1,0 +1,123 @@
+# Front-end performance bottlenecks
+
+This note captures the highest-impact front-end performance risks found during a static audit of the Stims runtime. It focuses on hot paths that execute every frame, on user input, or on overlay/catalog refreshes.
+
+## Highest-priority bottlenecks
+
+### 1. Per-frame VM and renderer data reconstruction
+
+The MilkDrop runtime rebuilds large visual payloads on every animation tick:
+
+- `MilkdropPresetVM.step()` rebuilds the frame state, including waves, mesh geometry, motion vectors, shapes, borders, shader controls, and a full variable snapshot on each frame.
+- `buildMainWave()` allocates a new `positions` array sized to the current sample count and also copies `smoothedSamples` into `lastWaveSamples` every frame.
+- `buildMesh()` and `buildMotionVectors()` rebuild arrays for line geometry each frame.
+
+Why this matters:
+
+- These allocations happen in the hottest path of the application.
+- The work scales with quality settings (`mesh_density`, detail scale, motion vector counts, wave sample counts).
+- This raises GC pressure and makes frame pacing more fragile on mobile or integrated GPUs.
+
+Recommended follow-up:
+
+- Reuse typed buffers for wave, mesh, and motion-vector positions instead of allocating fresh arrays each frame.
+- Avoid creating the full `variables` snapshot unless the inspector or debugging tools actively need it.
+- Consider splitting “simulation state” from “render payload” so only changed structures are rebuilt.
+
+### 2. Object-spread churn in the per-frame runtime update
+
+`createMilkdropExperience().update()` merges runtime signals with:
+
+- a freshly-built input override object,
+- optional signal overrides,
+- blend-state wrapper objects,
+- low-quality post-processing override objects.
+
+`buildMilkdropInputSignalOverrides()` also computes the same drag magnitude twice for camelCase and snake_case fields.
+
+Why this matters:
+
+- The update path already performs substantial VM and rendering work.
+- Repeated object spreads add avoidable allocations every frame.
+- Duplicate math and object creation add overhead without improving output quality.
+
+Recommended follow-up:
+
+- Reuse a mutable signal object and update fields in place.
+- Compute drag magnitude once and assign it to both aliases.
+- Move low-quality and blend-state toggles toward in-place flag updates or adapter-side branching.
+
+### 3. Full overlay browse-list re-rendering on every filter/search/catalog update
+
+The MilkDrop overlay rebuilds the entire browse DOM tree whenever search text changes, sort/filter selections change, collection filters change, or the preset catalog is refreshed.
+
+Why this matters:
+
+- Search uses the `input` event, so a full re-render runs on every keystroke.
+- `renderBrowseList()` recreates rows, buttons, select controls, and warning blocks instead of diffing or reusing DOM nodes.
+- The cost grows with the preset catalog size and can compete with the active render loop when the overlay is open.
+
+Recommended follow-up:
+
+- Debounce search input.
+- Cache row elements by preset id and patch only changed fields.
+- Separate sorting/filtering from DOM updates so unchanged rows can be retained.
+- Consider virtualizing long browse lists if the catalog keeps growing.
+
+### 4. Catalog refreshes cascade into expensive UI work
+
+`syncCatalog()` repopulates the overlay catalog and triggers both collection-filter rebuilding and browse-list rendering. It is called after favorite/rating changes, imports, deletions, startup, preset selection, and editor-session updates.
+
+Why this matters:
+
+- The same expensive browse rebuild can happen repeatedly during interactive workflows.
+- `session.subscribe()` calls `syncCatalog()` after editor changes, even though most editor edits do not fundamentally change the catalog contents.
+- This creates avoidable main-thread work while the visualizer is already animating.
+
+Recommended follow-up:
+
+- Distinguish “catalog metadata changed” from “editor source changed”.
+- Only refresh the active row when rating/favorite state changes.
+- Throttle or batch catalog refreshes behind `requestAnimationFrame()` or a microtask queue.
+
+### 5. Inspector work still performs string-heavy summaries in active sessions
+
+When the inspector tab is open, `setInspectorState()` assembles a large HTML string containing compatibility, feature, and frame metrics, then writes it with `innerHTML` on a throttled cadence.
+
+Why this matters:
+
+- The method reads many nested runtime fields and performs multiple joins/string interpolations.
+- Even throttled, it competes with rendering on slower devices.
+- It encourages the runtime to continue producing rich per-frame diagnostic state.
+
+Recommended follow-up:
+
+- Render inspector fields once and patch only changing metric text nodes.
+- Reduce the diagnostic payload while animation is running.
+- Consider a lower refresh rate for diagnostics than for visuals.
+
+## Secondary bottlenecks
+
+### Blend-state cloning is expensive during preset transitions
+
+`cloneBlendState()` deep-copies wave positions, custom waves, shapes, borders, and motion vectors when blend transitions begin. This is not a per-frame cost, but it can cause visible spikes during preset switches, especially on dense presets.
+
+### Renderer adapter cleanup patterns create avoidable array churn
+
+The adapter frequently uses `group.children.slice(...)` and similar array-copy patterns while reconciling render groups. These are smaller costs than the VM allocations, but they still add pressure in a frame-critical path.
+
+## Recommended order of attack
+
+1. **Reduce per-frame allocations in `vm.ts` and `runtime.ts`.** This should produce the biggest frame-time improvement.
+2. **Stop full overlay re-renders for browse/search/catalog changes.** This should improve responsiveness while the panel is open.
+3. **Trim catalog refresh frequency.** This removes repeated UI work during editing and metadata tweaks.
+4. **Simplify inspector updates.** This lowers diagnostic overhead without changing visuals.
+5. **Optimize transition cloning and adapter reconciliation.** These are worthwhile once the bigger hotspots are addressed.
+
+## Evidence reviewed
+
+- `assets/js/milkdrop/runtime.ts`
+- `assets/js/milkdrop/vm.ts`
+- `assets/js/milkdrop/overlay.ts`
+- `assets/js/milkdrop/renderer-adapter.ts`
+- `assets/js/core/web-toy.ts`

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Stims now centers on a single browser-native MilkDrop-inspired visualizer. Older
 - [`PAGE_SPECIFICATIONS.md`](./PAGE_SPECIFICATIONS.md)
 - [`DEPLOYMENT.md`](./DEPLOYMENT.md)
 - [`DOCS_MAINTENANCE.md`](./DOCS_MAINTENANCE.md)
+- [`FRONTEND_PERFORMANCE_BOTTLENECKS.md`](./FRONTEND_PERFORMANCE_BOTTLENECKS.md)
 
 ## Historical or transitional docs
 

--- a/tests/milkdrop-input-signals.test.ts
+++ b/tests/milkdrop-input-signals.test.ts
@@ -64,4 +64,60 @@ describe('milkdrop input signal overrides', () => {
     expect(overrides.inputSourceMouse).toBe(1);
     expect(overrides.input_source_touch).toBe(0);
   });
+
+  test('can reuse a target object without recomputing divergent aliases', () => {
+    const input: UnifiedInputState = {
+      time: 100,
+      deltaMs: 16,
+      pointers: [],
+      pointerCount: 0,
+      centroid: { x: 0, y: 0 },
+      normalizedCentroid: { x: 0.25, y: -0.4 },
+      primary: null,
+      isPressed: true,
+      justPressed: false,
+      justReleased: false,
+      dragDelta: { x: 0.3, y: 0.4 },
+      source: 'pointer',
+      gesture: null,
+      mic: { level: 0.4, available: true },
+      performance: {
+        hoverActive: false,
+        hover: null,
+        wheelDelta: 0,
+        wheelAccum: 0,
+        dragIntensity: 0,
+        dragAngle: 0,
+        accentPulse: 0,
+        sourceFlags: {
+          pointer: true,
+          keyboard: false,
+          gamepad: false,
+          mouse: true,
+          touch: false,
+          pen: false,
+        },
+        actions: {
+          accent: 0,
+          modeNext: 0,
+          modePrevious: 0,
+          presetNext: 0,
+          presetPrevious: 0,
+          quickLook1: 0,
+          quickLook2: 0,
+          quickLook3: 0,
+          remix: 0,
+        },
+      },
+    };
+
+    const target = { stale: 1 } as Partial<
+      ReturnType<typeof buildMilkdropInputSignalOverrides>
+    >;
+    const overrides = buildMilkdropInputSignalOverrides(input, target);
+
+    expect(overrides).toBe(target);
+    expect(overrides.inputSpeed).toBeCloseTo(0.5, 6);
+    expect(overrides.input_speed).toBeCloseTo(0.5, 6);
+  });
 });

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { DEFAULT_QUALITY_PRESETS } from '../assets/js/core/settings-panel.ts';
 import { MilkdropOverlay } from '../assets/js/milkdrop/overlay.ts';
+import type { MilkdropCatalogEntry } from '../assets/js/milkdrop/types.ts';
 
 function createOverlay({
   onSelectQualityPreset = mock(),
@@ -92,6 +93,60 @@ function createInspectorPayload() {
   } as unknown as Parameters<MilkdropOverlay['setInspectorState']>[0];
 }
 
+function createCatalogEntry(id: string, title: string): MilkdropCatalogEntry {
+  return {
+    id,
+    title,
+    author: 'Stims',
+    origin: 'bundled',
+    featuresUsed: [],
+    warnings: [],
+    rating: 0,
+    isFavorite: false,
+    tags: [],
+    supports: {
+      webgl: {
+        status: 'supported',
+        reasons: [],
+        requiredFeatures: [],
+        unsupportedFeatures: [],
+      },
+      webgpu: {
+        status: 'supported',
+        reasons: [],
+        requiredFeatures: [],
+        unsupportedFeatures: [],
+      },
+    },
+    fidelityClass: 'exact',
+    visualEvidenceTier: 'none',
+    evidence: {
+      compile: 'verified',
+      runtime: 'not-run',
+      visual: 'not-captured',
+    },
+    certification: 'bundled',
+    corpusTier: 'bundled',
+    parity: {
+      ignoredFields: [],
+      approximatedShaderLines: [],
+      missingAliasesOrFunctions: [],
+      backendDivergence: [],
+      visualFallbacks: [],
+      blockedConstructs: [],
+      blockingConstructDetails: [],
+      degradationReasons: [],
+      fidelityClass: 'exact',
+      evidence: {
+        compile: 'verified',
+        runtime: 'not-run',
+        visual: 'not-captured',
+      },
+      visualEvidenceTier: 'none',
+    },
+  } as MilkdropCatalogEntry;
+}
+
 describe('milkdrop overlay quality controls', () => {
   const OriginalMutationObserver = globalThis.MutationObserver;
 
@@ -173,6 +228,60 @@ describe('milkdrop overlay inspector metrics', () => {
     expect(overlay.shouldRenderInspectorMetrics()).toBe(true);
     overlay.setInspectorState(payload);
     expect(metrics?.textContent).toContain('Backend:');
+
+    overlay.dispose();
+  });
+});
+
+describe('milkdrop overlay browse rendering', () => {
+  const OriginalMutationObserver = globalThis.MutationObserver;
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    globalThis.MutationObserver = OriginalMutationObserver;
+  });
+
+  test('debounces search-driven browse rerenders', async () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    overlay.setCatalog(
+      [
+        createCatalogEntry('signal-bloom', 'Signal Bloom'),
+        createCatalogEntry('aurora-drift', 'Aurora Drift'),
+      ],
+      'signal-bloom',
+      'webgl',
+    );
+
+    const browse = document.querySelector(
+      '.milkdrop-overlay__browse',
+    ) as HTMLElement | null;
+    const search = document.querySelector(
+      '.milkdrop-overlay__search',
+    ) as HTMLInputElement | null;
+
+    expect(browse?.textContent).toContain('Aurora Drift');
+
+    if (!search || !browse) {
+      throw new Error('Expected overlay browse controls to exist.');
+    }
+
+    search.value = 'signal';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(browse.textContent).toContain('Aurora Drift');
+
+    await new Promise((resolve) => window.setTimeout(resolve, 150));
+
+    expect(browse.textContent).toContain('Signal Bloom');
+    expect(browse.textContent).not.toContain('Aurora Drift');
 
     overlay.dispose();
   });


### PR DESCRIPTION
### Motivation

- Reduce main-thread allocations and DOM churn during frequent interactions (search typing, sort/filter changes, catalog updates) to improve runtime responsiveness.
- Avoid repeated per-frame and per-input object allocations by reusing a mutable signals object and eliminating duplicate math for input speed.
- Batch catalog refreshes to a single rAF tick to prevent repeated expensive UI rebuilds during common workflows.

### Description

- Added `scheduleBrowseRender()` and a `browseRenderDebounceId` to `MilkdropOverlay` and replaced immediate `renderBrowseList()` calls from search and select controls with debounced scheduling, and cleared the timeout in `dispose()`.
- Modified `buildMilkdropInputSignalOverrides()` to accept an optional `target` object, compute `inputSpeed` once, assign both aliases (`inputSpeed`/`input_speed`) and return the mutated target via `Object.assign()` to enable reuse of a single signal object.
- Introduced `mergedSignals` in the runtime and switched update merge logic to mutate and reuse `mergedSignals` via `Object.assign()` instead of creating new spreads each frame, and added a `lowQualityPostOverride` to reduce create-on-frame overrides by using `Object.assign()` for post-processing toggles.
- Implemented `scheduleCatalogSync()` which batches `syncCatalog()` calls behind `requestAnimationFrame()` using a promise to coalesce multiple triggers, replaced direct `syncCatalog()` calls with `scheduleCatalogSync()`, and ensure `cancelAnimationFrame()` and promise cleanup in `dispose()`.
- Added a performance notes doc `docs/FRONTEND_PERFORMANCE_BOTTLENECKS.md` and updated `docs/README.md` to link it.
- Added unit tests: a new test to verify reusable `target` behavior for input signals in `tests/milkdrop-input-signals.test.ts` and a browse debounce integration test in `tests/milkdrop-overlay.test.ts`.

### Testing

- Ran unit tests with `bun test`, which exercised `tests/milkdrop-input-signals.test.ts` and `tests/milkdrop-overlay.test.ts`, and all tests passed.
- Confirmed overlay cleanup behavior by exercising `dispose()` paths to clear the browse debounce timer and cancel scheduled catalog sync frames, with no test failures observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde7533d748332abce8c9781c0016b)