### PR TITLE
Wrap 3D aux texture slices in feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -374,9 +374,9 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return sampleAuxTexture2d(source, wrappedUv);
           }
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
-          float scaledSlice = clamp(sliceZ, 0.0, 1.0) * (sliceCount - 1.0);
+          float scaledSlice = fract(sliceZ) * sliceCount;
           float sliceIndexA = floor(scaledSlice);
-          float sliceIndexB = min(sliceIndexA + 1.0, sliceCount - 1.0);
+          float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);
           vec4 sliceA = sampleAuxTexture2d(source, atlasSliceUv(wrappedUv, sliceIndexA));
           vec4 sliceB = sampleAuxTexture2d(source, atlasSliceUv(wrappedUv, sliceIndexB));

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -225,13 +225,11 @@ function createSampleAuxTextureNode(
   return Fn(
     ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
       const wrappedUv = fract(sampleUv);
-      const scaledSlice = clamp(sliceZ, 0, 1).mul(
-        AUX_TEXTURE_ATLAS_SLICE_COUNT - 1,
-      );
+      const sliceCount = float(AUX_TEXTURE_ATLAS_SLICE_COUNT);
+      const scaledSlice = fract(sliceZ).mul(sliceCount);
       const sliceIndexA = floor(scaledSlice);
-      const sliceIndexB = min(
-        sliceIndexA.add(1),
-        float(AUX_TEXTURE_ATLAS_SLICE_COUNT - 1),
+      const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
+        sliceCount,
       );
       const sliceBlend = fract(scaledSlice);
       const planarSample = sampleAuxTexture2dNode(source, wrappedUv);


### PR DESCRIPTION
### Motivation
- Prevent volume-noise and other `tex3D`-driven presets from freezing when the runtime `volumeSliceZ` leaves `[0,1]` by wrapping the slice coordinate instead of clamping it. 
- Keep WebGL/shared and WebGPU feedback sampling behavior aligned so both backends animate atlas-based 3D approximations consistently.

### Description
- Replace clamping of `sliceZ` with wraparound using `fract(...)` and wrap the adjacent-slice lookup so the atlas cycles from last slice back to first in `assets/js/milkdrop/feedback-manager-shared.ts`.
- Mirror the same wraparound logic in the WebGPU node graph in `assets/js/milkdrop/feedback-manager-webgpu.ts` by computing `sliceCount`, using `fract(sliceZ) * sliceCount`, and wrapping the B index accordingly.
- The change preserves prior 2D sampling paths and only alters the atlas-style 3D sampling interpolation so volume animations remain deterministic and animatable.

### Testing
- Ran `bun run check`, which reported the repo quality gate but ended non-green due to unrelated, pre-existing failures in `tests/system-controls-tv-mode.test.ts` (failure not caused by these changes). (fail)
- Ran targeted Milkdrop tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts`, and all targeted tests passed. (pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be34f9ea1c8332a9cb3eeac2ebea48)