### PR TITLE
Fix tex3D shader alias extraction regressions

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -1527,7 +1527,7 @@ function isShaderSampleRgbExpression(
     node.type === 'member' &&
     ['rgb', 'xyz'].includes(node.property.toLowerCase()) &&
     node.object.type === 'call' &&
-    ['tex2d', 'tex3d'].includes(normalizeShaderCallName(node.object.name)) &&
+    normalizeShaderCallName(node.object.name) === 'tex2d' &&
     node.object.args.length >= 2
   );
 }
@@ -1540,7 +1540,7 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
     node.type !== 'member' ||
     !['rgb', 'xyz'].includes(node.property.toLowerCase()) ||
     node.object.type !== 'call' ||
-    !['tex2d', 'tex3d'].includes(normalizeShaderCallName(node.object.name)) ||
+    normalizeShaderCallName(node.object.name) !== 'tex2d' ||
     node.object.args.length < 2
   ) {
     return null;

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,7 +1310,13 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [],
+    "diagnostics": [
+      {
+        "severity": "warning",
+        "code": "preset_unsupported_shader_text",
+        "field": null
+      }
+    ],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1321,35 +1327,44 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
-        "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
+        "This preset includes custom shader text outside the fully supported subset and will be approximated.",
+        "WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL."
       ],
-      "featuresUsed": ["base-globals"],
+      "featuresUsed": ["base-globals", "unsupported-shader-text"],
       "backends": {
         "webgl": {
-          "status": "supported",
-          "evidence": []
-        },
-        "webgpu": {
           "status": "partial",
           "evidence": [
             {
               "scope": "backend",
               "status": "partial",
-              "code": "supported-shader-text-gap",
-              "feature": null
+              "code": "unsupported-shader-text-gap",
+              "feature": "unsupported-shader-text"
+            }
+          ]
+        },
+        "webgpu": {
+          "status": "unsupported",
+          "evidence": [
+            {
+              "scope": "backend",
+              "status": "unsupported",
+              "code": "unsupported-shader-text-gap",
+              "feature": "unsupported-shader-text"
             }
           ]
         }
       },
       "parity": {
-        "fidelityClass": "near-exact",
-        "backendDivergence": [
-          "status:webgl=supported,webgpu=partial",
-          "webgpu:supported-shader-text-gap"
-        ],
+        "fidelityClass": "fallback",
+        "backendDivergence": ["status:webgl=partial,webgpu=unsupported"],
         "ignoredFields": [],
-        "blockedConstructs": [],
-        "approximatedShaderLines": [],
+        "blockedConstructs": [
+          "shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
+        ],
+        "approximatedShaderLines": [
+          "ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
+        ],
         "missingAliasesOrFunctions": []
       }
     }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -538,7 +538,7 @@ comp_shader=float3 tintScale = float3(1.2, 0.9, 0.7); ret = tex2d(sampler_main, 
     expect(compiled.ir.post.shaderControls.tint.b).toBeCloseTo(0.4, 6);
   });
 
-  test('supports tex3D and texture3D shader sampler aliases', () => {
+  test('flags tex3D and texture3D shader sampler aliases as unsupported volume lookups', () => {
     for (const sampleCall of ['tex3D', 'texture3D'] as const) {
       const compiled = compileMilkdropPresetSource(
         `
@@ -548,17 +548,39 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
         { id: `shader-volume-alias-${sampleCall.toLowerCase()}` },
       );
 
-      expect(compiled.ir.shaderText.supported).toBe(true);
-      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe(
-        'simplex',
+      expect(compiled.ir.shaderText.supported).toBe(false);
+      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
+      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+        'unsupported',
       );
-      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
-      expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
-        [],
-      );
+      expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
+        `ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
+      ]);
     }
+  });
+
+  test('does not remap tex3D inversion mixes onto invert boosts', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Shader Volume Invert Mix
+comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz, 0.35)
+      `.trim(),
+      { id: 'shader-volume-invert-mix' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(false);
+    expect(compiled.ir.post.shaderControls.invertBoost).toBeCloseTo(0, 6);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+      'unsupported',
+    );
+    expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
+      'ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz, 0.35)',
+    ]);
   });
 
   test('supports resolved temp shader outputs for invert and runtime tint mixes', () => {

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,6 +96,21 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
+const UNSUPPORTED_SHADER_TEXT_EXPECTATION = {
+  diagnostics: ['preset_unsupported_shader_text'],
+  webgl: 'partial',
+  webgpu: 'unsupported',
+  divergence: ['status:webgl=partial,webgpu=unsupported'],
+  warnings: [
+    'This preset includes custom shader text outside the fully supported subset and will be approximated.',
+    'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
+  ],
+  blockedConstructs: [
+    'shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz',
+  ],
+  unsupportedKeys: [],
+} as const satisfies ProjectMFixtureExpectation;
+
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -132,7 +147,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': UNSUPPORTED_SHADER_TEXT_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -125,20 +125,23 @@ describe('milkdrop shader sampler aliases', () => {
     }
   });
 
-  test('keeps 3D sampler aliases aligned across tex3D and texture3D spellings', () => {
+  test('keeps 3D sampler aliases unsupported in compiler extraction despite AST normalization', () => {
     for (const sampleCall of ['tex3D', 'texture3D'] as const) {
       const compiled = compileMilkdropPresetSource(
         `title=Volume Alias\ncomp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
         { id: `volume-${sampleCall.toLowerCase()}` },
       );
 
-      expect(compiled.ir.shaderText.supported).toBe(true);
-      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe(
-        'simplex',
+      expect(compiled.ir.shaderText.supported).toBe(false);
+      expect(compiled.ir.shaderText.unsupportedLines).toEqual([
+        `ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
+      ]);
+      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
+      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+        'unsupported',
       );
-      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent 3D volume lookups (`tex3D`/`texture3D`) introduced by the shader-alias work from being misclassified as 2D texture-layer samples or remapped into `invertBoost`/`solarizeBoost` controls by the compiler.
- Keep AST normalization (accepting `float2`/`float3` and `tex3D` aliases) while ensuring compiler extraction only treats true 2D samples as shader-control inputs so volume sampling remains unsupported at compile time.

### Description
- Restrict sample-detection in the compiler so `isShaderSampleRgbExpression` and `getShaderSampleInfo` only treat normalized call name `tex2d` as a 2D sample, excluding `tex3d`/`texture3D` from textureLayer/invert/solarize extraction (file: `assets/js/milkdrop/compiler.ts`).
- Add regression tests asserting that `tex3D`/`texture3D` volume lookups remain unsupported by compiler extraction and that `mix(tex2d(...), 1.0 - tex3D(...), amount)` does not map to `invertBoost` (files: `tests/milkdrop-shader-sampler-aliases.test.ts`, `tests/milkdrop-compiler.test.ts`).
- Update projectM compatibility expectations and the compatibility snapshot for `261-compshader-noisevol_lq.milk` to reflect that the preset now reports unsupported shader-text fallback behavior rather than being treated as supported/near-exact (file: `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json`).
- Formatting/lint fixes applied where needed during test iteration.

### Testing
- Ran targeted unit tests: `bun run test tests/milkdrop-shader-sampler-aliases.test.ts` — all tests passed.
- Ran combined shader/compiler/compat tests: `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-projectm-compat.test.ts` — all tests passed.
- Quality gate: `bun run check` (Biome and TypeScript checks passed), but the full test suite still exposes two pre-existing, order-dependent failures in `tests/system-controls-tv-mode.test.ts`; those failures are unrelated to these shader/compiler changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be251831988332ba43c514e007952a)