### PR TITLE
Simplify MilkDrop browse header

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2777,28 +2777,24 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__browse-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.8fr);
-  gap: 10px;
+  gap: 8px;
   margin-top: 0;
-  padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.14);
-  border-radius: 16px;
-  background:
-    linear-gradient(145deg, rgba(8, 15, 31, 0.82), rgba(14, 22, 41, 0.68)),
-    radial-gradient(
-      circle at top left,
-      rgba(56, 189, 248, 0.12),
-      transparent 42%
-    );
+  padding: 8px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(9, 15, 27, 0.68);
 }
 
 .milkdrop-overlay__browse-copy {
   display: grid;
-  gap: 6px;
-  align-content: start;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "active quality"
+    "meta meta";
+  gap: 4px 10px;
+  align-items: center;
 }
 
-.milkdrop-overlay__browse-eyebrow,
 .milkdrop-overlay__browse-control-label,
 .milkdrop-overlay__quality-label {
   margin: 0;
@@ -2810,42 +2806,49 @@ body.tv-mode .control-panel input {
 }
 
 .milkdrop-overlay__browse-active {
-  font-size: 0.98rem;
+  grid-area: active;
+  min-width: 0;
+  font-size: 0.94rem;
   font-weight: 700;
   color: #f8fafc;
+  line-height: 1.3;
 }
 
 .milkdrop-overlay__browse-meta {
+  grid-area: meta;
   margin: 0;
-  color: rgba(191, 219, 254, 0.78);
-  font-size: 0.84rem;
+  color: rgba(191, 219, 254, 0.72);
+  font-size: 0.78rem;
+  line-height: 1.3;
 }
 
 .milkdrop-overlay__quality {
-  display: grid;
-  gap: 8px;
-  align-content: start;
-  padding: 10px 12px;
-  border: 1px solid rgba(125, 211, 252, 0.16);
-  border-radius: 14px;
-  background: rgba(10, 19, 36, 0.74);
+  grid-area: quality;
+  display: inline-grid;
+  justify-items: end;
+  gap: 3px;
+  align-items: center;
 }
 
 .milkdrop-overlay__quality-label {
-  display: grid;
+  display: inline-grid;
+  grid-auto-flow: column;
   gap: 8px;
+  align-items: center;
 }
 
 .milkdrop-overlay__quality-select {
-  width: 100%;
+  width: auto;
+  min-width: 128px;
 }
 
-.milkdrop-overlay__quality-hint,
-.milkdrop-overlay__quality-meta {
+.milkdrop-overlay__quality-hint {
   margin: 0;
-  color: rgba(226, 232, 240, 0.84);
-  font-size: 0.8rem;
-  line-height: 1.35;
+  max-width: 28ch;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.74rem;
+  line-height: 1.25;
+  text-align: right;
 }
 
 .milkdrop-overlay__browse-controls {
@@ -3158,8 +3161,25 @@ body.tv-mode .control-panel input {
     max-height: min(80vh, 760px);
   }
 
-  .milkdrop-overlay__browse-hero {
-    grid-template-columns: 1fr;
+  .milkdrop-overlay__browse-copy {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "active"
+      "quality"
+      "meta";
+  }
+
+  .milkdrop-overlay__quality {
+    justify-items: start;
+  }
+
+  .milkdrop-overlay__quality-label {
+    grid-auto-flow: row;
+    justify-items: start;
+  }
+
+  .milkdrop-overlay__quality-hint {
+    text-align: left;
   }
 
   .milkdrop-overlay__browse-controls {
@@ -3251,33 +3271,28 @@ body.tv-mode .control-panel input {
   }
 
   .milkdrop-overlay__browse-hero {
-    gap: 8px;
+    gap: 6px;
     margin-top: 0;
-    padding: 8px 0 0;
+    padding: 6px 0 0;
     border: 0;
     border-radius: 0;
     background: none;
   }
 
   .milkdrop-overlay__browse-copy {
-    gap: 4px;
+    gap: 4px 8px;
   }
 
   .milkdrop-overlay__browse-meta {
-    display: none;
+    font-size: 0.74rem;
   }
 
   .milkdrop-overlay__quality {
-    gap: 6px;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: none;
+    gap: 4px;
   }
 
-  .milkdrop-overlay__quality-hint,
-  .milkdrop-overlay__quality-meta {
-    font-size: 0.76rem;
+  .milkdrop-overlay__quality-hint {
+    font-size: 0.72rem;
   }
 
   .milkdrop-overlay__browse-controls {

--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -178,8 +178,6 @@ export class MilkdropOverlay {
   private readonly browseMetaLabel: HTMLElement;
   private readonly browseQualitySelect: HTMLSelectElement;
   private readonly browseQualityHint: HTMLElement;
-  private readonly browseQualityScopeHint: HTMLElement;
-  private readonly browseQualityImpact: HTMLElement;
   private readonly diagnosticsList: HTMLElement;
   private readonly editorStatus: HTMLElement;
   private readonly inspectorControls: HTMLElement;
@@ -406,31 +404,18 @@ export class MilkdropOverlay {
     const browseCopy = document.createElement('div');
     browseCopy.className = 'milkdrop-overlay__browse-copy';
 
-    const browseEyebrow = document.createElement('p');
-    browseEyebrow.className = 'milkdrop-overlay__browse-eyebrow';
-    browseEyebrow.textContent = 'Preset chooser';
-
     this.browseActiveLabel = document.createElement('div');
     this.browseActiveLabel.className = 'milkdrop-overlay__browse-active';
     this.browseActiveLabel.textContent = 'Loading presets...';
-
-    this.browseMetaLabel = document.createElement('p');
-    this.browseMetaLabel.className = 'milkdrop-overlay__browse-meta';
-    this.browseMetaLabel.textContent =
-      'Keep playback moving while you browse and tune quality here.';
-
-    browseCopy.append(
-      browseEyebrow,
-      this.browseActiveLabel,
-      this.browseMetaLabel,
-    );
+    this.browseActiveLabel.setAttribute('aria-live', 'polite');
+    this.browseActiveLabel.setAttribute('aria-atomic', 'true');
 
     const qualityCard = document.createElement('div');
     qualityCard.className = 'milkdrop-overlay__quality';
 
     const qualityLabel = document.createElement('label');
     qualityLabel.className = 'milkdrop-overlay__quality-label';
-    qualityLabel.textContent = 'Quality preset';
+    qualityLabel.textContent = 'Quality';
 
     this.browseQualitySelect = document.createElement('select');
     this.browseQualitySelect.className =
@@ -442,23 +427,23 @@ export class MilkdropOverlay {
     });
     qualityLabel.appendChild(this.browseQualitySelect);
 
+    this.browseMetaLabel = document.createElement('p');
+    this.browseMetaLabel.className = 'milkdrop-overlay__browse-meta';
+    this.browseMetaLabel.textContent = 'Loading status…';
+    this.browseMetaLabel.setAttribute('aria-live', 'polite');
+    this.browseMetaLabel.setAttribute('role', 'status');
+
     this.browseQualityHint = document.createElement('p');
     this.browseQualityHint.className = 'milkdrop-overlay__quality-hint';
 
-    this.browseQualityScopeHint = document.createElement('p');
-    this.browseQualityScopeHint.className = 'milkdrop-overlay__quality-meta';
+    qualityCard.append(qualityLabel, this.browseQualityHint);
 
-    this.browseQualityImpact = document.createElement('p');
-    this.browseQualityImpact.className = 'milkdrop-overlay__quality-meta';
-
-    qualityCard.append(
-      qualityLabel,
-      this.browseQualityHint,
-      this.browseQualityScopeHint,
-      this.browseQualityImpact,
+    browseCopy.append(
+      this.browseActiveLabel,
+      qualityCard,
+      this.browseMetaLabel,
     );
-
-    browseHero.append(browseCopy, qualityCard);
+    browseHero.append(browseCopy);
 
     this.searchInput = document.createElement('input');
     this.searchInput.type = 'search';
@@ -712,11 +697,12 @@ export class MilkdropOverlay {
     }
 
     this.browseQualitySelect.value = preset.id;
-    this.browseQualityHint.textContent = preset.description ?? '';
-    this.browseQualityScopeHint.textContent = getQualityPresetScopeHint(
+    const impactSummary = describeQualityPresetImpact(preset);
+    const persistenceHint = getQualityPresetScopeHint(
       this.browseQualityStorageKey,
     );
-    this.browseQualityImpact.textContent = describeQualityPresetImpact(preset);
+    this.browseQualityHint.textContent = impactSummary || persistenceHint;
+    this.browseQualityHint.hidden = !this.browseQualityHint.textContent;
   }
 
   private renderBrowseSummary(filteredCount = this.presets.length) {
@@ -725,12 +711,16 @@ export class MilkdropOverlay {
     );
     this.browseActiveLabel.textContent = activePreset
       ? `Now playing ${activePreset.title}`
-      : 'Preset chooser';
+      : 'No preset selected';
+
+    const modeLabel = this.browseModeSelect.selectedOptions[0]?.textContent;
     this.browseMetaLabel.textContent = [
       `${filteredCount} shown`,
-      `${this.presets.length} total`,
+      modeLabel,
       this.activeBackend.toUpperCase(),
-    ].join(' · ');
+    ]
+      .filter(Boolean)
+      .join(' · ');
   }
 
   private matchesBrowseFilters(preset: MilkdropCatalogEntry, query: string) {
@@ -1321,8 +1311,7 @@ export class MilkdropOverlay {
     if (!initialPreset) {
       this.browseQualitySelect.disabled = true;
       this.browseQualityHint.textContent = '';
-      this.browseQualityScopeHint.textContent = '';
-      this.browseQualityImpact.textContent = '';
+      this.browseQualityHint.hidden = true;
       return;
     }
 

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -182,7 +182,7 @@ describe('milkdrop overlay quality controls', () => {
     expect(select).not.toBeNull();
     expect(select?.value).toBe('balanced');
     expect(document.body.textContent).toContain(
-      'Saved on this device for this toy profile.',
+      'What changes: pixel ratio up to 1.50x, render scale 1.00x, particle density 1.00x.',
     );
 
     if (select) {
@@ -192,7 +192,7 @@ describe('milkdrop overlay quality controls', () => {
 
     expect(onSelectQualityPreset).toHaveBeenCalledWith('tv');
     expect(document.body.textContent).toContain(
-      'Comfortable 10-foot visuals with softer density and steadier frame pacing.',
+      'What changes: pixel ratio up to 1.10x, render scale 0.85x, particle density 0.70x.',
     );
 
     overlay.dispose();


### PR DESCRIPTION
### Motivation
- Make the browse hero more compact and toolbar-like so users see a single active-state line and can adjust quality without a separate feature card.
- Reduce visual and verbal noise by removing the eyebrow and long explanatory sentence and by surfacing only the concise status and one-line quality hint.
- Preserve accessibility: keep keyboard labeling for the quality select and expose live/status semantics for screen readers.

### Description
- Reworked the browse hero DOM in `assets/js/milkdrop/overlay.ts` to remove the eyebrow and long explanatory copy, keep a single active-state line (`browseActiveLabel`), and place the quality selector inline with that label.
- Simplified quality helper copy to a single optional line chosen as the impact summary or, when absent, the persistence hint; hid the helper when empty via `browseQualityHint.hidden`.
- Updated `renderBrowseSummary()` to report only compact orientation text (shown count, current browse mode label, and backend) and to change the inactive line to `No preset selected`.
- Tightened CSS in `assets/css/base.css` for `.milkdrop-overlay__browse-hero`, `.milkdrop-overlay__browse-copy`, `.milkdrop-overlay__browse-active`, `.milkdrop-overlay__browse-meta`, and `.milkdrop-overlay__quality` so the header reads like a toolbar on desktop and collapses cleanly at narrow breakpoints.
- Preserved accessibility attributes: the active label uses `aria-live=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be37dc59e88332af44bd7cb017f5b4)