### PR TITLE
Follow-up: normalize echo_orient program assignments

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -4464,7 +4464,10 @@ function pushProgramStatement(
     const parsed = parseMilkdropStatement(statement, line);
     diagnostics.push(...parsed.diagnostics);
     if (parsed.value) {
-      block.statements.push(parsed.value);
+      block.statements.push({
+        ...parsed.value,
+        target: normalizeProgramAssignmentTarget(parsed.value.target),
+      });
       block.sourceLines.push(statement);
     }
   });
@@ -4602,6 +4605,12 @@ function normalizeFieldKey(field: MilkdropPresetField) {
     return 'shape_1_thickoutline';
   }
   return rawKey;
+}
+
+function normalizeProgramAssignmentTarget(target: string) {
+  const normalizedTarget = normalizeFieldSuffix(target);
+  const aliasedTarget = aliasMap[normalizedTarget];
+  return aliasedTarget ?? normalizedTarget;
 }
 
 function ensureWaveDefinition(

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -1012,6 +1012,29 @@ ${programLine}
     expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
   });
 
+  test.each([
+    ['init', 'init_1=echo_orient=3;', 'init'],
+    ['per-frame', 'per_frame_1=echo_orient=3;', 'perFrame'],
+  ] as const)('normalizes echo_orient assignment targets in %s programs', (_label, programLine, blockKey) => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Echo Orientation Program Alias
+video_echo=1
+${programLine}
+        `.trim(),
+      { id: 'echo-orientation-program-alias', origin: 'imported' },
+    );
+
+    expect(compiled.ir.programs[blockKey].statements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: 'video_echo_orientation',
+        }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+  });
+
   test('classifies echo orientation as supported backend input after implementation', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -183,6 +183,27 @@ fGammaAdj=1.75
     expect(frameState.post.gammaAdj).toBeCloseTo(1.75, 6);
   });
 
+  test.each([
+    ['init', 'init_1=echo_orient=3;'],
+    ['per-frame', 'per_frame_1=echo_orient=3;'],
+  ])('applies echo_orient program aliases to runtime post state in %s programs', (_label, programLine) => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Echo Orientation VM Alias
+video_echo=1
+${programLine}
+        `.trim(),
+      { id: 'echo-orientation-vm-alias' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
+
+    expect(frameState.post.videoEchoEnabled).toBe(true);
+    expect(frameState.post.videoEchoOrientation).toBe(3);
+    expect(frameState.variables.video_echo_orientation).toBeCloseTo(3, 6);
+    expect(frameState.variables.echo_orient).toBeUndefined();
+  });
+
   test('builds motion vector overlays from per-pixel transforms', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Fix a parity bug where script assignments using aliases like `echo_orient` in `init`/`per_frame` programs wrote the raw alias into VM state instead of the canonical `video_echo_orientation`, leaving `frame.post.videoEchoOrientation` at the default and breaking imported presets that animate `echo_orient`.

### Description
- Normalize parsed program assignment targets before storing them by adding `normalizeProgramAssignmentTarget()` which consults `aliasMap` and `normalizeFieldSuffix` and returning the canonical key when present.
- Update `pushProgramStatement()` to replace `parsed.value.target` with the normalized target so per-program assignments like `per_frame_1=echo_orient=3;` write to `video_echo_orientation` in the compiled IR.
- Add regression tests to `tests/milkdrop-compiler.test.ts` to assert `echo_orient` in `init` and `per_frame` blocks compiles to `video_echo_orientation` and to `tests/milkdrop-vm.test.ts` to assert the normalized alias updates runtime/post state and does not leave `echo_orient` in `frame.variables`.

### Testing
- Ran the targeted compiler tests with `bun run test tests/milkdrop-compiler.test.ts` and all tests passed (50/50 in that file).
- Ran the targeted VM tests with `bun run test tests/milkdrop-vm.test.ts` and all tests passed (28/28 in that file).
- Ran the full quality gate with `bun run check`; TypeScript and most tests passed, but the quality gate failed due to two pre-existing unrelated test expectations in `tests/system-controls-tv-mode.test.ts`, not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3d6ecce483328c3b8d6b9cee8d88)