### PR TITLE
Follow up: fix mobile overlay toggle layout regression

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2646,8 +2646,7 @@ body.tv-mode .control-panel input {
 }
 
 .milkdrop-overlay.is-open .milkdrop-overlay__toggle {
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 .milkdrop-overlay__header,


### PR DESCRIPTION
### Motivation
- Prevent the invisible presets launcher from occupying layout and focus when the MilkDrop overlay is open so the mobile sheet can fit in the viewport and the header is not pushed off-screen.

### Description
- Update `assets/css/base.css` to replace the open-overlay rule that set `opacity: 0; pointer-events: none;` with `display: none;` for `.milkdrop-overlay.is-open .milkdrop-overlay__toggle`, removing the launcher from layout and the tab order while the sheet is open.

### Testing
- Ran `bun run check` (Biome + typecheck + tests); the quality gate failed due to two unrelated pre-existing failures in `tests/system-controls-tv-mode.test.ts`.
- Ran targeted overlay tests with `bun run test tests/milkdrop-overlay.test.ts tests/milkdrop-overlay-stacking.test.ts tests/preflight-mobile-visibility.test.ts`, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be34f93a688332bfd84ea531567c50)