### PR TITLE
Fix wrapped tex3D slice scaling in feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -376,8 +376,10 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return sampleAuxTexture2d(source, wrappedUv);
           }
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
-          float wrappedSliceZ = (sliceZ >= 0.0 && sliceZ <= 1.0) ? sliceZ : fract(sliceZ);
-          float scaledSlice = wrappedSliceZ * (sliceCount - 1.0);
+          bool sliceInRange = sliceZ >= 0.0 && sliceZ <= 1.0;
+          float wrappedSliceZ = sliceInRange ? sliceZ : fract(sliceZ);
+          float sliceScale = sliceInRange ? (sliceCount - 1.0) : sliceCount;
+          float scaledSlice = wrappedSliceZ * sliceScale;
           float sliceIndexA = floor(scaledSlice);
           float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -226,12 +226,12 @@ function createSampleAuxTextureNode(
     ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
       const wrappedUv = fract(sampleUv);
       const sliceCount = float(AUX_TEXTURE_ATLAS_SLICE_COUNT);
-      const wrappedSliceZ = select(
-        sliceZ.greaterThanEqual(0).and(sliceZ.lessThanEqual(1)),
-        sliceZ,
-        fract(sliceZ),
-      );
-      const scaledSlice = wrappedSliceZ.mul(sliceCount.sub(1));
+      const sliceInRange = sliceZ
+        .greaterThanEqual(0)
+        .and(sliceZ.lessThanEqual(1));
+      const wrappedSliceZ = select(sliceInRange, sliceZ, fract(sliceZ));
+      const sliceScale = select(sliceInRange, sliceCount.sub(1), sliceCount);
+      const scaledSlice = wrappedSliceZ.mul(sliceScale);
       const sliceIndexA = floor(scaledSlice);
       const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
         sliceCount,


### PR DESCRIPTION
### Motivation
- Preserve the original in-range phase-to-slice mapping for tex3D atlas lookups while fixing a regression that compressed wrapped cycles and prevented the last atlas slice from blending back to slice 0 when `volumeSliceZ` leaves `[0,1]`.
- Keep WebGL/shared and WebGPU feedback sampling logic behaviorally aligned so both backends interpolate atlas slices consistently.

### Description
- In `assets/js/milkdrop/feedback-manager-shared.ts` compute `sliceInRange` and choose `sliceScale` as `(sliceCount - 1.0)` for in-range phases and `sliceCount` for wrapped phases, then use `scaledSlice = wrappedSliceZ * sliceScale` before floor/mod/blend operations.
- In `assets/js/milkdrop/feedback-manager-webgpu.ts` mirror the same selection logic in the node graph using `select(...)` so the WebGPU path matches the shared/WebGL semantics.
- Apply Biome formatting fixes to keep code style consistent.

### Testing
- Ran the quality gate with `bun run check` which completed Biome, typecheck, and the test suite and exited green (pass).
- Ran targeted tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts` and they all passed (pass).
- Docs: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3efb38dc83329b653cb90fd16df7)