### PR TITLE
Preserve previous main-wave samples for correct velocity computation

### DIFF
--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -218,6 +218,7 @@ type MeshField = {
 
 type WaveFrameBuffers = {
   liveSamples: number[];
+  previousSamples: number[];
   smoothedSamples: number[];
 };
 
@@ -235,6 +236,7 @@ class MilkdropPresetVM implements MilkdropVM {
   private lastMeshField: MeshField | null = null;
   private readonly waveBuffers: WaveFrameBuffers = {
     liveSamples: [],
+    previousSamples: [],
     smoothedSamples: [],
   };
   private readonly frameTransformCache = new Map<
@@ -282,6 +284,7 @@ class MilkdropPresetVM implements MilkdropVM {
     );
     this.lastMeshField = null;
     this.waveBuffers.liveSamples.length = 0;
+    this.waveBuffers.previousSamples.length = 0;
     this.waveBuffers.smoothedSamples.length = 0;
     this.frameTransformCache.clear();
 
@@ -520,10 +523,14 @@ class MilkdropPresetVM implements MilkdropVM {
       1,
     );
     const liveSamples = this.waveBuffers.liveSamples;
+    const previousSamples = this.waveBuffers.previousSamples;
     const smoothedSamples = this.waveBuffers.smoothedSamples;
     liveSamples.length = samples;
+    previousSamples.length = samples;
     smoothedSamples.length = samples;
-    const previousSamples = this.lastWaveSamples;
+    for (let index = 0; index < samples; index += 1) {
+      previousSamples[index] = this.lastWaveSamples[index] ?? 0;
+    }
     const historyBlend = clamp(
       0.26 + signals.beatPulse * 0.48 + signals.deltaMs / 120,
       0.24,

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -6,14 +6,16 @@ import { createMilkdropVM } from '../assets/js/milkdrop/vm.ts';
 function makeSignals({
   frame = 1,
   beatPulse = 0.1,
+  frequencyValue = 160,
   time = frame / 60,
 }: {
   frame?: number;
   beatPulse?: number;
+  frequencyValue?: number;
   time?: number;
 } = {}): MilkdropRuntimeSignals {
   const frequencyData = new Uint8Array(64);
-  frequencyData.fill(160);
+  frequencyData.fill(frequencyValue);
 
   return {
     time,
@@ -203,6 +205,35 @@ per_pixel_1=zoom=1.08; rot=0.12; warp=0.35;
     expect(frameState.motionVectors[0]?.positions).toHaveLength(6);
     expect(frameState.motionVectors[0]?.color.b).toBeCloseTo(1, 6);
     expect(frameState.motionVectors[0]?.alpha).toBeGreaterThan(0.28);
+  });
+
+  test('preserves prior frame wave samples for velocity-driven main wave animation', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Wave Velocity History
+wave_mode=4
+wave_x=0.5
+wave_y=0.5
+wave_scale=1
+      `.trim(),
+      { id: 'wave-velocity-history' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.step(makeSignals({ frame: 1, frequencyValue: 32, time: 0.25 }));
+    const withHistory = vm.step(
+      makeSignals({ frame: 2, frequencyValue: 224, time: 0.25 }),
+    );
+    const withoutHistory = createMilkdropVM(preset).step(
+      makeSignals({ frame: 2, frequencyValue: 224, time: 0.25 }),
+    );
+
+    expect(withHistory.mainWave.positions).not.toEqual(
+      withoutHistory.mainWave.positions,
+    );
+    expect(withHistory.mainWave.positions[1]).toBeLessThan(
+      withoutHistory.mainWave.positions[1] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   test('applies legacy cx/cy/sx/sy/dx/dy mesh transforms', () => {


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where the previous-frame wave samples were aliased and mutated before velocity was computed, causing velocity-driven offsets in `buildMainWave()` to collapse and flatten the waveform animation.
- Keep the VM change efficient and allocation-minimizing by reusing per-frame buffers rather than introducing transient arrays.

### Description
- Add a dedicated `previousSamples` buffer to `WaveFrameBuffers` and allocate/clear it alongside the existing `liveSamples` and `smoothedSamples` buffers in the VM.
- Snapshot `this.lastWaveSamples` into the per-frame `previousSamples` buffer before computing `smoothedSamples` so velocity calculations use an immutable copy of the prior frame.
- Add a regression test in `tests/milkdrop-vm.test.ts` that injects different synthetic frequency inputs and verifies a history-aware VM step produces different main-wave positions than a fresh VM step, proving the velocity-driven animation is preserved.

### Testing
- Ran the targeted VM tests with `bun run test tests/milkdrop-vm.test.ts` and the modified test file passed (new regression test included) with all VM assertions green.
- Ran the full quality gate `bun run check` which completed linting and typechecking successfully, but the full test sweep failed due to two pre-existing unrelated failures in `tests/system-controls-tv-mode.test.ts` (341 pass, 2 fail), so the change itself did not cause regressions in the VM tests.
- Biome formatting/linting and `tsc --noEmit` typecheck ran as part of the quality gate and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be07fc4938833283607045705cb23d)