### PR TITLE
Treat supported MilkDrop volume samplers as fully classified

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -5298,16 +5298,6 @@ function createIR(
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
-  const usesVolumeShaderApproximation = [
-    shaderWarpAnalysis.controls.textureLayer,
-    shaderWarpAnalysis.controls.warpTexture,
-    shaderCompAnalysis.controls.textureLayer,
-    shaderCompAnalysis.controls.warpTexture,
-    mergedShaderControls.controls.textureLayer,
-    mergedShaderControls.controls.warpTexture,
-  ].some(
-    (sample) => sample.source !== 'none' && sample.sampleDimension === '3d',
-  );
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
@@ -5365,14 +5355,6 @@ function createIR(
       'Shader-text sections include lines outside the supported subset.',
     );
   }
-  if (usesVolumeShaderApproximation) {
-    addDiagnostic(
-      diagnostics,
-      'warning',
-      'preset_shader_volume_approximation',
-      'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
-    );
-  }
   const featureAnalysis = buildFeatureAnalysis({
     programs,
     customWaves,
@@ -5389,11 +5371,6 @@ function createIR(
       ({ key, feature, message }) =>
         `Unsupported feature "${feature}" from preset field "${key}": ${message}`,
     ),
-    ...(usesVolumeShaderApproximation
-      ? [
-          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
-        ]
-      : []),
   ];
   const backends = {
     webgl: buildBackendSupport({

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1310,13 +1310,7 @@
   },
   {
     "file": "261-compshader-noisevol_lq.milk",
-    "diagnostics": [
-      {
-        "severity": "warning",
-        "code": "preset_shader_volume_approximation",
-        "field": null
-      }
-    ],
+    "diagnostics": [],
     "normalizedPrograms": {
       "init": [],
       "perFrame": [],
@@ -1327,13 +1321,12 @@
     "compatibility": {
       "unsupportedKeys": [],
       "warnings": [
-        "Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.",
         "WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL."
       ],
       "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
-          "status": "partial",
+          "status": "supported",
           "evidence": []
         },
         "webgpu": {
@@ -1350,7 +1343,10 @@
       },
       "parity": {
         "fidelityClass": "near-exact",
-        "backendDivergence": ["webgpu:supported-shader-text-gap"],
+        "backendDivergence": [
+          "status:webgl=supported,webgpu=partial",
+          "webgpu:supported-shader-text-gap"
+        ],
         "ignoredFields": [],
         "blockedConstructs": [],
         "approximatedShaderLines": [],

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
 import type { MilkdropVideoEchoOrientation } from '../assets/js/milkdrop/types.ts';
 
@@ -585,20 +587,11 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
       expect(
         compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
       ).toBeCloseTo(0, 6);
-      expect(compiled.diagnostics).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            code: 'preset_shader_volume_approximation',
-            severity: 'warning',
-          }),
-        ]),
-      );
-      expect(compiled.ir.compatibility.warnings).toEqual(
-        expect.arrayContaining([
-          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
-        ]),
-      );
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+      expect(compiled.diagnostics).toEqual([]);
+      expect(compiled.ir.compatibility.warnings).toEqual([
+        'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+      ]);
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
       expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
         [],
@@ -630,19 +623,16 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     expect(
       compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
     ).not.toBeNull();
-    expect(compiled.diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: 'preset_shader_volume_approximation',
-          severity: 'warning',
-        }),
-      ]),
-    );
-    expect(compiled.ir.compatibility.warnings).toEqual(
-      expect.arrayContaining([
-        'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
-      ]),
-    );
+    expect(compiled.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'preset_unsupported_shader_text',
+        severity: 'warning',
+      }),
+    ]);
+    expect(compiled.ir.compatibility.warnings).toEqual([
+      'This preset includes custom shader text outside the fully supported subset and will be approximated.',
+      'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
+    ]);
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
     expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
       'unsupported',
@@ -693,6 +683,39 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex3D(sampler_fw_noisevol_lq,
     expect(
       compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
     ).not.toBeNull();
+  });
+
+  test('classifies the projectM noisevol fixture as supported volume sampling', () => {
+    const fixturePath = join(
+      process.cwd(),
+      'tests',
+      'fixtures',
+      'milkdrop',
+      'projectm-upstream',
+      '261-compshader-noisevol_lq.milk',
+    );
+    const compiled = compileMilkdropPresetSource(
+      readFileSync(fixturePath, 'utf8'),
+      {
+        id: 'projectm-noisevol-fixture',
+        title: '261-compshader-noisevol_lq.milk',
+        fileName: '261-compshader-noisevol_lq.milk',
+        path: fixturePath,
+        origin: 'user',
+      },
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '3d',
+    );
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.warnings).toEqual([
+      'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+    ]);
   });
 
   test('supports resolved temp shader outputs for invert and runtime tint mixes', () => {

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -96,13 +96,15 @@ const WEBGPU_SHADER_TRANSLATION_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
-const VOLUME_SHADER_APPROXIMATION_EXPECTATION = {
-  diagnostics: ['preset_shader_volume_approximation'],
-  webgl: 'partial',
+const VOLUME_SHADER_SUPPORT_EXPECTATION = {
+  diagnostics: [],
+  webgl: 'supported',
   webgpu: 'partial',
-  divergence: ['webgpu:supported-shader-text-gap'],
+  divergence: [
+    'status:webgl=supported,webgpu=partial',
+    'webgpu:supported-shader-text-gap',
+  ],
   warnings: [
-    'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
     'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
   ],
   blockedConstructs: [],
@@ -145,7 +147,7 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
   '260-compshader-noise_lq.milk': WEBGPU_SHADER_TRANSLATION_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': VOLUME_SHADER_APPROXIMATION_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': VOLUME_SHADER_SUPPORT_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -164,20 +164,11 @@ describe('milkdrop shader sampler aliases', () => {
       expect(
         compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
       ).not.toBeNull();
-      expect(compiled.diagnostics).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            code: 'preset_shader_volume_approximation',
-            severity: 'warning',
-          }),
-        ]),
-      );
-      expect(compiled.ir.compatibility.warnings).toEqual(
-        expect.arrayContaining([
-          'Volume shader sampling uses the compatibility approximation path and may diverge from native 3D lookups.',
-        ]),
-      );
-      expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+      expect(compiled.diagnostics).toEqual([]);
+      expect(compiled.ir.compatibility.warnings).toEqual([
+        'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+      ]);
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
       expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     }
   });


### PR DESCRIPTION
### Motivation

- The feedback renderers already implement atlas-based slice lookup + inter-slice blending for MilkDrop volume atlases, so extracting `tex3D`/`texture3D` into an atlas-driven path is a real supported implementation rather than an always-approximate fallback.  
- The compiler nonetheless forced `preset_shader_volume_approximation` and downgraded backends for any extracted 3D sample, causing an unnecessary partial classification for fixtures like `261-compshader-noisevol_lq.milk`.

### Description

- Stop treating every extracted 3D shader sample as an automatic approximation by removing the `usesVolumeShaderApproximation` emission and the unconditional `preset_shader_volume_approximation` diagnostic from the compiler (update in `assets/js/milkdrop/compiler.ts`).
- Keep shader-text incompatibility diagnostics intact so genuinely unsupported shader constructs still degrade for the correct reason (`preset_unsupported_shader_text`).
- Update regression tests to reflect the real behavior: tidy expectations in `tests/milkdrop-shader-sampler-aliases.test.ts` and `tests/milkdrop-compiler.test.ts`, and add a targeted test that asserts `261-compshader-noisevol_lq.milk` is classified as `webgl: supported` / `webgpu: partial`.
- Refresh the vendored compatibility snapshot `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` so the projectM fixture reflects the revised classification (WebGL supported, WebGPU partial due to existing shader-text translation gap).

### Testing

- Ran focused regressions with `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-projectm-compat.test.ts`, and all targeted tests passed.  
- Ran the full quality gate with `bun run check` (Biome formatting/lint, `tsc`, and the full test suite), and the full test suite and checks passed (no failures).  
- Updated snapshot file formatting with Biome (`biome format`) as part of the quality gate; snapshot refresh was intentionally limited to the revised fixture entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3c1011a08332b117759f0b1b89e6)