### PR TITLE
Gate video echo orientation blockers on enabled echo

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -348,6 +348,10 @@ type HardUnsupportedFieldSpec = {
   aliases?: readonly string[];
 };
 
+type PendingHardUnsupportedField = HardUnsupportedFieldSpec & {
+  line: number;
+};
+
 /**
  * Inventory of MilkDrop2 preset fields that map to features Stims does not
  * currently emulate safely. These are treated as hard blockers instead of
@@ -557,6 +561,16 @@ function createBackendEvidence(
 
 function getHardUnsupportedField(key: string) {
   return hardUnsupportedKeys.get(key);
+}
+
+function isHardUnsupportedFieldBlocking(
+  spec: HardUnsupportedFieldSpec,
+  numericFields: Partial<Record<string, number>>,
+) {
+  if (spec.feature === 'video-echo-orientation') {
+    return (numericFields.video_echo_enabled ?? 0) > 0.5;
+  }
+  return true;
 }
 
 function buildBackendDivergence({
@@ -4911,11 +4925,14 @@ function createIR(
   const customShapeMap = new Map<number, MilkdropShapeDefinition>();
   const softUnknownKeys = new Set<string>();
   const hardUnsupportedFields = new Map<string, HardUnsupportedFieldSpec>();
+  const pendingHardUnsupportedFields = new Map<
+    string,
+    PendingHardUnsupportedField
+  >();
   const pendingProgramSources = new Map<
     MilkdropProgramBlock,
     { sourceLine: string; line: number }
   >();
-  const unsupportedKeys = new Set<string>();
   let unsupportedShaderText = false;
   let supportedShaderText = false;
   let warpShaderText: string | null = null;
@@ -5011,21 +5028,12 @@ function createIR(
       }
       if (!(normalizedKey in DEFAULT_MILKDROP_STATE)) {
         if (hardUnsupportedField) {
-          hardUnsupportedFields.set(normalizedKey, {
+          pendingHardUnsupportedFields.set(normalizedKey, {
             key: normalizedKey,
             feature: hardUnsupportedField.feature,
             message: hardUnsupportedField.message,
+            line: field.line,
           });
-          addDiagnostic(
-            diagnostics,
-            'warning',
-            'preset_unsupported_field',
-            `Unsupported MilkDrop feature "${hardUnsupportedField.feature}" uses preset field "${normalizedKey}". ${hardUnsupportedField.message}`,
-            {
-              line: field.line,
-              field: normalizedKey,
-            },
-          );
           return;
         }
         softUnknownKeys.add(normalizedKey);
@@ -5066,21 +5074,12 @@ function createIR(
 
     if (!(normalizedKey in DEFAULT_MILKDROP_STATE)) {
       if (hardUnsupportedField) {
-        hardUnsupportedFields.set(normalizedKey, {
+        pendingHardUnsupportedFields.set(normalizedKey, {
           key: normalizedKey,
           feature: hardUnsupportedField.feature,
           message: hardUnsupportedField.message,
+          line: field.line,
         });
-        addDiagnostic(
-          diagnostics,
-          'warning',
-          'preset_unsupported_field',
-          `Unsupported MilkDrop feature "${hardUnsupportedField.feature}" uses preset field "${normalizedKey}". ${hardUnsupportedField.message}`,
-          {
-            line: field.line,
-            field: normalizedKey,
-          },
-        );
         return;
       }
       softUnknownKeys.add(normalizedKey);
@@ -5115,6 +5114,27 @@ function createIR(
       parsedExpressions.push(compiledScalar.expression);
     }
     numericFields[normalizedKey] = compiledScalar.value;
+  });
+
+  pendingHardUnsupportedFields.forEach((pendingField, normalizedKey) => {
+    if (!isHardUnsupportedFieldBlocking(pendingField, numericFields)) {
+      return;
+    }
+    hardUnsupportedFields.set(normalizedKey, {
+      key: normalizedKey,
+      feature: pendingField.feature,
+      message: pendingField.message,
+    });
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'preset_unsupported_field',
+      `Unsupported MilkDrop feature "${pendingField.feature}" uses preset field "${normalizedKey}". ${pendingField.message}`,
+      {
+        line: pendingField.line,
+        field: normalizedKey,
+      },
+    );
   });
 
   pendingProgramSources.forEach(({ sourceLine, line }, block) => {

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -733,6 +733,7 @@ definitely_not_a_real_field=1
     const compiled = compileMilkdropPresetSource(
       `
 title=Blocked Import
+video_echo=1
 video_echo_orientation=2
       `.trim(),
       { id: 'blocked-import', origin: 'imported' },
@@ -773,6 +774,32 @@ video_echo_orientation=2
           message: expect.stringContaining('video-echo-orientation'),
         }),
       ]),
+    );
+  });
+
+  test('ignores dormant video echo orientation blockers when echo is disabled', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Dormant Echo Orientation
+video_echo_orientation=2
+video_echo=0
+      `.trim(),
+      { id: 'dormant-echo-orientation', origin: 'imported' },
+    );
+
+    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([]);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(
+      compiled.diagnostics.some(
+        (entry) =>
+          entry.code === 'preset_unsupported_field' &&
+          entry.field === 'video_echo_orientation',
+      ),
+    ).toBe(false);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.recommendedFallback).toBe(
+      undefined,
     );
   });
 


### PR DESCRIPTION
### Motivation

- Prevent dormant preset fields like `video_echo_orientation` from marking a preset unsupported when video echo is not actually enabled.
- Ensure hard-unsupported classification uses the resolved numeric preset state (so field order in source does not affect compatibility decisions).

### Description

- Defer hard-unsupported classification until after scalar parsing by introducing `PendingHardUnsupportedField` and collecting pending hard-unsupported fields while parsing then finalizing them once `numericFields` is known.
- Add `isHardUnsupportedFieldBlocking()` to gate `video-echo-orientation` so it only blocks when `video_echo_enabled > 0.5` and leave other hard-specs to default to blocking behavior.
- Update diagnostics to only emit `preset_unsupported_field` warnings when a hard-unsupported field is actually blocking, and add regression coverage in `tests/milkdrop-compiler.test.ts` for the active (`video_echo=1`) and dormant (`video_echo=0`) cases.

### Testing

- Ran the focused compiler tests with `bun run test tests/milkdrop-compiler.test.ts`, which passed (36 tests, 0 failures).
- Ran the project quality gate with `bun run check`, which completed but exited non-zero due to two pre-existing unrelated failures in `tests/system-controls-tv-mode.test.ts` (these failures are outside the scope of this change).
- Files changed: `assets/js/milkdrop/compiler.ts`, `tests/milkdrop-compiler.test.ts` (no docs changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be171efea08332a4f61a3cc8cb0456)