### PR TITLE
Share MilkDrop shader sampler canonicalization

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -14,6 +14,10 @@ import {
   evaluateMilkdropShaderExpression,
   parseMilkdropShaderStatement,
 } from './shader-ast';
+import {
+  isMilkdropShaderSamplerName,
+  normalizeMilkdropShaderSamplerName,
+} from './shader-samplers';
 import type {
   MilkdropBackendSupport,
   MilkdropBackendSupportEvidence,
@@ -48,18 +52,6 @@ import type {
 
 const MAX_CUSTOM_WAVES = 32;
 const MAX_CUSTOM_SHAPES = 32;
-const SHADER_TEXTURE_SAMPLERS = new Set([
-  'main',
-  'none',
-  'noise',
-  'perlin',
-  'simplex',
-  'voronoi',
-  'aura',
-  'caustics',
-  'pattern',
-  'fractal',
-]);
 const SHADER_TEXTURE_BLEND_MODES = new Set([
   'none',
   'replace',
@@ -67,16 +59,6 @@ const SHADER_TEXTURE_BLEND_MODES = new Set([
   'add',
   'multiply',
 ]);
-
-const SHADER_TEXTURE_SAMPLER_ALIASES: Record<
-  string,
-  MilkdropShaderTextureSampler | 'main'
-> = {
-  fw_noise_lq: 'noise',
-  fw_noise_hq: 'noise',
-  noise_lq: 'noise',
-  noise_hq: 'noise',
-};
 
 function createDefaultShapeSlot(index: number): Record<string, number> {
   if (index === 1) {
@@ -1399,16 +1381,7 @@ function parseShaderSampleMixPattern(rawValue: string) {
 function normalizeShaderSamplerName(
   value: string,
 ): MilkdropShaderTextureSampler | 'main' | null {
-  const normalized = value.trim().toLowerCase();
-  const sampler = normalized.startsWith('sampler_')
-    ? normalized.slice('sampler_'.length)
-    : normalized;
-  const canonicalSampler = SHADER_TEXTURE_SAMPLER_ALIASES[sampler] ?? sampler;
-  return SHADER_TEXTURE_SAMPLERS.has(canonicalSampler)
-    ? ((canonicalSampler === 'main' ? 'main' : canonicalSampler) as
-        | MilkdropShaderTextureSampler
-        | 'main')
-    : null;
+  return normalizeMilkdropShaderSamplerName(value);
 }
 
 function normalizeShaderTextureBlendMode(
@@ -1435,7 +1408,7 @@ function parseShaderTextureBlendMode(
 function isAuxShaderSamplerName(
   value: string,
 ): value is MilkdropShaderTextureSampler {
-  return value !== 'main' && SHADER_TEXTURE_SAMPLERS.has(value);
+  return value !== 'main' && isMilkdropShaderSamplerName(value);
 }
 
 function isKnownShaderScalarKey(key: string) {
@@ -4916,7 +4889,6 @@ function createIR(
     MilkdropProgramBlock,
     { sourceLine: string; line: number }
   >();
-  const unsupportedKeys = new Set<string>();
   let unsupportedShaderText = false;
   let supportedShaderText = false;
   let warpShaderText: string | null = null;

--- a/assets/js/milkdrop/shader-ast.ts
+++ b/assets/js/milkdrop/shader-ast.ts
@@ -1,8 +1,10 @@
 import { evaluateMilkdropExpression } from './expression';
+import { normalizeMilkdropShaderSamplerName } from './shader-samplers';
 import type {
   MilkdropExpressionNode,
   MilkdropShaderExpressionNode,
   MilkdropShaderStatement,
+  MilkdropShaderTextureSampler,
 } from './types';
 
 type Token =
@@ -18,14 +20,14 @@ type ShaderValue =
   | { kind: 'scalar'; value: number }
   | { kind: 'vec2'; value: [number, number] }
   | { kind: 'vec3'; value: [number, number, number] }
-  | { kind: 'sample'; source: string; uv: ShaderValue };
+  | {
+      kind: 'sample';
+      source: MilkdropShaderTextureSampler | 'main' | null;
+      uv: ShaderValue;
+    };
 
 function normalizeShaderSamplerName(value: string) {
-  const normalized = value.trim().toLowerCase();
-  if (normalized.startsWith('sampler_')) {
-    return normalized.slice('sampler_'.length);
-  }
-  return normalized;
+  return normalizeMilkdropShaderSamplerName(value);
 }
 
 const operatorTokens = ['<=', '>=', '==', '!=', '&&', '||'];

--- a/assets/js/milkdrop/shader-samplers.ts
+++ b/assets/js/milkdrop/shader-samplers.ts
@@ -1,0 +1,53 @@
+import type { MilkdropShaderTextureSampler } from './types';
+
+export const MILKDROP_SHADER_TEXTURE_SAMPLERS = new Set<
+  MilkdropShaderTextureSampler | 'main'
+>([
+  'main',
+  'none',
+  'noise',
+  'perlin',
+  'simplex',
+  'voronoi',
+  'aura',
+  'caustics',
+  'pattern',
+  'fractal',
+]);
+
+const SHADER_TEXTURE_SAMPLER_ALIASES: Record<
+  string,
+  MilkdropShaderTextureSampler | 'main'
+> = {
+  fw_noise_lq: 'noise',
+  fw_noise_hq: 'noise',
+  noise_lq: 'noise',
+  noise_hq: 'noise',
+  fw_noisevol: 'simplex',
+  fw_noisevol_lq: 'simplex',
+  fw_noisevol_hq: 'simplex',
+  noisevol: 'simplex',
+  noisevol_lq: 'simplex',
+  noisevol_hq: 'simplex',
+};
+
+export function normalizeMilkdropShaderSamplerName(
+  value: string,
+): MilkdropShaderTextureSampler | 'main' | null {
+  const normalized = value.trim().toLowerCase();
+  const sampler = normalized.startsWith('sampler_')
+    ? normalized.slice('sampler_'.length)
+    : normalized;
+  const canonicalSampler = SHADER_TEXTURE_SAMPLER_ALIASES[sampler] ?? sampler;
+  return MILKDROP_SHADER_TEXTURE_SAMPLERS.has(canonicalSampler)
+    ? canonicalSampler
+    : null;
+}
+
+export function isMilkdropShaderSamplerName(
+  value: string,
+): value is MilkdropShaderTextureSampler | 'main' {
+  return MILKDROP_SHADER_TEXTURE_SAMPLERS.has(
+    value as MilkdropShaderTextureSampler | 'main',
+  );
+}

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -466,6 +466,8 @@ describe('milkdrop vendored projectM fixture corpus', () => {
 
     expect(compiled.ir.numericFields.zoom).toBeCloseTo(1, 6);
     expect(compiled.ir.numericFields.zoomexp).toBeCloseTo(0.75, 6);
+  });
+
   test('keeps compiled compatibility metadata and normalized program sources stable', () => {
     const corpus = loadProjectMPresetCorpus();
     const actualSnapshot = corpus.map(({ file, compiled }) =>

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
+import {
+  evaluateMilkdropShaderExpression,
+  parseMilkdropShaderStatement,
+} from '../assets/js/milkdrop/shader-ast.ts';
+import { normalizeMilkdropShaderSamplerName } from '../assets/js/milkdrop/shader-samplers.ts';
+
+const SAMPLER_ALIAS_CASES = [
+  {
+    alias: 'sampler_fw_noise_lq',
+    canonical: 'noise',
+  },
+  {
+    alias: 'fw_noise_hq',
+    canonical: 'noise',
+  },
+  {
+    alias: 'sampler_noisevol',
+    canonical: 'simplex',
+  },
+  {
+    alias: 'sampler_fw_noisevol_lq',
+    canonical: 'simplex',
+  },
+] as const;
+
+describe('milkdrop shader sampler aliases', () => {
+  test('normalizes supported aliases through the shared helper', () => {
+    for (const { alias, canonical } of SAMPLER_ALIAS_CASES) {
+      expect(normalizeMilkdropShaderSamplerName(alias)).toBe(canonical);
+    }
+
+    expect(normalizeMilkdropShaderSamplerName('sampler_unknown_alias')).toBe(
+      null,
+    );
+  });
+
+  test('keeps AST shader sampling aligned with compiler shader extraction', () => {
+    for (const { alias, canonical } of SAMPLER_ALIAS_CASES) {
+      const astStatement = parseMilkdropShaderStatement(
+        `ret = tex2d(${alias}, uv)`,
+      );
+      expect(astStatement).not.toBeNull();
+      if (!astStatement) {
+        throw new Error(`Failed to parse shader statement for ${alias}`);
+      }
+      const astValue = evaluateMilkdropShaderExpression(
+        astStatement.expression,
+        { uv: { kind: 'vec2', value: [0.25, 0.75] } },
+        {},
+      );
+
+      expect(astValue).toMatchObject({
+        kind: 'sample',
+        source: canonical,
+      });
+
+      const sampledCompile = compileMilkdropPresetSource(
+        `title=Alias Sample\ncomp_shader=ret = tex2d(${alias}, uv).rgb`,
+        { id: `sample-${alias}` },
+      );
+      expect(sampledCompile.ir.shaderText.supported).toBe(true);
+      expect(sampledCompile.ir.post.shaderControls.textureLayer.source).toBe(
+        canonical,
+      );
+      expect(sampledCompile.ir.post.shaderControls.textureLayer.mode).toBe(
+        'replace',
+      );
+
+      const assignedCompile = compileMilkdropPresetSource(
+        `title=Alias Control\ncomp_shader=texture_source = ${alias}`,
+        { id: `control-${alias}` },
+      );
+      expect(assignedCompile.ir.shaderText.supported).toBe(true);
+      expect(assignedCompile.ir.post.shaderControls.textureLayer.source).toBe(
+        canonical,
+      );
+      expect(assignedCompile.ir.post.shaderControls.textureLayer.mode).toBe(
+        'mix',
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure compiler and shader-AST code paths normalize shader sampler identifiers the same way so sampler aliases resolve consistently across parsing, extraction, and evaluation. 
- Add support for MilkDrop2-style volume-noise (`noisevol` / `fw_noisevol_*`) aliases and keep legacy framebuffer-noise aliases canonicalized to `noise`.

### Description
- Add `assets/js/milkdrop/shader-samplers.ts` which centralizes canonical sampler names, alias mappings (including `fw_noise*` and `noisevol*`), and a typed normalizer `normalizeMilkdropShaderSamplerName(...)` plus `isMilkdropShaderSamplerName(...)`.
- Update `assets/js/milkdrop/compiler.ts` to import and use the shared normalizer and sampler-name predicate, removing the local alias table and inlining of sampler sets.
- Update `assets/js/milkdrop/shader-ast.ts` to call the shared normalizer and type shader sample sources as `MilkdropShaderTextureSampler | 'main' | null` so AST evaluation agrees with the compiler.
- Add regression tests `tests/milkdrop-shader-sampler-aliases.test.ts` that exercise the shared helper, AST `tex2d(...)` evaluation, and compiler extraction paths with legacy (`sampler_fw_noise_lq`, `fw_noise_hq`) and new volume-noise aliases (`sampler_noisevol`, `sampler_fw_noisevol_lq`).
- Small test-file parse fix in `tests/milkdrop-projectm-compat.test.ts` and a trivial unused-variable cleanup to satisfy linters during the change.

### Testing
- `bun run test tests/milkdrop-shader-sampler-aliases.test.ts` — passed (2 tests).
- `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-projectm-compat.test.ts` — passed (both targeted suites passed).
- `bun run check` (repository quality gate: Biome + typecheck + tests) — ran but the full gate still surfaces unrelated existing failures in `tests/system-controls-tv-mode.test.ts` (2 failing assertions); the changes in this PR do not introduce those failures.

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be168fee188332a02163f21920ca18)