### PR TITLE
Add MilkDrop volume-noise shader translation

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -52,6 +52,7 @@ const SHADER_TEXTURE_SAMPLERS = new Set([
   'main',
   'none',
   'noise',
+  'noisevol',
   'perlin',
   'simplex',
   'voronoi',
@@ -74,8 +75,12 @@ const SHADER_TEXTURE_SAMPLER_ALIASES: Record<
 > = {
   fw_noise_lq: 'noise',
   fw_noise_hq: 'noise',
+  fw_noisevol_lq: 'noisevol',
+  fw_noisevol_hq: 'noisevol',
   noise_lq: 'noise',
   noise_hq: 'noise',
+  noisevol_lq: 'noisevol',
+  noisevol_hq: 'noisevol',
 };
 
 function createDefaultShapeSlot(index: number): Record<string, number> {
@@ -1515,9 +1520,37 @@ function isShaderSampleRgbExpression(
     node.type === 'member' &&
     ['rgb', 'xyz'].includes(node.property.toLowerCase()) &&
     node.object.type === 'call' &&
-    ['tex2d', 'texture'].includes(node.object.name.toLowerCase()) &&
+    ['tex2d', 'texture', 'tex3d', 'texture3d'].includes(
+      node.object.name.toLowerCase(),
+    ) &&
     node.object.args.length >= 2
   );
+}
+
+function extractShaderSampleUvCoordinate(
+  node: MilkdropShaderExpressionNode,
+): MilkdropShaderExpressionNode | null {
+  if (
+    node.type === 'call' &&
+    ['vec3', 'float3'].includes(node.name.toLowerCase()) &&
+    node.args.length >= 2
+  ) {
+    const firstArg = node.args[0];
+    if (!firstArg) {
+      return null;
+    }
+    if (isShaderUvIdentifier(firstArg)) {
+      return firstArg;
+    }
+    if (
+      firstArg.type === 'call' &&
+      firstArg.name.toLowerCase() === 'vec2' &&
+      firstArg.args.length >= 2
+    ) {
+      return firstArg;
+    }
+  }
+  return node;
 }
 
 function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
@@ -1528,7 +1561,9 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
     node.type !== 'member' ||
     !['rgb', 'xyz'].includes(node.property.toLowerCase()) ||
     node.object.type !== 'call' ||
-    !['tex2d', 'texture'].includes(node.object.name.toLowerCase()) ||
+    !['tex2d', 'texture', 'tex3d', 'texture3d'].includes(
+      node.object.name.toLowerCase(),
+    ) ||
     node.object.args.length < 2
   ) {
     return null;
@@ -1545,9 +1580,13 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
   if (!source) {
     return null;
   }
+  const uv = extractShaderSampleUvCoordinate(uvArg);
+  if (!uv) {
+    return null;
+  }
   return {
     source,
-    uv: uvArg,
+    uv,
   };
 }
 
@@ -1902,7 +1941,9 @@ function applyShaderAstStatement({
     );
 
   if (
-    (statement.declaration === 'vec2' || statement.declaration === 'vec3') &&
+    (statement.declaration === 'vec2' ||
+      statement.declaration === 'vec3' ||
+      statement.declaration === 'float3') &&
     key !== 'uv' &&
     key !== 'tint' &&
     key !== 'ret' &&
@@ -4916,7 +4957,6 @@ function createIR(
     MilkdropProgramBlock,
     { sourceLine: string; line: number }
   >();
-  const unsupportedKeys = new Set<string>();
   let unsupportedShaderText = false;
   let supportedShaderText = false;
   let warpShaderText: string | null = null;

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -323,6 +323,19 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           return wrapMode > 0.5 ? fract(uv) : clamp(uv, 0.0, 1.0);
         }
 
+        vec4 sampleVolumeNoise(vec2 uv, float slice) {
+          vec2 wrappedUv = fract(uv);
+          float slicePhase = fract(slice);
+          vec2 sliceOffsetA = vec2(slice * 0.071, -slice * 0.053);
+          vec2 sliceOffsetB = vec2(-slice * 0.041, slice * 0.067);
+          vec3 simplexA = texture2D(simplexTex, fract(wrappedUv + sliceOffsetA)).rgb;
+          vec3 simplexB = texture2D(simplexTex, fract(wrappedUv * 1.37 + sliceOffsetB)).rgb;
+          vec3 noiseA = texture2D(noiseTex, fract(wrappedUv * 1.91 + sliceOffsetB.yx)).rgb;
+          vec3 noiseB = texture2D(noiseTex, fract(wrappedUv * 0.83 + sliceOffsetA.yx)).rgb;
+          vec3 blended = mix(mix(simplexA, noiseA, 0.5), mix(simplexB, noiseB, 0.5), slicePhase);
+          return vec4(blended, 1.0);
+        }
+
         vec4 sampleAuxTexture(float source, vec2 uv) {
           vec2 wrappedUv = fract(uv);
           if (source < 0.5) {
@@ -346,7 +359,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           if (source < 6.5) {
             return texture2D(patternTex, wrappedUv);
           }
-          return texture2D(fractalTex, wrappedUv);
+          if (source < 7.5) {
+            return texture2D(fractalTex, wrappedUv);
+          }
+          return sampleVolumeNoise(
+            wrappedUv + vec2(signalTime * 0.021, -signalTime * 0.017),
+            signalTime * 0.1 + dot(wrappedUv, vec2(0.31, 0.27)),
+          );
         }
 
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -179,6 +179,33 @@ function createSampleAuxTextureNode(
   return Fn(([source, sampleUv]: [any, any]) => {
     const wrappedUv = fract(sampleUv);
     const flat = vec4(0.5, 0.5, 0.5, 1);
+    const volumeNoise = Fn(() => {
+      const animatedUv = wrappedUv.add(
+        vec2(_uniforms.signalTime.mul(0.021), _uniforms.signalTime.mul(-0.017)),
+      );
+      const slice = _uniforms.signalTime
+        .mul(0.1)
+        .add(dot(wrappedUv, vec2(0.31, 0.27)));
+      const slicePhase = fract(slice);
+      const sliceOffsetA = vec2(slice.mul(0.071), slice.mul(-0.053));
+      const sliceOffsetB = vec2(slice.mul(-0.041), slice.mul(0.067));
+      const simplexA = simplexTexNode.sample(
+        fract(animatedUv.add(sliceOffsetA)),
+      ).rgb;
+      const simplexB = simplexTexNode.sample(
+        fract(animatedUv.mul(1.37).add(sliceOffsetB)),
+      ).rgb;
+      const noiseA = noiseTexNode.sample(
+        fract(animatedUv.mul(1.91).add(vec2(sliceOffsetB.y, sliceOffsetB.x))),
+      ).rgb;
+      const noiseB = noiseTexNode.sample(
+        fract(animatedUv.mul(0.83).add(vec2(sliceOffsetA.y, sliceOffsetA.x))),
+      ).rgb;
+      return vec4(
+        mix(mix(simplexA, noiseA, 0.5), mix(simplexB, noiseB, 0.5), slicePhase),
+        1,
+      );
+    });
     return select(
       source.lessThan(0.5),
       flat,
@@ -200,7 +227,11 @@ function createSampleAuxTextureNode(
                 select(
                   source.lessThan(6.5),
                   patternTexNode.sample(wrappedUv),
-                  fractalTexNode.sample(wrappedUv),
+                  select(
+                    source.lessThan(7.5),
+                    fractalTexNode.sample(wrappedUv),
+                    volumeNoise(),
+                  ),
                 ),
               ),
             ),

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -442,6 +442,8 @@ function getShaderTextureSourceId(source: string) {
     case 'noise':
     case 'perlin':
       return 1;
+    case 'noisevol':
+      return 8;
     case 'simplex':
       return 2;
     case 'voronoi':

--- a/assets/js/milkdrop/shader-ast.ts
+++ b/assets/js/milkdrop/shader-ast.ts
@@ -18,7 +18,7 @@ type ShaderValue =
   | { kind: 'scalar'; value: number }
   | { kind: 'vec2'; value: [number, number] }
   | { kind: 'vec3'; value: [number, number, number] }
-  | { kind: 'sample'; source: string; uv: ShaderValue };
+  | { kind: 'sample'; source: string; coord: ShaderValue; dimension: 2 | 3 };
 
 function normalizeShaderSamplerName(value: string) {
   const normalized = value.trim().toLowerCase();
@@ -282,7 +282,7 @@ export function parseMilkdropShaderStatement(
   line: string,
 ): MilkdropShaderStatement | null {
   const assignment = line.match(
-    /^(?:(const|float|vec2|vec3)\s+)?([a-z_][a-z0-9_]*)\s*(=|\+=|-=|\*=|\/=)\s*(.+)$/iu,
+    /^(?:(const|float|vec2|vec3|float3)\s+)?([a-z_][a-z0-9_]*)\s*(=|\+=|-=|\*=|\/=)\s*(.+)$/iu,
   );
   if (!assignment) {
     return null;
@@ -302,6 +302,7 @@ export function parseMilkdropShaderStatement(
         | 'float'
         | 'vec2'
         | 'vec3'
+        | 'float3'
         | undefined) ?? null,
     target: assignment[2]?.toLowerCase() ?? '',
     operator: (assignment[3] ?? '=') as '=' | '+=' | '-=' | '*=' | '/=',
@@ -439,8 +440,11 @@ function toScalarMilkdropExpression(
       if (
         name === 'vec2' ||
         name === 'vec3' ||
+        name === 'float3' ||
         name === 'tex2d' ||
-        name === 'texture'
+        name === 'texture' ||
+        name === 'tex3d' ||
+        name === 'texture3d'
       ) {
         return null;
       }
@@ -532,13 +536,38 @@ export function evaluateMilkdropShaderExpression(
       ) {
         return vec3(args[0].value, args[1].value, args[2].value);
       }
+      if (
+        name === 'float3' &&
+        args.length >= 2 &&
+        isVec2(args[0]) &&
+        isScalar(args[1])
+      ) {
+        return vec3(args[0].value[0], args[0].value[1], args[1].value);
+      }
+      if (
+        name === 'float3' &&
+        args.length >= 3 &&
+        isScalar(args[0]) &&
+        isScalar(args[1]) &&
+        isScalar(args[2])
+      ) {
+        return vec3(args[0].value, args[1].value, args[2].value);
+      }
       if ((name === 'tex2d' || name === 'texture') && args.length >= 2) {
         const samplerArg = node.args[0];
         const source =
           samplerArg?.type === 'identifier'
             ? normalizeShaderSamplerName(samplerArg.name)
             : 'main';
-        return { kind: 'sample', source, uv: args[1] };
+        return { kind: 'sample', source, coord: args[1], dimension: 2 };
+      }
+      if ((name === 'tex3d' || name === 'texture3d') && args.length >= 2) {
+        const samplerArg = node.args[0];
+        const source =
+          samplerArg?.type === 'identifier'
+            ? normalizeShaderSamplerName(samplerArg.name)
+            : 'main';
+        return { kind: 'sample', source, coord: args[1], dimension: 3 };
       }
       if (name === 'mix' && args.length >= 3 && isScalar(args[2])) {
         const blend = args[2].value;
@@ -605,7 +634,7 @@ export function evaluateMilkdropShaderExpression(
         return null;
       }
       const property = node.property.toLowerCase();
-      if (object.kind === 'sample' && property === 'rgb') {
+      if (object.kind === 'sample' && ['rgb', 'xyz'].includes(property)) {
         return vec3(1, 1, 1);
       }
       if (isVec2(object)) {

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -261,6 +261,7 @@ export type MilkdropShaderColorControls = {
 export type MilkdropShaderTextureSampler =
   | 'none'
   | 'noise'
+  | 'noisevol'
   | 'perlin'
   | 'simplex'
   | 'voronoi'
@@ -337,7 +338,7 @@ export type MilkdropShaderExpressionNode =
     };
 
 export type MilkdropShaderStatement = {
-  declaration: 'const' | 'float' | 'vec2' | 'vec3' | null;
+  declaration: 'const' | 'float' | 'vec2' | 'vec3' | 'float3' | null;
   target: string;
   operator: '=' | '+=' | '-=' | '*=' | '/=';
   rawValue: string;

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,13 +1310,7 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [
-      {
-        "severity": "warning",
-        "code": "preset_unsupported_shader_text",
-        "field": null
-      }
-    ],
+    "diagnostics": [],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1327,44 +1321,35 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
-        "This preset includes custom shader text outside the fully supported subset and will be approximated.",
-        "WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL."
+        "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
-      "featuresUsed": ["base-globals", "unsupported-shader-text"],
+      "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
+          "status": "supported",
+          "evidence": []
+        },
+        "webgpu": {
           "status": "partial",
           "evidence": [
             {
               "scope": "backend",
               "status": "partial",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
-            }
-          ]
-        },
-        "webgpu": {
-          "status": "unsupported",
-          "evidence": [
-            {
-              "scope": "backend",
-              "status": "unsupported",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
+              "code": "supported-shader-text-gap",
+              "feature": null
             }
           ]
         }
       },
       "parity": {
-        "fidelityClass": "fallback",
-        "backendDivergence": ["status:webgl=partial,webgpu=unsupported"],
+        "fidelityClass": "near-exact",
+        "backendDivergence": [
+          "status:webgl=supported,webgpu=partial",
+          "webgpu:supported-shader-text-gap"
+        ],
         "ignoredFields": [],
-        "blockedConstructs": [
-          "shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
-        "approximatedShaderLines": [
-          "ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
         "missingAliasesOrFunctions": []
       }
     }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -910,4 +910,28 @@ per_frame_1=zoom = missing_alias + unsupported_fn(bass_att)
       'unsupported_fn',
     ]);
   });
+
+  test('translates canonical volume-noise shader samples into supported texture controls', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Volume Noise
+comp_shader=ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz
+      `.trim(),
+      { id: 'volume-noise' },
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
+      [],
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe(
+      'noisevol',
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
+    expect(compiled.ir.post.shaderControls.textureLayer.amount).toBeCloseTo(
+      1,
+      6,
+    );
+  });
 });

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,21 +96,6 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
-const SHADER_FALLBACK_EXPECTATION = {
-  diagnostics: ['preset_unsupported_shader_text'],
-  webgl: 'partial',
-  webgpu: 'unsupported',
-  divergence: ['status:webgl=partial,webgpu=unsupported'],
-  warnings: [
-    'This preset includes custom shader text outside the fully supported subset and will be approximated.',
-    'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
-  ],
-  blockedConstructs: [
-    'shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz',
-  ],
-  unsupportedKeys: [],
-} as const satisfies ProjectMFixtureExpectation;
-
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -147,7 +132,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': SHADER_FALLBACK_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],
@@ -466,6 +451,8 @@ describe('milkdrop vendored projectM fixture corpus', () => {
 
     expect(compiled.ir.numericFields.zoom).toBeCloseTo(1, 6);
     expect(compiled.ir.numericFields.zoomexp).toBeCloseTo(0.75, 6);
+  });
+
   test('keeps compiled compatibility metadata and normalized program sources stable', () => {
     const corpus = loadProjectMPresetCorpus();
     const actualSnapshot = corpus.map(({ file, compiled }) =>


### PR DESCRIPTION
### Motivation
- Preserve a canonical MilkDrop2 volume-noise source in the shader model and let the compiler/AST detect `tex3D/texture3D` uses with `float3(...)` coordinates so they can be translated into the existing texture-control pipeline instead of being treated as unsupported shader text.
- Provide a stable, backend-compatible visual fallback that approximates 3D noise by slicing/animating existing 2D noise assets so both WebGL and WebGPU feedback managers can render volume-noise presets without hard-falling back.

### Description
- Extended the shader model and declarations by adding a `noisevol` sampler and `float3` shader declaration support in `assets/js/milkdrop/types.ts`.
- Expanded compiler sampler sets and aliases and taught the shader-analysis path to recognize `tex3d`/`texture3d` calls and `float3(...)` coordinates via `getShaderSampleInfo`, `isShaderSampleRgbExpression`, and `extractShaderSampleUvCoordinate` in `assets/js/milkdrop/compiler.ts`.
- Added parsing and evaluation for `tex3d` / `texture3d` and `float3` constructors in `assets/js/milkdrop/shader-ast.ts` so AST-based inspection resolves the same constructs the compiler accepts.
- Implemented a compatibility translation approximation for volume noise using animated 2D slices in both feedback backends by adding `sampleVolumeNoise` in `assets/js/milkdrop/feedback-manager-shared.ts` and a `volumeNoise` node in `assets/js/milkdrop/feedback-manager-webgpu.ts`.
- Mapped the new `noisevol` sampler to a texture source id in `assets/js/milkdrop/renderer-adapter.ts` so feedback uniforms route correctly.
- Updated tests: added a focused unit test for `tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz` in `tests/milkdrop-compiler.test.ts`, changed the ProjectM fixture expectation for `261-compshader-noisevol_lq.milk` in `tests/milkdrop-projectm-compat.test.ts`, and regenerated the compatibility snapshot at `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` to reflect the new classification.

### Testing
- Ran targeted tests with `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-projectm-compat.test.ts`, and both test files passed (new unit test and updated fixture expectation succeeded).
- Regenerated the ProjectM compatibility snapshot with the updated classification and committed `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` to keep fixtures in sync.
- Ran the full quality gate with `bun run check`; linting/format/typecheck completed, but the full test suite reported two pre-existing failures in `tests/system-controls-tv-mode.test.ts` unrelated to these shader changes, causing the overall `check` to fail (targeted compiler/compat tests remain green).

Docs
- None changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be168f751c83329a3014fcc01841ea)