### PR TITLE
Refactor MilkDrop browse controls progressive disclosure

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2853,18 +2853,84 @@ body.tv-mode .control-panel input {
 
 .milkdrop-overlay__browse-controls {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin-top: 10px;
+  grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+  gap: 6px;
+  margin-top: 8px;
 }
 
 .milkdrop-overlay__browse-control {
   display: grid;
-  gap: 4px;
+  gap: 3px;
 }
 
 .milkdrop-overlay__browse-control--search {
   grid-column: 1 / -1;
+}
+
+.milkdrop-overlay__browse-mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.milkdrop-overlay__browse-mode-tab {
+  min-height: 28px;
+  padding: 4px 9px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.56);
+  color: rgba(226, 232, 240, 0.92);
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.milkdrop-overlay__browse-mode-tab[data-active="true"] {
+  border-color: rgba(56, 189, 248, 0.38);
+  background: rgba(56, 189, 248, 0.16);
+  color: #e0f2fe;
+}
+
+.milkdrop-overlay__browse-options {
+  margin: 0;
+  align-self: end;
+}
+
+.milkdrop-overlay__browse-options > summary {
+  list-style: none;
+}
+
+.milkdrop-overlay__browse-options > summary::-webkit-details-marker {
+  display: none;
+}
+
+.milkdrop-overlay__browse-options-summary {
+  min-height: 28px;
+  padding: 5px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.56);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.78rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.milkdrop-overlay__browse-options[open]
+  .milkdrop-overlay__browse-options-summary {
+  border-color: rgba(56, 189, 248, 0.38);
+  background: rgba(56, 189, 248, 0.16);
+  color: #e0f2fe;
+}
+
+.milkdrop-overlay__browse-options-body {
+  display: grid;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.38);
 }
 
 .milkdrop-overlay__search,
@@ -2874,24 +2940,24 @@ body.tv-mode .control-panel input {
   border-radius: 14px;
   background: rgba(15, 23, 42, 0.62);
   color: #f8fafc;
-  padding: 10px 12px;
+  padding: 8px 10px;
 }
 
 .milkdrop-overlay__collection-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 8px;
+  gap: 4px;
+  margin-top: 6px;
 }
 
 .milkdrop-overlay__collection-filter {
-  min-height: 30px;
-  padding: 5px 10px;
+  min-height: 26px;
+  padding: 4px 8px;
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 999px;
   background: rgba(15, 23, 42, 0.56);
   color: rgba(226, 232, 240, 0.92);
-  font-size: 0.82rem;
+  font-size: 0.76rem;
 }
 
 .milkdrop-overlay__collection-filter[data-active="true"] {
@@ -3206,7 +3272,7 @@ body.tv-mode .control-panel input {
   }
 
   .milkdrop-overlay__browse-controls {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .milkdrop-overlay__toolbar {
@@ -3319,13 +3385,21 @@ body.tv-mode .control-panel input {
   }
 
   .milkdrop-overlay__browse-controls {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: 6px;
     margin-top: 8px;
   }
 
   .milkdrop-overlay__browse-control--search {
     grid-column: 1 / -1;
+  }
+
+  .milkdrop-overlay__browse-mode-tabs {
+    gap: 4px;
+  }
+
+  .milkdrop-overlay__browse-options-body {
+    padding: 6px;
   }
 
   .milkdrop-overlay__collection-filters {

--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -201,6 +201,10 @@ export class MilkdropOverlay {
   private readonly browseMetaLabel: HTMLElement;
   private readonly browseQualitySelect: HTMLSelectElement;
   private readonly browseQualityHint: HTMLElement;
+  private readonly browseModeTabs: HTMLElement;
+  private readonly browseModeButtons: HTMLButtonElement[] = [];
+  private readonly browseOptionsDisclosure: HTMLDetailsElement;
+  private readonly browseOptionsSummary: HTMLElement;
   private readonly diagnosticsList: HTMLElement;
   private readonly editorStatus: HTMLElement;
   private readonly inspectorControls: HTMLElement;
@@ -494,6 +498,8 @@ export class MilkdropOverlay {
     });
     this.browseModeSelect.addEventListener('change', () => {
       this.browseMode = this.browseModeSelect.value as BrowseMode;
+      this.syncBrowseModeButtons();
+      this.updateBrowseFilterVisibility();
       this.scheduleBrowseRender(0);
     });
 
@@ -539,17 +545,66 @@ export class MilkdropOverlay {
       this.scheduleBrowseRender(0);
     });
 
+    this.browseModeTabs = document.createElement('div');
+    this.browseModeTabs.className = 'milkdrop-overlay__browse-mode-tabs';
+    this.browseModeTabs.setAttribute('role', 'tablist');
+    this.browseModeTabs.setAttribute('aria-label', 'Preset browse modes');
+    (
+      [
+        ['featured', 'Featured'],
+        ['all', 'All presets'],
+        ['recent', 'Recent'],
+        ['favorites', 'Favorites'],
+      ] satisfies Array<[BrowseMode, string]>
+    ).forEach(([value, label]) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'milkdrop-overlay__browse-mode-tab';
+      button.dataset.mode = value;
+      button.setAttribute('role', 'tab');
+      button.textContent = label;
+      button.addEventListener('click', () => {
+        this.browseModeSelect.value = value;
+        this.browseMode = value;
+        this.syncBrowseModeButtons();
+        this.updateBrowseFilterVisibility();
+        this.scheduleBrowseRender(0);
+      });
+      this.browseModeButtons.push(button);
+      this.browseModeTabs.appendChild(button);
+    });
+    this.syncBrowseModeButtons();
+
+    this.browseOptionsDisclosure = document.createElement('details');
+    this.browseOptionsDisclosure.className = 'milkdrop-overlay__browse-options';
+    this.browseOptionsSummary = document.createElement('summary');
+    this.browseOptionsSummary.className =
+      'milkdrop-overlay__browse-options-summary';
+    this.browseOptionsSummary.textContent = 'More filters';
+    this.browseOptionsDisclosure.appendChild(this.browseOptionsSummary);
+
+    const browseOptionsBody = document.createElement('div');
+    browseOptionsBody.className = 'milkdrop-overlay__browse-options-body';
+    browseOptionsBody.append(
+      this.buildBrowseControl('Fidelity', this.browseSupportSelect),
+      this.buildBrowseControl('Sort', this.browseSortSelect),
+    );
+    this.browseOptionsDisclosure.appendChild(browseOptionsBody);
+    this.browseOptionsDisclosure.addEventListener('toggle', () => {
+      this.updateBrowseFilterVisibility();
+    });
+
     const browseControls = document.createElement('div');
     browseControls.className = 'milkdrop-overlay__browse-controls';
     browseControls.append(
       this.buildBrowseControl('Search', this.searchInput, true),
-      this.buildBrowseControl('View', this.browseModeSelect),
-      this.buildBrowseControl('Fidelity', this.browseSupportSelect),
-      this.buildBrowseControl('Sort', this.browseSortSelect),
+      this.buildBrowseControl('Browse', this.browseModeTabs),
+      this.browseOptionsDisclosure,
     );
 
     this.collectionFilters = document.createElement('div');
     this.collectionFilters.className = 'milkdrop-overlay__collection-filters';
+    this.updateBrowseFilterVisibility();
     this.browseList = document.createElement('div');
     this.browseList.className = 'milkdrop-overlay__browse';
     this.tabPanels.browse.append(
@@ -697,7 +752,7 @@ export class MilkdropOverlay {
 
   private buildBrowseControl(
     label: string,
-    control: HTMLInputElement | HTMLSelectElement,
+    control: HTMLElement,
     isSearch = false,
   ) {
     const wrap = document.createElement('label');
@@ -709,6 +764,23 @@ export class MilkdropOverlay {
 
     wrap.append(title, control);
     return wrap;
+  }
+
+  private syncBrowseModeButtons() {
+    this.browseModeButtons.forEach((button) => {
+      const isActive = button.dataset.mode === this.browseMode;
+      button.dataset.active = String(isActive);
+      button.setAttribute('aria-selected', String(isActive));
+      button.tabIndex = isActive ? 0 : -1;
+    });
+  }
+
+  private updateBrowseFilterVisibility() {
+    const shouldShowCollections =
+      this.browseMode === 'all' ||
+      this.browseOptionsDisclosure.open ||
+      this.activeCollectionTag.length > 0;
+    this.collectionFilters.hidden = !shouldShowCollections;
   }
 
   private updateBrowseQualityDetails(presetId: string) {
@@ -1087,6 +1159,7 @@ export class MilkdropOverlay {
     }
     this.lastBrowseRenderSignature = renderSignature;
     this.browseDirty = false;
+    this.updateBrowseFilterVisibility();
     const filtered = this.sortBrowsePresets(
       this.presets.filter((preset) => this.matchesBrowseFilters(preset, query)),
     );
@@ -1155,6 +1228,7 @@ export class MilkdropOverlay {
       button.addEventListener('click', () => {
         this.activeCollectionTag = option.tag;
         this.browseDirty = true;
+        this.updateBrowseFilterVisibility();
         this.renderCollectionFilters();
         this.renderBrowseList();
       });

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -407,6 +407,119 @@ describe('milkdrop overlay browse rendering', () => {
     overlay.dispose();
   });
 
+  test('keeps the simplified default browse state focused on search and featured results', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const featuredPreset = createCatalogEntry('signal-bloom', 'Signal Bloom');
+    featuredPreset.historyIndex = 0;
+    const discoveryPreset = createCatalogEntry('aurora-drift', 'Aurora Drift');
+
+    overlay.setCatalog(
+      [featuredPreset, discoveryPreset],
+      'signal-bloom',
+      'webgl',
+    );
+
+    const search = document.querySelector(
+      '.milkdrop-overlay__search',
+    ) as HTMLInputElement | null;
+    const modeTabs = [
+      ...document.querySelectorAll('.milkdrop-overlay__browse-mode-tab'),
+    ] as HTMLButtonElement[];
+    const optionsDisclosure = document.querySelector(
+      '.milkdrop-overlay__browse-options',
+    ) as HTMLDetailsElement | null;
+    const collectionFilters = document.querySelector(
+      '.milkdrop-overlay__collection-filters',
+    ) as HTMLElement | null;
+    const browse = document.querySelector(
+      '.milkdrop-overlay__browse',
+    ) as HTMLElement | null;
+
+    expect(search?.placeholder).toBe('Search presets');
+    expect(modeTabs.map((tab) => tab.textContent?.trim())).toEqual([
+      'Featured',
+      'All presets',
+      'Recent',
+      'Favorites',
+    ]);
+    expect(
+      modeTabs
+        .find((tab) => tab.dataset.active === 'true')
+        ?.textContent?.trim(),
+    ).toBe('Featured');
+    expect(optionsDisclosure?.open).toBe(false);
+    expect(collectionFilters?.hidden).toBe(true);
+    expect(browse?.textContent).toContain('Signal Bloom');
+    expect(browse?.textContent).toContain('Aurora Drift');
+
+    overlay.dispose();
+  });
+
+  test('reveals advanced browse filters on demand and shows collections for all presets', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const classicPreset = createCatalogEntry('signal-bloom', 'Signal Bloom');
+    classicPreset.tags = ['collection:classic-milkdrop'];
+    const feedbackPreset = createCatalogEntry('aurora-drift', 'Aurora Drift');
+    feedbackPreset.tags = ['collection:feedback-lab'];
+
+    overlay.setCatalog(
+      [classicPreset, feedbackPreset],
+      'signal-bloom',
+      'webgl',
+    );
+
+    const optionsDisclosure = document.querySelector(
+      '.milkdrop-overlay__browse-options',
+    ) as HTMLDetailsElement | null;
+    const collectionFilters = document.querySelector(
+      '.milkdrop-overlay__collection-filters',
+    ) as HTMLElement | null;
+    const fidelitySelect = document.querySelector(
+      '.milkdrop-overlay__browse-options .milkdrop-overlay__rating-select',
+    ) as HTMLSelectElement | null;
+    const allPresetsTab = document.querySelector(
+      '.milkdrop-overlay__browse-mode-tab[data-mode="all"]',
+    ) as HTMLButtonElement | null;
+
+    expect(fidelitySelect?.value).toBe('all');
+    expect(collectionFilters?.hidden).toBe(true);
+
+    if (!optionsDisclosure || !allPresetsTab) {
+      throw new Error('Expected browse options disclosure and mode tabs.');
+    }
+
+    optionsDisclosure.open = true;
+    optionsDisclosure.dispatchEvent(new Event('toggle'));
+    expect(collectionFilters?.hidden).toBe(false);
+
+    optionsDisclosure.open = false;
+    optionsDisclosure.dispatchEvent(new Event('toggle'));
+    expect(collectionFilters?.hidden).toBe(true);
+
+    allPresetsTab.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(collectionFilters?.hidden).toBe(false);
+    expect(collectionFilters?.textContent).toContain('Classic MilkDrop');
+    expect(collectionFilters?.textContent).toContain('Feedback Lab');
+
+    overlay.dispose();
+  });
+
   test('keeps preset rows focused on launch metadata and compact secondary actions', () => {
     globalThis.MutationObserver = class {
       disconnect() {}


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the MilkDrop overlay so `Search` remains the primary, always-visible control and advanced browse options are progressively disclosed. 
- Make the browse mode control more compact and discoverable while keeping the existing featured listing behavior intact. 
- Hide collection chips by default to increase the chance the chooser fits above the fold.

### Description
- Replace the bulky `browseModeSelect` presentation with compact mode tabs (`Featured`, `All presets`, `Recent`, `Favorites`) and keep a hidden `select` in sync for programmatic state. (`assets/js/milkdrop/overlay.ts`).
- Move fidelity and sort controls into a small details disclosure labeled `More filters`, and add a disclosure body that contains the fidelity and sort controls so they are collapsed by default. (`assets/js/milkdrop/overlay.ts`).
- Hide collection chips by default unless the user opens the advanced `More filters` disclosure, selects `All presets`, or a collection tag is active; add `updateBrowseFilterVisibility()` and call it from `renderBrowseList()` and relevant handlers to preserve featured rendering when advanced filters are collapsed. (`assets/js/milkdrop/overlay.ts`).
- Shrink and tighten the browse controls, control paddings, and collection chip sizing in the overlay stylesheet and add styles for mode tabs and the disclosure UI. (`assets/css/base.css`).
- Add and update overlay tests to cover the simplified default state and the advanced filters disclosure behavior. (`tests/milkdrop-overlay.test.ts`).

### Testing
- Ran `bun run test tests/milkdrop-overlay.test.ts` and the overlay tests passed. 
- Ran `bun run test tests/system-controls-tv-mode.test.ts` in isolation and it passed. 
- Ran the full quality gate with `bun run check`; overlay-specific changes passed, but the full suite surfaced an existing flaky failure in `tests/system-controls-tv-mode.test.ts` when run with the entire suite (this test passes in isolation).

Docs
- None changed or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3cf7d1008332994950f703a5cdd4)