### PR TITLE
Approximate tex3D auxiliary sampling and preserve volume sampling state

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -862,6 +862,8 @@ function createDefaultShaderControls(): MilkdropShaderControls {
     tint: { r: 1, g: 1, b: 1 },
     textureLayer: {
       source: 'none',
+      sampleDimension: '2d',
+      z: 0,
       mode: 'none',
       amount: 0,
       scaleX: 1,
@@ -871,6 +873,8 @@ function createDefaultShaderControls(): MilkdropShaderControls {
     },
     warpTexture: {
       source: 'none',
+      sampleDimension: '2d',
+      z: 0,
       amount: 0,
       scaleX: 1,
       scaleY: 1,
@@ -897,6 +901,7 @@ function createDefaultShaderControlExpressions(): MilkdropShaderControlExpressio
     solarizeBoost: null,
     tint: { r: null, g: null, b: null },
     textureLayer: {
+      z: null,
       amount: null,
       scaleX: null,
       scaleY: null,
@@ -904,6 +909,7 @@ function createDefaultShaderControlExpressions(): MilkdropShaderControlExpressio
       offsetY: null,
     },
     warpTexture: {
+      z: null,
       amount: null,
       scaleX: null,
       scaleY: null,
@@ -1493,34 +1499,88 @@ function isShaderSampleRgbExpression(
   );
 }
 
+function buildShaderVec2Node(
+  x: MilkdropShaderExpressionNode,
+  y: MilkdropShaderExpressionNode,
+): MilkdropShaderExpressionNode {
+  return {
+    type: 'call',
+    name: 'vec2',
+    args: [cloneShaderNode(x), cloneShaderNode(y)],
+  };
+}
+
+function extractShaderSampleCoordinate(
+  coordinate: MilkdropShaderExpressionNode,
+): {
+  sampleDimension: '2d' | '3d';
+  uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
+} | null {
+  if (
+    coordinate.type === 'call' &&
+    ['vec3', 'float3'].includes(coordinate.name.toLowerCase())
+  ) {
+    if (coordinate.args.length >= 2) {
+      const [first, second, third] = coordinate.args;
+      if (first && second && !third) {
+        return {
+          sampleDimension: '3d',
+          uv: cloneShaderNode(first),
+          z: cloneShaderNode(second),
+        };
+      }
+      if (first && second && third) {
+        return {
+          sampleDimension: '3d',
+          uv: buildShaderVec2Node(first, second),
+          z: cloneShaderNode(third),
+        };
+      }
+    }
+    return null;
+  }
+
+  return {
+    sampleDimension: '2d',
+    uv: cloneShaderNode(coordinate),
+    z: null,
+  };
+}
+
 function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
   source: string;
+  sampleDimension: '2d' | '3d';
   uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
 } | null {
   if (
     node.type !== 'member' ||
     !['rgb', 'xyz'].includes(node.property.toLowerCase()) ||
     node.object.type !== 'call' ||
-    !['tex2d', 'texture'].includes(node.object.name.toLowerCase()) ||
+    !['tex2d', 'texture', 'tex3d'].includes(node.object.name.toLowerCase()) ||
     node.object.args.length < 2
   ) {
     return null;
   }
   const samplerArg = node.object.args[0];
-  const uvArg = node.object.args[1];
-  if (!samplerArg || !uvArg) {
+  const coordinateArg = node.object.args[1];
+  if (!samplerArg || !coordinateArg) {
     return null;
   }
   const source =
     samplerArg.type === 'identifier'
       ? normalizeShaderSamplerName(samplerArg.name)
       : 'main';
-  if (!source) {
+  const coordinate = extractShaderSampleCoordinate(coordinateArg);
+  if (!source || !coordinate) {
     return null;
   }
   return {
     source,
-    uv: uvArg,
+    sampleDimension: coordinate.sampleDimension,
+    uv: coordinate.uv,
+    z: coordinate.z,
   };
 }
 
@@ -1540,7 +1600,9 @@ function extractScaledShaderSampleExpression(
   amountValue: number;
   sample: {
     source: string;
+    sampleDimension: '2d' | '3d';
     uv: MilkdropShaderExpressionNode;
+    z: MilkdropShaderExpressionNode | null;
   };
 } | null {
   const directSample = getShaderSampleInfo(node);
@@ -2169,8 +2231,19 @@ function applyShaderAstStatement({
         return false;
       }
       controls.textureLayer.source = directSample.source;
+      controls.textureLayer.sampleDimension = directSample.sampleDimension;
       controls.textureLayer.mode = 'replace';
       controls.textureLayer.amount = 1;
+      if (directSample.z) {
+        const zExpression = toMilkdropExpression(directSample.z);
+        controls.textureLayer.z = zExpression
+          ? evaluateMilkdropExpression(zExpression, shaderEnv)
+          : 0;
+        expressions.textureLayer.z = zExpression;
+      } else {
+        controls.textureLayer.z = 0;
+        expressions.textureLayer.z = null;
+      }
       expressions.textureLayer.amount = createLiteralExpression(1);
       if (uvTransform) {
         controls.textureLayer.scaleX = uvTransform.scaleX;
@@ -2406,8 +2479,20 @@ function applyShaderAstStatement({
           return false;
         }
         controls.textureLayer.source = auxSample.sample.source;
+        controls.textureLayer.sampleDimension =
+          auxSample.sample.sampleDimension;
         controls.textureLayer.mode = 'add';
         controls.textureLayer.amount = auxSample.amountValue;
+        if (auxSample.sample.z) {
+          const zExpression = toMilkdropExpression(auxSample.sample.z);
+          controls.textureLayer.z = zExpression
+            ? evaluateMilkdropExpression(zExpression, shaderEnv)
+            : 0;
+          expressions.textureLayer.z = zExpression;
+        } else {
+          controls.textureLayer.z = 0;
+          expressions.textureLayer.z = null;
+        }
         expressions.textureLayer.amount = auxSample.amountExpression;
         if (uvTransform) {
           controls.textureLayer.scaleX = uvTransform.scaleX;
@@ -2439,8 +2524,20 @@ function applyShaderAstStatement({
           return false;
         }
         controls.textureLayer.source = auxSample.sample.source;
+        controls.textureLayer.sampleDimension =
+          auxSample.sample.sampleDimension;
         controls.textureLayer.mode = 'multiply';
         controls.textureLayer.amount = auxSample.amountValue;
+        if (auxSample.sample.z) {
+          const zExpression = toMilkdropExpression(auxSample.sample.z);
+          controls.textureLayer.z = zExpression
+            ? evaluateMilkdropExpression(zExpression, shaderEnv)
+            : 0;
+          expressions.textureLayer.z = zExpression;
+        } else {
+          controls.textureLayer.z = 0;
+          expressions.textureLayer.z = null;
+        }
         expressions.textureLayer.amount = auxSample.amountExpression;
         if (uvTransform) {
           controls.textureLayer.scaleX = uvTransform.scaleX;
@@ -3975,6 +4072,13 @@ function mergeShaderControlAnalysis(
     warpAnalysis.expressions.textureLayer.offsetY,
     0,
   );
+  const textureLayerZ = pickShaderScalar(
+    compAnalysis.controls.textureLayer.z,
+    compAnalysis.expressions.textureLayer.z,
+    warpAnalysis.controls.textureLayer.z,
+    warpAnalysis.expressions.textureLayer.z,
+    0,
+  );
   const warpTextureAmount = pickShaderScalar(
     warpAnalysis.controls.warpTexture.amount,
     warpAnalysis.expressions.warpTexture.amount,
@@ -4010,6 +4114,21 @@ function mergeShaderControlAnalysis(
     compAnalysis.expressions.warpTexture.offsetY,
     0,
   );
+  const warpTextureZ = pickShaderScalar(
+    warpAnalysis.controls.warpTexture.z,
+    warpAnalysis.expressions.warpTexture.z,
+    compAnalysis.controls.warpTexture.z,
+    compAnalysis.expressions.warpTexture.z,
+    0,
+  );
+  const textureLayerSource =
+    compAnalysis.controls.textureLayer.source !== 'none'
+      ? compAnalysis.controls.textureLayer.source
+      : warpAnalysis.controls.textureLayer.source;
+  const warpTextureSource =
+    warpAnalysis.controls.warpTexture.source !== 'none'
+      ? warpAnalysis.controls.warpTexture.source
+      : compAnalysis.controls.warpTexture.source;
 
   return {
     controls: {
@@ -4036,10 +4155,12 @@ function mergeShaderControlAnalysis(
         b: tint.b.value,
       },
       textureLayer: {
-        source:
+        source: textureLayerSource,
+        sampleDimension:
           compAnalysis.controls.textureLayer.source !== 'none'
-            ? compAnalysis.controls.textureLayer.source
-            : warpAnalysis.controls.textureLayer.source,
+            ? compAnalysis.controls.textureLayer.sampleDimension
+            : warpAnalysis.controls.textureLayer.sampleDimension,
+        z: textureLayerZ.value,
         mode:
           compAnalysis.controls.textureLayer.mode !== 'none'
             ? compAnalysis.controls.textureLayer.mode
@@ -4051,10 +4172,12 @@ function mergeShaderControlAnalysis(
         offsetY: textureLayerOffsetY.value,
       },
       warpTexture: {
-        source:
+        source: warpTextureSource,
+        sampleDimension:
           warpAnalysis.controls.warpTexture.source !== 'none'
-            ? warpAnalysis.controls.warpTexture.source
-            : compAnalysis.controls.warpTexture.source,
+            ? warpAnalysis.controls.warpTexture.sampleDimension
+            : compAnalysis.controls.warpTexture.sampleDimension,
+        z: warpTextureZ.value,
         amount: warpTextureAmount.value,
         scaleX: warpTextureScaleX.value,
         scaleY: warpTextureScaleY.value,
@@ -4086,6 +4209,7 @@ function mergeShaderControlAnalysis(
         b: tint.b.expression,
       },
       textureLayer: {
+        z: textureLayerZ.expression,
         amount: textureLayerAmount.expression,
         scaleX: textureLayerScaleX.expression,
         scaleY: textureLayerScaleY.expression,
@@ -4093,6 +4217,7 @@ function mergeShaderControlAnalysis(
         offsetY: textureLayerOffsetY.expression,
       },
       warpTexture: {
+        z: warpTextureZ.expression,
         amount: warpTextureAmount.expression,
         scaleX: warpTextureScaleX.expression,
         scaleY: warpTextureScaleY.expression,
@@ -5106,6 +5231,9 @@ function createIR(
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
+  const hasVolumeShaderSampling =
+    mergedShaderControls.controls.textureLayer.sampleDimension === '3d' ||
+    mergedShaderControls.controls.warpTexture.sampleDimension === '3d';
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
@@ -5172,6 +5300,11 @@ function createIR(
     supportedShaderText,
   });
   const sharedWarnings = [
+    ...(hasVolumeShaderSampling
+      ? [
+          'tex3D auxiliary sampling is approximated with deterministic animated 2D slices, so exact MilkDrop2 parity is not guaranteed.',
+        ]
+      : []),
     ...[...softUnknownKeys].map(
       (key) => `Unknown preset field "${key}" was ignored.`,
     ),

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -213,11 +213,15 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         feedbackSoftness: { value: this.profile.feedbackSoftness },
         currentFrameBoost: { value: this.profile.currentFrameBoost },
         overlayTextureSource: { value: 0 },
+        overlayTextureIs3D: { value: 0 },
+        overlayTextureZ: { value: 0 },
         overlayTextureMode: { value: 0 },
         overlayTextureAmount: { value: 0 },
         overlayTextureScale: { value: new Vector2(1, 1) },
         overlayTextureOffset: { value: new Vector2(0, 0) },
         warpTextureSource: { value: 0 },
+        warpTextureIs3D: { value: 0 },
+        warpTextureZ: { value: 0 },
         warpTextureAmount: { value: 0 },
         warpTextureScale: { value: new Vector2(1, 1) },
         warpTextureOffset: { value: new Vector2(0, 0) },
@@ -276,11 +280,15 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform float feedbackSoftness;
         uniform float currentFrameBoost;
         uniform float overlayTextureSource;
+        uniform float overlayTextureIs3D;
+        uniform float overlayTextureZ;
         uniform float overlayTextureMode;
         uniform float overlayTextureAmount;
         uniform vec2 overlayTextureScale;
         uniform vec2 overlayTextureOffset;
         uniform float warpTextureSource;
+        uniform float warpTextureIs3D;
+        uniform float warpTextureZ;
         uniform float warpTextureAmount;
         uniform vec2 warpTextureScale;
         uniform vec2 warpTextureOffset;
@@ -323,7 +331,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           return wrapMode > 0.5 ? fract(uv) : clamp(uv, 0.0, 1.0);
         }
 
-        vec4 sampleAuxTexture(float source, vec2 uv) {
+        vec4 sampleAuxTexture2D(float source, vec2 uv) {
           vec2 wrappedUv = fract(uv);
           if (source < 0.5) {
             return vec4(0.5, 0.5, 0.5, 1.0);
@@ -347,6 +355,33 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return texture2D(patternTex, wrappedUv);
           }
           return texture2D(fractalTex, wrappedUv);
+        }
+
+        vec2 volumeSliceOffset(float source, float z, float phase) {
+          float wrappedZ = fract(z);
+          vec2 seedUv = fract(vec2(
+            wrappedZ * 0.137 + source * 0.071 + phase * 0.19,
+            wrappedZ * 0.293 + source * 0.113 - phase * 0.17
+          ));
+          vec2 noiseWarp = texture2D(simplexTex, seedUv).rg - 0.5;
+          float angle = wrappedZ * 6.28318530718 + phase + source * 0.43;
+          float radius = 0.035 + 0.045 * wrappedZ;
+          return vec2(cos(angle), sin(angle)) * radius + noiseWarp * 0.08;
+        }
+
+        vec4 sampleAuxTexture(float source, vec2 uv, float sampleIs3D, float z) {
+          if (sampleIs3D < 0.5) {
+            return sampleAuxTexture2D(source, uv);
+          }
+          float slicePosition = fract(z) * 16.0;
+          float sliceA = floor(slicePosition) / 16.0;
+          float sliceB = fract(sliceA + (1.0 / 16.0));
+          float sliceMix = fract(slicePosition);
+          vec2 offsetA = volumeSliceOffset(source, sliceA, 0.0);
+          vec2 offsetB = volumeSliceOffset(source, sliceB, 1.57079632679);
+          vec4 sampleA = sampleAuxTexture2D(source, uv + offsetA);
+          vec4 sampleB = sampleAuxTexture2D(source, uv + offsetB);
+          return mix(sampleA, sampleB, sliceMix);
         }
 
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {
@@ -380,7 +415,12 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           );
           if (warpTextureSource > 0.5 && warpTextureAmount > 0.0001) {
             vec2 warpUv = vUv * warpTextureScale + warpTextureOffset;
-            vec2 warpVector = sampleAuxTexture(warpTextureSource, warpUv).rg - 0.5;
+            vec2 warpVector = sampleAuxTexture(
+              warpTextureSource,
+              warpUv,
+              warpTextureIs3D,
+              warpTextureZ + signalTime * 0.1
+            ).rg - 0.5;
             currentUv += warpVector * warpTextureAmount * 0.12;
             prevUv += warpVector * warpTextureAmount * 0.08;
           }
@@ -427,7 +467,12 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           color *= tint;
           if (overlayTextureSource > 0.5 && overlayTextureMode > 0.5 && overlayTextureAmount > 0.0001) {
             vec2 overlayUv = vUv * overlayTextureScale + overlayTextureOffset;
-            vec3 overlayColor = sampleAuxTexture(overlayTextureSource, overlayUv).rgb;
+            vec3 overlayColor = sampleAuxTexture(
+              overlayTextureSource,
+              overlayUv,
+              overlayTextureIs3D,
+              overlayTextureZ + signalTime * 0.1
+            ).rgb;
             float amount = clamp(overlayTextureAmount, 0.0, 1.5);
             if (overlayTextureMode < 1.5) {
               color = mix(color, overlayColor, clamp(amount, 0.0, 1.0));
@@ -502,6 +547,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.solarizeBoost.value = state.solarizeBoost;
     uniforms.tint.value.setRGB(state.tint.r, state.tint.g, state.tint.b);
     uniforms.overlayTextureSource.value = state.overlayTextureSource;
+    uniforms.overlayTextureIs3D.value = state.overlayTextureIs3D;
+    uniforms.overlayTextureZ.value = state.overlayTextureZ;
     uniforms.overlayTextureMode.value = state.overlayTextureMode;
     uniforms.overlayTextureAmount.value = state.overlayTextureAmount;
     uniforms.overlayTextureScale.value.set(
@@ -513,6 +560,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
       state.overlayTextureOffset.y,
     );
     uniforms.warpTextureSource.value = state.warpTextureSource;
+    uniforms.warpTextureIs3D.value = state.warpTextureIs3D;
+    uniforms.warpTextureZ.value = state.warpTextureZ;
     uniforms.warpTextureAmount.value = state.warpTextureAmount;
     uniforms.warpTextureScale.value.set(
       state.warpTextureScale.x,

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -31,6 +31,7 @@ const {
   dot,
   Fn,
   float,
+  floor,
   fract,
   If,
   length,
@@ -176,7 +177,7 @@ function createSampleAuxTextureNode(
   patternTexNode: ReturnType<typeof texture>,
   fractalTexNode: ReturnType<typeof texture>,
 ) {
-  return Fn(([source, sampleUv]: [any, any]) => {
+  const sampleAuxTexture2DNode = Fn(([source, sampleUv]: [any, any]) => {
     const wrappedUv = fract(sampleUv);
     const flat = vec4(0.5, 0.5, 0.5, 1);
     return select(
@@ -207,6 +208,46 @@ function createSampleAuxTextureNode(
           ),
         ),
       ),
+    );
+  });
+
+  const volumeSliceOffsetNode = Fn(
+    ([source, zValue, phase]: [any, any, any]) => {
+      const wrappedZ = fract(zValue);
+      const seedUv = fract(
+        vec2(
+          wrappedZ.mul(0.137).add(source.mul(0.071)).add(phase.mul(0.19)),
+          wrappedZ.mul(0.293).add(source.mul(0.113)).sub(phase.mul(0.17)),
+        ),
+      );
+      const noiseWarp = simplexTexNode.sample(seedUv).rg.sub(0.5);
+      const angle = wrappedZ
+        .mul(6.28318530718)
+        .add(phase)
+        .add(source.mul(0.43));
+      const radius = float(0.035).add(wrappedZ.mul(0.045));
+      return vec2(cos(angle), sin(angle)).mul(radius).add(noiseWarp.mul(0.08));
+    },
+  );
+
+  return Fn(([source, sampleUv, sampleIs3D, zValue]: [any, any, any, any]) => {
+    const slicePosition = fract(zValue).mul(16);
+    const sliceA = floor(slicePosition).div(16);
+    const sliceB = fract(sliceA.add(1 / 16));
+    const sliceMix = fract(slicePosition);
+    const sampleA = sampleAuxTexture2DNode(
+      source,
+      sampleUv.add(volumeSliceOffsetNode(source, sliceA, 0)),
+    );
+    const sampleB = sampleAuxTexture2DNode(
+      source,
+      sampleUv.add(volumeSliceOffsetNode(source, sliceB, 1.57079632679)),
+    );
+    const volumeSample = mix(sampleA, sampleB, sliceMix);
+    return select(
+      sampleIs3D.lessThan(0.5),
+      sampleAuxTexture2DNode(source, sampleUv),
+      volumeSample,
     );
   });
 }
@@ -255,11 +296,15 @@ function createCompositeUniforms(
       WEBGPU_MILKDROP_BACKEND_BEHAVIOR.feedbackProfile.currentFrameBoost,
     ),
     overlayTextureSource: uniform(0),
+    overlayTextureIs3D: uniform(0),
+    overlayTextureZ: uniform(0),
     overlayTextureMode: uniform(0),
     overlayTextureAmount: uniform(0),
     overlayTextureScale: uniform(new Vector2(1, 1)),
     overlayTextureOffset: uniform(new Vector2(0, 0)),
     warpTextureSource: uniform(0),
+    warpTextureIs3D: uniform(0),
+    warpTextureZ: uniform(0),
     warpTextureAmount: uniform(0),
     warpTextureScale: uniform(new Vector2(1, 1)),
     warpTextureOffset: uniform(new Vector2(0, 0)),
@@ -317,7 +362,12 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const warpUv = baseUv
       .mul(uniforms.warpTextureScale)
       .add(uniforms.warpTextureOffset);
-    const warpVector = sampleAuxTextureNode(uniforms.warpTextureSource, warpUv)
+    const warpVector = sampleAuxTextureNode(
+      uniforms.warpTextureSource,
+      warpUv,
+      uniforms.warpTextureIs3D,
+      uniforms.warpTextureZ.add(uniforms.signalTime.mul(0.1)),
+    )
       .rg.sub(0.5)
       .toVar();
     currentUv.addAssign(
@@ -456,6 +506,8 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const overlayColor = sampleAuxTextureNode(
       uniforms.overlayTextureSource,
       overlayUv,
+      uniforms.overlayTextureIs3D,
+      uniforms.overlayTextureZ.add(uniforms.signalTime.mul(0.1)),
     ).rgb;
     const overlayAmount = clamp(uniforms.overlayTextureAmount, 0, 1.5);
     const overlayMixAmount = clamp(overlayAmount, 0, 1);
@@ -495,8 +547,18 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
       .sub(
         vec2(uniforms.signalTime.mul(0.018), uniforms.signalTime.mul(-0.026)),
       );
-    const spectralA = sampleAuxTextureNode(float(2), spectralUvA).rgb;
-    const spectralB = sampleAuxTextureNode(float(5), spectralUvB).rgb;
+    const spectralA = sampleAuxTextureNode(
+      float(2),
+      spectralUvA,
+      float(0),
+      0,
+    ).rgb;
+    const spectralB = sampleAuxTextureNode(
+      float(5),
+      spectralUvB,
+      float(0),
+      0,
+    ).rgb;
     const spectralPulse = sin(
       baseUv.x
         .add(baseUv.y)
@@ -644,6 +706,10 @@ class WebGPUMilkdropFeedbackManager {
     );
     this.compositeMaterial.uniforms.overlayTextureSource.value =
       state.overlayTextureSource;
+    this.compositeMaterial.uniforms.overlayTextureIs3D.value =
+      state.overlayTextureIs3D;
+    this.compositeMaterial.uniforms.overlayTextureZ.value =
+      state.overlayTextureZ;
     this.compositeMaterial.uniforms.overlayTextureMode.value =
       state.overlayTextureMode;
     this.compositeMaterial.uniforms.overlayTextureAmount.value =
@@ -658,6 +724,9 @@ class WebGPUMilkdropFeedbackManager {
     );
     this.compositeMaterial.uniforms.warpTextureSource.value =
       state.warpTextureSource;
+    this.compositeMaterial.uniforms.warpTextureIs3D.value =
+      state.warpTextureIs3D;
+    this.compositeMaterial.uniforms.warpTextureZ.value = state.warpTextureZ;
     this.compositeMaterial.uniforms.warpTextureAmount.value =
       state.warpTextureAmount;
     this.compositeMaterial.uniforms.warpTextureScale.value.set(

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -2056,6 +2056,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       overlayTextureSource: getShaderTextureSourceId(
         controls.textureLayer.source,
       ),
+      overlayTextureIs3D:
+        controls.textureLayer.sampleDimension === '3d' ? 1 : 0,
+      overlayTextureZ: controls.textureLayer.z,
       overlayTextureMode: getShaderTextureBlendModeId(
         controls.textureLayer.mode,
       ),
@@ -2069,6 +2072,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         y: controls.textureLayer.offsetY,
       },
       warpTextureSource: getShaderTextureSourceId(controls.warpTexture.source),
+      warpTextureIs3D: controls.warpTexture.sampleDimension === '3d' ? 1 : 0,
+      warpTextureZ: controls.warpTexture.z,
       warpTextureAmount: controls.warpTexture.amount,
       warpTextureScale: {
         x: controls.warpTexture.scaleX,

--- a/assets/js/milkdrop/shader-ast.ts
+++ b/assets/js/milkdrop/shader-ast.ts
@@ -441,7 +441,10 @@ function toScalarMilkdropExpression(
       if (
         name === 'vec2' ||
         name === 'vec3' ||
+        name === 'float2' ||
+        name === 'float3' ||
         name === 'tex2d' ||
+        name === 'tex3d' ||
         name === 'texture'
       ) {
         return null;
@@ -518,7 +521,7 @@ export function evaluateMilkdropShaderExpression(
       }
       const name = node.name.toLowerCase();
       if (
-        name === 'vec2' &&
+        (name === 'vec2' || name === 'float2') &&
         args.length >= 2 &&
         isScalar(args[0]) &&
         isScalar(args[1])
@@ -526,15 +529,28 @@ export function evaluateMilkdropShaderExpression(
         return vec2(args[0].value, args[1].value);
       }
       if (
-        name === 'vec3' &&
-        args.length >= 3 &&
-        isScalar(args[0]) &&
-        isScalar(args[1]) &&
-        isScalar(args[2])
+        (name === 'vec3' || name === 'float3') &&
+        ((args.length >= 3 &&
+          isScalar(args[0]) &&
+          isScalar(args[1]) &&
+          isScalar(args[2])) ||
+          (args.length >= 2 && isVec2(args[0]) && isScalar(args[1])))
       ) {
-        return vec3(args[0].value, args[1].value, args[2].value);
+        if (isVec2(args[0]) && isScalar(args[1])) {
+          return vec3(args[0].value[0], args[0].value[1], args[1].value);
+        }
+        const x = args[0];
+        const y = args[1];
+        const z = args[2];
+        if (isScalar(x) && isScalar(y) && isScalar(z)) {
+          return vec3(x.value, y.value, z.value);
+        }
+        return null;
       }
-      if ((name === 'tex2d' || name === 'texture') && args.length >= 2) {
+      if (
+        (name === 'tex2d' || name === 'tex3d' || name === 'texture') &&
+        args.length >= 2
+      ) {
         const samplerArg = node.args[0];
         const source =
           samplerArg?.type === 'identifier'

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -276,8 +276,12 @@ export type MilkdropShaderTextureBlendMode =
   | 'add'
   | 'multiply';
 
+export type MilkdropShaderTextureSampleDimension = '2d' | '3d';
+
 export type MilkdropShaderTextureLayerControls = {
   source: MilkdropShaderTextureSampler;
+  sampleDimension: MilkdropShaderTextureSampleDimension;
+  z: number;
   mode: MilkdropShaderTextureBlendMode;
   amount: number;
   scaleX: number;
@@ -288,6 +292,8 @@ export type MilkdropShaderTextureLayerControls = {
 
 export type MilkdropShaderTextureWarpControls = {
   source: MilkdropShaderTextureSampler;
+  sampleDimension: MilkdropShaderTextureSampleDimension;
+  z: number;
   amount: number;
   scaleX: number;
   scaleY: number;
@@ -296,6 +302,7 @@ export type MilkdropShaderTextureWarpControls = {
 };
 
 export type MilkdropShaderTextureLayerExpressions = {
+  z: MilkdropExpressionNode | null;
   amount: MilkdropExpressionNode | null;
   scaleX: MilkdropExpressionNode | null;
   scaleY: MilkdropExpressionNode | null;
@@ -304,6 +311,7 @@ export type MilkdropShaderTextureLayerExpressions = {
 };
 
 export type MilkdropShaderTextureWarpExpressions = {
+  z: MilkdropExpressionNode | null;
   amount: MilkdropExpressionNode | null;
   scaleX: MilkdropExpressionNode | null;
   scaleY: MilkdropExpressionNode | null;
@@ -761,6 +769,8 @@ export type MilkdropFeedbackCompositeState = {
     b: number;
   };
   overlayTextureSource: number;
+  overlayTextureIs3D: number;
+  overlayTextureZ: number;
   overlayTextureMode: number;
   overlayTextureAmount: number;
   overlayTextureScale: {
@@ -772,6 +782,8 @@ export type MilkdropFeedbackCompositeState = {
     y: number;
   };
   warpTextureSource: number;
+  warpTextureIs3D: number;
+  warpTextureZ: number;
   warpTextureAmount: number;
   warpTextureScale: {
     x: number;

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -18,6 +18,14 @@ describe('audio controls primary emphasis', () => {
     document.body.appendChild(bootstrapScript);
     globalThis.HTMLButtonElement =
       window.HTMLButtonElement as unknown as typeof HTMLButtonElement;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: undefined,
+    });
     window.matchMedia = ((query: string) =>
       ({
         media: query,

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,13 +1310,7 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [
-      {
-        "severity": "warning",
-        "code": "preset_unsupported_shader_text",
-        "field": null
-      }
-    ],
+    "diagnostics": [],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1327,44 +1321,33 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
-        "This preset includes custom shader text outside the fully supported subset and will be approximated.",
-        "WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL."
+        "tex3D auxiliary sampling is approximated with deterministic animated 2D slices, so exact MilkDrop2 parity is not guaranteed.",
+        "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
-      "featuresUsed": ["base-globals", "unsupported-shader-text"],
+      "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
+          "status": "partial",
+          "evidence": []
+        },
+        "webgpu": {
           "status": "partial",
           "evidence": [
             {
               "scope": "backend",
               "status": "partial",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
-            }
-          ]
-        },
-        "webgpu": {
-          "status": "unsupported",
-          "evidence": [
-            {
-              "scope": "backend",
-              "status": "unsupported",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
+              "code": "supported-shader-text-gap",
+              "feature": null
             }
           ]
         }
       },
       "parity": {
-        "fidelityClass": "fallback",
-        "backendDivergence": ["status:webgl=partial,webgpu=unsupported"],
+        "fidelityClass": "near-exact",
+        "backendDivergence": ["webgpu:supported-shader-text-gap"],
         "ignoredFields": [],
-        "blockedConstructs": [
-          "shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
-        "approximatedShaderLines": [
-          "ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
         "missingAliasesOrFunctions": []
       }
     }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -354,6 +354,44 @@ comp_shader=ret = tex2d(sampler_fw_noise_lq, uv).rgb
     );
   });
 
+  test('preserves tex3D auxiliary sampling coordinates in shader controls', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Framebuffer Noise Volume Alias
+comp_shader=ret = tex3D(sampler_fw_noisevol_lq, float3(uv * 1.25 + vec2(0.1, -0.2), time / 10.0)).xyz
+      `.trim(),
+      { id: 'framebuffer-noise-volume-alias' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '3d',
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.scaleX).toBeCloseTo(
+      1.25,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.scaleY).toBeCloseTo(
+      1.25,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.offsetX).toBeCloseTo(
+      0.1,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.offsetY).toBeCloseTo(
+      -0.2,
+      6,
+    );
+    expect(
+      compiled.ir.post.shaderControlExpressions.textureLayer.z,
+    ).not.toBeNull();
+    expect(compiled.ir.compatibility.warnings).toContain(
+      'tex3D auxiliary sampling is approximated with deterministic animated 2D slices, so exact MilkDrop2 parity is not guaranteed.',
+    );
+  });
+
   test('supports warp texture controls in shader text', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,18 +96,16 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
-const SHADER_FALLBACK_EXPECTATION = {
-  diagnostics: ['preset_unsupported_shader_text'],
+const SHADER_VOLUME_APPROXIMATION_EXPECTATION = {
+  diagnostics: [],
   webgl: 'partial',
-  webgpu: 'unsupported',
-  divergence: ['status:webgl=partial,webgpu=unsupported'],
+  webgpu: 'partial',
+  divergence: ['webgpu:supported-shader-text-gap'],
   warnings: [
-    'This preset includes custom shader text outside the fully supported subset and will be approximated.',
-    'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
+    'tex3D auxiliary sampling is approximated with deterministic animated 2D slices, so exact MilkDrop2 parity is not guaranteed.',
+    'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
   ],
-  blockedConstructs: [
-    'shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz',
-  ],
+  blockedConstructs: [],
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
@@ -147,7 +145,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': SHADER_FALLBACK_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': SHADER_VOLUME_APPROXIMATION_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -1217,4 +1217,57 @@ warp_shader=warp_texture_source = sampler_noise; warp_texture_amount = 0.08; war
       feedback?.compositeMaterial.uniforms.warpTextureScale.value.y,
     ).toBeCloseTo(1.7, 6);
   });
+
+  test('forwards tex3D auxiliary sampling state into composite uniforms', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Shader Texture Volume Uniforms
+comp_shader=ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz
+      `.trim(),
+      { id: 'shader-texture-volume-uniforms' },
+    );
+
+    const signals = makeSignals();
+    const frameState = createMilkdropVM(preset).step(signals);
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const fakeRenderer = Object.create(
+      WebGLRenderer.prototype,
+    ) as WebGLRenderer;
+    fakeRenderer.getSize = (target: Vector2) => target.set(640, 360);
+    fakeRenderer.setRenderTarget = () => fakeRenderer;
+    fakeRenderer.render = () => fakeRenderer;
+
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      renderer: fakeRenderer,
+      backend: 'webgl',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const feedback = (
+      adapter as unknown as {
+        feedback: { compositeMaterial: ShaderMaterial } | null;
+      }
+    ).feedback;
+
+    expect(
+      feedback?.compositeMaterial.uniforms.overlayTextureSource.value,
+    ).toBe(2);
+    expect(feedback?.compositeMaterial.uniforms.overlayTextureIs3D.value).toBe(
+      1,
+    );
+    expect(
+      feedback?.compositeMaterial.uniforms.overlayTextureZ.value,
+    ).toBeCloseTo(signals.time / 10, 6);
+    expect(feedback?.compositeMaterial.uniforms.overlayTextureMode.value).toBe(
+      1,
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- Some MilkDrop2 presets use `tex3D(..., float3(uv, z))` for auxiliary sampling but the pipeline collapsed those to 2D controls and fell back, causing visual instability; the change preserves the original sampling intent and provides a deterministic approximation so accepted presets render instead of falling back.

### Description
- Extend shader-control types and compiler analysis to carry `sampleDimension` and the `z` coordinate expression/value for auxiliary tex sampling, and parse `tex3D(...)` coordinates rather than collapsing them to 2D. (changes: `assets/js/milkdrop/types.ts`, `assets/js/milkdrop/shader-ast.ts`, `assets/js/milkdrop/compiler.ts`)
- Propagate the new volume-sampling state into the renderer composite state so feedback compositors receive `is3D` and `z` uniforms. (changes: `assets/js/milkdrop/renderer-adapter.ts`, types updates)
- Implement a renderer-side approximation that samples deterministic animated 2D slices and blends adjacent slices when `sampleDimension==='3d'`, reusing existing noise/simplex assets for slice variation in both shared/WebGL and WebGPU feedback managers. (changes: `assets/js/milkdrop/feedback-manager-shared.ts`, `assets/js/milkdrop/feedback-manager-webgpu.ts`)
- Add compiler/renderer tests to ensure `tex3D(..., float3(uv, time / 10.0))` preserves `z` expression and emits the new composite uniforms, update the ProjectM compatibility expectations and snapshot for `261-compshader-noisevol_lq.milk`, and stabilize an audio-controls test baseline to avoid permission flakiness. (changes: `tests/milkdrop-compiler.test.ts`, `tests/milkdrop-renderer-adapter.test.ts`, `tests/milkdrop-projectm-compat.test.ts`, `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json`, `tests/audio-controls.test.ts`)

### Testing
- Ran `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-renderer-adapter.test.ts` and the new/updated unit tests passed. (passed)
- Ran `bun run test tests/milkdrop-projectm-compat.test.ts` with the updated fixture expectation and snapshot and the corpus compatibility tests passed. (passed)
- Ran `bun run test tests/audio-controls.test.ts` after stabilizing navigator globals and the audio-controls tests passed. (passed)
- Ran the full quality gate `bun run check` (Biome format/lint, `tsc --noEmit`, and the full test suite) and it completed with all automated checks passing. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be212dc56c83328acabec56933e1fa)