### PR TITLE
Preserve tex3D volume sampling through compiler and renderer and add deterministic slice-blend approximations

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -877,19 +877,23 @@ function createDefaultShaderControls(): MilkdropShaderControls {
     textureLayer: {
       source: 'none',
       mode: 'none',
+      sampleDimension: '2d',
       amount: 0,
       scaleX: 1,
       scaleY: 1,
       offsetX: 0,
       offsetY: 0,
+      volumeSliceZ: 0,
     },
     warpTexture: {
       source: 'none',
+      sampleDimension: '2d',
       amount: 0,
       scaleX: 1,
       scaleY: 1,
       offsetX: 0,
       offsetY: 0,
+      volumeSliceZ: 0,
     },
   };
 }
@@ -916,6 +920,7 @@ function createDefaultShaderControlExpressions(): MilkdropShaderControlExpressio
       scaleY: null,
       offsetX: null,
       offsetY: null,
+      volumeSliceZ: null,
     },
     warpTexture: {
       amount: null,
@@ -923,6 +928,7 @@ function createDefaultShaderControlExpressions(): MilkdropShaderControlExpressio
       scaleY: null,
       offsetX: null,
       offsetY: null,
+      volumeSliceZ: null,
     },
   };
 }
@@ -1532,9 +1538,52 @@ function isShaderSampleRgbExpression(
   );
 }
 
+function splitShaderSampleCoordinate(node: MilkdropShaderExpressionNode): {
+  uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
+  dimension: '2d' | '3d';
+} | null {
+  if (
+    node.type === 'call' &&
+    normalizeShaderCallName(node.name) === 'vec3' &&
+    node.args.length >= 2
+  ) {
+    const first = node.args[0];
+    const second = node.args[1];
+    const third = node.args[2];
+    if (!first || !second) {
+      return null;
+    }
+    if (third) {
+      return {
+        uv: {
+          type: 'call',
+          name: 'vec2',
+          args: [cloneShaderNode(first), cloneShaderNode(second)],
+        },
+        z: cloneShaderNode(third),
+        dimension: '3d',
+      };
+    }
+    return {
+      uv: cloneShaderNode(first),
+      z: cloneShaderNode(second),
+      dimension: '3d',
+    };
+  }
+
+  return {
+    uv: cloneShaderNode(node),
+    z: null,
+    dimension: '2d',
+  };
+}
+
 function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
   source: string;
   uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
+  dimension: '2d' | '3d';
 } | null {
   if (
     node.type !== 'member' ||
@@ -1557,9 +1606,17 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
   if (!source) {
     return null;
   }
+  const dimension =
+    normalizeShaderCallName(node.object.name) === 'tex3d' ? '3d' : '2d';
+  const coordinate = splitShaderSampleCoordinate(uvArg);
+  if (!coordinate || coordinate.dimension !== dimension) {
+    return null;
+  }
   return {
     source,
-    uv: uvArg,
+    uv: coordinate.uv,
+    z: coordinate.z,
+    dimension,
   };
 }
 
@@ -1580,6 +1637,8 @@ function extractScaledShaderSampleExpression(
   sample: {
     source: string;
     uv: MilkdropShaderExpressionNode;
+    z: MilkdropShaderExpressionNode | null;
+    dimension: '2d' | '3d';
   };
 } | null {
   const directSample = getShaderSampleInfo(node);
@@ -1794,6 +1853,21 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
   return null;
 }
 
+function analyzeShaderVolumeSlice(
+  node: MilkdropShaderExpressionNode | null,
+  valueEnv: ShaderRuntimeEnv,
+  scalarEnv: Record<string, number>,
+  expressionEnv: ShaderExpressionEnv,
+): {
+  value: number;
+  expression: MilkdropExpressionNode | null;
+} | null {
+  if (!node) {
+    return null;
+  }
+  return evaluateShaderScalarResult(node, valueEnv, scalarEnv, expressionEnv);
+}
+
 function isShaderUvIdentifier(node: MilkdropShaderExpressionNode) {
   return node.type === 'identifier' && node.name.toLowerCase() === 'uv';
 }
@@ -1865,6 +1939,57 @@ function buildTintBlendExpression(
       right: amountExpression,
     },
   } satisfies MilkdropExpressionNode;
+}
+
+function applyTextureSampleState({
+  target,
+  targetExpressions,
+  sample,
+  shaderValueEnv,
+  shaderEnv,
+  shaderExpressionEnv,
+}: {
+  target:
+    | MilkdropShaderControls['textureLayer']
+    | MilkdropShaderControls['warpTexture'];
+  targetExpressions:
+    | MilkdropShaderControlExpressions['textureLayer']
+    | MilkdropShaderControlExpressions['warpTexture'];
+  sample: {
+    source: MilkdropShaderTextureSampler;
+    uv: MilkdropShaderExpressionNode;
+    z: MilkdropShaderExpressionNode | null;
+    dimension: '2d' | '3d';
+  };
+  shaderValueEnv: ShaderRuntimeEnv;
+  shaderEnv: Record<string, number>;
+  shaderExpressionEnv: ShaderExpressionEnv;
+}) {
+  const uvTransform = analyzeShaderUvTransform(sample.uv);
+  const volumeSlice = analyzeShaderVolumeSlice(
+    sample.z,
+    shaderValueEnv,
+    shaderEnv,
+    shaderExpressionEnv,
+  );
+
+  target.source = sample.source;
+  target.sampleDimension = sample.dimension;
+  target.volumeSliceZ = volumeSlice?.value ?? 0;
+  targetExpressions.volumeSliceZ = volumeSlice?.expression ?? null;
+
+  if (!uvTransform) {
+    return;
+  }
+
+  target.scaleX = uvTransform.scaleX;
+  target.scaleY = uvTransform.scaleY;
+  target.offsetX = uvTransform.offsetX;
+  target.offsetY = uvTransform.offsetY;
+  targetExpressions.scaleX = uvTransform.expressions.scaleX;
+  targetExpressions.scaleY = uvTransform.expressions.scaleY;
+  targetExpressions.offsetX = uvTransform.expressions.offsetX;
+  targetExpressions.offsetY = uvTransform.expressions.offsetY;
 }
 
 function applyShaderAstStatement({
@@ -2203,24 +2328,23 @@ function applyShaderAstStatement({
       directSample.source !== 'main' &&
       directSample.source !== 'none'
     ) {
-      const uvTransform = analyzeShaderUvTransform(directSample.uv);
       if (!isAuxShaderSamplerName(directSample.source)) {
         return false;
       }
-      controls.textureLayer.source = directSample.source;
+      applyTextureSampleState({
+        target: controls.textureLayer,
+        targetExpressions: expressions.textureLayer,
+        sample: {
+          ...directSample,
+          source: directSample.source,
+        },
+        shaderValueEnv,
+        shaderEnv,
+        shaderExpressionEnv,
+      });
       controls.textureLayer.mode = 'replace';
       controls.textureLayer.amount = 1;
       expressions.textureLayer.amount = createLiteralExpression(1);
-      if (uvTransform) {
-        controls.textureLayer.scaleX = uvTransform.scaleX;
-        controls.textureLayer.scaleY = uvTransform.scaleY;
-        controls.textureLayer.offsetX = uvTransform.offsetX;
-        controls.textureLayer.offsetY = uvTransform.offsetY;
-        expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-        expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-        expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-        expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-      }
       return true;
     }
 
@@ -2327,24 +2451,23 @@ function applyShaderAstStatement({
           auxSample.source !== 'main' &&
           auxSample.source !== 'none'
         ) {
-          const uvTransform = analyzeShaderUvTransform(auxSample.uv);
           if (!isAuxShaderSamplerName(auxSample.source)) {
             return false;
           }
-          controls.textureLayer.source = auxSample.source;
+          applyTextureSampleState({
+            target: controls.textureLayer,
+            targetExpressions: expressions.textureLayer,
+            sample: {
+              ...auxSample,
+              source: auxSample.source,
+            },
+            shaderValueEnv,
+            shaderEnv,
+            shaderExpressionEnv,
+          });
           controls.textureLayer.mode = 'mix';
           controls.textureLayer.amount = amount.value;
           expressions.textureLayer.amount = amount.expression;
-          if (uvTransform) {
-            controls.textureLayer.scaleX = uvTransform.scaleX;
-            controls.textureLayer.scaleY = uvTransform.scaleY;
-            controls.textureLayer.offsetX = uvTransform.offsetX;
-            controls.textureLayer.offsetY = uvTransform.offsetY;
-            expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-            expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-            expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-            expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-          }
           return true;
         }
         if (isShaderInvertSampleExpression(targetNode)) {
@@ -2440,24 +2563,23 @@ function applyShaderAstStatement({
         : resolvedExpression.left;
       const auxSample = extractScaledShaderSampleExpression(auxNode);
       if (auxSample) {
-        const uvTransform = analyzeShaderUvTransform(auxSample.sample.uv);
         if (!isAuxShaderSamplerName(auxSample.sample.source)) {
           return false;
         }
-        controls.textureLayer.source = auxSample.sample.source;
+        applyTextureSampleState({
+          target: controls.textureLayer,
+          targetExpressions: expressions.textureLayer,
+          sample: {
+            ...auxSample.sample,
+            source: auxSample.sample.source,
+          },
+          shaderValueEnv,
+          shaderEnv,
+          shaderExpressionEnv,
+        });
         controls.textureLayer.mode = 'add';
         controls.textureLayer.amount = auxSample.amountValue;
         expressions.textureLayer.amount = auxSample.amountExpression;
-        if (uvTransform) {
-          controls.textureLayer.scaleX = uvTransform.scaleX;
-          controls.textureLayer.scaleY = uvTransform.scaleY;
-          controls.textureLayer.offsetX = uvTransform.offsetX;
-          controls.textureLayer.offsetY = uvTransform.offsetY;
-          expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-          expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-          expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-          expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-        }
         return true;
       }
     }
@@ -2473,24 +2595,23 @@ function applyShaderAstStatement({
         : resolvedExpression.left;
       const auxSample = extractScaledShaderSampleExpression(auxNode);
       if (auxSample) {
-        const uvTransform = analyzeShaderUvTransform(auxSample.sample.uv);
         if (!isAuxShaderSamplerName(auxSample.sample.source)) {
           return false;
         }
-        controls.textureLayer.source = auxSample.sample.source;
+        applyTextureSampleState({
+          target: controls.textureLayer,
+          targetExpressions: expressions.textureLayer,
+          sample: {
+            ...auxSample.sample,
+            source: auxSample.sample.source,
+          },
+          shaderValueEnv,
+          shaderEnv,
+          shaderExpressionEnv,
+        });
         controls.textureLayer.mode = 'multiply';
         controls.textureLayer.amount = auxSample.amountValue;
         expressions.textureLayer.amount = auxSample.amountExpression;
-        if (uvTransform) {
-          controls.textureLayer.scaleX = uvTransform.scaleX;
-          controls.textureLayer.scaleY = uvTransform.scaleY;
-          controls.textureLayer.offsetX = uvTransform.offsetX;
-          controls.textureLayer.offsetY = uvTransform.offsetY;
-          expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-          expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-          expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-          expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-        }
         return true;
       }
     }
@@ -3843,6 +3964,21 @@ function pickShaderScalar(
   return { value: secondaryValue, expression: secondaryExpression };
 }
 
+function pickShaderTextureDimension(
+  primaryDimension: '2d' | '3d',
+  primaryExpression: MilkdropExpressionNode | null,
+  secondaryDimension: '2d' | '3d',
+  secondaryExpression: MilkdropExpressionNode | null,
+) {
+  if (primaryDimension === '3d' || primaryExpression) {
+    return primaryDimension;
+  }
+  if (secondaryDimension === '3d' || secondaryExpression) {
+    return secondaryDimension;
+  }
+  return primaryDimension;
+}
+
 function mergeShaderControlAnalysis(
   warpAnalysis: ReturnType<typeof extractShaderControls>,
   compAnalysis: ReturnType<typeof extractShaderControls>,
@@ -4012,6 +4148,19 @@ function mergeShaderControlAnalysis(
     warpAnalysis.expressions.textureLayer.offsetY,
     0,
   );
+  const textureLayerVolumeSliceZ = pickShaderScalar(
+    compAnalysis.controls.textureLayer.volumeSliceZ,
+    compAnalysis.expressions.textureLayer.volumeSliceZ,
+    warpAnalysis.controls.textureLayer.volumeSliceZ,
+    warpAnalysis.expressions.textureLayer.volumeSliceZ,
+    0,
+  );
+  const textureLayerSampleDimension = pickShaderTextureDimension(
+    compAnalysis.controls.textureLayer.sampleDimension,
+    compAnalysis.expressions.textureLayer.volumeSliceZ,
+    warpAnalysis.controls.textureLayer.sampleDimension,
+    warpAnalysis.expressions.textureLayer.volumeSliceZ,
+  );
   const warpTextureAmount = pickShaderScalar(
     warpAnalysis.controls.warpTexture.amount,
     warpAnalysis.expressions.warpTexture.amount,
@@ -4047,6 +4196,19 @@ function mergeShaderControlAnalysis(
     compAnalysis.expressions.warpTexture.offsetY,
     0,
   );
+  const warpTextureVolumeSliceZ = pickShaderScalar(
+    warpAnalysis.controls.warpTexture.volumeSliceZ,
+    warpAnalysis.expressions.warpTexture.volumeSliceZ,
+    compAnalysis.controls.warpTexture.volumeSliceZ,
+    compAnalysis.expressions.warpTexture.volumeSliceZ,
+    0,
+  );
+  const warpTextureSampleDimension = pickShaderTextureDimension(
+    warpAnalysis.controls.warpTexture.sampleDimension,
+    warpAnalysis.expressions.warpTexture.volumeSliceZ,
+    compAnalysis.controls.warpTexture.sampleDimension,
+    compAnalysis.expressions.warpTexture.volumeSliceZ,
+  );
 
   return {
     controls: {
@@ -4081,22 +4243,26 @@ function mergeShaderControlAnalysis(
           compAnalysis.controls.textureLayer.mode !== 'none'
             ? compAnalysis.controls.textureLayer.mode
             : warpAnalysis.controls.textureLayer.mode,
+        sampleDimension: textureLayerSampleDimension,
         amount: textureLayerAmount.value,
         scaleX: textureLayerScaleX.value,
         scaleY: textureLayerScaleY.value,
         offsetX: textureLayerOffsetX.value,
         offsetY: textureLayerOffsetY.value,
+        volumeSliceZ: textureLayerVolumeSliceZ.value,
       },
       warpTexture: {
         source:
           warpAnalysis.controls.warpTexture.source !== 'none'
             ? warpAnalysis.controls.warpTexture.source
             : compAnalysis.controls.warpTexture.source,
+        sampleDimension: warpTextureSampleDimension,
         amount: warpTextureAmount.value,
         scaleX: warpTextureScaleX.value,
         scaleY: warpTextureScaleY.value,
         offsetX: warpTextureOffsetX.value,
         offsetY: warpTextureOffsetY.value,
+        volumeSliceZ: warpTextureVolumeSliceZ.value,
       },
     },
     expressions: {
@@ -4128,6 +4294,7 @@ function mergeShaderControlAnalysis(
         scaleY: textureLayerScaleY.expression,
         offsetX: textureLayerOffsetX.expression,
         offsetY: textureLayerOffsetY.expression,
+        volumeSliceZ: textureLayerVolumeSliceZ.expression,
       },
       warpTexture: {
         amount: warpTextureAmount.expression,
@@ -4135,6 +4302,7 @@ function mergeShaderControlAnalysis(
         scaleY: warpTextureScaleY.expression,
         offsetX: warpTextureOffsetX.expression,
         offsetY: warpTextureOffsetY.expression,
+        volumeSliceZ: warpTextureVolumeSliceZ.expression,
       },
     },
   };
@@ -5150,6 +5318,24 @@ function createIR(
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
+  const volumeSamplingWarnings = [
+    mergedShaderControls.controls.textureLayer.source !== 'none' &&
+    mergedShaderControls.controls.textureLayer.sampleDimension === '3d'
+      ? `Auxiliary texture layer "${mergedShaderControls.controls.textureLayer.source}" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.`
+      : null,
+    mergedShaderControls.controls.warpTexture.source !== 'none' &&
+    mergedShaderControls.controls.warpTexture.sampleDimension === '3d'
+      ? `Warp auxiliary texture "${mergedShaderControls.controls.warpTexture.source}" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.`
+      : null,
+  ].filter((warning): warning is string => warning !== null);
+  volumeSamplingWarnings.forEach((message) =>
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'preset_shader_volume_approximation',
+      message,
+    ),
+  );
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
@@ -5223,6 +5409,7 @@ function createIR(
       ({ key, feature, message }) =>
         `Unsupported feature "${feature}" from preset field "${key}": ${message}`,
     ),
+    ...volumeSamplingWarnings,
   ];
   const backends = {
     webgl: buildBackendSupport({

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -214,13 +214,17 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         currentFrameBoost: { value: this.profile.currentFrameBoost },
         overlayTextureSource: { value: 0 },
         overlayTextureMode: { value: 0 },
+        overlayTextureSampleDimension: { value: 1 },
         overlayTextureAmount: { value: 0 },
         overlayTextureScale: { value: new Vector2(1, 1) },
         overlayTextureOffset: { value: new Vector2(0, 0) },
+        overlayTextureVolumeSliceZ: { value: 0 },
         warpTextureSource: { value: 0 },
+        warpTextureSampleDimension: { value: 1 },
         warpTextureAmount: { value: 0 },
         warpTextureScale: { value: new Vector2(1, 1) },
         warpTextureOffset: { value: new Vector2(0, 0) },
+        warpTextureVolumeSliceZ: { value: 0 },
         signalBass: { value: 0 },
         signalMid: { value: 0 },
         signalTreb: { value: 0 },
@@ -277,13 +281,17 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform float currentFrameBoost;
         uniform float overlayTextureSource;
         uniform float overlayTextureMode;
+        uniform float overlayTextureSampleDimension;
         uniform float overlayTextureAmount;
         uniform vec2 overlayTextureScale;
         uniform vec2 overlayTextureOffset;
+        uniform float overlayTextureVolumeSliceZ;
         uniform float warpTextureSource;
+        uniform float warpTextureSampleDimension;
         uniform float warpTextureAmount;
         uniform vec2 warpTextureScale;
         uniform vec2 warpTextureOffset;
+        uniform float warpTextureVolumeSliceZ;
         uniform float signalBass;
         uniform float signalMid;
         uniform float signalTreb;
@@ -323,8 +331,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           return wrapMode > 0.5 ? fract(uv) : clamp(uv, 0.0, 1.0);
         }
 
-        vec4 sampleAuxTexture(float source, vec2 uv) {
-          vec2 wrappedUv = fract(uv);
+        vec4 sampleAuxTexture2D(float source, vec2 wrappedUv) {
           if (source < 0.5) {
             return vec4(0.5, 0.5, 0.5, 1.0);
           }
@@ -347,6 +354,37 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return texture2D(patternTex, wrappedUv);
           }
           return texture2D(fractalTex, wrappedUv);
+        }
+
+        vec2 sampleVolumeAtlasUv(vec2 wrappedUv, float sliceIndex) {
+          float slicesPerAxis = 8.0;
+          float tileSize = 1.0 / slicesPerAxis;
+          float clampedSlice = clamp(sliceIndex, 0.0, slicesPerAxis * slicesPerAxis - 1.0);
+          float tileX = mod(clampedSlice, slicesPerAxis);
+          float tileY = floor(clampedSlice / slicesPerAxis);
+          return (fract(wrappedUv) + vec2(tileX, tileY)) * tileSize;
+        }
+
+        vec4 sampleAuxTexture(float source, vec2 uv, float sampleDimension, float sliceZ) {
+          vec2 wrappedUv = fract(uv);
+          if (sampleDimension < 1.5) {
+            return sampleAuxTexture2D(source, wrappedUv);
+          }
+          float totalSlices = 64.0;
+          float normalizedZ = fract(sliceZ);
+          float slicePosition = normalizedZ * (totalSlices - 1.0);
+          float sliceFloor = floor(slicePosition);
+          float sliceCeil = min(sliceFloor + 1.0, totalSlices - 1.0);
+          float sliceMix = fract(slicePosition);
+          vec4 lowerSlice = sampleAuxTexture2D(
+            source,
+            sampleVolumeAtlasUv(wrappedUv, sliceFloor)
+          );
+          vec4 upperSlice = sampleAuxTexture2D(
+            source,
+            sampleVolumeAtlasUv(wrappedUv, sliceCeil)
+          );
+          return mix(lowerSlice, upperSlice, sliceMix);
         }
 
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {
@@ -380,7 +418,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           );
           if (warpTextureSource > 0.5 && warpTextureAmount > 0.0001) {
             vec2 warpUv = vUv * warpTextureScale + warpTextureOffset;
-            vec2 warpVector = sampleAuxTexture(warpTextureSource, warpUv).rg - 0.5;
+            vec2 warpVector =
+              sampleAuxTexture(
+                warpTextureSource,
+                warpUv,
+                warpTextureSampleDimension,
+                warpTextureVolumeSliceZ
+              ).rg - 0.5;
             currentUv += warpVector * warpTextureAmount * 0.12;
             prevUv += warpVector * warpTextureAmount * 0.08;
           }
@@ -427,7 +471,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           color *= tint;
           if (overlayTextureSource > 0.5 && overlayTextureMode > 0.5 && overlayTextureAmount > 0.0001) {
             vec2 overlayUv = vUv * overlayTextureScale + overlayTextureOffset;
-            vec3 overlayColor = sampleAuxTexture(overlayTextureSource, overlayUv).rgb;
+            vec3 overlayColor =
+              sampleAuxTexture(
+                overlayTextureSource,
+                overlayUv,
+                overlayTextureSampleDimension,
+                overlayTextureVolumeSliceZ
+              ).rgb;
             float amount = clamp(overlayTextureAmount, 0.0, 1.5);
             if (overlayTextureMode < 1.5) {
               color = mix(color, overlayColor, clamp(amount, 0.0, 1.0));
@@ -503,6 +553,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.tint.value.setRGB(state.tint.r, state.tint.g, state.tint.b);
     uniforms.overlayTextureSource.value = state.overlayTextureSource;
     uniforms.overlayTextureMode.value = state.overlayTextureMode;
+    uniforms.overlayTextureSampleDimension.value =
+      state.overlayTextureSampleDimension;
     uniforms.overlayTextureAmount.value = state.overlayTextureAmount;
     uniforms.overlayTextureScale.value.set(
       state.overlayTextureScale.x,
@@ -512,7 +564,11 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
       state.overlayTextureOffset.x,
       state.overlayTextureOffset.y,
     );
+    uniforms.overlayTextureVolumeSliceZ.value =
+      state.overlayTextureVolumeSliceZ;
     uniforms.warpTextureSource.value = state.warpTextureSource;
+    uniforms.warpTextureSampleDimension.value =
+      state.warpTextureSampleDimension;
     uniforms.warpTextureAmount.value = state.warpTextureAmount;
     uniforms.warpTextureScale.value.set(
       state.warpTextureScale.x,
@@ -522,6 +578,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
       state.warpTextureOffset.x,
       state.warpTextureOffset.y,
     );
+    uniforms.warpTextureVolumeSliceZ.value = state.warpTextureVolumeSliceZ;
     uniforms.signalBass.value = state.signalBass;
     uniforms.signalMid.value = state.signalMid;
     uniforms.signalTreb.value = state.signalTreb;

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -211,6 +211,18 @@ function createSampleAuxTextureNode(
   });
 }
 
+function createSampleVolumeAtlasUvNode() {
+  return Fn(([wrappedUv, sliceIndex]: [any, any]) => {
+    const slicesPerAxis = float(8);
+    const tileSize = float(1).div(slicesPerAxis);
+    const maxSliceIndex = slicesPerAxis.mul(slicesPerAxis).sub(1);
+    const clampedSlice = clamp(sliceIndex, 0, maxSliceIndex);
+    const tileY = clampedSlice.div(slicesPerAxis).floor();
+    const tileX = clampedSlice.sub(tileY.mul(slicesPerAxis));
+    return fract(wrappedUv).add(vec2(tileX, tileY)).mul(tileSize);
+  });
+}
+
 function createCompositeUniforms(
   sceneTexture: Texture,
   previousTexture: Texture,
@@ -256,13 +268,17 @@ function createCompositeUniforms(
     ),
     overlayTextureSource: uniform(0),
     overlayTextureMode: uniform(0),
+    overlayTextureSampleDimension: uniform(1),
     overlayTextureAmount: uniform(0),
     overlayTextureScale: uniform(new Vector2(1, 1)),
     overlayTextureOffset: uniform(new Vector2(0, 0)),
+    overlayTextureVolumeSliceZ: uniform(0),
     warpTextureSource: uniform(0),
+    warpTextureSampleDimension: uniform(1),
     warpTextureAmount: uniform(0),
     warpTextureScale: uniform(new Vector2(1, 1)),
     warpTextureOffset: uniform(new Vector2(0, 0)),
+    warpTextureVolumeSliceZ: uniform(0),
     signalBass: uniform(0),
     signalMid: uniform(0),
     signalTreb: uniform(0),
@@ -285,6 +301,28 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     uniforms.causticsTex,
     uniforms.patternTex,
     uniforms.fractalTex,
+  );
+  const sampleVolumeAtlasUvNode = createSampleVolumeAtlasUvNode();
+  const sampleAuxTextureWithDimensionNode = Fn(
+    ([source, sampleUv, sampleDimension, sliceZ]: [any, any, any, any]) => {
+      const wrappedUv = fract(sampleUv);
+      const totalSlices = float(64);
+      const slicePosition = fract(sliceZ).mul(totalSlices.sub(1)).toVar();
+      const lowerIndex = slicePosition.floor();
+      const upperIndex = min(lowerIndex.add(1), totalSlices.sub(1));
+      const sliceMix = fract(slicePosition);
+      const lowerSlice = sampleAuxTextureNode(
+        source,
+        sampleVolumeAtlasUvNode(wrappedUv, lowerIndex),
+      );
+      const upperSlice = sampleAuxTextureNode(
+        source,
+        sampleVolumeAtlasUvNode(wrappedUv, upperIndex),
+      );
+      const volumeSample = mix(lowerSlice, upperSlice, sliceMix);
+      const planarSample = sampleAuxTextureNode(source, wrappedUv);
+      return mix(planarSample, volumeSample, step(1.5, sampleDimension));
+    },
   );
 
   return Fn(() => {
@@ -317,7 +355,12 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const warpUv = baseUv
       .mul(uniforms.warpTextureScale)
       .add(uniforms.warpTextureOffset);
-    const warpVector = sampleAuxTextureNode(uniforms.warpTextureSource, warpUv)
+    const warpVector = sampleAuxTextureWithDimensionNode(
+      uniforms.warpTextureSource,
+      warpUv,
+      uniforms.warpTextureSampleDimension,
+      uniforms.warpTextureVolumeSliceZ,
+    )
       .rg.sub(0.5)
       .toVar();
     currentUv.addAssign(
@@ -453,9 +496,11 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const overlayUv = baseUv
       .mul(uniforms.overlayTextureScale)
       .add(uniforms.overlayTextureOffset);
-    const overlayColor = sampleAuxTextureNode(
+    const overlayColor = sampleAuxTextureWithDimensionNode(
       uniforms.overlayTextureSource,
       overlayUv,
+      uniforms.overlayTextureSampleDimension,
+      uniforms.overlayTextureVolumeSliceZ,
     ).rgb;
     const overlayAmount = clamp(uniforms.overlayTextureAmount, 0, 1.5);
     const overlayMixAmount = clamp(overlayAmount, 0, 1);
@@ -646,6 +691,8 @@ class WebGPUMilkdropFeedbackManager {
       state.overlayTextureSource;
     this.compositeMaterial.uniforms.overlayTextureMode.value =
       state.overlayTextureMode;
+    this.compositeMaterial.uniforms.overlayTextureSampleDimension.value =
+      state.overlayTextureSampleDimension;
     this.compositeMaterial.uniforms.overlayTextureAmount.value =
       state.overlayTextureAmount;
     this.compositeMaterial.uniforms.overlayTextureScale.value.set(
@@ -656,8 +703,12 @@ class WebGPUMilkdropFeedbackManager {
       state.overlayTextureOffset.x,
       state.overlayTextureOffset.y,
     );
+    this.compositeMaterial.uniforms.overlayTextureVolumeSliceZ.value =
+      state.overlayTextureVolumeSliceZ;
     this.compositeMaterial.uniforms.warpTextureSource.value =
       state.warpTextureSource;
+    this.compositeMaterial.uniforms.warpTextureSampleDimension.value =
+      state.warpTextureSampleDimension;
     this.compositeMaterial.uniforms.warpTextureAmount.value =
       state.warpTextureAmount;
     this.compositeMaterial.uniforms.warpTextureScale.value.set(
@@ -668,6 +719,8 @@ class WebGPUMilkdropFeedbackManager {
       state.warpTextureOffset.x,
       state.warpTextureOffset.y,
     );
+    this.compositeMaterial.uniforms.warpTextureVolumeSliceZ.value =
+      state.warpTextureVolumeSliceZ;
     this.compositeMaterial.uniforms.signalBass.value = state.signalBass;
     this.compositeMaterial.uniforms.signalMid.value = state.signalMid;
     this.compositeMaterial.uniforms.signalTreb.value = state.signalTreb;

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -474,6 +474,10 @@ function getShaderTextureBlendModeId(mode: string) {
   }
 }
 
+function getShaderTextureSampleDimensionId(dimension: string) {
+  return dimension === '3d' ? 2 : 1;
+}
+
 export function getFeedbackBackendProfile(
   backend: 'webgl' | 'webgpu',
 ): FeedbackBackendProfile {
@@ -2059,6 +2063,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       overlayTextureMode: getShaderTextureBlendModeId(
         controls.textureLayer.mode,
       ),
+      overlayTextureSampleDimension: getShaderTextureSampleDimensionId(
+        controls.textureLayer.sampleDimension,
+      ),
       overlayTextureAmount: controls.textureLayer.amount,
       overlayTextureScale: {
         x: controls.textureLayer.scaleX,
@@ -2068,7 +2075,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         x: controls.textureLayer.offsetX,
         y: controls.textureLayer.offsetY,
       },
+      overlayTextureVolumeSliceZ: controls.textureLayer.volumeSliceZ,
       warpTextureSource: getShaderTextureSourceId(controls.warpTexture.source),
+      warpTextureSampleDimension: getShaderTextureSampleDimensionId(
+        controls.warpTexture.sampleDimension,
+      ),
       warpTextureAmount: controls.warpTexture.amount,
       warpTextureScale: {
         x: controls.warpTexture.scaleX,
@@ -2078,6 +2089,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         x: controls.warpTexture.offsetX,
         y: controls.warpTexture.offsetY,
       },
+      warpTextureVolumeSliceZ: controls.warpTexture.volumeSliceZ,
       signalBass: frameState.signals.bass,
       signalMid: frameState.signals.mid,
       signalTreb: frameState.signals.treb,

--- a/assets/js/milkdrop/shader-ast.ts
+++ b/assets/js/milkdrop/shader-ast.ts
@@ -23,7 +23,9 @@ type ShaderValue =
   | {
       kind: 'sample';
       source: MilkdropShaderTextureSampler | 'main' | null;
+      dimension: '2d' | '3d';
       uv: ShaderValue;
+      z: ShaderValue | null;
     };
 
 function normalizeShaderSamplerName(value: string) {
@@ -589,7 +591,23 @@ export function evaluateMilkdropShaderExpression(
           samplerArg?.type === 'identifier'
             ? normalizeShaderSamplerName(samplerArg.name)
             : 'main';
-        return { kind: 'sample', source, uv: args[1] };
+        const coordinate = args[1];
+        const isVolumeSample = name === 'tex3d';
+        let uv: ShaderValue = coordinate;
+        let z: ShaderValue | null = null;
+
+        if (isVolumeSample && coordinate.kind === 'vec3') {
+          uv = vec2(coordinate.value[0], coordinate.value[1]);
+          z = scalar(coordinate.value[2]);
+        }
+
+        return {
+          kind: 'sample',
+          source,
+          dimension: isVolumeSample ? '3d' : '2d',
+          uv,
+          z,
+        };
       }
       if (name === 'mix' && args.length >= 3 && isScalar(args[2])) {
         const blend = args[2].value;

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -276,23 +276,29 @@ export type MilkdropShaderTextureBlendMode =
   | 'add'
   | 'multiply';
 
+export type MilkdropShaderTextureSampleDimension = '2d' | '3d';
+
 export type MilkdropShaderTextureLayerControls = {
   source: MilkdropShaderTextureSampler;
   mode: MilkdropShaderTextureBlendMode;
+  sampleDimension: MilkdropShaderTextureSampleDimension;
   amount: number;
   scaleX: number;
   scaleY: number;
   offsetX: number;
   offsetY: number;
+  volumeSliceZ: number;
 };
 
 export type MilkdropShaderTextureWarpControls = {
   source: MilkdropShaderTextureSampler;
+  sampleDimension: MilkdropShaderTextureSampleDimension;
   amount: number;
   scaleX: number;
   scaleY: number;
   offsetX: number;
   offsetY: number;
+  volumeSliceZ: number;
 };
 
 export type MilkdropShaderTextureLayerExpressions = {
@@ -301,6 +307,7 @@ export type MilkdropShaderTextureLayerExpressions = {
   scaleY: MilkdropExpressionNode | null;
   offsetX: MilkdropExpressionNode | null;
   offsetY: MilkdropExpressionNode | null;
+  volumeSliceZ: MilkdropExpressionNode | null;
 };
 
 export type MilkdropShaderTextureWarpExpressions = {
@@ -309,6 +316,7 @@ export type MilkdropShaderTextureWarpExpressions = {
   scaleY: MilkdropExpressionNode | null;
   offsetX: MilkdropExpressionNode | null;
   offsetY: MilkdropExpressionNode | null;
+  volumeSliceZ: MilkdropExpressionNode | null;
 };
 
 export type MilkdropShaderExpressionNode =
@@ -762,6 +770,7 @@ export type MilkdropFeedbackCompositeState = {
   };
   overlayTextureSource: number;
   overlayTextureMode: number;
+  overlayTextureSampleDimension: number;
   overlayTextureAmount: number;
   overlayTextureScale: {
     x: number;
@@ -771,7 +780,9 @@ export type MilkdropFeedbackCompositeState = {
     x: number;
     y: number;
   };
+  overlayTextureVolumeSliceZ: number;
   warpTextureSource: number;
+  warpTextureSampleDimension: number;
   warpTextureAmount: number;
   warpTextureScale: {
     x: number;
@@ -781,6 +792,7 @@ export type MilkdropFeedbackCompositeState = {
     x: number;
     y: number;
   };
+  warpTextureVolumeSliceZ: number;
   signalBass: number;
   signalMid: number;
   signalTreb: number;

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -8,12 +8,25 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 let initAudioControls: typeof import('../assets/js/ui/audio-controls.ts').initAudioControls;
 let buildTryThisFirstRecommendation: typeof import('../assets/js/ui/audio-controls.ts').buildTryThisFirstRecommendation;
+const originalNavigator = globalThis.navigator;
 
 describe('audio controls primary emphasis', () => {
   beforeEach(async () => {
     document.body.innerHTML = '';
     sessionStorage.clear();
     localStorage.clear();
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: originalNavigator.mediaDevices,
+    });
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: originalNavigator.permissions,
+    });
     const bootstrapScript = document.createElement('script');
     document.body.appendChild(bootstrapScript);
     globalThis.HTMLButtonElement =

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,7 +1310,13 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [],
+    "diagnostics": [
+      {
+        "severity": "warning",
+        "code": "preset_shader_volume_approximation",
+        "field": null
+      }
+    ],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1321,12 +1327,13 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
+        "Auxiliary texture layer \"simplex\" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.",
         "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
       "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
-          "status": "supported",
+          "status": "partial",
           "evidence": []
         },
         "webgpu": {
@@ -1343,10 +1350,7 @@
       },
       "parity": {
         "fidelityClass": "near-exact",
-        "backendDivergence": [
-          "status:webgl=supported,webgpu=partial",
-          "webgpu:supported-shader-text-gap"
-        ],
+        "backendDivergence": ["webgpu:supported-shader-text-gap"],
         "ignoredFields": [],
         "blockedConstructs": [],
         "approximatedShaderLines": [],

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -553,10 +553,23 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
         'simplex',
       );
       expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+        '3d',
+      );
+      expect(compiled.ir.post.shaderControls.textureLayer.volumeSliceZ).toBe(0);
+      expect(
+        compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
+      ).toMatchObject({
+        type: 'binary',
+        operator: '/',
+      });
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
       expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
         [],
+      );
+      expect(compiled.ir.compatibility.warnings).toContain(
+        'Auxiliary texture layer "simplex" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.',
       );
     }
   });

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,6 +96,19 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
+const VOLUME_SHADER_APPROXIMATION_EXPECTATION = {
+  diagnostics: ['preset_shader_volume_approximation'],
+  webgl: 'partial',
+  webgpu: 'partial',
+  divergence: ['webgpu:supported-shader-text-gap'],
+  warnings: [
+    'Auxiliary texture layer "simplex" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.',
+    'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+  ],
+  blockedConstructs: [],
+  unsupportedKeys: [],
+} as const satisfies ProjectMFixtureExpectation;
+
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -132,7 +145,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': VOLUME_SHADER_APPROXIMATION_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -594,6 +594,69 @@ video_echo=1
     );
   });
 
+  test('forwards tex3D overlay state into feedback composite uniforms', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Volume Feedback Contract
+comp_shader=ret = tex3D(sampler_fw_noisevol_lq, float3(uv * 1.5 + float2(0.1, -0.2), time / 10.0)).xyz
+      `.trim(),
+      { id: 'volume-feedback-contract' },
+    );
+
+    const compositeStates: MilkdropFeedbackCompositeState[] = [];
+    const feedback = {
+      applyCompositeState(state: MilkdropFeedbackCompositeState) {
+        compositeStates.push(state);
+      },
+      render() {
+        return true;
+      },
+      swap() {},
+      resize() {},
+      dispose() {},
+    } as MilkdropFeedbackManager;
+
+    const renderer = {
+      getSize: (target: Vector2) => target.set(320, 180),
+      render() {},
+      setRenderTarget() {},
+    };
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapterCore({
+      scene,
+      camera,
+      renderer,
+      backend: 'webgl',
+      createFeedbackManager: () => feedback,
+    });
+
+    const vm = createMilkdropVM(preset);
+    const signals = makeSignals();
+    signals.time = 2;
+    signals.frame = 120;
+    const frameState = vm.step(signals);
+
+    adapter.attach();
+    expect(
+      adapter.render({
+        frameState,
+        blendState: null,
+      }),
+    ).toBe(true);
+
+    expect(compositeStates[0]).toMatchObject({
+      overlayTextureSource: 2,
+      overlayTextureMode: 1,
+      overlayTextureSampleDimension: 2,
+    });
+    expect(compositeStates[0]?.overlayTextureScale.x).toBeCloseTo(1.5, 6);
+    expect(compositeStates[0]?.overlayTextureScale.y).toBeCloseTo(1.5, 6);
+    expect(compositeStates[0]?.overlayTextureOffset.x).toBeCloseTo(0.1, 6);
+    expect(compositeStates[0]?.overlayTextureOffset.y).toBeCloseTo(-0.2, 6);
+    expect(compositeStates[0]?.overlayTextureVolumeSliceZ).toBeCloseTo(0.2, 6);
+  });
+
   test('renders main wave and trails directly on webgpu line-wave presets', () => {
     const preset = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -67,6 +67,21 @@ describe('milkdrop shader sampler aliases', () => {
       kind: 'vec3',
       value: [1, 1, 1],
     });
+
+    if (volumeStatement.expression.type !== 'member') {
+      throw new Error('Expected volume statement to evaluate a sampled member');
+    }
+
+    const sampleValue = evaluateMilkdropShaderExpression(
+      volumeStatement.expression.object,
+      { uv: { kind: 'vec2', value: [0.25, 0.75] } },
+      { time: 2 },
+    );
+    expect(sampleValue).toMatchObject({
+      kind: 'sample',
+      source: 'simplex',
+      dimension: '3d',
+    });
   });
 
   test('normalizes supported aliases through the shared helper', () => {
@@ -137,8 +152,14 @@ describe('milkdrop shader sampler aliases', () => {
         'simplex',
       );
       expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+        '3d',
+      );
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+      expect(compiled.ir.compatibility.warnings).toContain(
+        'Auxiliary texture layer "simplex" uses tex3D volume sampling and will be approximated with deterministic 2D slice blending.',
+      );
     }
   });
 });


### PR DESCRIPTION
### Motivation
- tex3D/texture3D shader samples were collapsing to planar sampling during AST extraction and control merge, losing the sampled z expression/value and causing auxiliary volume samplers to fall back or render unstably. 
- The renderer composite path needed to receive volume sampling state so feedback compositors can approximate animated slices deterministically. 
- Tests and compatibility metadata needed updates to codify the expected approximation behavior and to stabilize an audio-controls baseline that manipulates navigator globals. 

### Description
- Extend types and AST so shader samples include `dimension` and `z` and the AST `sample` value carries a `dimension: '2d' | '3d'` plus `uv` and `z`. 
- Preserve and propagate volume sampling state in the compiler: `splitShaderSampleCoordinate`, `analyzeShaderVolumeSlice`, `applyTextureSampleState`, and merged shader controls now carry `sampleDimension` and `volumeSliceZ`, and the compiler emits a `preset_shader_volume_approximation` warning when tex3D is used for aux samplers. 
- Forward volume sampling into renderer composite uniforms and adapter state: added `overlayTextureSampleDimension`, `overlayTextureVolumeSliceZ`, `warpTextureSampleDimension`, `warpTextureVolumeSliceZ` and mapping helpers so feedback managers receive the sample dimension and slice value. 
- Implement deterministic 2D slice-blending approximations for volume samplers in both the shared/WebGL (`feedback-manager-shared.ts`) and WebGPU (`feedback-manager-webgpu.ts`) feedback compositors by sampling a tiled atlas of slices and linearly blending adjacent slices by computed z, falling back to planar sampling when `sampleDimension` indicates 2D. 
- Tests and expectations updated: added/adjusted assertions in `tests/milkdrop-shader-sampler-aliases.test.ts`, `tests/milkdrop-compiler.test.ts`, `tests/milkdrop-renderer-adapter.test.ts`, and updated the projectM compatibility expectation and snapshot for `261-compshader-noisevol_lq.milk` to reflect the approximation; stabilized `tests/audio-controls.test.ts` by resetting navigator globals in `beforeEach`. 

### Testing
- Ran targeted suites: `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-projectm-compat.test.ts tests/audio-controls.test.ts` and observed the updated assertions pass. 
- Verified the full compatibility corpus and projectM snapshot with `bun run test tests/milkdrop-projectm-compat.test.ts` and updated snapshot entries passed. 
- Ran the full quality gate with `bun run check` (Biome format/lint, TypeScript typecheck, and the full test suite) and all checks completed successfully. 

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2570508483328b8ff7ddd8bc2501)