### PR TITLE
Follow-up: restore wrapped tex3D seam blending for feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -378,8 +378,10 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
           bool sliceInRange = sliceZ >= 0.0 && sliceZ <= 1.0;
           float wrappedSliceZ = sliceInRange ? sliceZ : fract(sliceZ);
-          // Preserve the original 0..1 atlas mapping so modulo-equivalent tex3D phases stay periodic.
-          float scaledSlice = wrappedSliceZ * (sliceCount - 1.0);
+          // Keep the original 0..1 mapping for in-range phases, but let wrapped cycles span the
+          // full atlas count so the last segment blends the final slice back to slice 0.
+          float sliceScale = sliceInRange ? (sliceCount - 1.0) : sliceCount;
+          float scaledSlice = wrappedSliceZ * sliceScale;
           float sliceIndexA = floor(scaledSlice);
           float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -230,8 +230,10 @@ function createSampleAuxTextureNode(
         .greaterThanEqual(0)
         .and(sliceZ.lessThanEqual(1));
       const wrappedSliceZ = select(sliceInRange, sliceZ, fract(sliceZ));
-      // Preserve the original 0..1 atlas mapping so modulo-equivalent tex3D phases stay periodic.
-      const scaledSlice = wrappedSliceZ.mul(sliceCount.sub(1));
+      // Keep the original 0..1 mapping for in-range phases, but let wrapped cycles span the
+      // full atlas count so the last segment blends the final slice back to slice 0.
+      const sliceScale = select(sliceInRange, sliceCount.sub(1), sliceCount);
+      const scaledSlice = wrappedSliceZ.mul(sliceScale);
       const sliceIndexA = floor(scaledSlice);
       const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
         sliceCount,


### PR DESCRIPTION
### Motivation
- Fix a regression where out-of-range `tex3D` phases (e.g. `time/10.0` > 1.0) stopped blending the final atlas slice back to slice 0 and produced a visible seam once per loop, and keep WebGL/shared and WebGPU feedback sampling behavior aligned.

### Description
- Update `assets/js/milkdrop/feedback-manager-shared.ts` to conditionally use a `sliceScale` of `sliceCount - 1` for in-range `sliceZ` and `sliceCount` for wrapped/out-of-range phases, then compute `scaledSlice = wrappedSliceZ * sliceScale` so the final slice blends back to slice 0.
- Mirror the same change in `assets/js/milkdrop/feedback-manager-webgpu.ts` by adding the equivalent `sliceScale` selection in the TSL node graph so both backends preserve periodic sampling semantics.

### Testing
- Ran `bun run check` which completed Biome formatting and TypeScript typecheck but exited non-zero because of two pre-existing unrelated failures in `tests/system-controls-tv-mode.test.ts`.
- Ran targeted tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts` and all targeted MilkDrop tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be42b457b88332af596061a6db3eb8)