### PR TITLE
Preserve volume sample metadata through shader extraction

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -30,6 +30,7 @@ import type {
   MilkdropDiagnostic,
   MilkdropDiagnosticSeverity,
   MilkdropExpressionNode,
+  MilkdropExtractedShaderSampleMetadata,
   MilkdropFeatureAnalysis,
   MilkdropFeatureKey,
   MilkdropFidelityClass,
@@ -43,6 +44,7 @@ import type {
   MilkdropShaderControlExpressions,
   MilkdropShaderControls,
   MilkdropShaderExpressionNode,
+  MilkdropShaderSampleDimension,
   MilkdropShaderStatement,
   MilkdropShaderTextureBlendMode,
   MilkdropShaderTextureSampler,
@@ -912,19 +914,23 @@ function createDefaultShaderControls(): MilkdropShaderControls {
     textureLayer: {
       source: 'none',
       mode: 'none',
+      sampleDimension: '2d',
       amount: 0,
       scaleX: 1,
       scaleY: 1,
       offsetX: 0,
       offsetY: 0,
+      volumeSliceZ: null,
     },
     warpTexture: {
       source: 'none',
+      sampleDimension: '2d',
       amount: 0,
       scaleX: 1,
       scaleY: 1,
       offsetX: 0,
       offsetY: 0,
+      volumeSliceZ: null,
     },
   };
 }
@@ -946,18 +952,22 @@ function createDefaultShaderControlExpressions(): MilkdropShaderControlExpressio
     solarizeBoost: null,
     tint: { r: null, g: null, b: null },
     textureLayer: {
+      sampleDimension: '2d',
       amount: null,
       scaleX: null,
       scaleY: null,
       offsetX: null,
       offsetY: null,
+      volumeSliceZ: null,
     },
     warpTexture: {
+      sampleDimension: '2d',
       amount: null,
       scaleX: null,
       scaleY: null,
       offsetX: null,
       offsetY: null,
+      volumeSliceZ: null,
     },
   };
 }
@@ -1562,27 +1572,80 @@ function isShaderSampleRgbExpression(
     node.type === 'member' &&
     ['rgb', 'xyz'].includes(node.property.toLowerCase()) &&
     node.object.type === 'call' &&
-    normalizeShaderCallName(node.object.name) === 'tex2d' &&
+    ['tex2d', 'tex3d'].includes(normalizeShaderCallName(node.object.name)) &&
     node.object.args.length >= 2
   );
 }
 
-function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
-  source: string;
+function splitShaderSampleCoordinate(
+  name: 'tex2d' | 'tex3d',
+  coordinate: MilkdropShaderExpressionNode,
+): {
+  dimension: MilkdropShaderSampleDimension;
   uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
 } | null {
+  if (name === 'tex2d') {
+    return {
+      dimension: '2d',
+      uv: coordinate,
+      z: null,
+    };
+  }
+
+  if (
+    coordinate.type === 'call' &&
+    normalizeShaderCallName(coordinate.name) === 'vec3'
+  ) {
+    if (coordinate.args.length >= 2) {
+      return {
+        dimension: '3d',
+        uv: coordinate.args[0] as MilkdropShaderExpressionNode,
+        z: coordinate.args[1] as MilkdropShaderExpressionNode,
+      };
+    }
+
+    if (coordinate.args.length >= 3) {
+      const [x, y, z] = coordinate.args;
+      if (x && y && z) {
+        return {
+          dimension: '3d',
+          uv: {
+            type: 'call',
+            name: 'vec2',
+            args: [x, y],
+          },
+          z,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function getShaderSampleInfo(
+  node: MilkdropShaderExpressionNode,
+): MilkdropExtractedShaderSampleMetadata | null {
   if (
     node.type !== 'member' ||
     !['rgb', 'xyz'].includes(node.property.toLowerCase()) ||
     node.object.type !== 'call' ||
-    normalizeShaderCallName(node.object.name) !== 'tex2d' ||
+    !['tex2d', 'tex3d'].includes(normalizeShaderCallName(node.object.name)) ||
     node.object.args.length < 2
   ) {
     return null;
   }
   const samplerArg = node.object.args[0];
-  const uvArg = node.object.args[1];
-  if (!samplerArg || !uvArg) {
+  const coordinateArg = node.object.args[1];
+  if (!samplerArg || !coordinateArg) {
+    return null;
+  }
+  const callName = normalizeShaderCallName(node.object.name) as
+    | 'tex2d'
+    | 'tex3d';
+  const coordinate = splitShaderSampleCoordinate(callName, coordinateArg);
+  if (!coordinate) {
     return null;
   }
   const source =
@@ -1594,7 +1657,9 @@ function getShaderSampleInfo(node: MilkdropShaderExpressionNode): {
   }
   return {
     source,
-    uv: uvArg,
+    sampleDimension: coordinate.dimension,
+    uv: coordinate.uv,
+    volumeSliceZ: coordinate.z,
   };
 }
 
@@ -1612,10 +1677,7 @@ function extractScaledShaderSampleExpression(
 ): {
   amountExpression: MilkdropExpressionNode | null;
   amountValue: number;
-  sample: {
-    source: string;
-    uv: MilkdropShaderExpressionNode;
-  };
+  sample: MilkdropExtractedShaderSampleMetadata;
 } | null {
   const directSample = getShaderSampleInfo(node);
   if (
@@ -1829,6 +1891,61 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
   return null;
 }
 
+function analyzeShaderVolumeSlice(node: MilkdropShaderExpressionNode | null): {
+  value: number | null;
+  expression: MilkdropExpressionNode | null;
+} {
+  if (!node) {
+    return {
+      value: null,
+      expression: null,
+    };
+  }
+
+  const scalar = evaluateShaderScalarResult(
+    node,
+    { uv: { kind: 'vec2', value: [0, 0] } },
+    DEFAULT_MILKDROP_STATE,
+    {},
+  );
+  return {
+    value: scalar?.value ?? null,
+    expression: scalar?.expression ?? null,
+  };
+}
+
+function analyzeShaderSampleCoordinate(
+  sample: MilkdropExtractedShaderSampleMetadata,
+) {
+  return {
+    uv: analyzeShaderUvTransform(sample.uv),
+    volumeSlice: analyzeShaderVolumeSlice(sample.volumeSliceZ),
+  };
+}
+
+function applyTextureLayerSample(
+  controls: MilkdropShaderControls,
+  expressions: MilkdropShaderControlExpressions,
+  sample: MilkdropExtractedShaderSampleMetadata,
+) {
+  const coordinate = analyzeShaderSampleCoordinate(sample);
+  controls.textureLayer.source = sample.source as MilkdropShaderTextureSampler;
+  controls.textureLayer.sampleDimension = sample.sampleDimension;
+  controls.textureLayer.volumeSliceZ = coordinate.volumeSlice.value;
+  expressions.textureLayer.sampleDimension = sample.sampleDimension;
+  expressions.textureLayer.volumeSliceZ = coordinate.volumeSlice.expression;
+  if (coordinate.uv) {
+    controls.textureLayer.scaleX = coordinate.uv.scaleX;
+    controls.textureLayer.scaleY = coordinate.uv.scaleY;
+    controls.textureLayer.offsetX = coordinate.uv.offsetX;
+    controls.textureLayer.offsetY = coordinate.uv.offsetY;
+    expressions.textureLayer.scaleX = coordinate.uv.expressions.scaleX;
+    expressions.textureLayer.scaleY = coordinate.uv.expressions.scaleY;
+    expressions.textureLayer.offsetX = coordinate.uv.expressions.offsetX;
+    expressions.textureLayer.offsetY = coordinate.uv.expressions.offsetY;
+  }
+}
+
 function isShaderUvIdentifier(node: MilkdropShaderExpressionNode) {
   return node.type === 'identifier' && node.name.toLowerCase() === 'uv';
 }
@@ -1840,7 +1957,7 @@ function isShaderInvertSampleExpression(
     node.type === 'binary' &&
     node.operator === '-' &&
     isShaderLiteralNumber(node.left, 1) &&
-    isShaderSampleRgbExpression(node.right)
+    isShaderMainSampleExpression(node.right)
   );
 }
 
@@ -1868,7 +1985,7 @@ function isShaderSolarizeSampleExpression(
   }
   const right = arg.right;
   const centeredSample =
-    isShaderSampleRgbExpression(arg.left) &&
+    isShaderMainSampleExpression(arg.left) &&
     (isShaderLiteralNumber(right, 0.5) ||
       (right?.type === 'call' &&
         normalizeShaderCallName(right.name) === 'vec3' &&
@@ -2238,24 +2355,13 @@ function applyShaderAstStatement({
       directSample.source !== 'main' &&
       directSample.source !== 'none'
     ) {
-      const uvTransform = analyzeShaderUvTransform(directSample.uv);
       if (!isAuxShaderSamplerName(directSample.source)) {
         return false;
       }
-      controls.textureLayer.source = directSample.source;
       controls.textureLayer.mode = 'replace';
       controls.textureLayer.amount = 1;
       expressions.textureLayer.amount = createLiteralExpression(1);
-      if (uvTransform) {
-        controls.textureLayer.scaleX = uvTransform.scaleX;
-        controls.textureLayer.scaleY = uvTransform.scaleY;
-        controls.textureLayer.offsetX = uvTransform.offsetX;
-        controls.textureLayer.offsetY = uvTransform.offsetY;
-        expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-        expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-        expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-        expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-      }
+      applyTextureLayerSample(controls, expressions, directSample);
       return true;
     }
 
@@ -2362,24 +2468,13 @@ function applyShaderAstStatement({
           auxSample.source !== 'main' &&
           auxSample.source !== 'none'
         ) {
-          const uvTransform = analyzeShaderUvTransform(auxSample.uv);
           if (!isAuxShaderSamplerName(auxSample.source)) {
             return false;
           }
-          controls.textureLayer.source = auxSample.source;
           controls.textureLayer.mode = 'mix';
           controls.textureLayer.amount = amount.value;
           expressions.textureLayer.amount = amount.expression;
-          if (uvTransform) {
-            controls.textureLayer.scaleX = uvTransform.scaleX;
-            controls.textureLayer.scaleY = uvTransform.scaleY;
-            controls.textureLayer.offsetX = uvTransform.offsetX;
-            controls.textureLayer.offsetY = uvTransform.offsetY;
-            expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-            expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-            expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-            expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-          }
+          applyTextureLayerSample(controls, expressions, auxSample);
           return true;
         }
         if (isShaderInvertSampleExpression(targetNode)) {
@@ -2475,24 +2570,13 @@ function applyShaderAstStatement({
         : resolvedExpression.left;
       const auxSample = extractScaledShaderSampleExpression(auxNode);
       if (auxSample) {
-        const uvTransform = analyzeShaderUvTransform(auxSample.sample.uv);
         if (!isAuxShaderSamplerName(auxSample.sample.source)) {
           return false;
         }
-        controls.textureLayer.source = auxSample.sample.source;
         controls.textureLayer.mode = 'add';
         controls.textureLayer.amount = auxSample.amountValue;
         expressions.textureLayer.amount = auxSample.amountExpression;
-        if (uvTransform) {
-          controls.textureLayer.scaleX = uvTransform.scaleX;
-          controls.textureLayer.scaleY = uvTransform.scaleY;
-          controls.textureLayer.offsetX = uvTransform.offsetX;
-          controls.textureLayer.offsetY = uvTransform.offsetY;
-          expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-          expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-          expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-          expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-        }
+        applyTextureLayerSample(controls, expressions, auxSample.sample);
         return true;
       }
     }
@@ -2508,24 +2592,13 @@ function applyShaderAstStatement({
         : resolvedExpression.left;
       const auxSample = extractScaledShaderSampleExpression(auxNode);
       if (auxSample) {
-        const uvTransform = analyzeShaderUvTransform(auxSample.sample.uv);
         if (!isAuxShaderSamplerName(auxSample.sample.source)) {
           return false;
         }
-        controls.textureLayer.source = auxSample.sample.source;
         controls.textureLayer.mode = 'multiply';
         controls.textureLayer.amount = auxSample.amountValue;
         expressions.textureLayer.amount = auxSample.amountExpression;
-        if (uvTransform) {
-          controls.textureLayer.scaleX = uvTransform.scaleX;
-          controls.textureLayer.scaleY = uvTransform.scaleY;
-          controls.textureLayer.offsetX = uvTransform.offsetX;
-          controls.textureLayer.offsetY = uvTransform.offsetY;
-          expressions.textureLayer.scaleX = uvTransform.expressions.scaleX;
-          expressions.textureLayer.scaleY = uvTransform.expressions.scaleY;
-          expressions.textureLayer.offsetX = uvTransform.expressions.offsetX;
-          expressions.textureLayer.offsetY = uvTransform.expressions.offsetY;
-        }
+        applyTextureLayerSample(controls, expressions, auxSample.sample);
         return true;
       }
     }
@@ -4047,6 +4120,10 @@ function mergeShaderControlAnalysis(
     warpAnalysis.expressions.textureLayer.offsetY,
     0,
   );
+  const textureLayerSample =
+    compAnalysis.controls.textureLayer.mode !== 'none'
+      ? compAnalysis
+      : warpAnalysis;
   const warpTextureAmount = pickShaderScalar(
     warpAnalysis.controls.warpTexture.amount,
     warpAnalysis.expressions.warpTexture.amount,
@@ -4082,6 +4159,10 @@ function mergeShaderControlAnalysis(
     compAnalysis.expressions.warpTexture.offsetY,
     0,
   );
+  const warpTextureSample =
+    warpAnalysis.controls.warpTexture.source !== 'none'
+      ? warpAnalysis
+      : compAnalysis;
 
   return {
     controls: {
@@ -4116,22 +4197,27 @@ function mergeShaderControlAnalysis(
           compAnalysis.controls.textureLayer.mode !== 'none'
             ? compAnalysis.controls.textureLayer.mode
             : warpAnalysis.controls.textureLayer.mode,
+        sampleDimension:
+          textureLayerSample.controls.textureLayer.sampleDimension,
         amount: textureLayerAmount.value,
         scaleX: textureLayerScaleX.value,
         scaleY: textureLayerScaleY.value,
         offsetX: textureLayerOffsetX.value,
         offsetY: textureLayerOffsetY.value,
+        volumeSliceZ: textureLayerSample.controls.textureLayer.volumeSliceZ,
       },
       warpTexture: {
         source:
           warpAnalysis.controls.warpTexture.source !== 'none'
             ? warpAnalysis.controls.warpTexture.source
             : compAnalysis.controls.warpTexture.source,
+        sampleDimension: warpTextureSample.controls.warpTexture.sampleDimension,
         amount: warpTextureAmount.value,
         scaleX: warpTextureScaleX.value,
         scaleY: warpTextureScaleY.value,
         offsetX: warpTextureOffsetX.value,
         offsetY: warpTextureOffsetY.value,
+        volumeSliceZ: warpTextureSample.controls.warpTexture.volumeSliceZ,
       },
     },
     expressions: {
@@ -4158,18 +4244,24 @@ function mergeShaderControlAnalysis(
         b: tint.b.expression,
       },
       textureLayer: {
+        sampleDimension:
+          textureLayerSample.expressions.textureLayer.sampleDimension,
         amount: textureLayerAmount.expression,
         scaleX: textureLayerScaleX.expression,
         scaleY: textureLayerScaleY.expression,
         offsetX: textureLayerOffsetX.expression,
         offsetY: textureLayerOffsetY.expression,
+        volumeSliceZ: textureLayerSample.expressions.textureLayer.volumeSliceZ,
       },
       warpTexture: {
+        sampleDimension:
+          warpTextureSample.expressions.warpTexture.sampleDimension,
         amount: warpTextureAmount.expression,
         scaleX: warpTextureScaleX.expression,
         scaleY: warpTextureScaleY.expression,
         offsetX: warpTextureOffsetX.expression,
         offsetY: warpTextureOffsetY.expression,
+        volumeSliceZ: warpTextureSample.expressions.warpTexture.volumeSliceZ,
       },
     },
   };

--- a/assets/js/milkdrop/shader-ast.ts
+++ b/assets/js/milkdrop/shader-ast.ts
@@ -3,6 +3,7 @@ import { normalizeMilkdropShaderSamplerName } from './shader-samplers';
 import type {
   MilkdropExpressionNode,
   MilkdropShaderExpressionNode,
+  MilkdropShaderSampleDimension,
   MilkdropShaderStatement,
   MilkdropShaderTextureSampler,
 } from './types';
@@ -22,8 +23,10 @@ type ShaderValue =
   | { kind: 'vec3'; value: [number, number, number] }
   | {
       kind: 'sample';
+      dimension: MilkdropShaderSampleDimension;
       source: MilkdropShaderTextureSampler | 'main' | null;
       uv: ShaderValue;
+      z: ShaderValue | null;
     };
 
 function normalizeShaderSamplerName(value: string) {
@@ -358,6 +361,29 @@ function vec3(r: number, g: number, b: number): ShaderValue {
   return { kind: 'vec3', value: [r, g, b] };
 }
 
+function splitShaderSampleCoordinate(
+  dimension: MilkdropShaderSampleDimension,
+  coordinate: ShaderValue,
+) {
+  if (dimension === '2d') {
+    return {
+      dimension,
+      uv: coordinate,
+      z: null,
+    };
+  }
+
+  if (isVec3(coordinate)) {
+    return {
+      dimension,
+      uv: vec2(coordinate.value[0], coordinate.value[1]),
+      z: scalar(coordinate.value[2]),
+    };
+  }
+
+  return null;
+}
+
 function isScalar(
   value: ShaderValue,
 ): value is { kind: 'scalar'; value: number } {
@@ -589,7 +615,18 @@ export function evaluateMilkdropShaderExpression(
           samplerArg?.type === 'identifier'
             ? normalizeShaderSamplerName(samplerArg.name)
             : 'main';
-        return { kind: 'sample', source, uv: args[1] };
+        const dimension = name === 'tex3d' ? '3d' : '2d';
+        const coordinate = splitShaderSampleCoordinate(dimension, args[1]);
+        if (!coordinate) {
+          return null;
+        }
+        return {
+          kind: 'sample',
+          source,
+          dimension: coordinate.dimension,
+          uv: coordinate.uv,
+          z: coordinate.z,
+        };
       }
       if (name === 'mix' && args.length >= 3 && isScalar(args[2])) {
         const blend = args[2].value;

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -276,39 +276,62 @@ export type MilkdropShaderTextureBlendMode =
   | 'add'
   | 'multiply';
 
+export type MilkdropShaderSampleDimension = '2d' | '3d';
+
+export type MilkdropShaderSampleValue = {
+  dimension: MilkdropShaderSampleDimension;
+  uv: MilkdropShaderExpressionNode;
+  z: MilkdropShaderExpressionNode | null;
+};
+
+export type MilkdropExtractedShaderSampleMetadata = {
+  source: string;
+  sampleDimension: MilkdropShaderSampleDimension;
+  uv: MilkdropShaderExpressionNode;
+  volumeSliceZ: MilkdropShaderExpressionNode | null;
+};
+
 export type MilkdropShaderTextureLayerControls = {
   source: MilkdropShaderTextureSampler;
   mode: MilkdropShaderTextureBlendMode;
+  sampleDimension: MilkdropShaderSampleDimension;
   amount: number;
   scaleX: number;
   scaleY: number;
   offsetX: number;
   offsetY: number;
+  volumeSliceZ: number | null;
 };
 
 export type MilkdropShaderTextureWarpControls = {
   source: MilkdropShaderTextureSampler;
+  sampleDimension: MilkdropShaderSampleDimension;
   amount: number;
   scaleX: number;
   scaleY: number;
   offsetX: number;
   offsetY: number;
+  volumeSliceZ: number | null;
 };
 
 export type MilkdropShaderTextureLayerExpressions = {
+  sampleDimension: MilkdropShaderSampleDimension;
   amount: MilkdropExpressionNode | null;
   scaleX: MilkdropExpressionNode | null;
   scaleY: MilkdropExpressionNode | null;
   offsetX: MilkdropExpressionNode | null;
   offsetY: MilkdropExpressionNode | null;
+  volumeSliceZ: MilkdropExpressionNode | null;
 };
 
 export type MilkdropShaderTextureWarpExpressions = {
+  sampleDimension: MilkdropShaderSampleDimension;
   amount: MilkdropExpressionNode | null;
   scaleX: MilkdropExpressionNode | null;
   scaleY: MilkdropExpressionNode | null;
   offsetX: MilkdropExpressionNode | null;
   offsetY: MilkdropExpressionNode | null;
+  volumeSliceZ: MilkdropExpressionNode | null;
 };
 
 export type MilkdropShaderExpressionNode =

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,13 +1310,7 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [
-      {
-        "severity": "warning",
-        "code": "preset_unsupported_shader_text",
-        "field": null
-      }
-    ],
+    "diagnostics": [],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1327,44 +1321,35 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
-        "This preset includes custom shader text outside the fully supported subset and will be approximated.",
-        "WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL."
+        "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
-      "featuresUsed": ["base-globals", "unsupported-shader-text"],
+      "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
+          "status": "supported",
+          "evidence": []
+        },
+        "webgpu": {
           "status": "partial",
           "evidence": [
             {
               "scope": "backend",
               "status": "partial",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
-            }
-          ]
-        },
-        "webgpu": {
-          "status": "unsupported",
-          "evidence": [
-            {
-              "scope": "backend",
-              "status": "unsupported",
-              "code": "unsupported-shader-text-gap",
-              "feature": "unsupported-shader-text"
+              "code": "supported-shader-text-gap",
+              "feature": null
             }
           ]
         }
       },
       "parity": {
-        "fidelityClass": "fallback",
-        "backendDivergence": ["status:webgl=partial,webgpu=unsupported"],
+        "fidelityClass": "near-exact",
+        "backendDivergence": [
+          "status:webgl=supported,webgpu=partial",
+          "webgpu:supported-shader-text-gap"
+        ],
         "ignoredFields": [],
-        "blockedConstructs": [
-          "shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
-        "approximatedShaderLines": [
-          "ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz"
-        ],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
         "missingAliasesOrFunctions": []
       }
     }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -313,6 +313,12 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex2d(sampler_aura, uv * 1.5 
     expect(compiled.ir.shaderText.supported).toBe(true);
     expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('aura');
     expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '2d',
+    );
+    expect(
+      compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
+    ).toBeNull();
     expect(compiled.ir.post.shaderControls.textureLayer.amount).toBeCloseTo(
       0.35,
       6,
@@ -538,7 +544,7 @@ comp_shader=float3 tintScale = float3(1.2, 0.9, 0.7); ret = tex2d(sampler_main, 
     expect(compiled.ir.post.shaderControls.tint.b).toBeCloseTo(0.4, 6);
   });
 
-  test('flags tex3D and texture3D shader sampler aliases as unsupported volume lookups', () => {
+  test('extracts tex3D and texture3D shader sampler aliases as volume lookups', () => {
     for (const sampleCall of ['tex3D', 'texture3D'] as const) {
       const compiled = compileMilkdropPresetSource(
         `
@@ -548,20 +554,26 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
         { id: `shader-volume-alias-${sampleCall.toLowerCase()}` },
       );
 
-      expect(compiled.ir.shaderText.supported).toBe(false);
-      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
-      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-        'unsupported',
+      expect(compiled.ir.shaderText.supported).toBe(true);
+      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe(
+        'simplex',
       );
-      expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
-        `ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
-      ]);
+      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
+      expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+        '3d',
+      );
+      expect(
+        compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
+      ).toBeCloseTo(0, 6);
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+      expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
+        [],
+      );
     }
   });
 
-  test('does not remap tex3D inversion mixes onto invert boosts', () => {
+  test('keeps tex3D inversion mixes attached to the selected aux sample', () => {
     const compiled = compileMilkdropPresetSource(
       `
 title=Shader Volume Invert Mix
@@ -581,6 +593,49 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual([
       'ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz, 0.35)',
     ]);
+  });
+
+  test('keeps tex3D mix extraction attached to the selected aux sample', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Shader Volume Mix
+comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex3D(sampler_fw_noisevol_lq, float3(uv * 1.5 + vec2(0.1, -0.2), time / 10.0)).xyz, 0.35)
+      `.trim(),
+      { id: 'shader-volume-mix' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '3d',
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.amount).toBeCloseTo(
+      0.35,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.scaleX).toBeCloseTo(
+      1.5,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.scaleY).toBeCloseTo(
+      1.5,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.offsetX).toBeCloseTo(
+      0.1,
+      6,
+    );
+    expect(compiled.ir.post.shaderControls.textureLayer.offsetY).toBeCloseTo(
+      -0.2,
+      6,
+    );
+    expect(
+      compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
+    ).toBeCloseTo(0, 6);
+    expect(
+      compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
+    ).not.toBeNull();
   });
 
   test('supports resolved temp shader outputs for invert and runtime tint mixes', () => {

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,21 +96,6 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
-const UNSUPPORTED_SHADER_TEXT_EXPECTATION = {
-  diagnostics: ['preset_unsupported_shader_text'],
-  webgl: 'partial',
-  webgpu: 'unsupported',
-  divergence: ['status:webgl=partial,webgpu=unsupported'],
-  warnings: [
-    'This preset includes custom shader text outside the fully supported subset and will be approximated.',
-    'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
-  ],
-  blockedConstructs: [
-    'shader:ret = tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz',
-  ],
-  unsupportedKeys: [],
-} as const satisfies ProjectMFixtureExpectation;
-
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -147,7 +132,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': UNSUPPORTED_SHADER_TEXT_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -67,6 +67,23 @@ describe('milkdrop shader sampler aliases', () => {
       kind: 'vec3',
       value: [1, 1, 1],
     });
+
+    const callValue = evaluateMilkdropShaderExpression(
+      volumeStatement.expression.type === 'member'
+        ? volumeStatement.expression.object
+        : volumeStatement.expression,
+      { uv: { kind: 'vec2', value: [0.25, 0.75] } },
+      { time: 2 },
+    );
+    expect(callValue).toMatchObject({
+      kind: 'sample',
+      source: 'simplex',
+      dimension: '3d',
+      z: {
+        kind: 'scalar',
+        value: 0.2,
+      },
+    });
   });
 
   test('normalizes supported aliases through the shared helper', () => {
@@ -125,23 +142,27 @@ describe('milkdrop shader sampler aliases', () => {
     }
   });
 
-  test('keeps 3D sampler aliases unsupported in compiler extraction despite AST normalization', () => {
+  test('keeps 3D sampler aliases aligned in compiler extraction', () => {
     for (const sampleCall of ['tex3D', 'texture3D'] as const) {
       const compiled = compileMilkdropPresetSource(
         `title=Volume Alias\ncomp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
         { id: `volume-${sampleCall.toLowerCase()}` },
       );
 
-      expect(compiled.ir.shaderText.supported).toBe(false);
-      expect(compiled.ir.shaderText.unsupportedLines).toEqual([
-        `ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz`,
-      ]);
-      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
-      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-        'unsupported',
+      expect(compiled.ir.shaderText.supported).toBe(true);
+      expect(compiled.ir.shaderText.unsupportedLines).toEqual([]);
+      expect(compiled.ir.post.shaderControls.textureLayer.source).toBe(
+        'simplex',
       );
+      expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
+      expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+        '3d',
+      );
+      expect(
+        compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
+      ).toBeCloseTo(0, 6);
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Support 3D texture samples in shader extraction by carrying explicit sample dimension and slice-Z metadata instead of implicitly treating all samples as 2D.
- Decompose tex3d coordinates into a 2D UV transform plus a volume-slice expression so texture-layer extraction (replace/mix/add/multiply) can preserve volume state.

### Description
- Add types for sample dimension, sample value, and extracted sample metadata and extend texture layer/warp controls and expressions to include `sampleDimension` and `volumeSliceZ` in `assets/js/milkdrop/types.ts`.
- Extend AST evaluation in `assets/js/milkdrop/shader-ast.ts` so `tex2d(...)` and `tex3d(...)` produce `sample` values carrying `dimension`, `uv`, and `z` (with a `splitShaderSampleCoordinate` helper) while keeping `.rgb`/`.xyz` access working.
- Update compiler `assets/js/milkdrop/compiler.ts` to parse and extract both `tex2d` and `tex3d` samples, add `splitShaderSampleCoordinate`, `analyzeShaderVolumeSlice`, `analyzeShaderSampleCoordinate`, and `applyTextureLayerSample` helpers, and change `getShaderSampleInfo`, `isShaderSampleRgbExpression`, and extraction paths so extracted samples include `sampleDimension` and `volumeSliceZ` and merges preserve volume state.
- Update callers and extraction paths so replace/mix/add/multiply texture-layer extraction preserves the selected sample's dimension and slice Z, and update tests and the projectM compatibility snapshot to reflect supported volume-sample extraction.

### Testing
- Ran targeted shader/compiler tests which passed: `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts` (all passing).
- Ran the projectM compat tests and refreshed snapshot which passed: `bun run test tests/milkdrop-projectm-compat.test.ts` (passing) and updated `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` accordingly.
- Verified `tests/system-controls-tv-mode.test.ts` in isolation passed, but the full quality gate `bun run check` still reports a failure only in the unrelated `tests/system-controls-tv-mode.test.ts` when run as part of the aggregate suite (flaky in the aggregate run); targeted shader/projectM tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2a22ca788332812fe944b10e24de)