### PR TITLE
Make the preflight dialog less modal

### DIFF
--- a/assets/js/core/capability-preflight.ts
+++ b/assets/js/core/capability-preflight.ts
@@ -451,55 +451,7 @@ export function attachCapabilityPreflight({
       container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
     ).filter((el) => !el.hasAttribute('aria-hidden'));
 
-  const trapFocus = (container: HTMLElement) => {
-    const handleKeydown = (event: KeyboardEvent) => {
-      if (event.key !== 'Tab') return;
-      const items = getFocusableElements(container);
-      if (items.length === 0) {
-        event.preventDefault();
-        container.focus();
-        return;
-      }
-
-      const first = items[0];
-      const last = items[items.length - 1];
-      const active = container.ownerDocument.activeElement;
-
-      if (event.shiftKey && active === first) {
-        event.preventDefault();
-        last.focus();
-        return;
-      }
-
-      if (!event.shiftKey && active === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    const handleFocusIn = (event: FocusEvent) => {
-      if (!(event.target instanceof Node) || container.contains(event.target)) {
-        return;
-      }
-      const items = getFocusableElements(container);
-      if (items.length > 0) {
-        items[0].focus();
-      } else {
-        container.focus();
-      }
-    };
-
-    container.addEventListener('keydown', handleKeydown);
-    container.ownerDocument.addEventListener('focusin', handleFocusIn);
-
-    return () => {
-      container.removeEventListener('keydown', handleKeydown);
-      container.ownerDocument.removeEventListener('focusin', handleFocusIn);
-    };
-  };
-
   let restoreFocusTarget: HTMLElement | null = null;
-  let focusCleanup: (() => void) | null = null;
   let closingFromHistory = false;
   let isAttached = false;
 
@@ -548,14 +500,14 @@ export function attachCapabilityPreflight({
   const openPanel = () => {
     if (isPanelOpen()) return;
     rememberToggle.checked = readRememberPreference();
-    if (typeof panel.showModal === 'function') {
+    if (typeof panel.show === 'function') {
+      panel.show();
+    } else if (typeof panel.showModal === 'function') {
       panel.showModal();
     } else {
       panel.setAttribute('open', 'true');
     }
     setPreflightOpenState(true);
-    focusCleanup?.();
-    focusCleanup = trapFocus(panel);
     const focusables = getFocusableElements(panel);
     if (focusables.length > 0) {
       focusables[0].focus();
@@ -571,8 +523,6 @@ export function attachCapabilityPreflight({
       panel.removeAttribute('open');
     }
     setPreflightOpenState(false);
-    focusCleanup?.();
-    focusCleanup = null;
   };
 
   const title = document.createElement('div');

--- a/tests/capability-preflight.test.ts
+++ b/tests/capability-preflight.test.ts
@@ -149,4 +149,46 @@ describe('capability preflight launch flow', () => {
 
     preflight.destroy();
   });
+
+  test('opens the preflight as a non-modal dialog when supported', async () => {
+    setTestUrl();
+
+    const dialogConstructor = window.HTMLDialogElement;
+    expect(dialogConstructor).toBeDefined();
+
+    const originalShow = dialogConstructor.prototype.show;
+    const originalShowModal = dialogConstructor.prototype.showModal;
+    let showCalls = 0;
+    let showModalCalls = 0;
+
+    dialogConstructor.prototype.show = function showPatched() {
+      showCalls += 1;
+      this.setAttribute('open', 'true');
+    };
+    dialogConstructor.prototype.showModal = function showModalPatched() {
+      showModalCalls += 1;
+      this.setAttribute('open', 'true');
+    };
+
+    try {
+      const preflight = attachCapabilityPreflight({
+        host: document.body,
+        openOnAttach: false,
+        showCloseButton: true,
+        runPreflight: async () => readyResult,
+      });
+
+      preflight.open();
+      await flush();
+      await flush();
+
+      expect(showCalls).toBe(1);
+      expect(showModalCalls).toBe(0);
+
+      preflight.destroy();
+    } finally {
+      dialogConstructor.prototype.show = originalShow;
+      dialogConstructor.prototype.showModal = originalShowModal;
+    }
+  });
 });


### PR DESCRIPTION
### Motivation
- Reduce first-session friction by making the capability preflight less blocking so the toy page feels less modal and more like a lightweight gate, aligning with UX guidance to prefer subtraction and hierarchy tightening.

### Description
- Prefer `dialog.show()` when available, falling back to `showModal()` or setting the `open` attribute, while preserving the existing URL/open-state and focus targeting behavior.
- Remove the internal focus-trap hookup so the panel behaves modelessly but still focuses the first focusable element when opened.
- Add a regression test that patches the dialog API and verifies the preflight uses the non-modal `show()` path instead of `showModal()`.
- Files changed: `assets/js/core/capability-preflight.ts` and `tests/capability-preflight.test.ts`.

### Testing
- Ran `bun run test tests/capability-preflight.test.ts` and the file's tests passed (3 passed, 0 failed).
- Ran `bun run check` (Biome lint/format, `tsc --noEmit`, and the full test suite) which executed the quality gate and test suite; the test run completed successfully though the check process in this environment reported a non-standard exit behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be408d2a848332996695d97f9c412a)