### PR TITLE
Refine MilkDrop preset browse rows

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2952,10 +2952,10 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__preset {
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
   align-items: start;
-  padding-top: 10px;
+  padding-top: 8px;
   border-top: 1px solid rgba(148, 163, 184, 0.12);
 }
 
@@ -2970,43 +2970,48 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__preset-launch {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   text-align: left;
-  padding: 0;
+  min-width: 0;
+  padding: 2px 0;
   border: 0;
   background: transparent;
 }
 
 .milkdrop-overlay__preset-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
 }
 
 .milkdrop-overlay__preset-title {
   font-weight: 700;
+  line-height: 1.2;
 }
 
 .milkdrop-overlay__preset-badges {
   display: inline-flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 6px;
+  gap: 4px;
+  flex-shrink: 0;
 }
 
 .milkdrop-overlay__preset-meta {
   color: rgba(191, 219, 254, 0.74);
-  font-size: 0.78rem;
-  line-height: 1.35;
+  font-size: 0.75rem;
+  line-height: 1.25;
+  min-height: 0;
 }
 
 .milkdrop-overlay__preset-actions {
   display: inline-grid;
-  grid-template-columns: repeat(2, minmax(88px, auto));
-  gap: 6px;
-  align-items: center;
-  justify-items: stretch;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 4px;
+  align-items: start;
+  justify-items: end;
 }
 
 .milkdrop-overlay__support {
@@ -3056,18 +3061,36 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__preset-warning {
   grid-column: 1 / -1;
-  font-size: 0.76rem;
+  font-size: 0.73rem;
+  line-height: 1.25;
   color: rgba(253, 230, 138, 0.9);
-  background: rgba(120, 53, 15, 0.18);
-  border: 1px solid rgba(245, 158, 11, 0.16);
-  border-radius: 10px;
-  padding: 7px 9px;
+  padding: 0;
 }
 
 .milkdrop-overlay__preset-flag {
   color: rgba(191, 219, 254, 0.66);
   font-size: 0.75rem;
   align-self: center;
+}
+
+.milkdrop-overlay__favorite,
+.milkdrop-overlay__rating-select {
+  min-height: 28px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.73rem;
+  background: rgba(15, 23, 42, 0.42);
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.milkdrop-overlay__favorite {
+  min-width: 28px;
+  font-size: 0.88rem;
+  line-height: 1;
+}
+
+.milkdrop-overlay__rating-select {
+  min-width: 58px;
 }
 
 .milkdrop-overlay__editor {
@@ -3316,12 +3339,12 @@ body.tv-mode .control-panel input {
 
   .milkdrop-overlay__preset {
     grid-template-columns: 1fr;
-    gap: 8px;
+    gap: 6px;
     padding-top: 8px;
   }
 
   .milkdrop-overlay__preset-actions {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: flex-start;
   }
 
   .milkdrop-overlay__editor {

--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -94,6 +94,25 @@ function fidelityLabel(fidelity: MilkdropFidelityClass) {
   }
 }
 
+function getPresetMetaQualifier(preset: MilkdropCatalogEntry) {
+  if (preset.historyIndex !== undefined) {
+    return 'Recent';
+  }
+  if (preset.rating > 0) {
+    return `${preset.rating}★`;
+  }
+  if (preset.origin !== 'bundled') {
+    return 'Imported';
+  }
+  const firstTag = preset.tags.find(
+    (tag) => !tag.startsWith(COLLECTION_TAG_PREFIX),
+  );
+  if (firstTag) {
+    return firstTag.replace(/[-_]/gu, ' ');
+  }
+  return null;
+}
+
 function compatibilityCategoryLabel(
   category: MilkdropCompatibilityIssueCategory,
 ) {
@@ -829,13 +848,6 @@ export class MilkdropOverlay {
       badges.appendChild(activeBadge);
     }
 
-    if (preset.isFavorite) {
-      const favoriteBadge = document.createElement('span');
-      favoriteBadge.className = 'milkdrop-overlay__preset-tag';
-      favoriteBadge.textContent = 'Saved';
-      badges.appendChild(favoriteBadge);
-    }
-
     const support = preset.supports[this.activeBackend];
     const supportBadge = document.createElement('span');
     supportBadge.className = `milkdrop-overlay__support milkdrop-overlay__support--${preset.fidelityClass}`;
@@ -846,16 +858,8 @@ export class MilkdropOverlay {
 
     const meta = document.createElement('div');
     meta.className = 'milkdrop-overlay__preset-meta';
-    meta.textContent = [
-      preset.author,
-      preset.origin,
-      preset.certification,
-      preset.rating > 0 ? `${preset.rating}★` : null,
-      preset.historyIndex !== undefined ? 'recent' : null,
-      ...preset.tags
-        .filter((tag) => !tag.startsWith(COLLECTION_TAG_PREFIX))
-        .slice(0, 2),
-    ]
+    const metaQualifier = getPresetMetaQualifier(preset);
+    meta.textContent = [preset.author, metaQualifier]
       .filter(Boolean)
       .join(' · ');
 
@@ -867,7 +871,12 @@ export class MilkdropOverlay {
     const favorite = document.createElement('button');
     favorite.type = 'button';
     favorite.className = 'milkdrop-overlay__favorite';
-    favorite.textContent = preset.isFavorite ? 'Saved' : 'Save';
+    favorite.textContent = preset.isFavorite ? '★' : '☆';
+    favorite.setAttribute(
+      'aria-label',
+      preset.isFavorite ? 'Remove saved preset' : 'Save preset',
+    );
+    favorite.title = preset.isFavorite ? 'Remove saved preset' : 'Save preset';
     favorite.addEventListener('click', (event) => {
       event.stopPropagation();
       this.callbacks.onToggleFavorite(preset.id, !preset.isFavorite);
@@ -875,10 +884,12 @@ export class MilkdropOverlay {
 
     const rating = document.createElement('select');
     rating.className = 'milkdrop-overlay__rating-select';
+    rating.setAttribute('aria-label', `Rate ${preset.title}`);
+    rating.title = `Rate ${preset.title}`;
     [0, 1, 2, 3, 4, 5].forEach((value) => {
       const option = document.createElement('option');
       option.value = String(value);
-      option.textContent = value === 0 ? 'Rate' : `${value}★`;
+      option.textContent = value === 0 ? '☆' : `${value}★`;
       rating.appendChild(option);
     });
     rating.value = String(preset.rating);
@@ -898,10 +909,10 @@ export class MilkdropOverlay {
 
     row.append(launch, actions);
 
-    if (
-      preset.parity.degradationReasons.length > 0 ||
-      support.reasons.length > 0
-    ) {
+    const hasCompatibilityWarning =
+      support.status !== 'supported' ||
+      preset.parity.degradationReasons.length > 0;
+    if (hasCompatibilityWarning) {
       const reasons = document.createElement('div');
       reasons.className = 'milkdrop-overlay__preset-warning';
       const primaryReason = [...preset.parity.degradationReasons].sort(

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -406,4 +406,89 @@ describe('milkdrop overlay browse rendering', () => {
 
     overlay.dispose();
   });
+
+  test('keeps preset rows focused on launch metadata and compact secondary actions', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const activePreset = createCatalogEntry('signal-bloom', 'Signal Bloom');
+    activePreset.historyIndex = 0;
+    activePreset.isFavorite = true;
+    activePreset.rating = 4;
+    activePreset.tags = ['collection:classic-milkdrop', 'slow-burn'];
+
+    const partialPreset = createCatalogEntry('aurora-drift', 'Aurora Drift');
+    partialPreset.author = 'Guest';
+    partialPreset.supports.webgl.status = 'partial';
+    partialPreset.supports.webgl.reasons = [
+      'Wave mesh falls back to a simpler path.',
+    ];
+    partialPreset.fidelityClass = 'partial';
+    partialPreset.parity.degradationReasons = [
+      {
+        code: 'backend-partial',
+        category: 'backend-degradation',
+        message: 'Wave mesh falls back to a simpler path.',
+        system: 'runtime',
+        blocking: false,
+      },
+    ];
+
+    overlay.setCatalog([activePreset, partialPreset], 'signal-bloom', 'webgl');
+
+    const rows = [
+      ...document.querySelectorAll('.milkdrop-overlay__preset'),
+    ] as HTMLElement[];
+    expect(rows).toHaveLength(2);
+
+    const activeRow = rows[0];
+    const activeMeta = activeRow?.querySelector(
+      '.milkdrop-overlay__preset-meta',
+    );
+    const activeBadges = [
+      ...((activeRow?.querySelectorAll(
+        '.milkdrop-overlay__preset-badges > *',
+      ) ?? []) as NodeListOf<HTMLElement>),
+    ].map((badge) => badge.textContent?.trim());
+    const activeFavorite = activeRow?.querySelector(
+      '.milkdrop-overlay__favorite',
+    ) as HTMLButtonElement | null;
+    const activeRating = activeRow?.querySelector(
+      '.milkdrop-overlay__rating-select',
+    ) as HTMLSelectElement | null;
+
+    expect(activeMeta?.textContent).toBe('Stims · Recent');
+    expect(activeBadges).toEqual(['Live', 'Exact']);
+    expect(activeFavorite?.textContent).toBe('★');
+    expect(activeFavorite?.getAttribute('aria-label')).toBe(
+      'Remove saved preset',
+    );
+    expect(activeRating?.value).toBe('4');
+    expect(
+      activeRow?.querySelector('.milkdrop-overlay__preset-warning'),
+    ).toBeNull();
+    expect(activeRow?.textContent).not.toContain('slow-burn');
+    expect(activeRow?.textContent).not.toContain('bundled');
+
+    const partialRow = rows[1];
+    const partialMeta = partialRow?.querySelector(
+      '.milkdrop-overlay__preset-meta',
+    );
+    const partialWarning = partialRow?.querySelector(
+      '.milkdrop-overlay__preset-warning',
+    );
+
+    expect(partialMeta?.textContent).toBe('Guest');
+    expect(partialWarning?.textContent).toBe(
+      'Backend degradation: Wave mesh falls back to a simpler path.',
+    );
+
+    overlay.dispose();
+  });
 });


### PR DESCRIPTION
### Motivation
- Make choosing a preset the clear primary action by promoting the title/launch region and reducing row clutter.
- Surface only the most useful metadata and badges so rows scan quickly and don’t compete with the primary click target.
- Move secondary actions into a compact cluster and show compatibility warnings only when a preset actually has issues.

### Description
- Add `getPresetMetaQualifier()` and simplify the meta line to `author · qualifier` so metadata collapses to a single useful line.
- Rework `buildPresetRow()` to make the full title/launch area the primary click target, keep only `Live` and a compact fidelity badge by default, and render compatibility warnings only when support problems exist.
- De-emphasize Save/Rate controls by making the favorite button compact (icon-only text) and tightening the rating control, and move these into a compact secondary `milkdrop-overlay__preset-actions` cluster.
- Tighten CSS for `.milkdrop-overlay__preset`, `.milkdrop-overlay__preset-launch`, `.milkdrop-overlay__preset-header`, `.milkdrop-overlay__preset-meta`, `.milkdrop-overlay__preset-actions`, and `.milkdrop-overlay__preset-warning` to reduce row height and side-column sprawl.
- Update `tests/milkdrop-overlay.test.ts` to assert the slimmer row structure, compact actions, and one-line compatibility messaging.

### Testing
- Ran `bun run test tests/milkdrop-overlay.test.ts` and the overlay browse tests passed.
- Ran `bun run test tests/system-controls-tv-mode.test.ts` and the targeted tv-mode system tests passed when executed directly.
- Ran the project quality gate with `bun run check`, fixed formatting/type-test issues surfaced by the gate, and then validated the changes with the test suite and typechecks (quality gate completed after fixes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3b3b48488332922d82999c4c31f2)