### PR TITLE
Follow-up: handle program-enabled video echo blockers

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -699,6 +699,41 @@ function buildBlockingConstructDetails({
   ];
 }
 
+function resolveRuntimeGlobals({
+  numericFields,
+  programs,
+}: {
+  numericFields: Record<string, number>;
+  programs: Pick<MilkdropPresetIR['programs'], 'init' | 'perFrame'>;
+}) {
+  const runtimeGlobals = {
+    ...DEFAULT_MILKDROP_STATE,
+    ...numericFields,
+  };
+  const evaluationEnv: Record<string, number> = {
+    ...runtimeGlobals,
+  };
+
+  for (let index = 1; index <= 32; index += 1) {
+    evaluationEnv[`q${index}`] = 0;
+  }
+
+  for (const block of [programs.init, programs.perFrame]) {
+    for (const statement of block.statements) {
+      const value = evaluateMilkdropExpression(
+        statement.expression,
+        evaluationEnv,
+      );
+      evaluationEnv[statement.target] = value;
+      if (statement.target in runtimeGlobals) {
+        runtimeGlobals[statement.target] = value;
+      }
+    }
+  }
+
+  return runtimeGlobals;
+}
+
 function buildDegradationReasons({
   blockedConstructDetails,
   backendDivergence,
@@ -5116,8 +5151,17 @@ function createIR(
     numericFields[normalizedKey] = compiledScalar.value;
   });
 
+  pendingProgramSources.forEach(({ sourceLine, line }, block) => {
+    pushProgramStatement(block, sourceLine, line, diagnostics);
+  });
+
+  const runtimeGlobals = resolveRuntimeGlobals({
+    numericFields,
+    programs,
+  });
+
   pendingHardUnsupportedFields.forEach((pendingField, normalizedKey) => {
-    if (!isHardUnsupportedFieldBlocking(pendingField, numericFields)) {
+    if (!isHardUnsupportedFieldBlocking(pendingField, runtimeGlobals)) {
       return;
     }
     hardUnsupportedFields.set(normalizedKey, {
@@ -5135,10 +5179,6 @@ function createIR(
         field: normalizedKey,
       },
     );
-  });
-
-  pendingProgramSources.forEach(({ sourceLine, line }, block) => {
-    pushProgramStatement(block, sourceLine, line, diagnostics);
   });
 
   const customWaves = [...customWaveMap.values()].sort(
@@ -5214,7 +5254,7 @@ function createIR(
     programs,
     customWaves,
     customShapes,
-    numericFields,
+    numericFields: runtimeGlobals,
     unsupportedShaderText,
     supportedShaderText,
   });

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -803,6 +803,41 @@ video_echo=0
     );
   });
 
+  test.each([
+    ['init', 'init_1=video_echo_enabled=1;'],
+    ['per-frame', 'per_frame_1=video_echo_enabled=1;'],
+  ])('keeps video echo orientation blocked when %s programs enable echo', (_label, programLine) => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Program Echo Orientation
+video_echo_orientation=2
+${programLine}
+        `.trim(),
+      { id: 'program-echo-orientation', origin: 'imported' },
+    );
+
+    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([
+      'video_echo_orientation',
+    ]);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([
+      'video_echo_orientation',
+    ]);
+    expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
+      'video-echo',
+    );
+    expect(
+      compiled.diagnostics.some(
+        (entry) =>
+          entry.code === 'preset_unsupported_field' &&
+          entry.field === 'video_echo_orientation',
+      ),
+    ).toBe(true);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('unsupported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+      'unsupported',
+    );
+  });
+
   test('keeps shader approximation as a partial backend support path', () => {
     const compiled = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where `video_echo_orientation` could be silently dropped when `video_echo_enabled` is turned on by `init` or `per_frame` program statements, causing runtime echo to be enabled even though the preset was classified as supported.

### Description

- Add `resolveRuntimeGlobals()` to evaluate `init` and `perFrame` program statements into resolved runtime globals so program-driven assignments are considered during compatibility analysis.
- Use the resolved `runtimeGlobals` when calling `isHardUnsupportedFieldBlocking()` and when building feature analysis so `video-echo-orientation` only blocks when `video_echo_enabled` is actually enabled at runtime.
- Add regression coverage in `tests/milkdrop-compiler.test.ts` for presets that enable `video_echo_enabled` from `init` and `per_frame` programs to ensure `video_echo_orientation` remains a blocking unsupported field when appropriate.
- Files changed: `assets/js/milkdrop/compiler.ts`, `tests/milkdrop-compiler.test.ts`.

### Testing

- Ran the focused compiler tests with `bun run test tests/milkdrop-compiler.test.ts`, which passed (38 tests, 0 failures). 
- Ran the project quality gate with `bun run check`; Biome/TypeScript checks completed but the full `check` exited non-zero due to two pre-existing, unrelated failures in `tests/system-controls-tv-mode.test.ts`.
- Ran formatter (`biome format`) to fix formatting issues introduced by the new tests before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be250cb3bc8332ad6a932ccc631a72)