### PR TITLE
Optimize Milkdrop UI and renderer: caching, throttling, and allocation reductions

### DIFF
--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -185,6 +185,13 @@ export class MilkdropOverlay {
   private suppressEditorChange = false;
   private editorDebounceId: number | null = null;
   private browseRenderDebounceId: number | null = null;
+  private browseDirty = true;
+  private lastCatalogSignature = '';
+  private lastBrowseRenderSignature = '';
+  private readonly presetRowCache = new Map<
+    string,
+    { signature: string; row: HTMLElement }
+  >();
   private lastInspectorSignature = '';
   private lastInspectorRenderAt = 0;
   private activeTab: 'browse' | 'editor' | 'inspector' = 'browse';
@@ -637,12 +644,22 @@ export class MilkdropOverlay {
     return this.isOpen() && this.activeTab === 'inspector';
   }
 
+  setCurrentPresetTitle(title: string) {
+    if (this.currentPresetLabel.textContent !== title) {
+      this.currentPresetLabel.textContent = title;
+    }
+  }
+
   private setActiveTab(tab: string) {
     this.activeTab = tab === 'editor' || tab === 'inspector' ? tab : 'browse';
     Object.entries(this.tabPanels).forEach(([id, panel]) => {
       panel.hidden = id !== tab;
     });
     setButtonActive(this.tabButtons, tab);
+    if (this.activeTab === 'browse' && this.browseDirty) {
+      this.renderCollectionFilters();
+      this.renderBrowseList();
+    }
   }
 
   private buildBrowseControl(
@@ -888,7 +905,54 @@ export class MilkdropOverlay {
     return row;
   }
 
-  private appendPresetSection(title: string, presets: MilkdropCatalogEntry[]) {
+  private getPresetRowSignature(preset: MilkdropCatalogEntry) {
+    const support = preset.supports[this.activeBackend];
+    const primaryReason = [...preset.parity.degradationReasons].sort(
+      (left, right) => {
+        if (left.blocking !== right.blocking) {
+          return left.blocking ? -1 : 1;
+        }
+        return (
+          compatibilityCategoryPriority(left.category) -
+          compatibilityCategoryPriority(right.category)
+        );
+      },
+    )[0];
+    return [
+      preset.id,
+      preset.title,
+      preset.author ?? '',
+      preset.origin,
+      preset.certification,
+      preset.rating,
+      preset.isFavorite ? 1 : 0,
+      preset.historyIndex ?? -1,
+      preset.tags.join(','),
+      this.activePresetId === preset.id ? 1 : 0,
+      this.activeBackend,
+      support.status,
+      support.reasons[0] ?? '',
+      primaryReason?.category ?? '',
+      primaryReason?.message ?? '',
+    ].join('|');
+  }
+
+  private getPresetRow(preset: MilkdropCatalogEntry) {
+    const signature = this.getPresetRowSignature(preset);
+    const cached = this.presetRowCache.get(preset.id);
+    if (cached && cached.signature === signature) {
+      return cached.row;
+    }
+    const row = this.buildPresetRow(preset);
+    this.presetRowCache.set(preset.id, { signature, row });
+    return row;
+  }
+
+  private appendPresetSection(
+    title: string,
+    presets: MilkdropCatalogEntry[],
+    target: DocumentFragment | HTMLElement = this.browseList,
+  ) {
     if (presets.length === 0) {
       return;
     }
@@ -903,12 +967,16 @@ export class MilkdropOverlay {
     heading.appendChild(count);
     section.appendChild(heading);
     presets.forEach((preset) => {
-      section.appendChild(this.buildPresetRow(preset));
+      section.appendChild(this.getPresetRow(preset));
     });
-    this.browseList.appendChild(section);
+    target.appendChild(section);
   }
 
   private scheduleBrowseRender(delayMs = 120) {
+    this.browseDirty = true;
+    if (this.activeTab !== 'browse') {
+      return;
+    }
     if (this.browseRenderDebounceId !== null) {
       window.clearTimeout(this.browseRenderDebounceId);
     }
@@ -920,17 +988,35 @@ export class MilkdropOverlay {
 
   private renderBrowseList() {
     const query = this.searchInput.value.trim().toLowerCase();
+    const renderSignature = [
+      this.lastCatalogSignature,
+      this.activePresetId ?? '',
+      this.activeBackend,
+      this.activeCollectionTag,
+      this.browseMode,
+      this.browseSupportFilter,
+      this.browseSort,
+      query,
+    ].join('|');
+    if (
+      renderSignature === this.lastBrowseRenderSignature &&
+      !this.browseDirty
+    ) {
+      return;
+    }
+    this.lastBrowseRenderSignature = renderSignature;
+    this.browseDirty = false;
     const filtered = this.sortBrowsePresets(
       this.presets.filter((preset) => this.matchesBrowseFilters(preset, query)),
     );
 
-    this.browseList.replaceChildren();
+    const fragment = document.createDocumentFragment();
     this.renderBrowseSummary(filtered.length);
     if (filtered.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'milkdrop-overlay__browse-empty';
       empty.textContent = 'No presets match the current filters.';
-      this.browseList.appendChild(empty);
+      this.browseList.replaceChildren(empty);
       return;
     }
 
@@ -943,8 +1029,9 @@ export class MilkdropOverlay {
 
     if (!useSections) {
       filtered.forEach((preset) => {
-        this.browseList.appendChild(this.buildPresetRow(preset));
+        fragment.appendChild(this.getPresetRow(preset));
       });
+      this.browseList.replaceChildren(fragment);
       return;
     }
 
@@ -974,12 +1061,17 @@ export class MilkdropOverlay {
         return true;
       });
 
-    this.appendPresetSection('Jump back in', dedupe(recent));
-    this.appendPresetSection('Favorites', dedupe(favorites));
-    this.appendPresetSection('Classic MilkDrop', dedupe(classic));
-    this.appendPresetSection('Feedback Lab', dedupe(feedback));
-    this.appendPresetSection('Low Motion', dedupe(lowMotion));
-    this.appendPresetSection('More presets', dedupe(filtered).slice(0, 12));
+    this.appendPresetSection('Jump back in', dedupe(recent), fragment);
+    this.appendPresetSection('Favorites', dedupe(favorites), fragment);
+    this.appendPresetSection('Classic MilkDrop', dedupe(classic), fragment);
+    this.appendPresetSection('Feedback Lab', dedupe(feedback), fragment);
+    this.appendPresetSection('Low Motion', dedupe(lowMotion), fragment);
+    this.appendPresetSection(
+      'More presets',
+      dedupe(filtered).slice(0, 12),
+      fragment,
+    );
+    this.browseList.replaceChildren(fragment);
   }
 
   private renderCollectionFilters() {
@@ -995,7 +1087,7 @@ export class MilkdropOverlay {
       );
     });
 
-    this.collectionFilters.replaceChildren();
+    const fragment = document.createDocumentFragment();
     const options = [
       { tag: '', label: 'All presets' },
       ...collectionTags.map((tag) => ({
@@ -1014,11 +1106,13 @@ export class MilkdropOverlay {
       button.dataset.active = String(option.tag === this.activeCollectionTag);
       button.addEventListener('click', () => {
         this.activeCollectionTag = option.tag;
+        this.browseDirty = true;
         this.renderCollectionFilters();
         this.renderBrowseList();
       });
-      this.collectionFilters.appendChild(button);
+      fragment.appendChild(button);
     });
+    this.collectionFilters.replaceChildren(fragment);
   }
 
   private buildInspectorField(
@@ -1215,11 +1309,38 @@ export class MilkdropOverlay {
     activePresetId: string | null,
     backend: 'webgl' | 'webgpu',
   ) {
+    const catalogSignature = presets
+      .map((preset) =>
+        [
+          preset.id,
+          preset.rating,
+          preset.isFavorite ? 1 : 0,
+          preset.historyIndex ?? -1,
+          preset.tags.join(','),
+          preset.supports[backend].status,
+        ].join(':'),
+      )
+      .join('|');
+    const activeChanged =
+      this.activePresetId !== activePresetId || this.activeBackend !== backend;
     this.presets = presets;
     this.activePresetId = activePresetId;
     this.activeBackend = backend;
-    this.renderCollectionFilters();
-    this.renderBrowseList();
+    this.browseDirty =
+      this.browseDirty ||
+      activeChanged ||
+      this.lastCatalogSignature !== catalogSignature;
+    this.lastCatalogSignature = catalogSignature;
+    const validIds = new Set(presets.map((preset) => preset.id));
+    Array.from(this.presetRowCache.keys()).forEach((id) => {
+      if (!validIds.has(id)) {
+        this.presetRowCache.delete(id);
+      }
+    });
+    if (this.activeTab === 'browse') {
+      this.renderCollectionFilters();
+      this.renderBrowseList();
+    }
     const activePreset = this.presets.find(
       (entry) => entry.id === activePresetId,
     );
@@ -1317,7 +1438,7 @@ export class MilkdropOverlay {
   }) {
     this.activeBackend = backend;
     if (compiled) {
-      this.currentPresetLabel.textContent = compiled.title;
+      this.setCurrentPresetTitle(compiled.title);
     }
 
     if (!frameState || !compiled) {

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -900,10 +900,11 @@ function ensureGeometryPositions(
 }
 
 function clearGroup(group: Group) {
-  group.children.slice().forEach((child) => {
+  for (let index = group.children.length - 1; index >= 0; index -= 1) {
+    const child = group.children[index];
     disposeObject(child);
     group.remove(child);
-  });
+  }
 }
 
 function disposeObject(object: { children?: unknown[] }) {
@@ -924,6 +925,14 @@ function disposeObject(object: { children?: unknown[] }) {
   }
   if ('material' in object) {
     disposeMaterial((object as Line | Mesh | Points).material);
+  }
+}
+
+function trimGroupChildren(group: Group, keepCount: number) {
+  for (let index = group.children.length - 1; index >= keepCount; index -= 1) {
+    const child = group.children[index];
+    disposeObject(child as { children?: unknown[] });
+    group.remove(child);
   }
 }
 
@@ -1751,7 +1760,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     waves: MilkdropWaveVisual[],
     alphaMultiplier = 1,
   ) {
-    waves.forEach((wave, index) => {
+    for (let index = 0; index < waves.length; index += 1) {
+      const wave = waves[index] as MilkdropWaveVisual;
       const existing = group.children[index] as
         | Line
         | LineLoop
@@ -1772,18 +1782,16 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(waves.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, waves.length);
   }
 
   private renderProceduralWaveGroup(
     group: Group,
     waves: MilkdropProceduralWaveVisual[],
   ) {
-    waves.forEach((wave, index) => {
+    for (let index = 0; index < waves.length; index += 1) {
+      const wave = waves[index] as MilkdropProceduralWaveVisual;
       const existing = group.children[index] as Line | undefined;
       const synced = syncProceduralWaveObject(existing, wave);
       if (!existing) {
@@ -1792,18 +1800,16 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(waves.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, waves.length);
   }
 
   private renderProceduralCustomWaveGroup(
     group: Group,
     waves: MilkdropProceduralCustomWaveVisual[],
   ) {
-    waves.forEach((wave, index) => {
+    for (let index = 0; index < waves.length; index += 1) {
+      const wave = waves[index] as MilkdropProceduralCustomWaveVisual;
       const existing = group.children[index] as Line | undefined;
       const synced = syncProceduralCustomWaveObject(existing, wave);
       if (!existing) {
@@ -1812,11 +1818,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(waves.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, waves.length);
   }
 
   private renderShapeGroup(
@@ -1824,7 +1827,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     shapes: MilkdropShapeVisual[],
     alphaMultiplier = 1,
   ) {
-    shapes.forEach((shape, index) => {
+    for (let index = 0; index < shapes.length; index += 1) {
+      const shape = shapes[index] as MilkdropShapeVisual;
       const existing = group.children[index] as Group | undefined;
       const synced = syncShapeObject(
         existing,
@@ -1838,11 +1842,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(shapes.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, shapes.length);
   }
 
   private renderBorderGroup(
@@ -1850,7 +1851,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     borders: MilkdropBorderVisual[],
     alphaMultiplier = 1,
   ) {
-    borders.forEach((border, index) => {
+    for (let index = 0; index < borders.length; index += 1) {
+      const border = borders[index] as MilkdropBorderVisual;
       const existing = group.children[index] as Group | undefined;
       const synced = syncBorderObject(
         existing,
@@ -1864,11 +1866,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(borders.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, borders.length);
   }
 
   private renderLineVisualGroup(
@@ -1881,7 +1880,13 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     }>,
     alphaMultiplier = 1,
   ) {
-    lines.forEach((line, index) => {
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] as {
+        positions: number[];
+        color: MilkdropColor;
+        alpha: number;
+        additive?: boolean;
+      };
       const existing = group.children[index] as Line | undefined;
       const synced = syncLineObject(
         existing,
@@ -1899,11 +1904,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         group.remove(existing);
         group.add(synced);
       }
-    });
-    group.children.slice(lines.length).forEach((child) => {
-      disposeObject(child as { children?: unknown[] });
-      group.remove(child);
-    });
+    }
+    trimGroupChildren(group, lines.length);
   }
 
   private renderMesh(

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -348,6 +348,28 @@ function cloneBlendState(
   };
 }
 
+function estimateFrameBlendWorkload(frameState: MilkdropFrameState | null) {
+  if (!frameState) {
+    return 0;
+  }
+
+  const customWavePoints = frameState.customWaves.reduce(
+    (total, wave) => total + Math.floor(wave.positions.length / 3),
+    0,
+  );
+  const motionVectorSegments = frameState.motionVectors.length;
+
+  return (
+    Math.floor(frameState.mainWave.positions.length / 3) +
+    customWavePoints +
+    Math.floor(frameState.mesh.positions.length / 6) * 0.5 +
+    motionVectorSegments * 2 +
+    frameState.shapes.length * 10 +
+    frameState.borders.length * 12 +
+    frameState.trails.length * 8
+  );
+}
+
 function isEditablePreset(entry: MilkdropCatalogEntry | undefined | null) {
   return entry?.origin === 'imported' || entry?.origin === 'user';
 }
@@ -471,6 +493,7 @@ export function createMilkdropExperience({
   let requestedOverlayTabListener: ((event: Event) => void) | null = null;
   let catalogSyncPromise: Promise<void> | null = null;
   let catalogSyncFrameId: number | null = null;
+  let lastInspectorOverlaySyncAt = 0;
   const mergedSignals: Partial<MilkdropRuntimeSignals> = {};
   const lowQualityPostOverride = {
     shaderEnabled: false,
@@ -574,6 +597,7 @@ export function createMilkdropExperience({
     vm.setPreset(compiled);
     vm.setRenderBackend(activeBackend);
     adapter?.setPreset(compiled);
+    overlay.setCurrentPresetTitle(compiled.title);
     overlay.setSessionState(session.getState());
     overlay.setInspectorState({
       compiled: activeCompiled,
@@ -623,7 +647,11 @@ export function createMilkdropExperience({
       return;
     }
 
-    if (transitionMode === 'blend' && blendDuration > 0) {
+    if (
+      transitionMode === 'blend' &&
+      blendDuration > 0 &&
+      estimateFrameBlendWorkload(currentFrameState) < 900
+    ) {
       blendState = cloneBlendState(currentFrameState);
       blendEndAtMs = performance.now() + blendDuration * 1000;
     } else {
@@ -1168,6 +1196,8 @@ export function createMilkdropExperience({
         return;
       }
 
+      const now = performance.now();
+
       const detailScale = getMilkdropDetailScale({
         backend: activeBackend,
         particleScale: quality.activeQuality.particleScale,
@@ -1195,24 +1225,26 @@ export function createMilkdropExperience({
       if (
         autoplay &&
         catalogEntries.length > 1 &&
-        performance.now() - lastPresetSwitchAt >
-          Math.max(12000, blendDuration * 1000 + 6000)
+        now - lastPresetSwitchAt > Math.max(12000, blendDuration * 1000 + 6000)
       ) {
         void selectRandomPreset();
       }
 
       currentFrameState = vm.step(signals);
       updateAgentDebugSnapshot();
+      const canBlendCurrentFrame =
+        estimateFrameBlendWorkload(currentFrameState) < 900;
       const activeBlendState =
         transitionMode === 'blend' &&
         frame.performance.shaderQuality !== 'low' &&
+        canBlendCurrentFrame &&
         blendState &&
-        performance.now() < blendEndAtMs
+        now < blendEndAtMs
           ? {
               ...blendState,
               alpha:
                 1 -
-                (performance.now() - (blendEndAtMs - blendDuration * 1000)) /
+                (now - (blendEndAtMs - blendDuration * 1000)) /
                   (blendDuration * 1000),
             }
           : null;
@@ -1241,11 +1273,17 @@ export function createMilkdropExperience({
       if (!adapterPresentedFrame) {
         runtime.toy.render();
       }
-      overlay.setInspectorState({
-        compiled: activeCompiled,
-        frameState: currentFrameState,
-        backend: activeBackend,
-      });
+      if (
+        overlay.shouldRenderInspectorMetrics() &&
+        now - lastInspectorOverlaySyncAt >= 180
+      ) {
+        lastInspectorOverlaySyncAt = now;
+        overlay.setInspectorState({
+          compiled: activeCompiled,
+          frameState: currentFrameState,
+          backend: activeBackend,
+        });
+      }
     },
 
     dispose() {

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -326,6 +326,13 @@ class MilkdropPresetVM implements MilkdropVM {
     };
   }
 
+  private syncLastWaveSamples(samples: number[], count: number) {
+    this.lastWaveSamples.length = count;
+    for (let index = 0; index < count; index += 1) {
+      this.lastWaveSamples[index] = samples[index] ?? 0;
+    }
+  }
+
   private nextRandom = () => {
     this.randomState = (1664525 * this.randomState + 1013904223) >>> 0;
     return this.randomState / 0xffffffff;
@@ -534,7 +541,7 @@ class MilkdropPresetVM implements MilkdropVM {
         historyBlend,
       );
     }
-    this.lastWaveSamples = smoothedSamples.slice(0, samples);
+    this.syncLastWaveSamples(smoothedSamples, samples);
 
     for (let index = 0; index < samples; index += 1) {
       const t = index / Math.max(1, samples - 1);
@@ -722,7 +729,8 @@ class MilkdropPresetVM implements MilkdropVM {
         frameLocals.a ?? 0.4,
       );
       const waveAlpha = clamp(frameLocals.a ?? 0.4, 0.02, 1);
-      const positions: number[] = [];
+      const positions = new Array<number>(sampleCount * 3);
+      const pointLocals: MutableState = { ...frameLocals };
 
       for (let point = 0; point < sampleCount; point += 1) {
         const sample = point / Math.max(1, sampleCount - 1);
@@ -737,8 +745,7 @@ class MilkdropPresetVM implements MilkdropVM {
             0.55 *
             scaling *
             (1 + (frameLocals.mystery ?? 0) * 0.25);
-        const pointLocals: MutableState = {
-          ...frameLocals,
+        Object.assign(pointLocals, frameLocals, {
           sample,
           value: spectrumValue,
           x: centerX + (-1 + sample * 2) * 0.85,
@@ -752,7 +759,7 @@ class MilkdropPresetVM implements MilkdropVM {
                 ) *
                   0.18 *
                   scaling,
-        };
+        });
         pointLocals.rad = Math.sqrt(
           pointLocals.x * pointLocals.x + pointLocals.y * pointLocals.y,
         );
@@ -762,7 +769,10 @@ class MilkdropPresetVM implements MilkdropVM {
           this.createEnv(signals, pointLocals),
           pointLocals,
         );
-        positions.push(pointLocals.x, pointLocals.y, 0.28);
+        const writeIndex = point * 3;
+        positions[writeIndex] = pointLocals.x;
+        positions[writeIndex + 1] = pointLocals.y;
+        positions[writeIndex + 2] = 0.28;
       }
 
       waves.push({
@@ -849,19 +859,19 @@ class MilkdropPresetVM implements MilkdropVM {
       8,
       28,
     );
-    const points: MeshFieldPoint[] = [];
+    const points = new Array<MeshFieldPoint>(density * density);
 
     for (let row = 0; row < density; row += 1) {
       for (let col = 0; col < density; col += 1) {
         const x = (col / Math.max(1, density - 1)) * 2 - 1;
         const y = (row / Math.max(1, density - 1)) * 2 - 1;
         const point = this.transformMeshPoint(signals, x, y);
-        points.push({
+        points[row * density + col] = {
           sourceX: x,
           sourceY: y,
           x: point.x,
           y: point.y,
-        });
+        };
       }
     }
 
@@ -869,7 +879,10 @@ class MilkdropPresetVM implements MilkdropVM {
   }
 
   private buildMesh(meshField: MeshField): MilkdropMeshVisual {
-    const positions: number[] = [];
+    const positions = new Array<number>(
+      meshField.density * Math.max(0, meshField.density - 1) * 12,
+    );
+    let writeIndex = 0;
 
     for (let row = 0; row < meshField.density; row += 1) {
       for (let col = 0; col < meshField.density; col += 1) {
@@ -882,21 +895,33 @@ class MilkdropPresetVM implements MilkdropVM {
         if (col + 1 < meshField.density) {
           const next = meshField.points[index + 1];
           if (next) {
-            positions.push(point.x, point.y, -0.25, next.x, next.y, -0.25);
+            positions[writeIndex] = point.x;
+            positions[writeIndex + 1] = point.y;
+            positions[writeIndex + 2] = -0.25;
+            positions[writeIndex + 3] = next.x;
+            positions[writeIndex + 4] = next.y;
+            positions[writeIndex + 5] = -0.25;
+            writeIndex += 6;
           }
         }
 
         if (row + 1 < meshField.density) {
           const next = meshField.points[index + meshField.density];
           if (next) {
-            positions.push(point.x, point.y, -0.25, next.x, next.y, -0.25);
+            positions[writeIndex] = point.x;
+            positions[writeIndex + 1] = point.y;
+            positions[writeIndex + 2] = -0.25;
+            positions[writeIndex + 3] = next.x;
+            positions[writeIndex + 4] = next.y;
+            positions[writeIndex + 5] = -0.25;
+            writeIndex += 6;
           }
         }
       }
     }
 
     return {
-      positions,
+      positions: positions.slice(0, writeIndex),
       color: color(
         this.state.mesh_r ?? 0.4,
         this.state.mesh_g ?? 0.6,
@@ -1017,12 +1042,15 @@ class MilkdropPresetVM implements MilkdropVM {
       );
     });
 
+    const customShapeIndices = new Set(
+      this.preset.ir.customShapes.map((shape) => shape.index),
+    );
     const built = builtFromCustom.filter(
       (shape): shape is MilkdropShapeVisual => shape !== null,
     );
 
     for (let index = 1; index <= MAX_CUSTOM_SHAPE_SLOTS; index += 1) {
-      if (this.preset.ir.customShapes.some((shape) => shape.index === index)) {
+      if (customShapeIndices.has(index)) {
         continue;
       }
       const prefix = `shape_${index}`;


### PR DESCRIPTION
### Motivation
- Reduce unnecessary DOM and renderer work during preset browsing and inspector updates to improve UI responsiveness.
- Avoid frequent allocations and array churn in the VM and renderer to reduce GC pressure and improve frame performance.
- Prevent expensive blends on heavy frames and throttle overlay inspector updates to stabilize runtime performance.

### Description
- Add browse list caching and change detection in `assets/js/milkdrop/overlay.ts` via `presetRowCache`, row signatures, `browseDirty` and `lastCatalogSignature` to skip redundant renders and use `DocumentFragment` for batched DOM updates; also trim cache entries for removed presets and introduce `setCurrentPresetTitle`.
- Throttle inspector overlay updates using `lastInspectorOverlaySyncAt` and `overlay.shouldRenderInspectorMetrics()` in `assets/js/milkdrop/runtime.ts`, and update the overlay title when applying a compiled preset via `applyCompiledPreset`.
- Introduce `estimateFrameBlendWorkload` and gate blending on estimated workload in `assets/js/milkdrop/runtime.ts` to avoid expensive blends for complex frames.
- In `assets/js/milkdrop/renderer-adapter.ts` replace `forEach`/slice-based child removal with index-based loops and add `trimGroupChildren` to efficiently dispose and remove excess group children while reducing intermediate allocations.
- Reduce allocations and improve reuse in the VM (`assets/js/milkdrop/vm.ts`) by preallocating numeric arrays for wave and mesh positions, tracking and syncing `lastWaveSamples`, and writing into arrays with index arithmetic instead of repeated `push` and temporary arrays.

### Testing
- Ran `tsc` typecheck and the codebase builds successfully with no type errors; status: passed.
- Executed the project's unit test suite via `npm test` and CI test job which exercise runtime and overlay logic; status: passed.
- Performed a local smoke integration run of the Milkdrop experience to verify UI browsing, preset switching, rendering, and inspector updates; status: passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be022472448332a1d575fd532da1ae)