### PR TITLE
Preserve tex3D approximation metadata in compiler and tests

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -1950,15 +1950,23 @@ function isShaderUvIdentifier(node: MilkdropShaderExpressionNode) {
   return node.type === 'identifier' && node.name.toLowerCase() === 'uv';
 }
 
-function isShaderInvertSampleExpression(
+function extractShaderInvertedSampleExpression(
   node: MilkdropShaderExpressionNode,
-): boolean {
-  return (
-    node.type === 'binary' &&
-    node.operator === '-' &&
-    isShaderLiteralNumber(node.left, 1) &&
-    isShaderMainSampleExpression(node.right)
-  );
+): MilkdropExtractedShaderSampleMetadata | 'main' | null {
+  if (
+    node.type !== 'binary' ||
+    node.operator !== '-' ||
+    !isShaderLiteralNumber(node.left, 1)
+  ) {
+    return null;
+  }
+
+  const sample = getShaderSampleInfo(node.right);
+  if (!sample) {
+    return null;
+  }
+
+  return sample.source === 'main' ? 'main' : sample;
 }
 
 function isShaderSolarizeSampleExpression(
@@ -2477,18 +2485,30 @@ function applyShaderAstStatement({
           applyTextureLayerSample(controls, expressions, auxSample);
           return true;
         }
-        if (isShaderInvertSampleExpression(targetNode)) {
-          const next = applyShaderControlValue(
-            operator,
-            controls.invertBoost,
-            expressions.invertBoost,
-            amount.value,
-            amount.expression,
-          );
-          controls.invertBoost = next.value;
-          expressions.invertBoost = next.expression;
-          shaderEnv.invert = next.value;
-          return true;
+        const invertedSample =
+          extractShaderInvertedSampleExpression(targetNode);
+        if (invertedSample) {
+          if (invertedSample === 'main') {
+            const next = applyShaderControlValue(
+              operator,
+              controls.invertBoost,
+              expressions.invertBoost,
+              amount.value,
+              amount.expression,
+            );
+            controls.invertBoost = next.value;
+            expressions.invertBoost = next.expression;
+            shaderEnv.invert = next.value;
+            return true;
+          }
+          if (!isAuxShaderSamplerName(invertedSample.source)) {
+            return false;
+          }
+          controls.textureLayer.mode = 'mix';
+          controls.textureLayer.amount = amount.value;
+          expressions.textureLayer.amount = amount.expression;
+          applyTextureLayerSample(controls, expressions, invertedSample);
+          return false;
         }
         if (isShaderSolarizeSampleExpression(targetNode)) {
           const next = applyShaderControlValue(
@@ -5282,6 +5302,16 @@ function createIR(
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
+  const usesVolumeShaderApproximation = [
+    shaderWarpAnalysis.controls.textureLayer,
+    shaderWarpAnalysis.controls.warpTexture,
+    shaderCompAnalysis.controls.textureLayer,
+    shaderCompAnalysis.controls.warpTexture,
+    mergedShaderControls.controls.textureLayer,
+    mergedShaderControls.controls.warpTexture,
+  ].some(
+    (sample) => sample.source !== 'none' && sample.sampleDimension === '3d',
+  );
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
@@ -5339,6 +5369,14 @@ function createIR(
       'Shader-text sections include lines outside the supported subset.',
     );
   }
+  if (usesVolumeShaderApproximation) {
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'preset_shader_volume_approximation',
+      'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+    );
+  }
   const featureAnalysis = buildFeatureAnalysis({
     programs,
     customWaves,
@@ -5355,6 +5393,11 @@ function createIR(
       ({ key, feature, message }) =>
         `Unsupported feature "${feature}" from preset field "${key}": ${message}`,
     ),
+    ...(usesVolumeShaderApproximation
+      ? [
+          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+        ]
+      : []),
   ];
   const backends = {
     webgl: buildBackendSupport({

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { YouTubeController } from '../assets/js/ui/youtube-controller.ts';
 
 const freshImport = async <T>(path: string): Promise<T> =>
@@ -9,8 +9,41 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 let initAudioControls: typeof import('../assets/js/ui/audio-controls.ts').initAudioControls;
 let buildTryThisFirstRecommendation: typeof import('../assets/js/ui/audio-controls.ts').buildTryThisFirstRecommendation;
 
+const baselineNavigator = globalThis.navigator;
+const baselineNavigatorPermissions = baselineNavigator.permissions;
+const baselineNavigatorMediaDevices = baselineNavigator.mediaDevices;
+const baselineMatchMedia = window.matchMedia;
+
+function restoreNavigatorBaseline() {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: baselineNavigator,
+  });
+  Object.defineProperty(globalThis.navigator, 'permissions', {
+    configurable: true,
+    value: {
+      ...baselineNavigatorPermissions,
+      query: mock(async () => ({ state: 'prompt' })),
+    },
+  });
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      ...baselineNavigatorMediaDevices,
+      getUserMedia: mock(async () => ({}) as MediaStream),
+    },
+  });
+}
+
 describe('audio controls primary emphasis', () => {
+  afterEach(() => {
+    restoreNavigatorBaseline();
+    window.matchMedia = baselineMatchMedia;
+    document.body.innerHTML = '';
+  });
+
   beforeEach(async () => {
+    restoreNavigatorBaseline();
     document.body.innerHTML = '';
     sessionStorage.clear();
     localStorage.clear();

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,7 +1310,13 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [],
+    "diagnostics": [
+      {
+        "severity": "warning",
+        "code": "preset_shader_volume_approximation",
+        "field": null
+      }
+    ],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1321,12 +1327,13 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
+        "Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.",
         "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
       "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
-          "status": "supported",
+          "status": "partial",
           "evidence": []
         },
         "webgpu": {
@@ -1343,10 +1350,7 @@
       },
       "parity": {
         "fidelityClass": "near-exact",
-        "backendDivergence": [
-          "status:webgl=supported,webgpu=partial",
-          "webgpu:supported-shader-text-gap"
-        ],
+        "backendDivergence": ["webgpu:supported-shader-text-gap"],
         "ignoredFields": [],
         "blockedConstructs": [],
         "approximatedShaderLines": [],

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -565,7 +565,20 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
       expect(
         compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
       ).toBeCloseTo(0, 6);
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(compiled.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'preset_shader_volume_approximation',
+            severity: 'warning',
+          }),
+        ]),
+      );
+      expect(compiled.ir.compatibility.warnings).toEqual(
+        expect.arrayContaining([
+          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+        ]),
+      );
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
       expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
         [],
@@ -584,8 +597,32 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
 
     expect(compiled.ir.shaderText.supported).toBe(false);
     expect(compiled.ir.post.shaderControls.invertBoost).toBeCloseTo(0, 6);
-    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('none');
-    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('none');
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '3d',
+    );
+    expect(compiled.ir.shaderText.controls.textureLayer.source).toBe('simplex');
+    expect(compiled.ir.shaderText.controls.textureLayer.mode).toBe('mix');
+    expect(
+      compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
+    ).toBeCloseTo(0, 6);
+    expect(
+      compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
+    ).not.toBeNull();
+    expect(compiled.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'preset_shader_volume_approximation',
+          severity: 'warning',
+        }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.warnings).toEqual(
+      expect.arrayContaining([
+        'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+      ]),
+    );
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
     expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
       'unsupported',

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,6 +96,19 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
+const VOLUME_SHADER_APPROXIMATION_EXPECTATION = {
+  diagnostics: ['preset_shader_volume_approximation'],
+  webgl: 'partial',
+  webgpu: 'partial',
+  divergence: ['webgpu:supported-shader-text-gap'],
+  warnings: [
+    'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+    'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+  ],
+  blockedConstructs: [],
+  unsupportedKeys: [],
+} as const satisfies ProjectMFixtureExpectation;
+
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -132,7 +145,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': VOLUME_SHADER_APPROXIMATION_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -594,6 +594,69 @@ video_echo=1
     );
   });
 
+  test('forwards overlay and warp volume sampling metadata into feedback state', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Feedback Volume Metadata
+video_echo=1
+      `.trim(),
+      { id: 'feedback-volume-metadata' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    frameState.post.shaderControls.textureLayer.source = 'simplex';
+    frameState.post.shaderControls.textureLayer.mode = 'mix';
+    frameState.post.shaderControls.textureLayer.sampleDimension = '3d';
+    frameState.post.shaderControls.textureLayer.volumeSliceZ = 0.25;
+    frameState.post.shaderControls.warpTexture.source = 'aura';
+    frameState.post.shaderControls.warpTexture.sampleDimension = '3d';
+    frameState.post.shaderControls.warpTexture.amount = 0.4;
+    frameState.post.shaderControls.warpTexture.volumeSliceZ = 0.75;
+
+    const compositeStates: MilkdropFeedbackCompositeState[] = [];
+    const feedback = {
+      applyCompositeState(state: MilkdropFeedbackCompositeState) {
+        compositeStates.push(state);
+      },
+      render() {
+        return true;
+      },
+      swap() {},
+      resize() {},
+      dispose() {},
+    } as MilkdropFeedbackManager;
+
+    const renderer = {
+      getSize: (target: Vector2) => target.set(320, 180),
+      render() {},
+      setRenderTarget() {},
+    };
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapterCore({
+      scene,
+      camera,
+      renderer,
+      backend: 'webgl',
+      createFeedbackManager: () => feedback,
+    });
+
+    adapter.attach();
+    expect(
+      adapter.render({
+        frameState,
+        blendState: null,
+      }),
+    ).toBe(true);
+
+    expect(compositeStates[0]).toMatchObject({
+      overlayTextureSampleDimension: 1,
+      overlayTextureVolumeSliceZ: 0.25,
+      warpTextureSampleDimension: 1,
+      warpTextureVolumeSliceZ: 0.75,
+    });
+  });
+
   test('renders main wave and trails directly on webgpu line-wave presets', () => {
     const preset = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -161,7 +161,23 @@ describe('milkdrop shader sampler aliases', () => {
       expect(
         compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
       ).toBeCloseTo(0, 6);
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+      expect(
+        compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
+      ).not.toBeNull();
+      expect(compiled.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'preset_shader_volume_approximation',
+            severity: 'warning',
+          }),
+        ]),
+      );
+      expect(compiled.ir.compatibility.warnings).toEqual(
+        expect.arrayContaining([
+          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
+        ]),
+      );
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     }
   });


### PR DESCRIPTION
### Motivation
- Preserve metadata for `tex3D` volume samples so 3D sampler approximations keep their `sampleDimension`, `volumeSliceZ`, and aux `textureLayer` info instead of being treated as a total fallback. 
- Surface a dedicated compatibility diagnostic (`preset_shader_volume_approximation`) to mark presets that used the 3D approximation path. 
- Harden audio test isolation so per-test mutations to `navigator`, `navigator.permissions`, `navigator.mediaDevices`, and `matchMedia` do not leak across the suite. 

### Description
- Update compiler: add `extractShaderInvertedSampleExpression` to preserve extracted sampler metadata for inverted `tex3D` samples, apply `applyTextureLayerSample` in approximation paths, and detect `usesVolumeShaderApproximation` to emit a `preset_shader_volume_approximation` diagnostic. 
- Adjust compiler IR composition to include volume-approximation warnings and to include preserved `sampleDimension`/`volumeSliceZ` in merged shader controls and expressions. 
- Tests updated: revise `tests/milkdrop-shader-sampler-aliases.test.ts`, `tests/milkdrop-compiler.test.ts`, and `tests/milkdrop-renderer-adapter.test.ts` to assert preserved `sampleDimension`, preserved `volumeSliceZ`, emitted `preset_shader_volume_approximation` warning, and merged shader controls retaining aux sampler source/mode; add renderer-focused regression asserting composite state forwarded into the feedback manager includes overlay/warp sample-dimension and slice-z values. 
- ProjectM fixture updates: move `261-compshader-noisevol_lq.milk` into an explicit approximation expectation and refresh `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json`. 
- Audio test isolation: restore baseline `globalThis.navigator`, `navigator.permissions`, `navigator.mediaDevices`, and `matchMedia` in `beforeEach`/`afterEach` in `tests/audio-controls.test.ts` so microphone-permission state is reset per test. 

### Testing
- Ran targeted unit suites with `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-projectm-compat.test.ts tests/audio-controls.test.ts`, and all targeted tests passed. 
- Ran the project quality gate with `bun run check`; targeted changes and formatting fixes were validated, however the repo-wide run at commit-time still surfaced two unrelated, pre-existing failures in `tests/system-controls-tv-mode.test.ts` (these were observed as existing test flakes and are not caused by the volume-sampler changes). 
- Updated snapshot file `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` to capture the new approximation warning shape.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3101d6b083328f8af68e4ac533e4)