### PR TITLE
Make parity metadata meaningful in compiler

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -1,11 +1,14 @@
 import {
   evaluateMilkdropExpression,
+  MILKDROP_INTRINSIC_FUNCTIONS,
+  MILKDROP_INTRINSIC_IDENTIFIERS,
   parseMilkdropExpression,
   parseMilkdropStatement,
   splitMilkdropStatements,
   walkMilkdropExpression,
 } from './expression';
 import { formatMilkdropPreset } from './formatter';
+import { isMilkdropParityConstructAllowlisted } from './parity-allowlist';
 import { parseMilkdropPreset } from './preset-parser';
 import {
   evaluateMilkdropShaderExpression,
@@ -338,6 +341,135 @@ function toBlockedShaderConstruct(line: string) {
   return `shader:${normalizeBlockedConstructValue(line)}`;
 }
 
+function buildSupportedExpressionIdentifierSet() {
+  const supported = new Set<string>([
+    ...Object.keys(DEFAULT_MILKDROP_STATE),
+    ...MILKDROP_INTRINSIC_IDENTIFIERS,
+    'time',
+    'frame',
+    'fps',
+    'bass',
+    'mid',
+    'mids',
+    'treb',
+    'treble',
+    'bass_att',
+    'mid_att',
+    'mids_att',
+    'treb_att',
+    'treble_att',
+    'bassatt',
+    'midsatt',
+    'trebleatt',
+    'beat',
+    'beat_pulse',
+    'beatpulse',
+    'rms',
+    'vol',
+    'music',
+    'weighted_energy',
+    'progress',
+    'sample',
+    'value1',
+    'x',
+    'y',
+    'rad',
+    'ang',
+    'sides',
+    'enabled',
+    'samples',
+    'spectrum',
+    'additive',
+    'usedots',
+    'scaling',
+    'smoothing',
+    'mystery',
+    'thick',
+    'a',
+    'r',
+    'g',
+    'b',
+    'a2',
+    'r2',
+    'g2',
+    'b2',
+    'border_a',
+    'border_r',
+    'border_g',
+    'border_b',
+    'thickoutline',
+  ]);
+  return supported;
+}
+
+function isSupportedExpressionIdentifier(
+  identifier: string,
+  supportedIdentifiers: Set<string>,
+) {
+  const normalized = identifier.toLowerCase();
+  return (
+    supportedIdentifiers.has(identifier) ||
+    supportedIdentifiers.has(normalized) ||
+    /^q\d+$/u.test(normalized) ||
+    /^t\d+$/u.test(normalized)
+  );
+}
+
+function collectExpressionCompatibilityGaps(
+  expressions: MilkdropExpressionNode[],
+  assignedTargets: Iterable<string>,
+) {
+  const supportedIdentifiers = buildSupportedExpressionIdentifierSet();
+  for (const target of assignedTargets) {
+    supportedIdentifiers.add(target);
+    supportedIdentifiers.add(target.toLowerCase());
+  }
+
+  const missing = new Set<string>();
+  for (const expression of expressions) {
+    walkMilkdropExpression(expression, (node) => {
+      if (node.type === 'identifier') {
+        if (!isSupportedExpressionIdentifier(node.name, supportedIdentifiers)) {
+          missing.add(node.name.toLowerCase());
+        }
+        return;
+      }
+      if (
+        node.type === 'call' &&
+        !MILKDROP_INTRINSIC_FUNCTIONS.has(node.name.toLowerCase())
+      ) {
+        missing.add(node.name.toLowerCase());
+      }
+    });
+  }
+
+  return [...missing].sort();
+}
+
+function collectExpressionsFromValue(
+  value: unknown,
+  expressions: MilkdropExpressionNode[],
+) {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+  if (
+    'type' in value &&
+    typeof value.type === 'string' &&
+    ['literal', 'identifier', 'unary', 'binary', 'call'].includes(value.type)
+  ) {
+    expressions.push(value as MilkdropExpressionNode);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectExpressionsFromValue(entry, expressions));
+    return;
+  }
+  Object.values(value).forEach((entry) =>
+    collectExpressionsFromValue(entry, expressions),
+  );
+}
+
 function buildBackendDivergence({
   webgl,
   webgpu,
@@ -381,38 +513,50 @@ function buildVisualFallbacks({
 }
 
 function buildBlockingConstructDetails({
+  sourceId,
   ignoredFields,
   approximatedShaderLines,
 }: {
+  sourceId?: string;
   ignoredFields: string[];
   approximatedShaderLines: string[];
 }): MilkdropBlockingConstruct[] {
   return [
-    ...ignoredFields.map((value) => ({
-      kind: 'field' as const,
-      value,
-      system: 'preset-field' as const,
-      allowlisted: false,
-    })),
-    ...approximatedShaderLines.map((value) => ({
-      kind: 'shader' as const,
-      value,
-      system: 'shader-text' as const,
-      allowlisted: false,
-    })),
+    ...ignoredFields.map((value) => {
+      const signature = toBlockedFieldConstruct(value);
+      return {
+        kind: 'field' as const,
+        value,
+        system: 'preset-field' as const,
+        allowlisted: isMilkdropParityConstructAllowlisted({
+          presetId: sourceId,
+          signature,
+        }),
+      };
+    }),
+    ...approximatedShaderLines.map((value) => {
+      const signature = toBlockedShaderConstruct(value);
+      return {
+        kind: 'shader' as const,
+        value,
+        system: 'shader-text' as const,
+        allowlisted: isMilkdropParityConstructAllowlisted({
+          presetId: sourceId,
+          signature,
+        }),
+      };
+    }),
   ];
 }
 
 function buildDegradationReasons({
-  ignoredFields,
-  approximatedShaderLines,
+  blockedConstructDetails,
   backendDivergence,
   visualFallbacks,
   webgl,
   webgpu,
 }: {
-  ignoredFields: string[];
-  approximatedShaderLines: string[];
+  blockedConstructDetails: MilkdropBlockingConstruct[];
   backendDivergence: string[];
   visualFallbacks: string[];
   webgl: MilkdropBackendSupport;
@@ -420,22 +564,29 @@ function buildDegradationReasons({
 }): MilkdropDegradationReason[] {
   const reasons: MilkdropDegradationReason[] = [];
 
-  ignoredFields.forEach((field) => {
+  blockedConstructDetails.forEach((construct) => {
+    if (construct.allowlisted) {
+      reasons.push({
+        code: 'allowlisted-gap',
+        category: 'acceptable-approximation',
+        message: `Allowlisted parity gap remains visible for ${construct.kind} "${construct.value}".`,
+        system: construct.kind === 'field' ? 'compiler' : 'shader',
+        blocking: false,
+      });
+      return;
+    }
     reasons.push({
-      code: 'unknown-field',
-      category: 'unsupported-syntax',
-      message: `Field "${field}" is outside the current runtime scope and was ignored.`,
-      system: 'compiler',
-      blocking: true,
-    });
-  });
-
-  approximatedShaderLines.forEach((line) => {
-    reasons.push({
-      code: 'shader-approximation',
-      category: 'unsupported-shader',
-      message: `Shader line "${line}" could not be executed directly and is being approximated.`,
-      system: 'shader',
+      code:
+        construct.kind === 'field' ? 'unknown-field' : 'shader-approximation',
+      category:
+        construct.kind === 'field'
+          ? 'unsupported-syntax'
+          : 'unsupported-shader',
+      message:
+        construct.kind === 'field'
+          ? `Field "${construct.value}" is outside the current runtime scope and was ignored.`
+          : `Shader line "${construct.value}" could not be executed directly and is being approximated.`,
+      system: construct.kind === 'field' ? 'compiler' : 'shader',
       blocking: true,
     });
   });
@@ -4385,9 +4536,15 @@ function createPresetSource(
   };
 }
 
-function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
+function createIR(
+  ast: MilkdropPresetAST,
+  diagnostics: MilkdropDiagnostic[],
+  source: Partial<MilkdropPresetSource> = {},
+) {
   const numericFields = { ...DEFAULT_MILKDROP_STATE };
   const stringFields: Record<string, string> = {};
+  const parsedExpressions: MilkdropExpressionNode[] = [];
+  const assignedTargets = new Set<string>();
   const programs = {
     init: createProgramBlock(),
     perFrame: createProgramBlock(),
@@ -4466,6 +4623,9 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
         );
         return;
       }
+      if (compiledScalar.expression) {
+        parsedExpressions.push(compiledScalar.expression);
+      }
       numericFields[normalizedKey] = compiledScalar.value;
       ensureWaveDefinition(customWaveMap, index).fields[suffix] =
         compiledScalar.value;
@@ -4508,6 +4668,9 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
         );
         return;
       }
+      if (compiledScalar.expression) {
+        parsedExpressions.push(compiledScalar.expression);
+      }
       numericFields[normalizedKey] = compiledScalar.value;
       ensureShapeDefinition(customShapeMap, index).fields[suffix] =
         compiledScalar.value;
@@ -4543,6 +4706,9 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
       );
       return;
     }
+    if (compiledScalar.expression) {
+      parsedExpressions.push(compiledScalar.expression);
+    }
     numericFields[normalizedKey] = compiledScalar.value;
   });
 
@@ -4557,6 +4723,33 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
   const mergedShaderControls = mergeShaderControlAnalysis(
     shaderWarpAnalysis,
     shaderCompAnalysis,
+  );
+  collectExpressionsFromValue(
+    mergedShaderControls.expressions,
+    parsedExpressions,
+  );
+  for (const block of [
+    programs.init,
+    programs.perFrame,
+    programs.perPixel,
+    ...customWaves.flatMap((wave) => [
+      wave.programs.init,
+      wave.programs.perFrame,
+      wave.programs.perPoint,
+    ]),
+    ...customShapes.flatMap((shape) => [
+      shape.programs.init,
+      shape.programs.perFrame,
+    ]),
+  ]) {
+    for (const statement of block.statements) {
+      assignedTargets.add(statement.target);
+      parsedExpressions.push(statement.expression);
+    }
+  }
+  const missingAliasesOrFunctions = collectExpressionCompatibilityGaps(
+    parsedExpressions,
+    assignedTargets,
   );
   supportedShaderText =
     shaderWarpAnalysis.supported || shaderCompAnalysis.supported;
@@ -4626,12 +4819,12 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
     webgpu: finalBackends.webgpu,
   });
   const blockingConstructDetails = buildBlockingConstructDetails({
+    sourceId: source.id,
     ignoredFields,
     approximatedShaderLines,
   });
   const degradationReasons = buildDegradationReasons({
-    ignoredFields,
-    approximatedShaderLines,
+    blockedConstructDetails: blockingConstructDetails,
     backendDivergence,
     visualFallbacks,
     webgl: finalBackends.webgl,
@@ -4658,7 +4851,7 @@ function createIR(ast: MilkdropPresetAST, diagnostics: MilkdropDiagnostic[]) {
   const parity: MilkdropParityReport = {
     ignoredFields,
     approximatedShaderLines,
-    missingAliasesOrFunctions: [],
+    missingAliasesOrFunctions,
     backendDivergence,
     visualFallbacks,
     blockedConstructs,
@@ -4781,7 +4974,7 @@ export function compileMilkdropPresetSource(
 ): MilkdropCompiledPreset {
   const parsed = parseMilkdropPreset(raw);
   const diagnostics = [...parsed.diagnostics];
-  const ir = createIR(parsed.ast, diagnostics);
+  const ir = createIR(parsed.ast, diagnostics, source);
   const presetSource = createPresetSource(source, raw, ir.title, ir.author);
 
   const compiled: MilkdropCompiledPreset = {

--- a/assets/js/milkdrop/expression.ts
+++ b/assets/js/milkdrop/expression.ts
@@ -19,6 +19,47 @@ type ParseResult<T> = {
 
 const operatorTokens = ['<=', '>=', '==', '!=', '&&', '||'];
 
+export const MILKDROP_INTRINSIC_IDENTIFIERS = new Set(['pi', 'e']);
+
+export const MILKDROP_INTRINSIC_FUNCTIONS = new Set([
+  'sin',
+  'cos',
+  'tan',
+  'asin',
+  'acos',
+  'atan',
+  'abs',
+  'sqrt',
+  'pow',
+  'mod',
+  'fmod',
+  'min',
+  'max',
+  'mix',
+  'lerp',
+  'floor',
+  'int',
+  'ceil',
+  'sqr',
+  'clamp',
+  'step',
+  'smoothstep',
+  'log',
+  'exp',
+  'sigmoid',
+  'sign',
+  'bor',
+  'band',
+  'bnot',
+  'atan2',
+  'frac',
+  'if',
+  'above',
+  'below',
+  'equal',
+  'rand',
+]);
+
 function toMilkdropInt(value: number) {
   return Number.isFinite(value) ? Math.trunc(value) : 0;
 }

--- a/assets/js/milkdrop/parity-allowlist.ts
+++ b/assets/js/milkdrop/parity-allowlist.ts
@@ -1,0 +1,38 @@
+import allowlistJson from '../../data/milkdrop-parity/allowlist.json' with {
+  type: 'json',
+};
+
+export type MilkdropParityAllowlistEntry = {
+  id: string;
+  reason: string;
+  category: string;
+  constructSignatures?: string[];
+};
+
+export type MilkdropParityAllowlist = {
+  version: number;
+  entries: MilkdropParityAllowlistEntry[];
+};
+
+type MilkdropParityAllowlistConstruct = {
+  presetId?: string;
+  signature: string;
+};
+
+const MILKDROP_PARITY_ALLOWLIST = allowlistJson as MilkdropParityAllowlist;
+
+export function loadMilkdropParityAllowlist(): MilkdropParityAllowlist {
+  return MILKDROP_PARITY_ALLOWLIST;
+}
+
+export function isMilkdropParityConstructAllowlisted({
+  presetId,
+  signature,
+}: MilkdropParityAllowlistConstruct): boolean {
+  return MILKDROP_PARITY_ALLOWLIST.entries.some((entry) => {
+    if (entry.id === presetId) {
+      return true;
+    }
+    return (entry.constructSignatures ?? []).includes(signature);
+  });
+}

--- a/assets/types/json-modules.d.ts
+++ b/assets/types/json-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.json' {
+  const value: unknown;
+  export default value;
+}

--- a/tests/fixtures/milkdrop/parity-corpus/parity-allowlisted-shader-gap.milk
+++ b/tests/fixtures/milkdrop/parity-corpus/parity-allowlisted-shader-gap.milk
@@ -1,4 +1,4 @@
 title=Parity Allowlisted Shader Gap
 author=Stim Legacy Corpus
 video_echo_enabled=1
-warp_shader=dx=0.028; rot=0.11; zoom=1.045
+warp_shader=dx=0.028; unsupported(shader)

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -697,4 +697,53 @@ warp_shader=unsupported(shader)
     );
     expect(compiled.ir.compatibility.parity.fidelityClass).toBe('fallback');
   });
+
+  test('marks allowlisted blocked constructs as visible but non-regressive', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Parity Allowlisted Shader Gap
+warp_shader=unsupported(shader)
+      `.trim(),
+      { id: 'parity-allowlisted-shader-gap' },
+    );
+
+    expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([
+      'shader:unsupported(shader)',
+    ]);
+    expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([
+      {
+        kind: 'shader',
+        value: 'unsupported(shader)',
+        system: 'shader-text',
+        allowlisted: true,
+      },
+    ]);
+    expect(
+      compiled.ir.compatibility.parity.degradationReasons.map(
+        (reason) => reason.code,
+      ),
+    ).toContain('allowlisted-gap');
+    expect(
+      compiled.ir.compatibility.parity.degradationReasons.some(
+        (reason) => reason.code === 'allowlisted-gap' && reason.blocking,
+      ),
+    ).toBe(false);
+    expect(compiled.ir.compatibility.parity.fidelityClass).toBe('near-exact');
+  });
+
+  test('lists missing aliases and functions from parsed expressions', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Missing Intrinsics
+wave_r=missing_alias + 0.1
+per_frame_1=zoom = missing_alias + unsupported_fn(bass_att)
+      `.trim(),
+      { id: 'missing-intrinsics' },
+    );
+
+    expect(compiled.ir.compatibility.parity.missingAliasesOrFunctions).toEqual([
+      'missing_alias',
+      'unsupported_fn',
+    ]);
+  });
 });

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
+import { loadMilkdropParityAllowlist } from '../assets/js/milkdrop/parity-allowlist.ts';
 import type {
   MilkdropFrameState,
   MilkdropRuntimeSignals,
@@ -27,15 +28,6 @@ type ParityManifest = {
     visualEvidenceTier: string;
   };
   presets: ParityManifestPreset[];
-};
-
-type ParityAllowlist = {
-  version: number;
-  entries: Array<{
-    id: string;
-    reason: string;
-    category: string;
-  }>;
 };
 
 type VisualBaseline = {
@@ -76,13 +68,6 @@ const PARITY_MANIFEST_PATH = join(
   'data',
   'milkdrop-parity',
   'corpus-manifest.json',
-);
-const PARITY_ALLOWLIST_PATH = join(
-  process.cwd(),
-  'assets',
-  'data',
-  'milkdrop-parity',
-  'allowlist.json',
 );
 const VISUAL_BASELINES_PATH = join(
   process.cwd(),
@@ -252,7 +237,7 @@ function buildFrameSummary(frameState: MilkdropFrameState) {
 describe('milkdrop parity corpus harness', () => {
   test('keeps the certified manifest, corpus, and allowlist in sync', () => {
     const manifest = loadJson<ParityManifest>(PARITY_MANIFEST_PATH);
-    const allowlist = loadJson<ParityAllowlist>(PARITY_ALLOWLIST_PATH);
+    const allowlist = loadMilkdropParityAllowlist();
     const allowlistedIds = new Set(allowlist.entries.map((entry) => entry.id));
 
     expect(manifest.version).toBe(1);
@@ -290,6 +275,44 @@ describe('milkdrop parity corpus harness', () => {
         compiled.ir.compatibility.backends[manifest.backendTarget].status,
       ).not.toBe('unsupported');
     });
+  });
+
+  test('treats allowlisted parity gaps as visible but non-regressive', () => {
+    const manifest = loadJson<ParityManifest>(PARITY_MANIFEST_PATH);
+    const allowlistedEntry = manifest.presets.find(
+      (entry) => entry.id === 'parity-allowlisted-shader-gap',
+    );
+
+    expect(allowlistedEntry).toBeDefined();
+    if (!allowlistedEntry) {
+      throw new Error('Missing allowlisted parity fixture in manifest.');
+    }
+
+    const compiled = compileParityPreset(allowlistedEntry);
+
+    expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([
+      'shader:unsupported(shader)',
+    ]);
+    expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([
+      {
+        kind: 'shader',
+        value: 'unsupported(shader)',
+        system: 'shader-text',
+        allowlisted: true,
+      },
+    ]);
+    expect(
+      compiled.ir.compatibility.parity.degradationReasons.map(
+        (reason) => reason.code,
+      ),
+    ).toContain('allowlisted-gap');
+    expect(
+      compiled.ir.compatibility.parity.degradationReasons.some(
+        (reason) =>
+          reason.code === 'allowlisted-gap' && reason.blocking === false,
+      ),
+    ).toBe(true);
+    expect(compiled.ir.compatibility.parity.fidelityClass).toBe('near-exact');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Parity allowlist entries should be usable by the compiler so known gaps are visible but not treated as regressions.
- Blocked construct reporting must include allowlist-aware metadata and emit a distinct degradation reason for allowlisted gaps.
- The parity report should surface missing aliases/functions discovered in parsed expressions to aid triage.

### Description
- Add a small allowlist loader `assets/js/milkdrop/parity-allowlist.ts` that imports `assets/data/milkdrop-parity/allowlist.json` and exposes `loadMilkdropParityAllowlist` and `isMilkdropParityConstructAllowlisted` for consumers.
- Export intrinsic identifier/function sets from `assets/js/milkdrop/expression.ts` and populate `missingAliasesOrFunctions` in the compiler by scanning parsed expressions and calls against those sets.
- Update the compiler (`assets/js/milkdrop/compiler.ts`) to mark blocked constructs in `blockingConstructDetails` as `allowlisted: true` when they match the allowlist or construct signatures, to emit `allowlisted-gap` degradation reasons for allowlisted constructs, and to leave non-allowlisted gaps regressive.
- Collect expressions from numeric fields, programs, and merged shader analysis so missing identifiers/functions are discovered and reported in `compiled.ir.compatibility.parity.missingAliasesOrFunctions`.
- Add a JSON module declaration `assets/types/json-modules.d.ts`, modify the parity fixture to exercise a shader gap, and add/update tests and fixtures: `tests/milkdrop-parity.test.ts`, `tests/milkdrop-compiler.test.ts`, and `tests/fixtures/milkdrop/parity-corpus/parity-allowlisted-shader-gap.milk`.

### Testing
- Ran `bun run test tests/milkdrop-compiler.test.ts` and all tests passed (32 passing assertions across the spec).
- Ran `bun run test tests/milkdrop-parity.test.ts` and all tests passed (parity harness and visual baseline checks passed).
- Ran `bun run test tests/system-controls-tv-mode.test.ts` (ran standalone) and it passed when re-run directly after addressing formatting/type issues.
- Ran the full quality gate with `bun run check`; initially surfaced formatter and TS import issues which were fixed, and the change set was validated, though a flaky existing spec (`tests/system-controls-tv-mode.test.ts`) was observed to intermittently fail when run with the entire suite but passed when run individually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be06d7572483329ad13f44aedff115)