### PR TITLE
Normalize echo_orient reads by sharing field-normalization between compiler and expression

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -7,6 +7,11 @@ import {
   splitMilkdropStatements,
   walkMilkdropExpression,
 } from './expression';
+import {
+  aliasMap,
+  normalizeFieldSuffix,
+  normalizeProgramAssignmentTarget,
+} from './field-normalization';
 import { formatMilkdropPreset } from './formatter';
 import { isMilkdropParityConstructAllowlisted } from './parity-allowlist';
 import { parseMilkdropPreset } from './preset-parser';
@@ -4278,55 +4283,6 @@ function mergeShaderControlAnalysis(
   };
 }
 
-const aliasMap: Record<string, string | null> = {
-  milkdrop_preset_version: null,
-  frating: 'fRating',
-  fdecay: 'decay',
-  fgammaadj: 'gammaadj',
-  fvideoechozoom: 'video_echo_zoom',
-  fvideoechoalpha: 'video_echo_alpha',
-  nvideoechoorientation: 'video_echo_orientation',
-  fwavealpha: 'wave_a',
-  fwavescale: 'wave_scale',
-  fwavesmoothing: 'wave_smoothing',
-  nwavemode: 'wave_mode',
-  fmodwavealphastart: 'modwavealphastart',
-  fmodwavealphaend: 'modwavealphaend',
-  fwarpscale: 'warp',
-  fwarpanimspeed: 'warpanimspeed',
-  fzoomexponent: 'zoomexp',
-  fshader: 'shader',
-  fbrighten: 'brighten',
-  fdarken: 'darken',
-  fsolarize: 'solarize',
-  finvert: 'invert',
-  bmaximizewavecolor: 'wave_brighten',
-  bbrighten: 'brighten',
-  bdarken: 'darken',
-  bsolarize: 'solarize',
-  binvert: 'invert',
-  fwaveparam: 'wave_mystery',
-  fwaver: 'wave_r',
-  fwaveg: 'wave_g',
-  fwaveb: 'wave_b',
-  fwavex: 'wave_x',
-  fwavey: 'wave_y',
-  fbeatsensitivity: 'beat_sensitivity',
-  fblendtimeseconds: 'blend_duration',
-  fouterbordersize: 'ob_size',
-  fouterborderr: 'ob_r',
-  fouterborderg: 'ob_g',
-  fouterborderb: 'ob_b',
-  fouterbordera: 'ob_a',
-  finnerbordersize: 'ib_size',
-  finnerborderr: 'ib_r',
-  finnerborderg: 'ib_g',
-  finnerborderb: 'ib_b',
-  finnerbordera: 'ib_a',
-  video_echo: 'video_echo_enabled',
-  echo_orient: 'video_echo_orientation',
-};
-
 const legacyCustomWaveSuffixMap: Record<string, string | null> = {
   mode: 'spectrum',
   bspectrum: 'spectrum',
@@ -4365,13 +4321,6 @@ function normalizeShaderFieldChunk(rawValue: string) {
     return null;
   }
   return normalized;
-}
-
-function normalizeFieldSuffix(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_]+/gu, '_');
 }
 
 function normalizeLegacyCustomWaveSuffix(value: string) {
@@ -4605,12 +4554,6 @@ function normalizeFieldKey(field: MilkdropPresetField) {
     return 'shape_1_thickoutline';
   }
   return rawKey;
-}
-
-function normalizeProgramAssignmentTarget(target: string) {
-  const normalizedTarget = normalizeFieldSuffix(target);
-  const aliasedTarget = aliasMap[normalizedTarget];
-  return aliasedTarget ?? normalizedTarget;
 }
 
 function ensureWaveDefinition(

--- a/assets/js/milkdrop/expression.ts
+++ b/assets/js/milkdrop/expression.ts
@@ -1,3 +1,4 @@
+import { resolveMilkdropIdentifier } from './field-normalization';
 import type {
   MilkdropCompiledStatement,
   MilkdropDiagnostic,
@@ -453,7 +454,7 @@ export function evaluateMilkdropExpression(
       const normalized = node.name.toLowerCase();
       if (normalized === 'pi') return Math.PI;
       if (normalized === 'e') return Math.E;
-      return env[node.name] ?? env[normalized] ?? 0;
+      return resolveMilkdropIdentifier(env, node.name) ?? 0;
     }
     case 'unary': {
       const value = evaluateMilkdropExpression(node.operand, env, helpers);

--- a/assets/js/milkdrop/field-normalization.ts
+++ b/assets/js/milkdrop/field-normalization.ts
@@ -1,0 +1,77 @@
+const aliasMap: Record<string, string | null> = {
+  milkdrop_preset_version: null,
+  frating: 'fRating',
+  fdecay: 'decay',
+  fgammaadj: 'gammaadj',
+  fvideoechozoom: 'video_echo_zoom',
+  fvideoechoalpha: 'video_echo_alpha',
+  nvideoechoorientation: 'video_echo_orientation',
+  fwavealpha: 'wave_a',
+  fwavescale: 'wave_scale',
+  fwavesmoothing: 'wave_smoothing',
+  nwavemode: 'wave_mode',
+  fmodwavealphastart: 'modwavealphastart',
+  fmodwavealphaend: 'modwavealphaend',
+  fwarpscale: 'warp',
+  fwarpanimspeed: 'warpanimspeed',
+  fzoomexponent: 'zoomexp',
+  fshader: 'shader',
+  fbrighten: 'brighten',
+  fdarken: 'darken',
+  fsolarize: 'solarize',
+  finvert: 'invert',
+  bmaximizewavecolor: 'wave_brighten',
+  bbrighten: 'brighten',
+  bdarken: 'darken',
+  bsolarize: 'solarize',
+  binvert: 'invert',
+  fwaveparam: 'wave_mystery',
+  fwaver: 'wave_r',
+  fwaveg: 'wave_g',
+  fwaveb: 'wave_b',
+  fwavex: 'wave_x',
+  fwavey: 'wave_y',
+  fbeatsensitivity: 'beat_sensitivity',
+  fblendtimeseconds: 'blend_duration',
+  fouterbordersize: 'ob_size',
+  fouterborderr: 'ob_r',
+  fouterborderg: 'ob_g',
+  fouterborderb: 'ob_b',
+  fouterbordera: 'ob_a',
+  finnerbordersize: 'ib_size',
+  finnerborderr: 'ib_r',
+  finnerborderg: 'ib_g',
+  finnerborderb: 'ib_b',
+  finnerbordera: 'ib_a',
+  video_echo: 'video_echo_enabled',
+  echo_orient: 'video_echo_orientation',
+};
+
+export function normalizeFieldSuffix(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/gu, '_');
+}
+
+export function normalizeProgramAssignmentTarget(target: string) {
+  const normalizedTarget = normalizeFieldSuffix(target);
+  const aliasedTarget = aliasMap[normalizedTarget];
+  return aliasedTarget ?? normalizedTarget;
+}
+
+export function resolveMilkdropIdentifier(
+  env: Record<string, number>,
+  identifier: string,
+) {
+  const normalizedIdentifier = normalizeFieldSuffix(identifier);
+  const aliasedIdentifier = aliasMap[normalizedIdentifier];
+
+  return (
+    env[identifier] ??
+    env[normalizedIdentifier] ??
+    (aliasedIdentifier ? env[aliasedIdentifier] : undefined)
+  );
+}
+
+export { aliasMap };

--- a/tests/milkdrop-expression.test.ts
+++ b/tests/milkdrop-expression.test.ts
@@ -18,4 +18,21 @@ describe('milkdrop expression', () => {
     }
     expect(evaluateMilkdropExpression(parsed.value, {})).toBeCloseTo(22.25, 6);
   });
+
+  test('resolves legacy aliases against canonical environment keys', () => {
+    const parsed = parseMilkdropExpression('echo_orient + fGammaAdj', 1);
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.value).not.toBeNull();
+    if (!parsed.value) {
+      throw new Error('Expected expression to parse.');
+    }
+
+    expect(
+      evaluateMilkdropExpression(parsed.value, {
+        video_echo_orientation: 3,
+        gammaadj: 1.25,
+      }),
+    ).toBeCloseTo(4.25, 6);
+  });
 });

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -204,6 +204,28 @@ ${programLine}
     expect(frameState.variables.echo_orient).toBeUndefined();
   });
 
+  test.each([
+    ['init', 'init_1=echo_orient=echo_orient+1; q1=echo_orient;'],
+    ['per-frame', 'per_frame_1=echo_orient=echo_orient+1; q1=echo_orient;'],
+  ])('keeps echo_orient self-references and follow-up reads normalized in %s programs', (_label, programLine) => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Echo Orientation VM Self Reference
+video_echo=1
+video_echo_orientation=2
+${programLine}
+        `.trim(),
+      { id: 'echo-orientation-vm-self-reference' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
+
+    expect(frameState.post.videoEchoOrientation).toBe(3);
+    expect(frameState.variables.video_echo_orientation).toBeCloseTo(3, 6);
+    expect(frameState.variables.q1).toBeCloseTo(3, 6);
+    expect(frameState.variables.echo_orient).toBeUndefined();
+  });
+
   test('builds motion vector overlays from per-pixel transforms', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Assignments that canonicalize LHS targets (e.g. `echo_orient -> video_echo_orientation`) still read legacy alias names on RHS and in later statements, causing incorrect runtime/post state for animated/imported presets.
- Unify alias/canonicalization logic so both compile-time target rewriting and runtime expression lookup use the same mapping and normalization rules.

### Description
- Add a shared helper `assets/js/milkdrop/field-normalization.ts` that exports `aliasMap`, `normalizeFieldSuffix`, `normalizeProgramAssignmentTarget`, and `resolveMilkdropIdentifier` so alias rules are centralized.
- Update the compiler to import and use the shared `normalizeProgramAssignmentTarget` and `aliasMap` instead of a local alias table so assignment targets are normalized consistently into the IR.
- Update the expression evaluator to use `resolveMilkdropIdentifier(env, identifier)` so identifier reads consult aliases and canonical keys (fixes RHS and self-referential reads like `echo_orient=echo_orient+1`).
- Add regression tests: `tests/milkdrop-expression.test.ts` checks alias lookup against canonical env keys and `tests/milkdrop-vm.test.ts` adds a scenario verifying `echo_orient=echo_orient+1; q1=echo_orient;` behaves correctly in both `init` and `per_frame` programs.

### Testing
- Ran `bun run test tests/milkdrop-expression.test.ts` and it passed (2 tests, 0 fail). 
- Ran `bun run test tests/milkdrop-vm.test.ts` and it passed (30 tests, 0 fail). 
- Ran the full quality gate with `bun run check`; TypeScript, Biome, and most tests passed but the gate failed due to two pre-existing unrelated test failures in `tests/system-controls-tv-mode.test.ts` (not caused by these changes).

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3ffd4e508332bf1ea9956a2636b4)