### PR TITLE
Tighten parity allowlist construct matching

### DIFF
--- a/assets/data/milkdrop-parity/allowlist.json
+++ b/assets/data/milkdrop-parity/allowlist.json
@@ -4,7 +4,8 @@
     {
       "id": "parity-allowlisted-shader-gap",
       "reason": "This fixture intentionally exercises the current shader-text approximation path until direct shader execution lands.",
-      "category": "unsupported-shader"
+      "category": "unsupported-shader",
+      "constructSignatures": ["shader:unsupported(shader)"]
     }
   ]
 }

--- a/assets/js/milkdrop/parity-allowlist.ts
+++ b/assets/js/milkdrop/parity-allowlist.ts
@@ -30,8 +30,8 @@ export function isMilkdropParityConstructAllowlisted({
   signature,
 }: MilkdropParityAllowlistConstruct): boolean {
   return MILKDROP_PARITY_ALLOWLIST.entries.some((entry) => {
-    if (entry.id === presetId) {
-      return true;
+    if (entry.id !== presetId) {
+      return false;
     }
     return (entry.constructSignatures ?? []).includes(signature);
   });

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -771,6 +771,49 @@ warp_shader=unsupported(shader)
     expect(compiled.ir.compatibility.parity.fidelityClass).toBe('near-exact');
   });
 
+  test('keeps non-allowlisted regressions blocking inside allowlisted presets', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Parity Allowlisted Shader Gap
+warp_shader=unsupported(shader)
+unknown_field=2
+      `.trim(),
+      { id: 'parity-allowlisted-shader-gap' },
+    );
+
+    expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([
+      'field:unknown_field',
+      'shader:unsupported(shader)',
+    ]);
+    expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([
+      {
+        kind: 'field',
+        value: 'unknown_field',
+        system: 'preset-field',
+        allowlisted: false,
+      },
+      {
+        kind: 'shader',
+        value: 'unsupported(shader)',
+        system: 'shader-text',
+        allowlisted: true,
+      },
+    ]);
+    expect(compiled.ir.compatibility.parity.degradationReasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unknown-field',
+          blocking: true,
+        }),
+        expect.objectContaining({
+          code: 'allowlisted-gap',
+          blocking: false,
+        }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.parity.fidelityClass).toBe('fallback');
+  });
+
   test('lists missing aliases and functions from parsed expressions', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -357,6 +357,39 @@ describe('milkdrop parity corpus harness', () => {
   });
 });
 
+test('only waive the constructs explicitly named in the allowlist', () => {
+  const compiled = compileMilkdropPresetSource(
+    `
+title=Parity Allowlisted Shader Gap
+warp_shader=unsupported(shader)
+unknown_field=2
+      `.trim(),
+    {
+      id: 'parity-allowlisted-shader-gap',
+      title: 'Parity Allowlisted Shader Gap',
+      fileName: 'parity-allowlisted-shader-gap.milk',
+      path: join(PARITY_CORPUS_DIR, 'parity-allowlisted-shader-gap.milk'),
+      origin: 'user',
+    },
+  );
+
+  expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([
+    {
+      kind: 'field',
+      value: 'unknown_field',
+      system: 'preset-field',
+      allowlisted: false,
+    },
+    {
+      kind: 'shader',
+      value: 'unsupported(shader)',
+      system: 'shader-text',
+      allowlisted: true,
+    },
+  ]);
+  expect(compiled.ir.compatibility.parity.fidelityClass).toBe('fallback');
+});
+
 describe('milkdrop parity visual baselines', () => {
   test('replays the canonical baseline suite through the VM', () => {
     const baselines = loadJson<VisualBaseline>(VISUAL_BASELINES_PATH);


### PR DESCRIPTION
### Motivation
- Prevent allowlist entries from blanket-waiving every blocked construct in a preset by making matches scoped to the preset ID and an explicit construct signature.
- Ensure the parity harness and compiler continue to surface unrelated regressions (e.g. new unknown fields) even when a known gap in the same fixture is allowlisted.

### Description
- Change `isMilkdropParityConstructAllowlisted` in `assets/js/milkdrop/parity-allowlist.ts` to require the allowlist entry `id` match the `presetId` and then check the entry's `constructSignatures` for the specific construct `signature` instead of allowing any construct for a matching preset ID.
- Add `constructSignatures` to `assets/data/milkdrop-parity/allowlist.json` for `parity-allowlisted-shader-gap` so the intended shader approximation (`shader:unsupported(shader)`) is explicitly waived.
- Add regression tests asserting that an unknown field in an allowlisted preset still blocks while the named shader gap remains non-regressive in `tests/milkdrop-compiler.test.ts` and `tests/milkdrop-parity.test.ts`.
- Apply formatting fixes to the updated JSON and test files to satisfy the repo formatter/linter.

### Testing
- Verified the allowlist lookup behavior with a quick runtime check using Bun that returns `{ shader: true, field: false, otherPreset: false }`, confirming the signature-scoped matching succeeded.
- Ran `bun run test tests/milkdrop-compiler.test.ts` and `bun run test tests/milkdrop-parity.test.ts`, both of which failed due to pre-existing parse/lint errors in `assets/js/milkdrop/compiler.ts` unrelated to these follow-up changes (the allowlist/unit test additions themselves are exercising as intended but cannot complete until the existing compiler parse issues are resolved).
- Ran the repo quality gate/tools (`biome` formatting) on changed files to fix formatting issues for `allowlist.json` and the updated test files, which succeeded; overall `bun run check` still reports the existing compiler parse/lint problems that must be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0a81a2a4833285bc3760a0070f0a)