### PR TITLE
Fix bundled toy module loading without manifest

### DIFF
--- a/assets/js/utils/toy-module-loader.ts
+++ b/assets/js/utils/toy-module-loader.ts
@@ -23,6 +23,17 @@ export type ToyModuleLoadSuccess = {
 
 export type ToyModuleLoadResult = ToyModuleLoadSuccess | ToyModuleLoadFailure;
 
+type ToyModuleExports = {
+  default?: { start?: unknown };
+  start?: unknown;
+};
+
+type ToyModuleImporter = () => Promise<ToyModuleExports>;
+
+const bundledToyImporters: Record<string, ToyModuleImporter> = {
+  'assets/js/toys/milkdrop-toy.ts': () => import('../toys/milkdrop-toy.ts'),
+};
+
 function resolveModuleImportUrl(moduleUrl: string) {
   if (moduleUrl.startsWith('./') || moduleUrl.startsWith('../')) {
     const moduleRootUrl = new URL(/* @vite-ignore */ '../', import.meta.url);
@@ -32,6 +43,61 @@ function resolveModuleImportUrl(moduleUrl: string) {
   return moduleUrl;
 }
 
+function getStarter(moduleExports: unknown) {
+  const startCandidate =
+    (moduleExports as { start?: unknown })?.start ??
+    (moduleExports as { default?: { start?: unknown } })?.default?.start;
+
+  return typeof startCandidate === 'function'
+    ? (startCandidate as ToyModuleStarter)
+    : null;
+}
+
+export function getBundledToyModuleImporter(
+  moduleId: string,
+): ToyModuleImporter | null {
+  if (!moduleId.startsWith('assets/js/')) {
+    return null;
+  }
+
+  return bundledToyImporters[moduleId] ?? null;
+}
+
+async function loadBundledToyModuleStarter(
+  moduleId: string,
+): Promise<ToyModuleLoadResult | null> {
+  const importer = getBundledToyModuleImporter(moduleId);
+  if (!importer) {
+    return null;
+  }
+
+  try {
+    const moduleExports = await importer();
+    const starter = getStarter(moduleExports);
+    if (!starter) {
+      return {
+        ok: false,
+        errorType: 'missing_start',
+        moduleUrl: moduleId,
+        error: new Error('Toy module did not export a start function.'),
+      };
+    }
+
+    return {
+      ok: true,
+      moduleUrl: moduleId,
+      starter,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      errorType: 'import',
+      moduleUrl: moduleId,
+      error: error as Error,
+    };
+  }
+}
+
 export async function loadToyModuleStarter({
   moduleId,
   manifestClient,
@@ -39,6 +105,11 @@ export async function loadToyModuleStarter({
   moduleId: string;
   manifestClient: ReturnType<typeof createManifestClient>;
 }): Promise<ToyModuleLoadResult> {
+  const bundledResult = await loadBundledToyModuleStarter(moduleId);
+  if (bundledResult) {
+    return bundledResult;
+  }
+
   let moduleUrl: string;
   try {
     moduleUrl = await manifestClient.resolveModulePath(moduleId);
@@ -63,13 +134,7 @@ export async function loadToyModuleStarter({
     };
   }
 
-  const startCandidate =
-    (moduleExports as { start?: unknown })?.start ??
-    (moduleExports as { default?: { start?: unknown } })?.default?.start;
-  const starter =
-    typeof startCandidate === 'function'
-      ? (startCandidate as ToyModuleStarter)
-      : null;
+  const starter = getStarter(moduleExports);
 
   if (!starter) {
     return {

--- a/tests/toy-module-loader.test.ts
+++ b/tests/toy-module-loader.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  getBundledToyModuleImporter,
+  loadToyModuleStarter,
+} from '../assets/js/utils/toy-module-loader.ts';
+
+describe('toy module loader', () => {
+  test('finds bundled toy modules without manifest indirection', async () => {
+    const importer = getBundledToyModuleImporter(
+      'assets/js/toys/milkdrop-toy.ts',
+    );
+
+    expect(importer).not.toBeNull();
+  });
+
+  test('loads bundled toy modules even when manifest resolution fails', async () => {
+    const manifestClient = {
+      resolveModulePath: mock(async () => {
+        throw new Error('manifest unavailable');
+      }),
+    };
+
+    const result = await loadToyModuleStarter({
+      moduleId: 'assets/js/toys/milkdrop-toy.ts',
+      manifestClient: manifestClient as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(manifestClient.resolveModulePath).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(typeof result.starter).toBe('function');
+      expect(result.moduleUrl).toBe('assets/js/toys/milkdrop-toy.ts');
+    }
+  });
+
+  test('uses manifest resolution for non-bundled module ids', async () => {
+    const manifestClient = {
+      resolveModulePath: mock(async () => './__mocks__/fake-module.js'),
+    };
+
+    const result = await loadToyModuleStarter({
+      moduleId: './__mocks__/fake-module.js',
+      manifestClient: manifestClient as never,
+    });
+
+    expect(manifestClient.resolveModulePath).toHaveBeenCalledWith(
+      './__mocks__/fake-module.js',
+    );
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the shipped MilkDrop toy can start even when the Vite/.vite manifest is unavailable so `/milkdrop/` does not fail in production or non-manifest environments.
- Centralize and reuse the logic that extracts a `start` export from a loaded module and short-circuit to a bundled import path for known in-repo toys.

### Description
- Add a bundled importer registry and helpers (`getBundledToyModuleImporter`, `loadBundledToyModuleStarter`, and `getStarter`) and wire it into `loadToyModuleStarter` so bundled modules (notably `assets/js/toys/milkdrop-toy.ts`) are imported directly before manifest resolution. (file: `assets/js/utils/toy-module-loader.ts`)
- Replace duplicated `start`-export extraction with the shared `getStarter` helper. (file: `assets/js/utils/toy-module-loader.ts`)
- Add focused regression tests that verify bundled-module loading and fallback to manifest resolution for non-bundled ids. (file: `tests/toy-module-loader.test.ts`)

### Testing
- Ran the focused unit tests: `bun run test tests/toy-module-loader.test.ts` — all tests in that file passed. 
- Built a production bundle to ensure the runtime import paths remain valid: `bun run build` — build succeeded. 
- Ran the full quality gate: `bun run check` — the gate runs the entire test suite and formatting/type checks; it completed but surfaced an existing, unrelated failing test (`tests/system-controls-tv-mode.test.ts`), so the failure is pre-existing and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3222a6cc833297dafdfa2cc0f2f0)