### PR TITLE
Restore keyboard access for browse mode tabs

### DIFF
--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -496,12 +496,9 @@ export class MilkdropOverlay {
       option.textContent = label;
       this.browseModeSelect.appendChild(option);
     });
-    this.browseModeSelect.addEventListener('change', () => {
-      this.browseMode = this.browseModeSelect.value as BrowseMode;
-      this.syncBrowseModeButtons();
-      this.updateBrowseFilterVisibility();
-      this.scheduleBrowseRender(0);
-    });
+    this.browseModeSelect.addEventListener('change', () =>
+      this.setBrowseMode(this.browseModeSelect.value as BrowseMode),
+    );
 
     this.browseSupportSelect = document.createElement('select');
     this.browseSupportSelect.className = 'milkdrop-overlay__rating-select';
@@ -549,6 +546,9 @@ export class MilkdropOverlay {
     this.browseModeTabs.className = 'milkdrop-overlay__browse-mode-tabs';
     this.browseModeTabs.setAttribute('role', 'tablist');
     this.browseModeTabs.setAttribute('aria-label', 'Preset browse modes');
+    this.browseModeTabs.addEventListener('keydown', (event) =>
+      this.handleBrowseModeTabsKeydown(event),
+    );
     (
       [
         ['featured', 'Featured'],
@@ -563,13 +563,7 @@ export class MilkdropOverlay {
       button.dataset.mode = value;
       button.setAttribute('role', 'tab');
       button.textContent = label;
-      button.addEventListener('click', () => {
-        this.browseModeSelect.value = value;
-        this.browseMode = value;
-        this.syncBrowseModeButtons();
-        this.updateBrowseFilterVisibility();
-        this.scheduleBrowseRender(0);
-      });
+      button.addEventListener('click', () => this.setBrowseMode(value));
       this.browseModeButtons.push(button);
       this.browseModeTabs.appendChild(button);
     });
@@ -764,6 +758,55 @@ export class MilkdropOverlay {
 
     wrap.append(title, control);
     return wrap;
+  }
+
+  private setBrowseMode(mode: BrowseMode) {
+    this.browseModeSelect.value = mode;
+    this.browseMode = mode;
+    this.syncBrowseModeButtons();
+    this.updateBrowseFilterVisibility();
+    this.scheduleBrowseRender(0);
+  }
+
+  private handleBrowseModeTabsKeydown(event: KeyboardEvent) {
+    const currentIndex = this.browseModeButtons.findIndex(
+      (button) => button.dataset.mode === this.browseMode,
+    );
+    if (currentIndex < 0) {
+      return;
+    }
+
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (currentIndex + 1) % this.browseModeButtons.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex =
+          (currentIndex - 1 + this.browseModeButtons.length) %
+          this.browseModeButtons.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = this.browseModeButtons.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const nextButton = this.browseModeButtons[nextIndex];
+    const nextMode = nextButton?.dataset.mode as BrowseMode | undefined;
+    if (!nextButton || !nextMode) {
+      return;
+    }
+
+    this.setBrowseMode(nextMode);
+    nextButton.focus();
   }
 
   private syncBrowseModeButtons() {

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -463,6 +463,75 @@ describe('milkdrop overlay browse rendering', () => {
     overlay.dispose();
   });
 
+  test('keeps browse mode tabs keyboard reachable with roving focus controls', () => {
+    globalThis.MutationObserver = class {
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof MutationObserver;
+
+    const overlay = createOverlay();
+    const classicPreset = createCatalogEntry('signal-bloom', 'Signal Bloom');
+    classicPreset.tags = ['collection:classic-milkdrop'];
+    classicPreset.historyIndex = 0;
+    const favoritePreset = createCatalogEntry('aurora-drift', 'Aurora Drift');
+    favoritePreset.isFavorite = true;
+
+    overlay.setCatalog(
+      [classicPreset, favoritePreset],
+      'signal-bloom',
+      'webgl',
+    );
+
+    const featuredTab = document.querySelector(
+      '.milkdrop-overlay__browse-mode-tab[data-mode="featured"]',
+    ) as HTMLButtonElement | null;
+    const allPresetsTab = document.querySelector(
+      '.milkdrop-overlay__browse-mode-tab[data-mode="all"]',
+    ) as HTMLButtonElement | null;
+    const favoritesTab = document.querySelector(
+      '.milkdrop-overlay__browse-mode-tab[data-mode="favorites"]',
+    ) as HTMLButtonElement | null;
+    const collectionFilters = document.querySelector(
+      '.milkdrop-overlay__collection-filters',
+    ) as HTMLElement | null;
+
+    if (!featuredTab || !allPresetsTab || !favoritesTab || !collectionFilters) {
+      throw new Error('Expected browse mode tabs and collection filters.');
+    }
+
+    expect(featuredTab.tabIndex).toBe(0);
+    expect(allPresetsTab.tabIndex).toBe(-1);
+    featuredTab.focus();
+
+    featuredTab.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        bubbles: true,
+      }),
+    );
+
+    expect(allPresetsTab.tabIndex).toBe(0);
+    expect(allPresetsTab.getAttribute('aria-selected')).toBe('true');
+    expect(featuredTab.tabIndex).toBe(-1);
+    expect(collectionFilters.hidden).toBe(false);
+
+    allPresetsTab.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'End',
+        bubbles: true,
+      }),
+    );
+
+    expect(favoritesTab.tabIndex).toBe(0);
+    expect(favoritesTab.getAttribute('aria-selected')).toBe('true');
+    expect(collectionFilters.hidden).toBe(true);
+
+    overlay.dispose();
+  });
+
   test('reveals advanced browse filters on demand and shows collections for all presets', () => {
     globalThis.MutationObserver = class {
       disconnect() {}


### PR DESCRIPTION
### Motivation
- The previous refactor replaced the `<select>` with compact browse mode tabs but removed the keyboard navigation needed for a roving-tabindex tablist, making non-default browse modes unreachable to keyboard-only users. 
- Ensure browse-mode changes remain synchronized between the hidden programmatic `<select>` and the visible tab buttons while preserving progressive-disclosure behavior for collection filters.

### Description
- Add `setBrowseMode()` to centralize mode updates so the hidden `browseModeSelect` and visible tab buttons stay in sync and trigger the same rendering and visibility updates (`assets/js/milkdrop/overlay.ts`).
- Add `handleBrowseModeTabsKeydown()` and attach a `keydown` handler to the tablist to support ArrowLeft/ArrowRight/ArrowUp/ArrowDown/Home/End navigation and to implement roving tabindex behavior with focus movement (`assets/js/milkdrop/overlay.ts`).
- Replace individual click/change handlers to call `setBrowseMode()` so clicks, programmatic changes, and keyboard navigation all run the same update path (`assets/js/milkdrop/overlay.ts`).
- Add a regression test that verifies keyboard navigation moves from the default `Featured` tab to other modes, that tabindex/aria-selected state roves correctly, and that collection filter visibility updates when the mode changes (`tests/milkdrop-overlay.test.ts`).

### Testing
- Ran `bun run test tests/milkdrop-overlay.test.ts` and the overlay test file passed (9 tests, 0 failures). 
- Ran `bun run check`; overlay-specific changes succeeded, but the full quality gate surfaced unrelated failures in `tests/system-controls-tv-mode.test.ts`, causing the full check to fail. 
- Linters/formatters were applied via the repository quality gate and the changes were formatted by `biome` as part of the checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3fb32164833296bb8cfb7884e458)