### PR TITLE
Implement video echo orientation support

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -269,6 +269,7 @@ export const DEFAULT_MILKDROP_STATE: Record<string, number> = {
   video_echo_enabled: 0,
   video_echo_alpha: 0.18,
   video_echo_zoom: 1.02,
+  video_echo_orientation: 0,
   ob_size: 0,
   ob_r: 0.92,
   ob_g: 0.96,
@@ -337,21 +338,7 @@ type PendingHardUnsupportedField = HardUnsupportedFieldSpec & {
   line: number;
 };
 
-/**
- * Inventory of MilkDrop2 preset fields that map to features Stims does not
- * currently emulate safely. These are treated as hard blockers instead of
- * generic unknown-field diagnostics so imports surface actionable compatibility
- * failures.
- */
-const HARD_UNSUPPORTED_FIELD_SPECS: readonly HardUnsupportedFieldSpec[] = [
-  {
-    key: 'video_echo_orientation',
-    feature: 'video-echo-orientation',
-    aliases: ['nvideoechoorientation', 'echo_orient'],
-    message:
-      'Video echo orientation is not implemented, so rotated or mirrored feedback trails cannot be reproduced.',
-  },
-];
+const HARD_UNSUPPORTED_FIELD_SPECS: readonly HardUnsupportedFieldSpec[] = [];
 const hardUnsupportedKeys = new Map<
   string,
   { feature: MilkdropCompatibilityFeatureKey; message: string }
@@ -551,13 +538,15 @@ function getHardUnsupportedField(key: string) {
 }
 
 function isHardUnsupportedFieldBlocking(
-  spec: HardUnsupportedFieldSpec,
-  numericFields: Partial<Record<string, number>>,
+  _spec: HardUnsupportedFieldSpec,
+  _numericFields: Partial<Record<string, number>>,
 ) {
-  if (spec.feature === 'video-echo-orientation') {
-    return (numericFields.video_echo_enabled ?? 0) > 0.5;
-  }
   return true;
+}
+
+function normalizeVideoEchoOrientation(value: number) {
+  const truncated = Math.trunc(value);
+  return (((truncated % 4) + 4) % 4) as 0 | 1 | 2 | 3;
 }
 
 function buildBackendDivergence({
@@ -4296,6 +4285,7 @@ const aliasMap: Record<string, string | null> = {
   fgammaadj: 'gammaadj',
   fvideoechozoom: 'video_echo_zoom',
   fvideoechoalpha: 'video_echo_alpha',
+  nvideoechoorientation: 'video_echo_orientation',
   fwavealpha: 'wave_a',
   fwavescale: 'wave_scale',
   fwavesmoothing: 'wave_smoothing',
@@ -4334,6 +4324,7 @@ const aliasMap: Record<string, string | null> = {
   finnerborderb: 'ib_b',
   finnerbordera: 'ib_a',
   video_echo: 'video_echo_enabled',
+  echo_orient: 'video_echo_orientation',
 };
 
 const legacyCustomWaveSuffixMap: Record<string, string | null> = {
@@ -5259,7 +5250,10 @@ function createIR(
     if (compiledScalar.expression) {
       parsedExpressions.push(compiledScalar.expression);
     }
-    numericFields[normalizedKey] = compiledScalar.value;
+    numericFields[normalizedKey] =
+      normalizedKey === 'video_echo_orientation'
+        ? normalizeVideoEchoOrientation(compiledScalar.value)
+        : compiledScalar.value;
   });
 
   pendingProgramSources.forEach(({ sourceLine, line }, block) => {
@@ -5513,7 +5507,8 @@ function createIR(
         key !== 'gammaadj' &&
         key !== 'video_echo_enabled' &&
         key !== 'video_echo_alpha' &&
-        key !== 'video_echo_zoom'
+        key !== 'video_echo_zoom' &&
+        key !== 'video_echo_orientation'
       );
     }),
   );
@@ -5575,6 +5570,9 @@ function createIR(
       videoEchoEnabled: (numericFields.video_echo_enabled ?? 0) > 0.5,
       videoEchoAlpha: numericFields.video_echo_alpha ?? 0,
       videoEchoZoom: numericFields.video_echo_zoom ?? 1,
+      videoEchoOrientation: normalizeVideoEchoOrientation(
+        numericFields.video_echo_orientation ?? 0,
+      ),
     },
     compatibility,
   } satisfies MilkdropPresetIR;

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -193,6 +193,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         fractalTex: { value: this.auxTextures.fractal },
         mixAlpha: { value: 0.18 },
         zoom: { value: 1.02 },
+        videoEchoOrientation: { value: 0 },
         brighten: { value: 0 },
         darken: { value: 0 },
         solarize: { value: 0 },
@@ -260,6 +261,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform sampler2D fractalTex;
         uniform float mixAlpha;
         uniform float zoom;
+        uniform float videoEchoOrientation;
         uniform float brighten;
         uniform float darken;
         uniform float solarize;
@@ -393,6 +395,15 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           return vec2(cos(angle), sin(angle)) * radius + 0.5;
         }
 
+        vec2 applyVideoEchoOrientationTransform(vec2 uv, float orientation) {
+          float flipU = step(0.5, mod(orientation, 2.0));
+          float flipV = step(1.5, mod(orientation, 4.0));
+          return vec2(
+            mix(uv.x, 1.0 - uv.x, flipU),
+            mix(uv.y, 1.0 - uv.y, flipV)
+          );
+        }
+
         void main() {
           vec2 centeredUv = vUv - 0.5;
           float rotSin = sin(rotation);
@@ -424,6 +435,10 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             currentUv += warpVector * warpTextureAmount * 0.12;
             prevUv += warpVector * warpTextureAmount * 0.08;
           }
+          prevUv = applyVideoEchoOrientationTransform(
+            prevUv,
+            videoEchoOrientation
+          );
           vec4 current = texture2D(currentTex, sampleUv(currentUv, textureWrap));
           vec4 previous = texture2D(previousTex, sampleUv(prevUv, textureWrap));
           vec3 previousColor = previous.rgb;
@@ -522,6 +537,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.previousTex.value = this.readTarget.texture;
     uniforms.mixAlpha.value = state.mixAlpha;
     uniforms.zoom.value = state.zoom;
+    uniforms.videoEchoOrientation.value = state.videoEchoOrientation;
     uniforms.brighten.value = state.brighten;
     uniforms.darken.value = state.darken;
     uniforms.solarize.value = state.solarize;

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -267,6 +267,7 @@ function createCompositeUniforms(
     fractalTex: texture(auxTextures.fractal),
     mixAlpha: uniform(0.18),
     zoom: uniform(1.02),
+    videoEchoOrientation: uniform(0),
     brighten: uniform(0),
     darken: uniform(0),
     solarize: uniform(0),
@@ -319,6 +320,22 @@ function createCompositeUniforms(
 function createCompositeOutputNode(uniforms: CompositeUniformBag) {
   const sampleUvNode = createSampleUvNode();
   const applyFeedbackWarpNode = createApplyFeedbackWarpNode();
+  const applyVideoEchoOrientationNode = Fn(
+    ([sampleUv, orientation]: [any, any]) => {
+      const flipX = step(
+        0.5,
+        orientation.sub(floor(orientation.div(2)).mul(2)),
+      );
+      const flipY = step(
+        1.5,
+        orientation.sub(floor(orientation.div(4)).mul(4)),
+      );
+      return vec2(
+        mix(sampleUv.x, float(1).sub(sampleUv.x), flipX),
+        mix(sampleUv.y, float(1).sub(sampleUv.y), flipY),
+      );
+    },
+  );
   const sampleAuxTextureNode = createSampleAuxTextureNode(
     uniforms,
     uniforms.noiseTex,
@@ -373,6 +390,9 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     );
     previousUv.addAssign(
       warpVector.mul(uniforms.warpTextureAmount).mul(0.08).mul(warpTextureMask),
+    );
+    previousUv.assign(
+      applyVideoEchoOrientationNode(previousUv, uniforms.videoEchoOrientation),
     );
 
     const current = uniforms.currentTex.sample(
@@ -673,6 +693,8 @@ class WebGPUMilkdropFeedbackManager {
   applyCompositeState(state: MilkdropFeedbackCompositeState) {
     this.compositeMaterial.uniforms.mixAlpha.value = state.mixAlpha;
     this.compositeMaterial.uniforms.zoom.value = state.zoom;
+    this.compositeMaterial.uniforms.videoEchoOrientation.value =
+      state.videoEchoOrientation;
     this.compositeMaterial.uniforms.brighten.value = state.brighten;
     this.compositeMaterial.uniforms.darken.value = state.darken;
     this.compositeMaterial.uniforms.solarize.value = state.solarize;

--- a/assets/js/milkdrop/formatter.ts
+++ b/assets/js/milkdrop/formatter.ts
@@ -61,6 +61,7 @@ const postOrder = [
   'video_echo_enabled',
   'video_echo_alpha',
   'video_echo_zoom',
+  'video_echo_orientation',
 ] as const;
 
 const customWaveFieldOrder = [

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -2029,6 +2029,9 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       zoom: frameState.post.videoEchoEnabled
         ? frameState.post.videoEchoZoom + controls.warpScale * 0.04
         : 1,
+      videoEchoOrientation: frameState.post.videoEchoEnabled
+        ? frameState.post.videoEchoOrientation
+        : 0,
       brighten: frameState.post.brighten ? 1 : 0,
       darken: frameState.post.darken ? 1 : 0,
       solarize: frameState.post.solarize ? 1 : 0,

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -414,6 +414,8 @@ export type MilkdropShaderControls = {
   warpTexture: MilkdropShaderTextureWarpControls;
 };
 
+export type MilkdropVideoEchoOrientation = 0 | 1 | 2 | 3;
+
 export type MilkdropPostEffects = {
   shaderEnabled: boolean;
   textureWrap: boolean;
@@ -430,6 +432,7 @@ export type MilkdropPostEffects = {
   videoEchoEnabled: boolean;
   videoEchoAlpha: number;
   videoEchoZoom: number;
+  videoEchoOrientation: MilkdropVideoEchoOrientation;
 };
 
 export type MilkdropPresetIR = {
@@ -602,6 +605,7 @@ export type MilkdropPostVisual = {
   videoEchoEnabled: boolean;
   videoEchoAlpha: number;
   videoEchoZoom: number;
+  videoEchoOrientation: MilkdropVideoEchoOrientation;
   warp: number;
 };
 
@@ -755,6 +759,7 @@ export type MilkdropRenderPayload = {
 export type MilkdropFeedbackCompositeState = {
   mixAlpha: number;
   zoom: number;
+  videoEchoOrientation: MilkdropVideoEchoOrientation;
   brighten: number;
   darken: number;
   solarize: number;

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -17,6 +17,7 @@ import type {
   MilkdropRuntimeSignals,
   MilkdropShapeDefinition,
   MilkdropShapeVisual,
+  MilkdropVideoEchoOrientation,
   MilkdropVM,
   MilkdropWaveDefinition,
   MilkdropWaveVisual,
@@ -28,6 +29,13 @@ const MAX_CUSTOM_SHAPE_SLOTS = 32;
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
+}
+
+function normalizeVideoEchoOrientation(
+  value: number,
+): MilkdropVideoEchoOrientation {
+  const truncated = Math.trunc(value);
+  return (((truncated % 4) + 4) % 4) as MilkdropVideoEchoOrientation;
 }
 
 function color(r: number, g: number, b: number, a = 1): MilkdropColor {
@@ -1213,6 +1221,9 @@ class MilkdropPresetVM implements MilkdropVM {
       videoEchoEnabled: (this.state.video_echo_enabled ?? 0) > 0.5,
       videoEchoAlpha: clamp(this.state.video_echo_alpha ?? 0.18, 0, 1),
       videoEchoZoom: clamp(this.state.video_echo_zoom ?? 1, 0.85, 1.3),
+      videoEchoOrientation: normalizeVideoEchoOrientation(
+        this.state.video_echo_orientation ?? 0,
+      ),
       warp: clamp(this.state.warp ?? 0.08, 0, 1),
     };
   }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
+import type { MilkdropVideoEchoOrientation } from '../assets/js/milkdrop/types.ts';
 
 describe('milkdrop compiler', () => {
   test('compiles preset metadata, scalars, and program statements', () => {
@@ -921,55 +922,7 @@ definitely_not_a_real_field=1
     ).toBe(true);
   });
 
-  test('classifies hard-unsupported fields as backend blockers', () => {
-    const compiled = compileMilkdropPresetSource(
-      `
-title=Blocked Import
-video_echo=1
-video_echo_orientation=2
-      `.trim(),
-      { id: 'blocked-import', origin: 'imported' },
-    );
-
-    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([
-      'video_echo_orientation',
-    ]);
-    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([
-      'video_echo_orientation',
-    ]);
-    expect(compiled.diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: 'preset_unsupported_field',
-          field: 'video_echo_orientation',
-        }),
-      ]),
-    );
-    expect(compiled.ir.compatibility.backends.webgl.status).toBe('unsupported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-      'unsupported',
-    );
-    expect(compiled.ir.compatibility.backends.webgl.evidence).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: 'unsupported-hard-feature',
-          feature: 'video-echo-orientation',
-          status: 'unsupported',
-        }),
-      ]),
-    );
-    expect(compiled.ir.compatibility.parity.degradationReasons).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: 'unsupported-hard-feature',
-          blocking: true,
-          message: expect.stringContaining('video-echo-orientation'),
-        }),
-      ]),
-    );
-  });
-
-  test('ignores dormant video echo orientation blockers when echo is disabled', () => {
+  test('ignores video echo orientation when echo is disabled', () => {
     const compiled = compileMilkdropPresetSource(
       `
 title=Dormant Echo Orientation
@@ -981,10 +934,12 @@ video_echo=0
 
     expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([]);
     expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(compiled.ir.numericFields.video_echo_orientation).toBe(2);
+    expect(compiled.ir.post.videoEchoOrientation).toBe(2);
     expect(
       compiled.diagnostics.some(
         (entry) =>
-          entry.code === 'preset_unsupported_field' &&
+          entry.code === 'preset_invalid_scalar' &&
           entry.field === 'video_echo_orientation',
       ),
     ).toBe(false);
@@ -996,37 +951,100 @@ video_echo=0
   });
 
   test.each([
-    ['init', 'init_1=video_echo_enabled=1;'],
-    ['per-frame', 'per_frame_1=video_echo_enabled=1;'],
-  ])('keeps video echo orientation blocked when %s programs enable echo', (_label, programLine) => {
+    ['canonical field', 'video_echo_orientation=0', 0],
+    ['horizontal mirror alias', 'nvideoechoorientation=1', 1],
+    ['vertical mirror alias', 'echo_orient=2', 2],
+    ['double mirror', 'video_echo_orientation=3', 3],
+  ] as const satisfies readonly [
+    string,
+    string,
+    MilkdropVideoEchoOrientation,
+  ][])('retains %s when video echo is enabled', (_label, orientationLine, expectedOrientation) => {
     const compiled = compileMilkdropPresetSource(
       `
-title=Program Echo Orientation
-video_echo_orientation=2
-${programLine}
+title=Echo Orientation Support
+video_echo=1
+${orientationLine}
         `.trim(),
-      { id: 'program-echo-orientation', origin: 'imported' },
+      { id: `echo-orientation-${expectedOrientation}`, origin: 'imported' },
     );
 
-    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([
-      'video_echo_orientation',
-    ]);
-    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([
-      'video_echo_orientation',
-    ]);
+    expect(compiled.ir.numericFields.video_echo_enabled).toBe(1);
+    expect(compiled.ir.numericFields.video_echo_orientation).toBe(
+      expectedOrientation,
+    );
+    expect(compiled.ir.post.videoEchoEnabled).toBe(true);
+    expect(compiled.ir.post.videoEchoOrientation).toBe(expectedOrientation);
+    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([]);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
     expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
       'video-echo',
     );
     expect(
       compiled.diagnostics.some(
-        (entry) =>
-          entry.code === 'preset_unsupported_field' &&
-          entry.field === 'video_echo_orientation',
+        (entry) => entry.field === 'video_echo_orientation',
       ),
-    ).toBe(true);
-    expect(compiled.ir.compatibility.backends.webgl.status).toBe('unsupported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-      'unsupported',
+    ).toBe(false);
+  });
+
+  test.each([
+    ['init', 'init_1=video_echo_enabled=1;'],
+    ['per-frame', 'per_frame_1=video_echo_enabled=1;'],
+  ])('keeps video echo orientation available when %s programs enable echo', (_label, programLine) => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Program Echo Orientation
+video_echo_orientation=2
+${programLine}
+      `.trim(),
+      { id: 'program-echo-orientation', origin: 'imported' },
+    );
+
+    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([]);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
+      'video-echo',
+    );
+    expect(compiled.ir.numericFields.video_echo_orientation).toBe(2);
+    expect(compiled.ir.post.videoEchoOrientation).toBe(2);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+  });
+
+  test('classifies echo orientation as supported backend input after implementation', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Echo Orientation Backend Support
+video_echo=1
+video_echo_orientation=3
+      `.trim(),
+      { id: 'echo-orientation-backend-support', origin: 'imported' },
+    );
+
+    expect(compiled.ir.compatibility.parity.ignoredFields).toEqual([]);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(
+      compiled.ir.compatibility.backends.webgl.unsupportedFeatures,
+    ).toEqual([]);
+    expect(
+      compiled.ir.compatibility.backends.webgpu.unsupportedFeatures,
+    ).toEqual(['video-echo']);
+    expect(compiled.ir.compatibility.backends.webgl.evidence).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          feature: 'video-echo-orientation',
+        }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.backends.webgpu.evidence).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          feature: 'video-echo-orientation',
+        }),
+      ]),
     );
   });
 


### PR DESCRIPTION
### Motivation
- The compiler treated `video_echo_orientation` (and aliases `nvideoechoorientation` / `echo_orient`) as a hard-import blocker, preventing rotated or mirrored MilkDrop2 feedback presets from importing correctly. 
- The goal is to implement orientation through the preset pipeline so presets that depend on echo orientation render approximately instead of being downgraded to an unsupported import path.

### Description
- Stop treating `video_echo_orientation` as a hard-unsupported field and instead parse and normalize it into the compiled numeric fields using `normalizeVideoEchoOrientation` in `assets/js/milkdrop/compiler.ts` and alias mappings for `nvideoechoorientation` / `echo_orient`.
- Add a typed orientation representation `MilkdropVideoEchoOrientation` and thread `videoEchoOrientation` into `MilkdropPostEffects`, `MilkdropPostVisual`, and `MilkdropFeedbackCompositeState` in `assets/js/milkdrop/types.ts` and related runtime state plumbing in `assets/js/milkdrop/vm.ts` and `assets/js/milkdrop/renderer-adapter.ts`.
- Forward the orientation into the feedback composite shader paths and apply a mirrored/rotated UV transform to the previous-frame sample in both `assets/js/milkdrop/feedback-manager-shared.ts` (WebGL GLSL) and `assets/js/milkdrop/feedback-manager-webgpu.ts` (TSL translation), and expose the uniform plumbing from renderer adapter into the feedback managers.
- Update formatter ordering to include `video_echo_orientation`, and add regression tests in `tests/milkdrop-compiler.test.ts` covering: echo orientation ignored when echo is disabled, each supported orientation/alias when echo is enabled, program-enabled echo, and backend compatibility classification; no docs were changed.

### Testing
- Ran the targeted compiler tests with `bun run test tests/milkdrop-compiler.test.ts`, which passed (all relevant tests green). 
- Ran the full quality gate with `bun run check` (Biome format/lint + `tsc --noEmit` + test suite), which completed successfully (typecheck and test suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3970bb388332be0f8edf6f679179)