### PR TITLE
Follow-up for #877: Stop browse tab arrow keys from escaping

### DIFF
--- a/assets/js/milkdrop/overlay.ts
+++ b/assets/js/milkdrop/overlay.ts
@@ -799,6 +799,7 @@ export class MilkdropOverlay {
     }
 
     event.preventDefault();
+    event.stopPropagation();
     const nextButton = this.browseModeButtons[nextIndex];
     const nextMode = nextButton?.dataset.mode as BrowseMode | undefined;
     if (!nextButton || !nextMode) {

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -497,10 +497,25 @@ describe('milkdrop overlay browse rendering', () => {
     const collectionFilters = document.querySelector(
       '.milkdrop-overlay__collection-filters',
     ) as HTMLElement | null;
+    const sentinelButton = document.createElement('button');
+    sentinelButton.type = 'button';
+    sentinelButton.textContent = 'Sentinel';
+    document.body.appendChild(sentinelButton);
 
     if (!featuredTab || !allPresetsTab || !favoritesTab || !collectionFilters) {
       throw new Error('Expected browse mode tabs and collection filters.');
     }
+
+    let globalArrowHandlerTriggered = false;
+    const handleWindowArrowKey = (event: KeyboardEvent) => {
+      if (event.key !== 'ArrowRight') {
+        return;
+      }
+
+      globalArrowHandlerTriggered = true;
+      sentinelButton.focus();
+    };
+    window.addEventListener('keydown', handleWindowArrowKey);
 
     expect(featuredTab.tabIndex).toBe(0);
     expect(allPresetsTab.tabIndex).toBe(-1);
@@ -517,6 +532,8 @@ describe('milkdrop overlay browse rendering', () => {
     expect(allPresetsTab.getAttribute('aria-selected')).toBe('true');
     expect(featuredTab.tabIndex).toBe(-1);
     expect(collectionFilters.hidden).toBe(false);
+    expect(document.activeElement).toBe(allPresetsTab);
+    expect(globalArrowHandlerTriggered).toBe(false);
 
     allPresetsTab.dispatchEvent(
       new window.KeyboardEvent('keydown', {
@@ -529,6 +546,7 @@ describe('milkdrop overlay browse rendering', () => {
     expect(favoritesTab.getAttribute('aria-selected')).toBe('true');
     expect(collectionFilters.hidden).toBe(true);
 
+    window.removeEventListener('keydown', handleWindowArrowKey);
     overlay.dispose();
   });
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority accessibility bug where ArrowLeft/Right/Up/Down used to bubble out of the overlay tablist and get handled by the app-level focus/gamepad navigation, breaking roving-tab keyboard behavior.

### Description
- Call `event.stopPropagation()` after `event.preventDefault()` in `MilkdropOverlay#handleBrowseModeTabsKeydown` to contain handled arrow/home/end key events to the overlay tablist (`assets/js/milkdrop/overlay.ts`).
- Add a regression assertion that simulates a window-level `keydown` listener and verifies the global handler is not triggered when navigating overlay tabs via keyboard (`tests/milkdrop-overlay.test.ts`).
- Files changed: `assets/js/milkdrop/overlay.ts` and `tests/milkdrop-overlay.test.ts`.

### Testing
- Ran `bun run test tests/milkdrop-overlay.test.ts` and the targeted overlay tests passed (9 tests, 0 failures). 
- Ran the full quality gate with `bun run check` and the repository test suite and checks completed successfully (full gate: 391 pass, 2 skip, 0 fail at time of run). 
- Linters/formatters were applied as part of the commit hooks/quality gate (`biome` formatting/linting applied).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be42b477c08332a974855f1994c724)