### PR TITLE
Simplify featured browse sections

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2908,7 +2908,7 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__browse-section {
   display: grid;
-  gap: 8px;
+  gap: 6px;
   padding: 0;
 }
 
@@ -2916,11 +2916,11 @@ body.tv-mode .control-panel input {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  color: rgba(226, 232, 240, 0.92);
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  gap: 8px;
+  color: rgba(226, 232, 240, 0.76);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -2928,14 +2928,14 @@ body.tv-mode .control-panel input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 30px;
-  min-height: 24px;
-  padding: 0 8px;
+  min-width: 24px;
+  min-height: 18px;
+  padding: 0 6px;
   border-radius: 999px;
-  background: rgba(56, 189, 248, 0.14);
-  color: #bae6fd;
-  font-size: 0.76rem;
-  font-weight: 700;
+  background: rgba(56, 189, 248, 0.1);
+  color: rgba(186, 230, 253, 0.8);
+  font-size: 0.68rem;
+  font-weight: 600;
 }
 
 .milkdrop-overlay__browse-empty {

--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -58,6 +58,10 @@ const COLLECTION_LABELS: Record<string, string> = {
 type BrowseMode = 'featured' | 'all' | 'recent' | 'favorites';
 type BrowseSort = 'recommended' | 'title' | 'rating' | 'recent';
 type BrowseFidelityFilter = 'all' | MilkdropFidelityClass;
+type BrowseSection = {
+  title: string;
+  presets: MilkdropCatalogEntry[];
+};
 
 function setButtonActive(buttons: HTMLButtonElement[], activeId: string) {
   buttons.forEach((button) => {
@@ -998,6 +1002,56 @@ export class MilkdropOverlay {
     target.appendChild(section);
   }
 
+  private dedupeBrowsePresets(
+    presets: MilkdropCatalogEntry[],
+    seen: Set<string>,
+  ) {
+    return presets.filter((preset) => {
+      if (seen.has(preset.id)) {
+        return false;
+      }
+      seen.add(preset.id);
+      return true;
+    });
+  }
+
+  private buildFeaturedBrowseSections(filtered: MilkdropCatalogEntry[]) {
+    const sections: BrowseSection[] = [];
+    const seen = new Set<string>();
+    const recent = filtered
+      .filter((preset) => preset.historyIndex !== undefined)
+      .slice(0, 4);
+    const favoriteRecovery = filtered
+      .filter(
+        (preset) =>
+          preset.isFavorite &&
+          !recent.some((recentPreset) => recentPreset.id === preset.id),
+      )
+      .slice(0, 4);
+    const recovery = this.dedupeBrowsePresets(
+      [...recent, ...favoriteRecovery],
+      seen,
+    ).slice(0, 6);
+
+    if (recovery.length > 0) {
+      const hasRecent = recent.length > 0;
+      const hasFavorites = favoriteRecovery.length > 0;
+      const title = hasRecent
+        ? hasFavorites
+          ? 'Continue listening'
+          : 'Recent'
+        : 'Favorites';
+      sections.push({ title, presets: recovery });
+    }
+
+    const recommended = this.dedupeBrowsePresets(filtered, seen).slice(0, 12);
+    if (recommended.length > 0) {
+      sections.push({ title: 'Recommended', presets: recommended });
+    }
+
+    return sections;
+  }
+
   private scheduleBrowseRender(delayMs = 120) {
     this.browseDirty = true;
     if (this.activeTab !== 'browse') {
@@ -1061,42 +1115,9 @@ export class MilkdropOverlay {
       return;
     }
 
-    const recent = filtered
-      .filter((preset) => preset.historyIndex !== undefined)
-      .slice(0, 6);
-    const favorites = filtered
-      .filter((preset) => preset.isFavorite)
-      .slice(0, 6);
-    const classic = filtered
-      .filter((preset) => preset.tags.includes('collection:classic-milkdrop'))
-      .slice(0, 8);
-    const feedback = filtered
-      .filter((preset) => preset.tags.includes('collection:feedback-lab'))
-      .slice(0, 8);
-    const lowMotion = filtered
-      .filter((preset) => preset.tags.includes('collection:low-motion'))
-      .slice(0, 6);
-
-    const seen = new Set<string>();
-    const dedupe = (presets: MilkdropCatalogEntry[]) =>
-      presets.filter((preset) => {
-        if (seen.has(preset.id)) {
-          return false;
-        }
-        seen.add(preset.id);
-        return true;
-      });
-
-    this.appendPresetSection('Jump back in', dedupe(recent), fragment);
-    this.appendPresetSection('Favorites', dedupe(favorites), fragment);
-    this.appendPresetSection('Classic MilkDrop', dedupe(classic), fragment);
-    this.appendPresetSection('Feedback Lab', dedupe(feedback), fragment);
-    this.appendPresetSection('Low Motion', dedupe(lowMotion), fragment);
-    this.appendPresetSection(
-      'More presets',
-      dedupe(filtered).slice(0, 12),
-      fragment,
-    );
+    this.buildFeaturedBrowseSections(filtered).forEach((section) => {
+      this.appendPresetSection(section.title, section.presets, fragment);
+    });
     this.browseList.replaceChildren(fragment);
   }
 

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -346,4 +346,64 @@ describe('milkdrop overlay browse rendering', () => {
 
     overlay.dispose();
   });
+
+  test('keeps featured browse focused on recovery and recommendations', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const recentFavorite = createCatalogEntry('signal-bloom', 'Signal Bloom');
+    recentFavorite.historyIndex = 0;
+    recentFavorite.isFavorite = true;
+    recentFavorite.tags = ['collection:classic-milkdrop'];
+
+    const recentOnly = createCatalogEntry('aurora-drift', 'Aurora Drift');
+    recentOnly.historyIndex = 1;
+    recentOnly.tags = ['collection:feedback-lab'];
+
+    const favoriteOnly = createCatalogEntry('night-drive', 'Night Drive');
+    favoriteOnly.isFavorite = true;
+    favoriteOnly.tags = ['collection:low-motion'];
+
+    const discoveryOne = createCatalogEntry('prism-burst', 'Prism Burst');
+    discoveryOne.tags = ['collection:classic-milkdrop'];
+
+    const discoveryTwo = createCatalogEntry('echo-grid', 'Echo Grid');
+    discoveryTwo.tags = ['collection:feedback-lab'];
+
+    overlay.setCatalog(
+      [recentFavorite, recentOnly, favoriteOnly, discoveryOne, discoveryTwo],
+      'signal-bloom',
+      'webgl',
+    );
+
+    const sections = [
+      ...document.querySelectorAll('.milkdrop-overlay__browse-section'),
+    ] as HTMLElement[];
+    const headings = sections.map((section) =>
+      (
+        section.querySelector('.milkdrop-overlay__browse-heading')
+          ?.childNodes[0]?.textContent ?? ''
+      ).trim(),
+    );
+
+    expect(sections).toHaveLength(2);
+    expect(headings).toEqual(['Continue listening', 'Recommended']);
+    expect(headings).not.toContain('Classic MilkDrop');
+    expect(headings).not.toContain('Feedback Lab');
+    expect(headings).not.toContain('Low Motion');
+
+    expect(sections[0]?.textContent).toContain('Signal Bloom');
+    expect(sections[0]?.textContent).toContain('Aurora Drift');
+    expect(sections[0]?.textContent).toContain('Night Drive');
+    expect(sections[1]?.textContent).toContain('Prism Burst');
+    expect(sections[1]?.textContent).toContain('Echo Grid');
+
+    overlay.dispose();
+  });
 });


### PR DESCRIPTION
### Motivation
- Reduce clutter in the default featured browse view so returning users see one lightweight recovery section and a single recommended discovery section, and defer themed collections to explicit collection filters or the `All presets` view.
- Make section headings and counts visually lighter so the browse groups provide supportive structure instead of dominating the overlay chrome.

### Description
- Extracted featured-section construction into `buildFeaturedBrowseSections` and a small `BrowseSection` type, and added `dedupeBrowsePresets` to keep items unique in `assets/js/milkdrop/overlay.ts`.
- Replaced the previous multi-themed section logic in `renderBrowseList()` with the new featured sections builder so the default featured state only renders a recovery section (titled `Continue listening` / `Recent` / `Favorites`) and a `Recommended` section.
- Removed hardcoded themed sections (`Classic MilkDrop`, `Feedback Lab`, `Low Motion`) from the featured default while preserving collection filters and the `All presets` mode via existing collection UI.
- Reduced visual emphasis for browse sections by tuning `.milkdrop-overlay__browse-section`, `.milkdrop-overlay__browse-heading`, and `.milkdrop-overlay__browse-count` styles in `assets/css/base.css`.
- Added/updated a test in `tests/milkdrop-overlay.test.ts` that asserts the featured default renders only the recovery and recommended sections and preserves recent/favorite recovery behavior.

### Testing
- Ran `bun run test tests/milkdrop-overlay.test.ts` and the updated tests passed locally.
- Ran the full project quality gate via `bun run check` (Biome format/lint, TypeScript typecheck, and test suite) and it passed with no failures.
- Files changed: `assets/js/milkdrop/overlay.ts`, `assets/css/base.css`, and `tests/milkdrop-overlay.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be37cf6f088332b78b0baf59740f47)