### PR TITLE
Add 3D aux texture sampling state to Milkdrop feedback

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -42,6 +42,9 @@ const MILKDROP_TEXTURE_FILES = {
   pattern: 'circuit_board_pattern.png',
   fractal: 'crystal_fractal.png',
 } as const;
+const AUX_TEXTURE_ATLAS_GRID_SIZE = 8;
+const AUX_TEXTURE_ATLAS_SLICE_COUNT =
+  AUX_TEXTURE_ATLAS_GRID_SIZE * AUX_TEXTURE_ATLAS_GRID_SIZE;
 
 function resolveTextureUrl(fileName: string) {
   const baseUrl =
@@ -214,13 +217,17 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         currentFrameBoost: { value: this.profile.currentFrameBoost },
         overlayTextureSource: { value: 0 },
         overlayTextureMode: { value: 0 },
+        overlayTextureSampleDimension: { value: 0 },
         overlayTextureAmount: { value: 0 },
         overlayTextureScale: { value: new Vector2(1, 1) },
         overlayTextureOffset: { value: new Vector2(0, 0) },
+        overlayTextureVolumeSliceZ: { value: 0 },
         warpTextureSource: { value: 0 },
+        warpTextureSampleDimension: { value: 0 },
         warpTextureAmount: { value: 0 },
         warpTextureScale: { value: new Vector2(1, 1) },
         warpTextureOffset: { value: new Vector2(0, 0) },
+        warpTextureVolumeSliceZ: { value: 0 },
         signalBass: { value: 0 },
         signalMid: { value: 0 },
         signalTreb: { value: 0 },
@@ -277,13 +284,17 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform float currentFrameBoost;
         uniform float overlayTextureSource;
         uniform float overlayTextureMode;
+        uniform float overlayTextureSampleDimension;
         uniform float overlayTextureAmount;
         uniform vec2 overlayTextureScale;
         uniform vec2 overlayTextureOffset;
+        uniform float overlayTextureVolumeSliceZ;
         uniform float warpTextureSource;
+        uniform float warpTextureSampleDimension;
         uniform float warpTextureAmount;
         uniform vec2 warpTextureScale;
         uniform vec2 warpTextureOffset;
+        uniform float warpTextureVolumeSliceZ;
         uniform float signalBass;
         uniform float signalMid;
         uniform float signalTreb;
@@ -323,30 +334,53 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           return wrapMode > 0.5 ? fract(uv) : clamp(uv, 0.0, 1.0);
         }
 
-        vec4 sampleAuxTexture(float source, vec2 uv) {
-          vec2 wrappedUv = fract(uv);
+        vec4 sampleAuxTexture2d(float source, vec2 uv) {
           if (source < 0.5) {
             return vec4(0.5, 0.5, 0.5, 1.0);
           }
           if (source < 1.5) {
-            return texture2D(noiseTex, wrappedUv);
+            return texture2D(noiseTex, uv);
           }
           if (source < 2.5) {
-            return texture2D(simplexTex, wrappedUv);
+            return texture2D(simplexTex, uv);
           }
           if (source < 3.5) {
-            return texture2D(voronoiTex, wrappedUv);
+            return texture2D(voronoiTex, uv);
           }
           if (source < 4.5) {
-            return texture2D(auraTex, wrappedUv);
+            return texture2D(auraTex, uv);
           }
           if (source < 5.5) {
-            return texture2D(causticsTex, wrappedUv);
+            return texture2D(causticsTex, uv);
           }
           if (source < 6.5) {
-            return texture2D(patternTex, wrappedUv);
+            return texture2D(patternTex, uv);
           }
-          return texture2D(fractalTex, wrappedUv);
+          return texture2D(fractalTex, uv);
+        }
+
+        vec2 atlasSliceUv(vec2 uv, float sliceIndex) {
+          vec2 localUv = mix(vec2(0.01), vec2(0.99), fract(uv));
+          float gridSize = ${AUX_TEXTURE_ATLAS_GRID_SIZE.toFixed(1)};
+          vec2 tileSize = vec2(1.0 / gridSize);
+          float column = mod(sliceIndex, gridSize);
+          float row = floor(sliceIndex / gridSize);
+          return (vec2(column, row) + localUv) * tileSize;
+        }
+
+        vec4 sampleAuxTexture(float source, float sampleDimension, vec2 uv, float sliceZ) {
+          vec2 wrappedUv = fract(uv);
+          if (sampleDimension < 0.5) {
+            return sampleAuxTexture2d(source, wrappedUv);
+          }
+          float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
+          float scaledSlice = clamp(sliceZ, 0.0, 1.0) * (sliceCount - 1.0);
+          float sliceIndexA = floor(scaledSlice);
+          float sliceIndexB = min(sliceIndexA + 1.0, sliceCount - 1.0);
+          float sliceBlend = fract(scaledSlice);
+          vec4 sliceA = sampleAuxTexture2d(source, atlasSliceUv(wrappedUv, sliceIndexA));
+          vec4 sliceB = sampleAuxTexture2d(source, atlasSliceUv(wrappedUv, sliceIndexB));
+          return mix(sliceA, sliceB, sliceBlend);
         }
 
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {
@@ -380,7 +414,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           );
           if (warpTextureSource > 0.5 && warpTextureAmount > 0.0001) {
             vec2 warpUv = vUv * warpTextureScale + warpTextureOffset;
-            vec2 warpVector = sampleAuxTexture(warpTextureSource, warpUv).rg - 0.5;
+            vec2 warpVector =
+              sampleAuxTexture(
+                warpTextureSource,
+                warpTextureSampleDimension,
+                warpUv,
+                warpTextureVolumeSliceZ
+              ).rg - 0.5;
             currentUv += warpVector * warpTextureAmount * 0.12;
             prevUv += warpVector * warpTextureAmount * 0.08;
           }
@@ -427,7 +467,12 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           color *= tint;
           if (overlayTextureSource > 0.5 && overlayTextureMode > 0.5 && overlayTextureAmount > 0.0001) {
             vec2 overlayUv = vUv * overlayTextureScale + overlayTextureOffset;
-            vec3 overlayColor = sampleAuxTexture(overlayTextureSource, overlayUv).rgb;
+            vec3 overlayColor = sampleAuxTexture(
+              overlayTextureSource,
+              overlayTextureSampleDimension,
+              overlayUv,
+              overlayTextureVolumeSliceZ
+            ).rgb;
             float amount = clamp(overlayTextureAmount, 0.0, 1.5);
             if (overlayTextureMode < 1.5) {
               color = mix(color, overlayColor, clamp(amount, 0.0, 1.0));
@@ -503,6 +548,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.tint.value.setRGB(state.tint.r, state.tint.g, state.tint.b);
     uniforms.overlayTextureSource.value = state.overlayTextureSource;
     uniforms.overlayTextureMode.value = state.overlayTextureMode;
+    uniforms.overlayTextureSampleDimension.value =
+      state.overlayTextureSampleDimension;
     uniforms.overlayTextureAmount.value = state.overlayTextureAmount;
     uniforms.overlayTextureScale.value.set(
       state.overlayTextureScale.x,
@@ -512,7 +559,11 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
       state.overlayTextureOffset.x,
       state.overlayTextureOffset.y,
     );
+    uniforms.overlayTextureVolumeSliceZ.value =
+      state.overlayTextureVolumeSliceZ;
     uniforms.warpTextureSource.value = state.warpTextureSource;
+    uniforms.warpTextureSampleDimension.value =
+      state.warpTextureSampleDimension;
     uniforms.warpTextureAmount.value = state.warpTextureAmount;
     uniforms.warpTextureScale.value.set(
       state.warpTextureScale.x,
@@ -522,6 +573,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
       state.warpTextureOffset.x,
       state.warpTextureOffset.y,
     );
+    uniforms.warpTextureVolumeSliceZ.value = state.warpTextureVolumeSliceZ;
     uniforms.signalBass.value = state.signalBass;
     uniforms.signalMid.value = state.signalMid;
     uniforms.signalTreb.value = state.signalTreb;

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -30,6 +30,7 @@ const {
   cos,
   dot,
   Fn,
+  floor,
   float,
   fract,
   If,
@@ -61,6 +62,9 @@ const MILKDROP_TEXTURE_FILES = {
   pattern: 'circuit_board_pattern.png',
   fractal: 'crystal_fractal.png',
 } as const;
+const AUX_TEXTURE_ATLAS_GRID_SIZE = 8;
+const AUX_TEXTURE_ATLAS_SLICE_COUNT =
+  AUX_TEXTURE_ATLAS_GRID_SIZE * AUX_TEXTURE_ATLAS_GRID_SIZE;
 
 type FeedbackRendererLike = {
   render: (scene: Scene, camera: Camera) => void;
@@ -176,31 +180,30 @@ function createSampleAuxTextureNode(
   patternTexNode: ReturnType<typeof texture>,
   fractalTexNode: ReturnType<typeof texture>,
 ) {
-  return Fn(([source, sampleUv]: [any, any]) => {
-    const wrappedUv = fract(sampleUv);
+  const sampleAuxTexture2dNode = Fn(([source, sampleUv]: [any, any]) => {
     const flat = vec4(0.5, 0.5, 0.5, 1);
     return select(
       source.lessThan(0.5),
       flat,
       select(
         source.lessThan(1.5),
-        noiseTexNode.sample(wrappedUv),
+        noiseTexNode.sample(sampleUv),
         select(
           source.lessThan(2.5),
-          simplexTexNode.sample(wrappedUv),
+          simplexTexNode.sample(sampleUv),
           select(
             source.lessThan(3.5),
-            voronoiTexNode.sample(wrappedUv),
+            voronoiTexNode.sample(sampleUv),
             select(
               source.lessThan(4.5),
-              auraTexNode.sample(wrappedUv),
+              auraTexNode.sample(sampleUv),
               select(
                 source.lessThan(5.5),
-                causticsTexNode.sample(wrappedUv),
+                causticsTexNode.sample(sampleUv),
                 select(
                   source.lessThan(6.5),
-                  patternTexNode.sample(wrappedUv),
-                  fractalTexNode.sample(wrappedUv),
+                  patternTexNode.sample(sampleUv),
+                  fractalTexNode.sample(sampleUv),
                 ),
               ),
             ),
@@ -209,6 +212,44 @@ function createSampleAuxTextureNode(
       ),
     );
   });
+
+  const atlasSliceUvNode = Fn(([sampleUv, sliceIndex]: [any, any]) => {
+    const localUv = mix(vec2(0.01), vec2(0.99), fract(sampleUv));
+    const gridSize = float(AUX_TEXTURE_ATLAS_GRID_SIZE);
+    const tileSize = vec2(float(1).div(gridSize));
+    const row = floor(sliceIndex.div(gridSize));
+    const column = sliceIndex.sub(row.mul(gridSize));
+    return vec2(column, row).add(localUv).mul(tileSize);
+  });
+
+  return Fn(
+    ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
+      const wrappedUv = fract(sampleUv);
+      const scaledSlice = clamp(sliceZ, 0, 1).mul(
+        AUX_TEXTURE_ATLAS_SLICE_COUNT - 1,
+      );
+      const sliceIndexA = floor(scaledSlice);
+      const sliceIndexB = min(
+        sliceIndexA.add(1),
+        float(AUX_TEXTURE_ATLAS_SLICE_COUNT - 1),
+      );
+      const sliceBlend = fract(scaledSlice);
+      const planarSample = sampleAuxTexture2dNode(source, wrappedUv);
+      const sliceA = sampleAuxTexture2dNode(
+        source,
+        atlasSliceUvNode(wrappedUv, sliceIndexA),
+      );
+      const sliceB = sampleAuxTexture2dNode(
+        source,
+        atlasSliceUvNode(wrappedUv, sliceIndexB),
+      );
+      return mix(
+        planarSample,
+        mix(sliceA, sliceB, sliceBlend),
+        step(0.5, sampleDimension),
+      );
+    },
+  );
 }
 
 function createCompositeUniforms(
@@ -256,13 +297,17 @@ function createCompositeUniforms(
     ),
     overlayTextureSource: uniform(0),
     overlayTextureMode: uniform(0),
+    overlayTextureSampleDimension: uniform(0),
     overlayTextureAmount: uniform(0),
     overlayTextureScale: uniform(new Vector2(1, 1)),
     overlayTextureOffset: uniform(new Vector2(0, 0)),
+    overlayTextureVolumeSliceZ: uniform(0),
     warpTextureSource: uniform(0),
+    warpTextureSampleDimension: uniform(0),
     warpTextureAmount: uniform(0),
     warpTextureScale: uniform(new Vector2(1, 1)),
     warpTextureOffset: uniform(new Vector2(0, 0)),
+    warpTextureVolumeSliceZ: uniform(0),
     signalBass: uniform(0),
     signalMid: uniform(0),
     signalTreb: uniform(0),
@@ -317,7 +362,12 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const warpUv = baseUv
       .mul(uniforms.warpTextureScale)
       .add(uniforms.warpTextureOffset);
-    const warpVector = sampleAuxTextureNode(uniforms.warpTextureSource, warpUv)
+    const warpVector = sampleAuxTextureNode(
+      uniforms.warpTextureSource,
+      uniforms.warpTextureSampleDimension,
+      warpUv,
+      uniforms.warpTextureVolumeSliceZ,
+    )
       .rg.sub(0.5)
       .toVar();
     currentUv.addAssign(
@@ -455,7 +505,9 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
       .add(uniforms.overlayTextureOffset);
     const overlayColor = sampleAuxTextureNode(
       uniforms.overlayTextureSource,
+      uniforms.overlayTextureSampleDimension,
       overlayUv,
+      uniforms.overlayTextureVolumeSliceZ,
     ).rgb;
     const overlayAmount = clamp(uniforms.overlayTextureAmount, 0, 1.5);
     const overlayMixAmount = clamp(overlayAmount, 0, 1);
@@ -495,8 +547,18 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
       .sub(
         vec2(uniforms.signalTime.mul(0.018), uniforms.signalTime.mul(-0.026)),
       );
-    const spectralA = sampleAuxTextureNode(float(2), spectralUvA).rgb;
-    const spectralB = sampleAuxTextureNode(float(5), spectralUvB).rgb;
+    const spectralA = sampleAuxTextureNode(
+      float(2),
+      float(0),
+      spectralUvA,
+      0,
+    ).rgb;
+    const spectralB = sampleAuxTextureNode(
+      float(5),
+      float(0),
+      spectralUvB,
+      0,
+    ).rgb;
     const spectralPulse = sin(
       baseUv.x
         .add(baseUv.y)
@@ -646,6 +708,8 @@ class WebGPUMilkdropFeedbackManager {
       state.overlayTextureSource;
     this.compositeMaterial.uniforms.overlayTextureMode.value =
       state.overlayTextureMode;
+    this.compositeMaterial.uniforms.overlayTextureSampleDimension.value =
+      state.overlayTextureSampleDimension;
     this.compositeMaterial.uniforms.overlayTextureAmount.value =
       state.overlayTextureAmount;
     this.compositeMaterial.uniforms.overlayTextureScale.value.set(
@@ -656,8 +720,12 @@ class WebGPUMilkdropFeedbackManager {
       state.overlayTextureOffset.x,
       state.overlayTextureOffset.y,
     );
+    this.compositeMaterial.uniforms.overlayTextureVolumeSliceZ.value =
+      state.overlayTextureVolumeSliceZ;
     this.compositeMaterial.uniforms.warpTextureSource.value =
       state.warpTextureSource;
+    this.compositeMaterial.uniforms.warpTextureSampleDimension.value =
+      state.warpTextureSampleDimension;
     this.compositeMaterial.uniforms.warpTextureAmount.value =
       state.warpTextureAmount;
     this.compositeMaterial.uniforms.warpTextureScale.value.set(
@@ -668,6 +736,8 @@ class WebGPUMilkdropFeedbackManager {
       state.warpTextureOffset.x,
       state.warpTextureOffset.y,
     );
+    this.compositeMaterial.uniforms.warpTextureVolumeSliceZ.value =
+      state.warpTextureVolumeSliceZ;
     this.compositeMaterial.uniforms.signalBass.value = state.signalBass;
     this.compositeMaterial.uniforms.signalMid.value = state.signalMid;
     this.compositeMaterial.uniforms.signalTreb.value = state.signalTreb;

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -474,6 +474,10 @@ function getShaderTextureBlendModeId(mode: string) {
   }
 }
 
+function getShaderSampleDimensionId(dimension: '2d' | '3d') {
+  return dimension === '3d' ? 1 : 0;
+}
+
 export function getFeedbackBackendProfile(
   backend: 'webgl' | 'webgpu',
 ): FeedbackBackendProfile {
@@ -2059,6 +2063,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       overlayTextureMode: getShaderTextureBlendModeId(
         controls.textureLayer.mode,
       ),
+      overlayTextureSampleDimension: getShaderSampleDimensionId(
+        controls.textureLayer.sampleDimension,
+      ),
       overlayTextureAmount: controls.textureLayer.amount,
       overlayTextureScale: {
         x: controls.textureLayer.scaleX,
@@ -2068,7 +2075,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         x: controls.textureLayer.offsetX,
         y: controls.textureLayer.offsetY,
       },
+      overlayTextureVolumeSliceZ: controls.textureLayer.volumeSliceZ ?? 0,
       warpTextureSource: getShaderTextureSourceId(controls.warpTexture.source),
+      warpTextureSampleDimension: getShaderSampleDimensionId(
+        controls.warpTexture.sampleDimension,
+      ),
       warpTextureAmount: controls.warpTexture.amount,
       warpTextureScale: {
         x: controls.warpTexture.scaleX,
@@ -2078,6 +2089,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         x: controls.warpTexture.offsetX,
         y: controls.warpTexture.offsetY,
       },
+      warpTextureVolumeSliceZ: controls.warpTexture.volumeSliceZ ?? 0,
       signalBass: frameState.signals.bass,
       signalMid: frameState.signals.mid,
       signalTreb: frameState.signals.treb,

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -785,6 +785,7 @@ export type MilkdropFeedbackCompositeState = {
   };
   overlayTextureSource: number;
   overlayTextureMode: number;
+  overlayTextureSampleDimension: number;
   overlayTextureAmount: number;
   overlayTextureScale: {
     x: number;
@@ -794,7 +795,9 @@ export type MilkdropFeedbackCompositeState = {
     x: number;
     y: number;
   };
+  overlayTextureVolumeSliceZ: number;
   warpTextureSource: number;
+  warpTextureSampleDimension: number;
   warpTextureAmount: number;
   warpTextureScale: {
     x: number;
@@ -804,6 +807,7 @@ export type MilkdropFeedbackCompositeState = {
     x: number;
     y: number;
   };
+  warpTextureVolumeSliceZ: number;
   signalBass: number;
   signalMid: number;
   signalTreb: number;


### PR DESCRIPTION
### Motivation
- Enable shader-driven overlay and warp samplers to express 2D vs 3D sampling and a volume-slice `z` so presets that use `tex3D`/volume samplers can be approximated in the feedback composite pipeline.
- Keep existing 2D behavior unchanged while providing a deterministic atlas-style approximation for 3D sampling that is stable and animatable across frames.

### Description
- Propagate sample-dimension and slice-z state through the compiled controls into runtime state by extending `MilkdropShaderTextureLayerControls`, `MilkdropShaderTextureWarpControls`, and `MilkdropFeedbackCompositeState` in `assets/js/milkdrop/types.ts` to include `*SampleDimension` and `*VolumeSliceZ` fields.
- Add `getShaderSampleDimensionId` helper and populate `overlayTextureSampleDimension`, `overlayTextureVolumeSliceZ`, `warpTextureSampleDimension`, and `warpTextureVolumeSliceZ` in `assets/js/milkdrop/renderer-adapter.ts` when building the composite state.
- Replace the planar-only `sampleAuxTexture` with a sampler that accepts `sampleDimension` and `sliceZ` in `assets/js/milkdrop/feedback-manager-shared.ts`, keep a `sampleAuxTexture2d` path for `2d`, and implement deterministic atlas-style slice selection with adjacent-slice linear blending (atlas grid size = 8, 64 slices total) for `3d`.
- Mirror the same uniforms, helper node, and atlas blending logic in the WebGPU/TSL pipeline in `assets/js/milkdrop/feedback-manager-webgpu.ts` so WebGL/shared and WebGPU sampling remain behaviorally aligned.
- Preserve prior 2D sampling behavior when the propagated dimension is `2d` and only enable atlas blending when the dimension indicates `3d`.

### Testing
- Ran the repo quality gate via `bun run check`, which reached the test suite and surfaced two unrelated, pre-existing failing TV-mode tests in `tests/system-controls-tv-mode.test.ts` (these failures are unrelated to the Milkdrop changes and block a full green check run). (fail)
- Ran targeted Milkdrop tests with `bun test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts`, and the targeted Milkdrop suites passed. (pass)

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2d5d9da48332b5917edcc155d332)