### PR TITLE
Preserve in-range tex3D slice alignment in feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -374,7 +374,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return sampleAuxTexture2d(source, wrappedUv);
           }
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
-          float scaledSlice = fract(sliceZ) * sliceCount;
+          float wrappedSliceZ = (sliceZ >= 0.0 && sliceZ <= 1.0) ? sliceZ : fract(sliceZ);
+          float scaledSlice = wrappedSliceZ * (sliceCount - 1.0);
           float sliceIndexA = floor(scaledSlice);
           float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -226,7 +226,12 @@ function createSampleAuxTextureNode(
     ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
       const wrappedUv = fract(sampleUv);
       const sliceCount = float(AUX_TEXTURE_ATLAS_SLICE_COUNT);
-      const scaledSlice = fract(sliceZ).mul(sliceCount);
+      const wrappedSliceZ = select(
+        sliceZ.greaterThanEqual(0).and(sliceZ.lessThanEqual(1)),
+        sliceZ,
+        fract(sliceZ),
+      );
+      const scaledSlice = wrappedSliceZ.mul(sliceCount.sub(1));
       const sliceIndexA = floor(scaledSlice);
       const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
         sliceCount,


### PR DESCRIPTION
### Motivation
- Fix a regression where changing atlas wrapping to `fract(sliceZ) * sliceCount` shifted in-range 3D atlas lookups by half a slice and altered rendering for presets that keep `volumeSliceZ` inside `[0,1]`.
- Only wrap truly out-of-range `sliceZ` values while preserving the prior `[0,1]` phase-to-slice mapping so behavior remains projectM-like for in-range coordinates.
- Keep WebGL/shared and WebGPU feedback sampling logic aligned so both backends produce consistent atlas interpolation.

### Description
- In `assets/js/milkdrop/feedback-manager-shared.ts` updated `sampleAuxTexture` to compute `wrappedSliceZ = (sliceZ >= 0.0 && sliceZ <= 1.0) ? sliceZ : fract(sliceZ)` and scale by `(sliceCount - 1.0)` to preserve the original in-range slice phase before floor/mod/blend operations.
- In `assets/js/milkdrop/feedback-manager-webgpu.ts` mirrored the same logic using a TSL `select(...)` to compute `wrappedSliceZ` and scale by `sliceCount.sub(1)`, keeping the node-graph semantics equivalent to the shared GLSL path.
- The change only alters the atlas-style 3D sampling interpolation path and preserves the planar 2D sampling path and wrap behavior for truly out-of-range coordinates.

### Testing
- Ran the repo quality gate with `bun run check` which completed Biome and TypeScript steps but the overall script exited non-green due to pre-existing unrelated failures in `tests/toy-page-bootstrap.test.ts` and `tests/system-controls-tv-mode.test.ts` (fail).
- Ran targeted MilkDrop tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts`, and all targeted tests passed (pass).
- No docs were modified in this change (`Docs: None`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be391a40448332b18269825b9da7f6)