### PR TITLE
Simplify the homepage launch surfaces

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -5517,13 +5517,18 @@ body[data-page="home"] .content {
   line-height: 0.95;
 }
 
+.home-hero__aside h2 {
+  font-size: clamp(1.3rem, 2vw, 1.8rem);
+}
+
 .home-hero__support {
   margin: 0;
   color: var(--text-muted);
   line-height: 1.6;
 }
 
-.home-hero__support code {
+.home-hero__support code,
+.home-hero__aside-label code {
   font-family: inherit;
 }
 
@@ -5531,9 +5536,9 @@ body[data-page="home"] .content {
   display: grid;
   gap: 1rem;
   align-self: stretch;
+  align-content: start;
 }
 
-.home-stat-grid,
 .home-proof-grid,
 .home-lineage__grid,
 .home-source__grid {
@@ -5541,17 +5546,13 @@ body[data-page="home"] .content {
   gap: 1rem;
 }
 
-.home-stat-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.home-stat,
+.home-hero__focus,
 .home-proof-card,
-.home-route-card,
 .home-lineage__card,
 .home-source__card,
 .home-showcase__frame,
-.home-footer {
+.home-footer,
+.home-hero__aside {
   padding: 1.15rem 1.2rem;
   border-radius: calc(var(--radius-lg) + 2px);
   border: 1px solid var(--surface-border);
@@ -5565,14 +5566,13 @@ body[data-page="home"] .content {
   box-shadow: var(--shadow-soft);
 }
 
-.home-stat {
+.home-hero__focus,
+.home-hero__aside {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.75rem;
 }
 
-.home-stat__label,
-.home-proof-card__eyebrow,
-.home-route-card__label {
+.home-proof-card__eyebrow {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.16em;
@@ -5580,17 +5580,16 @@ body[data-page="home"] .content {
   color: var(--text-muted);
 }
 
-.home-stat h2,
+.home-hero__aside h2,
 .home-proof-card h3,
-.home-route-card h2,
 .home-lineage__card h3,
 .home-source__card h3 {
   margin: 0;
 }
 
-.home-stat p,
+.home-hero__focus p,
+.home-hero__aside p,
 .home-proof-card p,
-.home-route-card p,
 .home-lineage__card p,
 .home-source__card p {
   margin: 0;
@@ -5598,24 +5597,28 @@ body[data-page="home"] .content {
   line-height: 1.55;
 }
 
-.home-route-strip {
+.home-hero__checklist {
+  margin: 0;
+  padding-left: 1.15rem;
   display: grid;
-  gap: 0.85rem;
+  gap: 0.55rem;
+  color: var(--text-muted);
 }
 
-.home-route-card {
-  display: grid;
-  gap: 0.7rem;
+.home-hero__checklist li {
+  line-height: 1.55;
 }
 
-.home-route-card__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
+.home-hero__aside {
+  align-content: start;
 }
 
-.home-route-card__actions .cta-button {
-  min-height: 40px;
+.home-hero__aside-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: var(--text-muted);
 }
 
 .home-proof-grid {
@@ -5778,7 +5781,6 @@ body[data-page="home"] .content {
 
 @media (max-width: 1080px) {
   .home-hero__grid,
-  .home-stat-grid,
   .home-proof-grid,
   .launch-intro__grid,
   .shell-header--launch .shell-panels,
@@ -5798,8 +5800,7 @@ body[data-page="home"] .content {
     font-size: clamp(2.5rem, 1.5rem + 6vw, 3.6rem);
   }
 
-  .hero-cta-row.launch-intro__actions,
-  .home-route-card__actions {
+  .hero-cta-row.launch-intro__actions {
     grid-template-columns: 1fr;
   }
 
@@ -5811,14 +5812,14 @@ body[data-page="home"] .content {
     position: static;
   }
 
-  .home-stat,
+  .home-hero__focus,
   .home-proof-card,
-  .home-route-card,
   .home-lineage__card,
   .home-source__card,
   .home-showcase__frame,
   .launch-check,
-  .home-footer {
+  .home-footer,
+  .home-hero__aside {
     padding: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -119,26 +119,16 @@
                 </a>
                 <a href="/milkdrop/" class="cta-button ghost">Set up live audio</a>
               </div>
-              <p class="home-hero__support">
-                Once you are in, you can switch audio sources, browse presets, tune quality,
-                and edit without leaving <code>/milkdrop/</code>.
-              </p>
-              <div class="home-stat-grid" aria-label="Core product signals">
-                <article class="home-stat">
-                  <p class="home-stat__label">See it working</p>
-                  <h2>Demo audio starts the visuals right away.</h2>
-                  <p>No permissions and no awkward setup pause before the first frame.</p>
-                </article>
-                <article class="home-stat">
-                  <p class="home-stat__label">Use your own sound</p>
-                  <h2>Mic and tab audio are ready when you want live response.</h2>
-                  <p>Audio setup happens in the same place you will keep using afterward.</p>
-                </article>
-                <article class="home-stat">
-                  <p class="home-stat__label">Keep exploring</p>
-                  <h2>Preset browsing and editing stay in the same session.</h2>
-                  <p>Move from first launch to customization without bouncing between pages.</p>
-                </article>
+              <div class="home-hero__focus" aria-label="Launch flow summary">
+                <p class="home-hero__support">
+                  One route gets you straight to the visuals. Everything else stays tucked inside
+                  <code>/milkdrop/</code> until you want it.
+                </p>
+                <ul class="home-hero__checklist">
+                  <li>Start with demo audio and see motion immediately.</li>
+                  <li>Switch to mic or tab audio later without leaving the session.</li>
+                  <li>Browse presets or edit only when you are ready to go deeper.</li>
+                </ul>
               </div>
             </div>
 
@@ -150,40 +140,15 @@
                   <div class="milkdrop-stage__wave"></div>
                   <div class="milkdrop-stage__core"></div>
                 </div>
-                <div class="home-route-strip" aria-label="Suggested starting paths">
-                  <article class="home-route-card">
-                    <p class="home-route-card__label">Fastest first run</p>
-                    <h2>Start with demo audio.</h2>
-                    <p>See Stims working immediately, with no permissions required.</p>
-                    <div class="home-route-card__actions">
-                      <a href="/milkdrop/?audio=demo" class="cta-button primary">
-                        Start with demo audio
-                      </a>
-                    </div>
-                  </article>
-                  <article class="home-route-card">
-                    <p class="home-route-card__label">Live response</p>
-                    <h2>Bring your own audio.</h2>
-                    <p>Choose mic or tab audio when you want the visuals tied to live sound.</p>
-                    <div class="home-route-card__actions">
-                      <a href="/milkdrop/" class="cta-button ghost">Set up live audio</a>
-                    </div>
-                  </article>
-                  <article class="home-route-card">
-                    <p class="home-route-card__label">Customize</p>
-                    <h2>Browse presets or jump straight into editing.</h2>
-                    <p>Open the preset browser for a starting point, or jump into the editor when you want to tweak source.</p>
-                    <div class="home-route-card__actions">
-                      <a href="/milkdrop/?audio=demo&panel=browse" class="cta-button ghost">
-                        Open preset browser
-                      </a>
-                      <a href="/milkdrop/?audio=demo&panel=editor" class="cta-button ghost">
-                        Open editor
-                      </a>
-                    </div>
-                  </article>
-                </div>
               </div>
+              <aside class="home-hero__aside" aria-label="What opens in MilkDrop">
+                <p class="home-hero__aside-label">Inside <code>/milkdrop/</code></p>
+                <h2>The visualizer stays center stage.</h2>
+                <p>
+                  Audio setup, preset browsing, and editing are still there, but they stay
+                  behind the first launch instead of competing with it on the homepage.
+                </p>
+              </aside>
             </div>
           </div>
         </header>


### PR DESCRIPTION
### Motivation
- Reduce competing UI surfaces on the homepage so the visualizer remains the clear primary focus. 
- Make the primary launch path (demo audio → visualizer) visually dominant while keeping deeper controls accessible inside `/milkdrop/` only after launch. 
- Remove duplicated route/stat blocks that increase cognitive load on first visit.

### Description
- Replace the multi-card stat and suggested-route stack in `index.html` with a compact `home-hero__focus` launch summary and a single `home-hero__aside` that frames deeper controls as secondary (keeps the original CTA pair intact). 
- Update `assets/css/index.css` to add focused hero and aside styles (`.home-hero__focus`, `.home-hero__aside`, `.home-hero__checklist`, etc.) and remove now-unused route/stat-card styling hooks to match the simplified layout. 
- Changes committed on the working branch as `Simplify the homepage launch surfaces`.

### Testing
- Ran `bun run check` (project quality gate) which failed due to pre-existing, unrelated issues in `assets/js/milkdrop/compiler.ts` and `tests/milkdrop-projectm-compat.test.ts`. 
- Ran `bunx biome check index.html assets/css/index.css` which succeeded for the modified files. 
- Ran `bun run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be180244f48332b4a8abf9b950be42)