### PR TITLE
Guard non-volume tex3D sampler classification

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -16,6 +16,7 @@ import {
 } from './shader-ast';
 import {
   isMilkdropShaderSamplerName,
+  isMilkdropVolumeShaderSamplerName,
   normalizeMilkdropShaderSamplerName,
 } from './shader-samplers';
 import type {
@@ -1488,6 +1489,41 @@ function isAuxShaderSamplerName(
   value: string,
 ): value is MilkdropShaderTextureSampler {
   return value !== 'main' && isMilkdropShaderSamplerName(value);
+}
+
+function buildUnsupportedVolumeSamplerWarnings(
+  controls: Pick<MilkdropShaderControls, 'textureLayer' | 'warpTexture'>,
+) {
+  const warnings: string[] = [];
+  const appendWarning = (
+    controlName: 'textureLayer' | 'warpTexture',
+    label: string,
+    source: MilkdropShaderTextureSampler,
+  ) => {
+    if (
+      controls[controlName].sampleDimension !== '3d' ||
+      source === 'none' ||
+      isMilkdropVolumeShaderSamplerName(source)
+    ) {
+      return;
+    }
+    warnings.push(
+      `${label} uses tex3D/texture3D with aux sampler "${source}", but only "simplex" is backed by the runtime volume atlas; this lookup will be approximated from a 2D texture.`,
+    );
+  };
+
+  appendWarning(
+    'textureLayer',
+    'Texture layer shader control',
+    controls.textureLayer.source,
+  );
+  appendWarning(
+    'warpTexture',
+    'Warp texture shader control',
+    controls.warpTexture.source,
+  );
+
+  return warnings;
 }
 
 function isKnownShaderScalarKey(key: string) {
@@ -4879,12 +4915,14 @@ function buildBackendSupport({
   sharedWarnings,
   softUnknownKeys,
   hardUnsupportedFields,
+  unsupportedVolumeSamplerWarnings,
 }: {
   backend: MilkdropRenderBackend;
   featureAnalysis: MilkdropFeatureAnalysis;
   sharedWarnings: string[];
   softUnknownKeys: string[];
   hardUnsupportedFields: HardUnsupportedFieldSpec[];
+  unsupportedVolumeSamplerWarnings: string[];
 }): MilkdropBackendSupport {
   const requiredFeatures = featureAnalysis.featuresUsed.filter(
     (feature) => feature !== 'unsupported-shader-text',
@@ -4914,6 +4952,18 @@ function buildBackendSupport({
         status: 'partial',
         code: 'unknown-field',
         message: `Unknown preset field "${key}" was ignored.`,
+      }),
+    );
+  });
+
+  unsupportedVolumeSamplerWarnings.forEach((message) => {
+    evidence.push(
+      createBackendEvidence({
+        backend,
+        scope: 'backend',
+        status: 'partial',
+        code: 'volume-sampler-gap',
+        message,
       }),
     );
   });
@@ -5372,6 +5422,16 @@ function createIR(
         `Unsupported feature "${feature}" from preset field "${key}": ${message}`,
     ),
   ];
+  const unsupportedVolumeSamplerWarnings =
+    buildUnsupportedVolumeSamplerWarnings(mergedShaderControls.controls);
+  unsupportedVolumeSamplerWarnings.forEach((message) => {
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'preset_shader_volume_approximation',
+      message,
+    );
+  });
   const backends = {
     webgl: buildBackendSupport({
       backend: 'webgl',
@@ -5379,6 +5439,7 @@ function createIR(
       sharedWarnings,
       softUnknownKeys: [...softUnknownKeys],
       hardUnsupportedFields: [...hardUnsupportedFields.values()],
+      unsupportedVolumeSamplerWarnings,
     }),
     webgpu: buildBackendSupport({
       backend: 'webgpu',
@@ -5386,6 +5447,7 @@ function createIR(
       sharedWarnings,
       softUnknownKeys: [...softUnknownKeys],
       hardUnsupportedFields: [...hardUnsupportedFields.values()],
+      unsupportedVolumeSamplerWarnings,
     }),
   };
   const blockedConstructs = [

--- a/assets/js/milkdrop/shader-samplers.ts
+++ b/assets/js/milkdrop/shader-samplers.ts
@@ -51,3 +51,9 @@ export function isMilkdropShaderSamplerName(
     value as MilkdropShaderTextureSampler | 'main',
   );
 }
+
+export function isMilkdropVolumeShaderSamplerName(
+  value: string,
+): value is 'simplex' {
+  return value === 'simplex';
+}

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -160,6 +160,7 @@ export type MilkdropBackendSupportEvidenceCode =
   | 'unsupported-hard-feature'
   | 'supported-shader-text-gap'
   | 'unsupported-shader-text-gap'
+  | 'volume-sampler-gap'
   | 'video-echo-gap'
   | 'post-effects-gap';
 

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -718,6 +718,50 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex3D(sampler_fw_noisevol_lq,
     ]);
   });
 
+  test('downgrades tex3D extraction for aux samplers without volume atlases', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Shader Non-volume 3D Alias
+comp_shader=ret = tex3D(sampler_fw_noise_lq, float3(uv, time / 10.0)).xyz
+      `.trim(),
+      { id: 'shader-non-volume-3d-alias' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('noise');
+    expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
+    expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
+      '3d',
+    );
+    expect(compiled.ir.shaderText.unsupportedLines).toEqual([]);
+    expect(compiled.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'preset_shader_volume_approximation',
+        severity: 'warning',
+        message:
+          'Texture layer shader control uses tex3D/texture3D with aux sampler "noise", but only "simplex" is backed by the runtime volume atlas; this lookup will be approximated from a 2D texture.',
+      }),
+    ]);
+    expect(compiled.ir.compatibility.warnings).toEqual([
+      'Texture layer shader control uses tex3D/texture3D with aux sampler "noise", but only "simplex" is backed by the runtime volume atlas; this lookup will be approximated from a 2D texture.',
+      'WebGPU applies supported shader-text controls through a compatibility translation path that may not exactly match WebGL.',
+    ]);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgl.evidence).toContainEqual(
+      expect.objectContaining({
+        code: 'volume-sampler-gap',
+        status: 'partial',
+      }),
+    );
+    expect(compiled.ir.compatibility.backends.webgpu.evidence).toContainEqual(
+      expect.objectContaining({
+        code: 'volume-sampler-gap',
+        status: 'partial',
+      }),
+    );
+  });
+
   test('supports resolved temp shader outputs for invert and runtime tint mixes', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -4,7 +4,10 @@ import {
   evaluateMilkdropShaderExpression,
   parseMilkdropShaderStatement,
 } from '../assets/js/milkdrop/shader-ast.ts';
-import { normalizeMilkdropShaderSamplerName } from '../assets/js/milkdrop/shader-samplers.ts';
+import {
+  isMilkdropVolumeShaderSamplerName as isVolumeSamplerName,
+  normalizeMilkdropShaderSamplerName,
+} from '../assets/js/milkdrop/shader-samplers.ts';
 
 const SAMPLER_ALIAS_CASES = [
   {
@@ -94,6 +97,12 @@ describe('milkdrop shader sampler aliases', () => {
     expect(normalizeMilkdropShaderSamplerName('sampler_unknown_alias')).toBe(
       null,
     );
+  });
+
+  test('identifies simplex as the only runtime-backed volume sampler', () => {
+    expect(isVolumeSamplerName('simplex')).toBe(true);
+    expect(isVolumeSamplerName('noise')).toBe(false);
+    expect(isVolumeSamplerName('voronoi')).toBe(false);
   });
 
   test('keeps AST shader sampling aligned with compiler shader extraction', () => {


### PR DESCRIPTION
### Motivation

- Prevent presets that call `tex3D`/`texture3D` on aux samplers that are plain 2D textures from being advertised as fully supported when the runtime only implements atlas-slice sampling for a single volume-backed texture.

### Description

- Add `isMilkdropVolumeShaderSamplerName` helper and treat only `simplex` as the runtime-backed volume atlas in `assets/js/milkdrop/shader-samplers.ts`.
- Reintroduce a targeted compiler guard that builds warnings for 3D aux samplers that are not volume-backed and surface a `preset_shader_volume_approximation` diagnostic, implemented in `assets/js/milkdrop/compiler.ts` via `buildUnsupportedVolumeSamplerWarnings` and plumbing into backend evidence.
- Add a new backend evidence code `volume-sampler-gap` to `assets/js/milkdrop/types.ts` so compatibility reports record partial backend evidence for these cases.
- Add regression tests for the helper and the downgrade behavior in `tests/milkdrop-shader-sampler-aliases.test.ts` and `tests/milkdrop-compiler.test.ts`.

### Testing

- Ran focused regressions with `bun run test tests/milkdrop-shader-sampler-aliases.test.ts tests/milkdrop-compiler.test.ts` and all targeted tests passed (55 passed, 0 failed).
- Ran the full quality gate with `bun run check`; Biome formatting/linting and typecheck completed, but the full test sweep reported two pre-existing unrelated failures in `tests/system-controls-tv-mode.test.ts`, causing the overall `check` command to exit non-zero.
- Applied Biome fixes/formatting during the workflow (`bunx biome check --write` / `biome format --write`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3eb59f74833286d24661e048c6b3)