### PR TITLE
Improve MilkDrop2 shader compatibility

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -67,6 +67,16 @@ const SHADER_TEXTURE_BLEND_MODES = new Set([
   'multiply',
 ]);
 
+const SHADER_TEXTURE_SAMPLER_ALIASES: Record<
+  string,
+  MilkdropShaderTextureSampler | 'main'
+> = {
+  fw_noise_lq: 'noise',
+  fw_noise_hq: 'noise',
+  noise_lq: 'noise',
+  noise_hq: 'noise',
+};
+
 function createDefaultShapeSlot(index: number): Record<string, number> {
   if (index === 1) {
     return {
@@ -501,6 +511,8 @@ function collectExpressionsFromValue(
   Object.values(value).forEach((entry) =>
     collectExpressionsFromValue(entry, expressions),
   );
+}
+
 function createBackendEvidence(
   evidence: MilkdropBackendSupportEvidence,
 ): MilkdropBackendSupportEvidence {
@@ -731,16 +743,27 @@ function classifyFidelity({
   const hasBlockingConstruct = blockedConstructDetails.some(
     (construct) => !construct.allowlisted,
   );
-  const hasBlockingReason = degradationReasons.some(
+  const blockingReasons = degradationReasons.filter(
     (reason) => reason.blocking,
   );
+  const hasBlockingReason = blockingReasons.length > 0;
   const hasUnsupportedBackend =
     webgl.status === 'unsupported' || webgpu.status === 'unsupported';
   const hasBackendPartial = [...webgl.evidence, ...webgpu.evidence].some(
     (entry) => entry.status === 'partial',
   );
+  const hasOnlyAllowlistedConstructs =
+    blockedConstructDetails.length > 0 &&
+    blockedConstructDetails.every((construct) => construct.allowlisted);
+  const hasOnlyAllowlistedBackendBlockingReasons =
+    hasOnlyAllowlistedConstructs &&
+    hasBlockingReason &&
+    blockingReasons.every((reason) => reason.code === 'backend-unsupported');
 
-  if (hasUnsupportedBackend || hasBlockingReason) {
+  if (
+    (hasUnsupportedBackend || hasBlockingReason) &&
+    !hasOnlyAllowlistedBackendBlockingReasons
+  ) {
     return 'fallback';
   }
   if (hasBlockingConstruct) {
@@ -1326,8 +1349,9 @@ function normalizeShaderSamplerName(
   const sampler = normalized.startsWith('sampler_')
     ? normalized.slice('sampler_'.length)
     : normalized;
-  return SHADER_TEXTURE_SAMPLERS.has(sampler)
-    ? ((sampler === 'main' ? 'main' : sampler) as
+  const canonicalSampler = SHADER_TEXTURE_SAMPLER_ALIASES[sampler] ?? sampler;
+  return SHADER_TEXTURE_SAMPLERS.has(canonicalSampler)
+    ? ((canonicalSampler === 'main' ? 'main' : canonicalSampler) as
         | MilkdropShaderTextureSampler
         | 'main')
     : null;
@@ -1435,7 +1459,7 @@ function isShaderSampleRgbExpression(
 ): boolean {
   return (
     node.type === 'member' &&
-    node.property.toLowerCase() === 'rgb' &&
+    ['rgb', 'xyz'].includes(node.property.toLowerCase()) &&
     node.object.type === 'call' &&
     ['tex2d', 'texture'].includes(node.object.name.toLowerCase()) &&
     node.object.args.length >= 2
@@ -1448,7 +1472,7 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
 } | null {
   if (
     node.type !== 'member' ||
-    node.property.toLowerCase() !== 'rgb' ||
+    !['rgb', 'xyz'].includes(node.property.toLowerCase()) ||
     node.object.type !== 'call' ||
     !['tex2d', 'texture'].includes(node.object.name.toLowerCase()) ||
     node.object.args.length < 2
@@ -4126,6 +4150,19 @@ function normalizeString(rawValue: string) {
   return trimmed;
 }
 
+function normalizeShaderFieldChunk(rawValue: string) {
+  const normalized = normalizeString(rawValue).replace(/^`+/u, '').trim();
+  if (
+    normalized.length === 0 ||
+    normalized === '{' ||
+    normalized === '}' ||
+    normalized.toLowerCase() === 'shader_body'
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
 function normalizeFieldSuffix(value: string) {
   return value
     .trim()
@@ -4755,7 +4792,10 @@ function createIR(
     }
 
     if (shaderFieldPattern.test(normalizedKey)) {
-      const rawValue = normalizeString(field.rawValue);
+      const rawValue = normalizeShaderFieldChunk(field.rawValue);
+      if (!rawValue) {
+        return;
+      }
       if (
         normalizedKey === 'warp_shader' ||
         normalizedKey === 'warp_code' ||
@@ -4897,6 +4937,16 @@ function createIR(
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
+  const ignoredFields = [...unsupportedKeys].sort();
+  const approximatedShaderLines = [
+    ...shaderWarpAnalysis.unsupportedLines,
+    ...shaderCompAnalysis.unsupportedLines,
+  ].map(normalizeBlockedConstructValue);
+  const blockingConstructDetails = buildBlockingConstructDetails({
+    sourceId: source.id,
+    ignoredFields,
+    approximatedShaderLines,
+  });
   collectExpressionsFromValue(
     mergedShaderControls.expressions,
     parsedExpressions,
@@ -4924,17 +4974,15 @@ function createIR(
     parsedExpressions,
     assignedTargets,
   );
+  const hasShaderText = Boolean(warpShaderText || compShaderText);
+  const hasBlockingShaderApproximation = blockingConstructDetails.some(
+    (construct) => construct.kind === 'shader' && !construct.allowlisted,
+  );
   supportedShaderText =
-    shaderWarpAnalysis.supported || shaderCompAnalysis.supported;
-  unsupportedShaderText =
-    (!shaderWarpAnalysis.supported &&
-      !!warpShaderText &&
-      shaderWarpAnalysis.unsupportedLines.length > 0) ||
-    (!shaderCompAnalysis.supported &&
-      !!compShaderText &&
-      shaderCompAnalysis.unsupportedLines.length > 0) ||
-    shaderWarpAnalysis.unsupportedLines.length > 0 ||
-    shaderCompAnalysis.unsupportedLines.length > 0;
+    shaderWarpAnalysis.supported ||
+    shaderCompAnalysis.supported ||
+    (hasShaderText && !hasBlockingShaderApproximation);
+  unsupportedShaderText = hasBlockingShaderApproximation;
   if (unsupportedShaderText) {
     addDiagnostic(
       diagnostics,
@@ -4970,11 +5018,6 @@ function createIR(
       unsupportedKeys: [...unsupportedKeys],
     }),
   };
-  const ignoredFields = [...unsupportedKeys].sort();
-  const approximatedShaderLines = [
-    ...shaderWarpAnalysis.unsupportedLines,
-    ...shaderCompAnalysis.unsupportedLines,
-  ].map(normalizeBlockedConstructValue);
   const blockedConstructs = [
     ...ignoredFields.map(toBlockedFieldConstruct),
     ...approximatedShaderLines.map(toBlockedShaderConstruct),
@@ -4985,11 +5028,6 @@ function createIR(
     approximatedShaderLines,
     webgl: finalBackends.webgl,
     webgpu: finalBackends.webgpu,
-  });
-  const blockingConstructDetails = buildBlockingConstructDetails({
-    sourceId: source.id,
-    ignoredFields,
-    approximatedShaderLines,
   });
   const degradationReasons = buildDegradationReasons({
     blockedConstructDetails: blockingConstructDetails,

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -321,6 +321,25 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex2d(sampler_aura, uv * 1.5 
     );
   });
 
+  test('supports MilkDrop2 framebuffer noise sampler aliases in shader text', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Framebuffer Noise Alias
+comp_shader=ret = tex2d(sampler_fw_noise_lq, uv).rgb
+      `.trim(),
+      { id: 'framebuffer-noise-alias' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('noise');
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
+      [],
+    );
+  });
+
   test('supports warp texture controls in shader text', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -39,9 +39,9 @@ const PROJECTM_BACKEND_EXPECTATIONS = {
     divergence: [],
   },
   '260-compshader-noise_lq.milk': {
-    webgl: 'partial',
-    webgpu: 'unsupported',
-    divergence: ['status:webgl=partial,webgpu=unsupported'],
+    webgl: 'supported',
+    webgpu: 'partial',
+    divergence: ['status:webgl=supported,webgpu=partial'],
   },
 } as const;
 


### PR DESCRIPTION
### Motivation

- Improve compatibility with MilkDrop2 / projectM-style presets that use backtick-wrapped multiline shader chunks and framebuffer noise sampler aliases so they are parsed and classified correctly.
- Ensure sampler aliases like `sampler_fw_noise_lq` are recognized and `.xyz` shader swizzles are accepted during shader-control extraction to reduce false unsupported-classifications.
- Prevent allowlisted shader gaps from forcing a fidelity downgrade while still surfacing them as visible, non-regressive diagnostics.

### Description

- Add a canonical alias map for shader samplers and normalize sampler names in `assets/js/milkdrop/compiler.ts` so aliases such as `fw_noise_lq`/`fw_noise_hq` map to `noise` and are accepted by the shader extractor. 
- Normalize projectM/MilkDrop2 multiline shader chunks by stripping backtick wrappers via a new `normalizeShaderFieldChunk` helper and concatenating `comp_*` / `warp_*` fragments into the supported shader-text path in `assets/js/milkdrop/compiler.ts`.
- Accept `.xyz` swizzles alongside `.rgb` when detecting shader sampling expressions and extract auxiliary sample controls into `textureLayer`/`warpTexture` controls during shader analysis in `assets/js/milkdrop/compiler.ts`.
- Adjust fidelity classification logic so allowlisted shader blocked constructs remain visible without automatically downgrading fidelity to `fallback`, preserving blocking semantics for non-allowlisted regressions in `assets/js/milkdrop/compiler.ts`.
- Add a regression test for MilkDrop2 framebuffer noise sampler aliases and update the vendored projectM expectation for `260-compshader-noise_lq.milk`; tests updated in `tests/milkdrop-compiler.test.ts` and `tests/milkdrop-projectm-compat.test.ts`.

### Testing

- Ran the targeted milkdrop tests with `bun test tests/milkdrop-compiler.test.ts`, `bun test tests/milkdrop-projectm-compat.test.ts`, and `bun test tests/milkdrop-parity.test.ts`, all of which passed.
- Ran the quick and full quality gates via `bun run check:quick` and `bun run check`, and the full test suite via `bun run check` which completed with no failures (349 passed, 2 skipped, 0 failed in the CI-local run).
- Files changed: `assets/js/milkdrop/compiler.ts`, `tests/milkdrop-compiler.test.ts`, and `tests/milkdrop-projectm-compat.test.ts`.
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0c143a208332afba1725a76fc75b)