### PR TITLE
Refactor backend-specific MilkDrop compatibility reporting

### DIFF
--- a/assets/js/milkdrop/catalog-store.ts
+++ b/assets/js/milkdrop/catalog-store.ts
@@ -398,6 +398,7 @@ export function createMilkdropCatalogStore({
                   status:
                     entry.supports?.webgl === false ? 'unsupported' : 'partial',
                   reasons: ['Bundled preset could not be analyzed.'],
+                  evidence: [],
                   requiredFeatures: [],
                   unsupportedFeatures: [],
                 },
@@ -407,6 +408,7 @@ export function createMilkdropCatalogStore({
                       ? 'unsupported'
                       : 'partial',
                   reasons: ['Bundled preset could not be analyzed.'],
+                  evidence: [],
                   requiredFeatures: [],
                   unsupportedFeatures: [],
                   recommendedFallback: 'webgl',

--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -13,6 +13,7 @@ import {
 } from './shader-ast';
 import type {
   MilkdropBackendSupport,
+  MilkdropBackendSupportEvidence,
   MilkdropBlockingConstruct,
   MilkdropCompatibilityEvidence,
   MilkdropCompiledPreset,
@@ -30,6 +31,7 @@ import type {
   MilkdropPresetIR,
   MilkdropPresetSource,
   MilkdropProgramBlock,
+  MilkdropRenderBackend,
   MilkdropShaderControlExpressions,
   MilkdropShaderControls,
   MilkdropShaderExpressionNode,
@@ -326,6 +328,37 @@ const shapecodeFieldPattern = /^shapecode_(\d+)_(.+)$/u;
 const shaderFieldPattern =
   /^(?:warp_[0-9]+|comp_[0-9]+|warp_shader|comp_shader|shader_text|warp_code|comp_code)$/u;
 const hardUnsupportedKeys = new Set<string>([]);
+const BACKEND_PARTIAL_FEATURE_GAPS: Record<
+  MilkdropRenderBackend,
+  Partial<Record<MilkdropFeatureKey, string>>
+> = {
+  webgl: {},
+  webgpu: {
+    'video-echo':
+      'WebGPU still routes video echo through the legacy feedback path and may diverge from WebGL output.',
+    'post-effects':
+      'WebGPU post-processing parity is still incomplete for MilkDrop post effects.',
+  },
+};
+const BACKEND_SHADER_TEXT_GAPS: Record<
+  MilkdropRenderBackend,
+  {
+    supportedSubset?: string;
+    unsupportedSubset?: string;
+  }
+> = {
+  webgl: {
+    unsupportedSubset:
+      'This preset includes custom shader text outside the fully supported subset and will be approximated.',
+  },
+  webgpu: {
+    supportedSubset:
+      'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+    unsupportedSubset:
+      'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
+  },
+};
+
 function normalizeBlockedConstructValue(value: string) {
   return value.trim().replace(/\s+/gu, ' ');
 }
@@ -336,6 +369,12 @@ function toBlockedFieldConstruct(key: string) {
 
 function toBlockedShaderConstruct(line: string) {
   return `shader:${normalizeBlockedConstructValue(line)}`;
+}
+
+function createBackendEvidence(
+  evidence: MilkdropBackendSupportEvidence,
+): MilkdropBackendSupportEvidence {
+  return evidence;
 }
 
 function buildBackendDivergence({
@@ -349,12 +388,34 @@ function buildBackendDivergence({
   if (webgl.status !== webgpu.status) {
     divergence.add(`status:webgl=${webgl.status},webgpu=${webgpu.status}`);
   }
-  webgl.reasons
-    .filter((reason) => !webgpu.reasons.includes(reason))
-    .forEach((reason) => divergence.add(`webgl:${reason}`));
-  webgpu.reasons
-    .filter((reason) => !webgl.reasons.includes(reason))
-    .forEach((reason) => divergence.add(`webgpu:${reason}`));
+  const webglEvidenceKeys = new Set(
+    webgl.evidence.map((entry) => `${entry.code}:${entry.feature ?? 'none'}`),
+  );
+  const webgpuEvidenceKeys = new Set(
+    webgpu.evidence.map((entry) => `${entry.code}:${entry.feature ?? 'none'}`),
+  );
+  webgl.evidence
+    .filter(
+      (entry) =>
+        entry.scope === 'backend' &&
+        !webgpuEvidenceKeys.has(`${entry.code}:${entry.feature ?? 'none'}`),
+    )
+    .forEach((entry) =>
+      divergence.add(
+        `webgl:${entry.code}${entry.feature ? `:${entry.feature}` : ''}`,
+      ),
+    );
+  webgpu.evidence
+    .filter(
+      (entry) =>
+        entry.scope === 'backend' &&
+        !webglEvidenceKeys.has(`${entry.code}:${entry.feature ?? 'none'}`),
+    )
+    .forEach((entry) =>
+      divergence.add(
+        `webgpu:${entry.code}${entry.feature ? `:${entry.feature}` : ''}`,
+      ),
+    );
   return [...divergence];
 }
 
@@ -371,6 +432,24 @@ function buildVisualFallbacks({
   if (approximatedShaderLines.length > 0) {
     fallbacks.add('shader-text-control-extraction');
   }
+  webgl.evidence
+    .filter(
+      (entry) => entry.status === 'unsupported' && entry.scope === 'backend',
+    )
+    .forEach((entry) =>
+      fallbacks.add(
+        `webgl:${entry.code}${entry.feature ? `:${entry.feature}` : ''}`,
+      ),
+    );
+  webgpu.evidence
+    .filter(
+      (entry) => entry.status === 'unsupported' && entry.scope === 'backend',
+    )
+    .forEach((entry) =>
+      fallbacks.add(
+        `webgpu:${entry.code}${entry.feature ? `:${entry.feature}` : ''}`,
+      ),
+    );
   if (webgl.recommendedFallback) {
     fallbacks.add(`webgl->${webgl.recommendedFallback}`);
   }
@@ -444,18 +523,20 @@ function buildDegradationReasons({
     backend: 'webgl' | 'webgpu',
     support: MilkdropBackendSupport,
   ) => {
-    if (support.status === 'supported') {
+    if (support.evidence.length === 0) {
       return;
     }
-    reasons.push({
-      code:
-        support.status === 'unsupported'
-          ? 'backend-unsupported'
-          : 'backend-partial',
-      category: 'backend-degradation',
-      message: `${backend.toUpperCase()} is ${support.status} for this preset.`,
-      system: 'backend',
-      blocking: support.status === 'unsupported',
+    support.evidence.forEach((entry) => {
+      reasons.push({
+        code:
+          entry.status === 'unsupported'
+            ? 'backend-unsupported'
+            : 'backend-partial',
+        category: 'backend-degradation',
+        message: `${backend.toUpperCase()}: ${entry.message}`,
+        system: 'backend',
+        blocking: entry.status === 'unsupported',
+      });
     });
   };
 
@@ -506,12 +587,18 @@ function classifyFidelity({
   );
   const hasUnsupportedBackend =
     webgl.status === 'unsupported' || webgpu.status === 'unsupported';
+  const hasBackendPartial = [...webgl.evidence, ...webgpu.evidence].some(
+    (entry) => entry.status === 'partial',
+  );
 
   if (hasUnsupportedBackend || hasBlockingReason) {
     return 'fallback';
   }
   if (hasBlockingConstruct) {
     return 'partial';
+  }
+  if (hasBackendPartial) {
+    return 'near-exact';
   }
   if (!noBlockedConstructs || degradationReasons.length > 0) {
     return 'near-exact';
@@ -4308,40 +4395,126 @@ function buildFeatureAnalysis({
 function buildBackendSupport({
   backend,
   featureAnalysis,
-  warnings,
+  sharedWarnings,
   unsupportedKeys,
 }: {
-  backend: 'webgl' | 'webgpu';
+  backend: MilkdropRenderBackend;
   featureAnalysis: MilkdropFeatureAnalysis;
-  warnings: string[];
+  sharedWarnings: string[];
   unsupportedKeys: string[];
 }): MilkdropBackendSupport {
   const requiredFeatures = featureAnalysis.featuresUsed.filter(
     (feature) => feature !== 'unsupported-shader-text',
   );
-  const reasons = [...warnings];
+  const evidence: MilkdropBackendSupportEvidence[] = [];
   const unsupportedFeatures: MilkdropFeatureKey[] = [];
 
-  if (featureAnalysis.unsupportedShaderText) {
-    reasons.push(
-      'This preset includes custom shader text outside the fully supported subset and will be approximated.',
+  if (unsupportedKeys.some((key) => hardUnsupportedKeys.has(key))) {
+    evidence.push(
+      createBackendEvidence({
+        backend,
+        scope: 'shared',
+        status: 'unsupported',
+        code: 'unsupported-hard-feature',
+        message:
+          'This preset depends on unsupported MilkDrop features that are outside the current runtime scope.',
+      }),
     );
+  }
+
+  unsupportedKeys.forEach((key) => {
+    evidence.push(
+      createBackendEvidence({
+        backend,
+        scope: 'shared',
+        status: 'partial',
+        code: 'unknown-field',
+        message: `Unknown preset field "${key}" was ignored.`,
+      }),
+    );
+  });
+
+  if (featureAnalysis.supportedShaderText) {
+    const shaderTextMessage = BACKEND_SHADER_TEXT_GAPS[backend].supportedSubset;
+    if (shaderTextMessage) {
+      evidence.push(
+        createBackendEvidence({
+          backend,
+          scope: 'backend',
+          status: 'partial',
+          code: 'supported-shader-text-gap',
+          message: shaderTextMessage,
+        }),
+      );
+    }
+  }
+
+  if (featureAnalysis.unsupportedShaderText) {
+    const unsupportedMessage =
+      BACKEND_SHADER_TEXT_GAPS[backend].unsupportedSubset;
+    if (unsupportedMessage) {
+      evidence.push(
+        createBackendEvidence({
+          backend,
+          scope: 'backend',
+          status: backend === 'webgpu' ? 'unsupported' : 'partial',
+          code: 'unsupported-shader-text-gap',
+          message: unsupportedMessage,
+          feature: 'unsupported-shader-text',
+        }),
+      );
+    }
     unsupportedFeatures.push('unsupported-shader-text');
   }
 
-  if (unsupportedKeys.some((key) => hardUnsupportedKeys.has(key))) {
-    reasons.push(
-      'This preset depends on unsupported MilkDrop features that are outside the current runtime scope.',
-    );
-  }
+  Object.entries(BACKEND_PARTIAL_FEATURE_GAPS[backend]).forEach(
+    ([feature, message]) => {
+      if (
+        !message ||
+        !featureAnalysis.featuresUsed.includes(feature as MilkdropFeatureKey)
+      ) {
+        return;
+      }
+      evidence.push(
+        createBackendEvidence({
+          backend,
+          scope: 'backend',
+          status: 'partial',
+          code:
+            feature === 'video-echo' ? 'video-echo-gap' : 'post-effects-gap',
+          message,
+          feature: feature as MilkdropFeatureKey,
+        }),
+      );
+      unsupportedFeatures.push(feature as MilkdropFeatureKey);
+    },
+  );
 
-  const uniqueReasons = [...new Set(reasons)];
+  const uniqueEvidence = evidence.filter(
+    (entry, index, entries) =>
+      entries.findIndex(
+        (candidate) =>
+          candidate.backend === entry.backend &&
+          candidate.scope === entry.scope &&
+          candidate.status === entry.status &&
+          candidate.code === entry.code &&
+          candidate.feature === entry.feature &&
+          candidate.message === entry.message,
+      ) === index,
+  );
+  const uniqueReasons = [
+    ...new Set([
+      ...sharedWarnings,
+      ...uniqueEvidence.map((entry) => entry.message),
+    ]),
+  ];
   const uniqueUnsupported = [...new Set(unsupportedFeatures)];
 
-  if (unsupportedKeys.some((key) => hardUnsupportedKeys.has(key))) {
+  if (uniqueEvidence.some((entry) => entry.status === 'unsupported')) {
     return {
       status: 'unsupported',
       reasons: uniqueReasons,
+      evidence: uniqueEvidence,
       requiredFeatures,
       unsupportedFeatures: uniqueUnsupported,
       recommendedFallback: backend === 'webgpu' ? 'webgl' : undefined,
@@ -4352,6 +4525,7 @@ function buildBackendSupport({
     return {
       status: 'partial',
       reasons: uniqueReasons,
+      evidence: uniqueEvidence,
       requiredFeatures,
       unsupportedFeatures: uniqueUnsupported,
       recommendedFallback: backend === 'webgpu' ? 'webgl' : undefined,
@@ -4361,6 +4535,7 @@ function buildBackendSupport({
   return {
     status: 'supported',
     reasons: [],
+    evidence: [],
     requiredFeatures,
     unsupportedFeatures: [],
   };
@@ -4585,27 +4760,22 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
     unsupportedShaderText,
     supportedShaderText,
   });
-  const warnings = [
+  const sharedWarnings = [
     ...[...unsupportedKeys].map(
       (key) => `Unknown preset field "${key}" was ignored.`,
     ),
-    ...(featureAnalysis.unsupportedShaderText
-      ? [
-          'Shader-text sections include unsupported lines and are being approximated.',
-        ]
-      : []),
   ];
   const backends = {
     webgl: buildBackendSupport({
       backend: 'webgl',
       featureAnalysis,
-      warnings,
+      sharedWarnings,
       unsupportedKeys: [...unsupportedKeys],
     }),
     webgpu: buildBackendSupport({
       backend: 'webgpu',
       featureAnalysis,
-      warnings,
+      sharedWarnings,
       unsupportedKeys: [...unsupportedKeys],
     }),
   };
@@ -4677,7 +4847,13 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
     backends: finalBackends,
     parity,
     featureAnalysis,
-    warnings,
+    warnings: [
+      ...new Set([
+        ...sharedWarnings,
+        ...finalBackends.webgl.reasons,
+        ...finalBackends.webgpu.reasons,
+      ]),
+    ],
     blockingReasons: [
       ...new Set(
         [

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -146,6 +146,25 @@ export type MilkdropCompatibilityEvidence = {
   visual: 'not-captured' | 'reference-suite';
 };
 
+export type MilkdropRenderBackend = 'webgl' | 'webgpu';
+
+export type MilkdropBackendSupportEvidenceCode =
+  | 'unknown-field'
+  | 'unsupported-hard-feature'
+  | 'supported-shader-text-gap'
+  | 'unsupported-shader-text-gap'
+  | 'video-echo-gap'
+  | 'post-effects-gap';
+
+export type MilkdropBackendSupportEvidence = {
+  backend: MilkdropRenderBackend;
+  scope: 'shared' | 'backend';
+  status: Exclude<MilkdropSupportStatus, 'supported'>;
+  code: MilkdropBackendSupportEvidenceCode;
+  message: string;
+  feature?: MilkdropFeatureKey;
+};
+
 export type MilkdropParityReport = {
   ignoredFields: string[];
   approximatedShaderLines: string[];
@@ -165,9 +184,10 @@ export type MilkdropCompileOptions = Record<string, never>;
 export type MilkdropBackendSupport = {
   status: MilkdropSupportStatus;
   reasons: string[];
+  evidence: MilkdropBackendSupportEvidence[];
   requiredFeatures: MilkdropFeatureKey[];
   unsupportedFeatures: MilkdropFeatureKey[];
-  recommendedFallback?: 'webgl' | 'webgpu';
+  recommendedFallback?: MilkdropRenderBackend;
 };
 
 export type MilkdropFeatureAnalysis = {

--- a/tests/milkdrop-catalog-store.test.ts
+++ b/tests/milkdrop-catalog-store.test.ts
@@ -60,10 +60,10 @@ describe('milkdrop catalog store', () => {
     );
 
     expect(bundled?.supports.webgl.status).toBe('supported');
-    expect(bundled?.supports.webgpu.status).toBe('supported');
-    expect(bundled?.fidelityClass).toBe('exact');
+    expect(bundled?.supports.webgpu.status).toBe('partial');
+    expect(bundled?.fidelityClass).toBe('near-exact');
     expect(bundled?.certification).toBe('bundled');
-    expect(bundled?.visualEvidenceTier).toBe('visual');
+    expect(bundled?.visualEvidenceTier).toBe('runtime');
     expect(bundled?.featuresUsed).toContain('video-echo');
     expect(bundled?.featuresUsed).toContain('custom-waves');
 
@@ -84,7 +84,7 @@ describe('milkdrop catalog store', () => {
     expect(imported?.isFavorite).toBe(true);
     expect(imported?.rating).toBe(5);
     expect(imported?.supports.webgl.status).toBe('partial');
-    expect(imported?.supports.webgpu.status).toBe('partial');
+    expect(imported?.supports.webgpu.status).toBe('unsupported');
     expect(imported?.fidelityClass).toBe('fallback');
     expect(imported?.certification).toBe('exploratory');
     expect(imported?.parity.approximatedShaderLines).toEqual(['unsupported']);

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -106,11 +106,22 @@ video_echo=1
 
     expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
       'video-echo',
     );
-    expect(compiled.ir.compatibility.blockingReasons).toEqual([]);
+    expect(compiled.ir.compatibility.parity.backendDivergence).toContain(
+      'status:webgl=supported,webgpu=partial',
+    );
+    expect(compiled.ir.compatibility.backends.webgpu.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'video-echo-gap',
+          feature: 'video-echo',
+          status: 'partial',
+        }),
+      ]),
+    );
   });
 
   test('maps gamma adjustment into post state and post-effect feature usage', () => {
@@ -127,6 +138,8 @@ fGammaAdj=1.75
     expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
       'post-effects',
     );
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
   });
 
   test('accepts motion vector fields as supported preset inputs', () => {
@@ -199,7 +212,7 @@ ib_border=1
     );
 
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     expect(
       compiled.ir.compatibility.featureAnalysis.unsupportedShaderText,
     ).toBe(false);
@@ -210,6 +223,12 @@ ib_border=1
     expect(compiled.ir.post.innerBorderStyle).toBe(true);
     expect(compiled.ir.post.shaderControls.hueShift).toBeCloseTo(0.35, 6);
     expect(compiled.ir.post.shaderControls.mixAlpha).toBeCloseTo(0.25, 6);
+    expect(compiled.ir.compatibility.parity.backendDivergence).toEqual(
+      expect.arrayContaining([
+        'status:webgl=supported,webgpu=partial',
+        'webgpu:supported-shader-text-gap',
+      ]),
+    );
   });
 
   test('supports shader transform controls in the subset', () => {
@@ -548,9 +567,13 @@ video_echo=1
       compiled.ir.customWaves[0]?.programs.perPoint.statements.length,
     ).toBe(1);
     expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
-    expect(compiled.ir.compatibility.warnings).toEqual([]);
+    expect(compiled.ir.compatibility.warnings).toEqual(
+      expect.arrayContaining([
+        'WebGPU still routes video echo through the legacy feedback path and may diverge from WebGL output.',
+      ]),
+    );
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
   });
 
   test('supports legacy max-slot custom shape aliases without warnings', () => {
@@ -624,6 +647,18 @@ warp_shader=this is unsupported
       'unsupported-shader-text',
     );
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+      'unsupported',
+    );
+    expect(compiled.ir.compatibility.backends.webgpu.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unsupported-shader-text-gap',
+          feature: 'unsupported-shader-text',
+          status: 'unsupported',
+        }),
+      ]),
+    );
     expect(compiled.ir.compatibility.parity.fidelityClass).toBe('fallback');
     expect(compiled.ir.compatibility.parity.visualEvidenceTier).toBe('compile');
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
@@ -685,13 +720,18 @@ warp_shader=unsupported(shader)
     );
 
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+      'unsupported',
+    );
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
       'unsupported(shader)',
     ]);
     expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([
       'shader:unsupported(shader)',
     ]);
+    expect(compiled.ir.compatibility.parity.visualFallbacks).toContain(
+      'webgpu:unsupported-shader-text-gap:unsupported-shader-text',
+    );
     expect(compiled.ir.compatibility.parity.visualFallbacks).toContain(
       'shader-text-control-extraction',
     );

--- a/tests/milkdrop-corpus-compat.test.ts
+++ b/tests/milkdrop-corpus-compat.test.ts
@@ -3,6 +3,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
 
+const BUNDLED_WEBGPU_PARTIAL_PRESETS = [
+  'aurora-feedback-core.milk',
+  'kinetic-grid-pulse.milk',
+  'low-motion-halo-drift.milk',
+  'prism-drum-tunnel.milk',
+] as const;
+
 function loadPresetCorpus(dir: string, origin: 'bundled' | 'user' = 'bundled') {
   return readdirSync(dir)
     .filter((file) => file.endsWith('.milk'))
@@ -37,14 +44,39 @@ describe('milkdrop bundled preset corpus', () => {
 
     expect(corpus.length).toBe(30);
 
-    const unsupported = corpus.filter(({ compiled }) => {
+    const unexpected = corpus.filter(({ file, compiled }) => {
+      const expectedWebgpuStatus = BUNDLED_WEBGPU_PARTIAL_PRESETS.includes(
+        file as (typeof BUNDLED_WEBGPU_PARTIAL_PRESETS)[number],
+      )
+        ? 'partial'
+        : 'supported';
+
       return (
         compiled.ir.compatibility.backends.webgl.status !== 'supported' ||
-        compiled.ir.compatibility.backends.webgpu.status !== 'supported'
+        compiled.ir.compatibility.backends.webgpu.status !==
+          expectedWebgpuStatus
       );
     });
 
-    expect(unsupported).toEqual([]);
+    expect(unexpected).toEqual([]);
+
+    BUNDLED_WEBGPU_PARTIAL_PRESETS.forEach((file) => {
+      const entry = corpus.find((preset) => preset.file === file);
+
+      expect(entry).toBeDefined();
+      expect(entry?.compiled.ir.compatibility.backends.webgl.status).toBe(
+        'supported',
+      );
+      expect(entry?.compiled.ir.compatibility.backends.webgpu.status).toBe(
+        'partial',
+      );
+      expect(entry?.compiled.ir.compatibility.parity.backendDivergence).toEqual(
+        expect.arrayContaining([
+          'status:webgl=supported,webgpu=partial',
+          'webgpu:post-effects-gap:post-effects',
+        ]),
+      );
+    });
   });
 });
 

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -57,8 +57,8 @@ function createInspectorPayload() {
         customShapes: [],
         compatibility: {
           backends: {
-            webgl: { status: 'supported', reasons: [] },
-            webgpu: { status: 'supported', reasons: [] },
+            webgl: { status: 'supported', reasons: [], evidence: [] },
+            webgpu: { status: 'supported', reasons: [], evidence: [] },
           },
           parity: {
             fidelityClass: 'exact',
@@ -108,12 +108,14 @@ function createCatalogEntry(id: string, title: string): MilkdropCatalogEntry {
       webgl: {
         status: 'supported',
         reasons: [],
+        evidence: [],
         requiredFeatures: [],
         unsupportedFeatures: [],
       },
       webgpu: {
         status: 'supported',
         reasons: [],
+        evidence: [],
         requiredFeatures: [],
         unsupportedFeatures: [],
       },

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -91,6 +91,30 @@ const VISUAL_BASELINES_PATH = join(
   'milkdrop-parity',
   'visual-baselines.json',
 );
+const REPRESENTATIVE_BACKEND_EXPECTATIONS = {
+  'parity-feedback-01': {
+    webgl: 'supported',
+    webgpu: 'partial',
+    divergence: ['status:webgl=supported,webgpu=partial'],
+  },
+  'parity-shader-01': {
+    webgl: 'supported',
+    webgpu: 'partial',
+    divergence: [
+      'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
+    ],
+  },
+  'parity-allowlisted-shader-gap': {
+    webgl: 'supported',
+    webgpu: 'partial',
+    divergence: [
+      'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
+      'webgpu:video-echo-gap:video-echo',
+    ],
+  },
+} as const;
 
 function loadJson<T>(filePath: string): T {
   return JSON.parse(readFileSync(filePath, 'utf8')) as T;
@@ -283,12 +307,29 @@ describe('milkdrop parity corpus harness', () => {
       );
 
       expect(errorDiagnostics).toEqual([]);
-      expect(
-        compiled.ir.compatibility.backends[manifest.fallbackBackend].status,
-      ).not.toBe('unsupported');
-      expect(
-        compiled.ir.compatibility.backends[manifest.backendTarget].status,
-      ).not.toBe('unsupported');
+      const expected =
+        REPRESENTATIVE_BACKEND_EXPECTATIONS[
+          entry.id as keyof typeof REPRESENTATIVE_BACKEND_EXPECTATIONS
+        ];
+      if (!expected) {
+        expect(
+          compiled.ir.compatibility.backends[manifest.fallbackBackend].status,
+        ).not.toBe('unsupported');
+        expect(
+          compiled.ir.compatibility.backends[manifest.backendTarget].status,
+        ).not.toBe('unsupported');
+      }
+      if (expected) {
+        expect(compiled.ir.compatibility.backends.webgl.status).toBe(
+          expected.webgl,
+        );
+        expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+          expected.webgpu,
+        );
+        expect(compiled.ir.compatibility.parity.backendDivergence).toEqual(
+          expect.arrayContaining(expected.divergence),
+        );
+      }
     });
   });
 });

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -27,6 +27,23 @@ const PROJECTM_PRESET_FILES = [
   '260-compshader-noise_lq.milk',
   '300-beatdetect-bassmidtreb.milk',
 ] as const;
+const PROJECTM_BACKEND_EXPECTATIONS = {
+  '000-empty.milk': {
+    webgl: 'supported',
+    webgpu: 'supported',
+    divergence: [],
+  },
+  '250-wavecode.milk': {
+    webgl: 'supported',
+    webgpu: 'supported',
+    divergence: [],
+  },
+  '260-compshader-noise_lq.milk': {
+    webgl: 'partial',
+    webgpu: 'unsupported',
+    divergence: ['status:webgl=partial,webgpu=unsupported'],
+  },
+} as const;
 
 function makeSignals({
   frame = 1,
@@ -225,16 +242,38 @@ describe('milkdrop vendored projectM fixture corpus', () => {
 
     expect(corpus.length).toBe(PROJECTM_PRESET_FILES.length);
 
-    corpus.forEach(({ compiled }) => {
+    corpus.forEach(({ file, compiled }) => {
       expect(
         compiled.diagnostics.filter((entry) => entry.severity === 'error'),
       ).toEqual([]);
-      expect(compiled.ir.compatibility.backends.webgl.status).not.toBe(
-        'unsupported',
+
+      const expected =
+        PROJECTM_BACKEND_EXPECTATIONS[
+          file as keyof typeof PROJECTM_BACKEND_EXPECTATIONS
+        ];
+      if (!expected) {
+        expect(compiled.ir.compatibility.backends.webgl.status).not.toBe(
+          'unsupported',
+        );
+        expect(compiled.ir.compatibility.backends.webgpu.status).not.toBe(
+          'unsupported',
+        );
+        return;
+      }
+
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe(
+        expected.webgl,
       );
-      expect(compiled.ir.compatibility.backends.webgpu.status).not.toBe(
-        'unsupported',
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+        expected.webgpu,
       );
+      if (expected.divergence.length > 0) {
+        expect(compiled.ir.compatibility.parity.backendDivergence).toEqual(
+          expect.arrayContaining(expected.divergence),
+        );
+      } else {
+        expect(compiled.ir.compatibility.parity.backendDivergence).toEqual([]);
+      }
     });
   });
 


### PR DESCRIPTION
### Motivation
- WebGL and WebGPU have different runtime and shader-text gaps that should be evaluated against separate rules so compatibility output can explain renderer-specific degradations. 
- The compiler previously mixed shared warnings and backend differences as plain strings, limiting downstream parity, fallback, and fidelity reasoning.

### Description
- Add structured backend evidence types (`MilkdropBackendSupportEvidence`, `MilkdropRenderBackend`) and extend `MilkdropBackendSupport` with an `evidence` array so backends can report scoped, machine-readable reasons (in `assets/js/milkdrop/types.ts`).
- Introduce per-backend matrices for feature/construct gaps (`BACKEND_PARTIAL_FEATURE_GAPS`, `BACKEND_SHADER_TEXT_GAPS`) and emit backend-scoped evidence during support evaluation in `assets/js/milkdrop/compiler.ts`.
- Update `buildBackendSupport`, `buildBackendDivergence`, `buildVisualFallbacks`, `buildDegradationReasons`, and `classifyFidelity` to consume and reason over backend-specific `evidence` rather than only shared strings, and aggregate shared warnings separately as `sharedWarnings`.
- Wire compatibility results through the IR and catalog plumbing, add empty `evidence` defaults in `assets/js/milkdrop/catalog-store.ts`, and update tests and fixtures to assert explicit backend differences (changes in `tests/*` include `milkdrop-compiler.test.ts`, `milkdrop-parity.test.ts`, `milkdrop-projectm-compat.test.ts`, `milkdrop-corpus-compat.test.ts`, `milkdrop-catalog-store.test.ts`, and `milkdrop-overlay.test.ts`).

### Testing
- Ran targeted compiler and parity tests with `bun run test tests/milkdrop-compiler.test.ts` and `bun run test tests/milkdrop-parity.test.ts tests/milkdrop-projectm-compat.test.ts tests/milkdrop-overlay.test.ts`, and assertions updated to expect backend-specific statuses and evidence entries. (All targeted tests passed.)
- Ran the full quality gate with `bun run check` which includes Biome formatting, TypeScript typecheck, and the test suite, and the suite passed (no failing tests after updates).
- Docs touched: `None`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be06d5884c833283088e2cd5d0b040)