### PR TITLE
Restore periodic tex3D atlas slice mapping for feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -378,8 +378,8 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
           bool sliceInRange = sliceZ >= 0.0 && sliceZ <= 1.0;
           float wrappedSliceZ = sliceInRange ? sliceZ : fract(sliceZ);
-          float sliceScale = sliceInRange ? (sliceCount - 1.0) : sliceCount;
-          float scaledSlice = wrappedSliceZ * sliceScale;
+          // Preserve the original 0..1 atlas mapping so modulo-equivalent tex3D phases stay periodic.
+          float scaledSlice = wrappedSliceZ * (sliceCount - 1.0);
           float sliceIndexA = floor(scaledSlice);
           float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -230,8 +230,8 @@ function createSampleAuxTextureNode(
         .greaterThanEqual(0)
         .and(sliceZ.lessThanEqual(1));
       const wrappedSliceZ = select(sliceInRange, sliceZ, fract(sliceZ));
-      const sliceScale = select(sliceInRange, sliceCount.sub(1), sliceCount);
-      const scaledSlice = wrappedSliceZ.mul(sliceScale);
+      // Preserve the original 0..1 atlas mapping so modulo-equivalent tex3D phases stay periodic.
+      const scaledSlice = wrappedSliceZ.mul(sliceCount.sub(1));
       const sliceIndexA = floor(scaledSlice);
       const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
         sliceCount,


### PR DESCRIPTION
### Motivation
- Fix a regression where wrapped `tex3D` phases (e.g. `0.25` vs `1.25`) sampled different atlas positions and produced visible jumps at wrap boundaries. 
- Preserve the original in-range `0..1` phase-to-slice mapping so modulo-equivalent phases remain periodic. 
- Keep WebGL/shared and WebGPU feedback sampling semantics aligned to avoid backend divergence.

### Description
- In `assets/js/milkdrop/feedback-manager-shared.ts` replace the split `sliceScale` logic and always compute `scaledSlice = wrappedSliceZ * (sliceCount - 1.0)` with an explanatory comment so wrapped phases map to the same atlas positions as the 0..1 cycle. 
- In `assets/js/milkdrop/feedback-manager-webgpu.ts` mirror the same change in the TSL node graph by computing `scaledSlice = wrappedSliceZ.mul(sliceCount.sub(1))` and adding the same explanatory comment. 
- Applied repository formatting checks (Biome) as part of the commit to keep style consistent.

### Testing
- Ran the quality gate with `bun run check`; Biome formatting and TypeScript typecheck completed, but the full test suite shows two pre-existing unrelated failures in `tests/system-controls-tv-mode.test.ts` so `bun run check` exits non-zero. 
- Ran targeted MilkDrop tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts`, and all targeted tests passed. 
- No docs were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be40ad63508332a7e1c6aab64c17d7)