### PR TITLE
Trim homepage copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,11 +107,10 @@
           <div class="home-hero__grid">
             <div class="home-hero__copy">
               <p class="eyebrow">Independent browser-native visualizer</p>
-              <h1>Stims brings MilkDrop-style visuals to the browser.</h1>
+              <h1>MilkDrop-style visuals, without leaving the browser.</h1>
               <p class="tagline">
-                Start with demo audio to see motion immediately. Open <code>/milkdrop/</code>
-                when you want mic or tab audio, bundled presets, quality controls, and live
-                editing in one place.
+                Start with demo audio now. Use <code>/milkdrop/</code> for mic or tab audio,
+                presets, and editing.
               </p>
               <div class="hero-cta-row" role="group" aria-label="Primary actions">
                 <a href="/milkdrop/?audio=demo" class="cta-button primary">
@@ -121,13 +120,13 @@
               </div>
               <div class="home-hero__focus" aria-label="Launch flow summary">
                 <p class="home-hero__support">
-                  One route gets you straight to the visuals. Everything else stays tucked inside
-                  <code>/milkdrop/</code> until you want it.
+                  The homepage stays simple: launch fast here, go deeper in
+                  <code>/milkdrop/</code> when you need more control.
                 </p>
                 <ul class="home-hero__checklist">
-                  <li>Start with demo audio and see motion immediately.</li>
-                  <li>Switch to mic or tab audio later without leaving the session.</li>
-                  <li>Browse presets or edit only when you are ready to go deeper.</li>
+                  <li>Start fast with demo audio.</li>
+                  <li>Switch to mic or tab audio later.</li>
+                  <li>Open presets or the editor only when you want them.</li>
                 </ul>
               </div>
             </div>
@@ -143,11 +142,8 @@
               </div>
               <aside class="home-hero__aside" aria-label="What opens in MilkDrop">
                 <p class="home-hero__aside-label">Inside <code>/milkdrop/</code></p>
-                <h2>The visualizer stays center stage.</h2>
-                <p>
-                  Audio setup, preset browsing, and editing are still there, but they stay
-                  behind the first launch instead of competing with it on the homepage.
-                </p>
+                <h2>Launch first. Tweak later.</h2>
+                <p>Audio setup, presets, and editing live inside <code>/milkdrop/</code>.</p>
               </aside>
             </div>
           </div>
@@ -156,36 +152,26 @@
         <section class="home-proof" id="experience" aria-labelledby="experience-title">
           <div class="section-heading">
             <p class="eyebrow">After launch</p>
-            <h2 id="experience-title">Everything you need stays in one session.</h2>
+            <h2 id="experience-title">One place for the full session.</h2>
             <p class="section-description">
-              Start audio, change the look, and edit presets without reorienting yourself after
-              the first click.
+              Audio, presets, and editing stay on the same route once you are in.
             </p>
           </div>
           <div class="home-proof-grid">
             <article class="home-proof-card">
               <p class="home-proof-card__eyebrow">Audio setup</p>
-              <h3>Choose the source that matches your situation.</h3>
-              <p>
-                Start with demo audio for instant feedback, then switch to microphone or tab
-                audio when you want visuals that follow live sound.
-              </p>
+              <h3>Pick an audio source.</h3>
+              <p>Start with demo audio, then switch to microphone or tab audio when you want.</p>
             </article>
             <article class="home-proof-card">
               <p class="home-proof-card__eyebrow">Preset control</p>
-              <h3>Browse a curated catalog without leaving the visualizer.</h3>
-              <p>
-                Favorites, recent picks, and collection filters stay inside the session, so the
-                preset browser feels like part of the instrument instead of a detour.
-              </p>
+              <h3>Browse presets in place.</h3>
+              <p>Favorites, recents, and collection filters stay inside the running session.</p>
             </article>
             <article class="home-proof-card">
               <p class="home-proof-card__eyebrow">Live editing</p>
-              <h3>Move from playing to tweaking without a mode switch.</h3>
-              <p>
-                Open the editor, inspect diagnostics, and keep adjusting the session while the
-                visualizer keeps running.
-              </p>
+              <h3>Edit without stopping.</h3>
+              <p>Open the editor, inspect diagnostics, and keep the visualizer running.</p>
             </article>
           </div>
         </section>
@@ -230,60 +216,31 @@
         <section class="home-lineage" id="lineage" aria-labelledby="lineage-title">
           <div class="section-heading">
             <p class="eyebrow">Lineage</p>
-            <h2 id="lineage-title">Built in MilkDrop&rsquo;s lineage, with its own identity.</h2>
+            <h2 id="lineage-title">MilkDrop lineage, clear ownership.</h2>
             <p class="section-description">
-              Stims is an independent browser-native visualizer that credits Ryan Geiss&rsquo;s
-              MilkDrop while making clear that this is its own implementation.
+              Stims credits Ryan Geiss&rsquo;s MilkDrop while staying explicit that this is an
+              independent browser-native implementation.
             </p>
           </div>
           <div class="home-lineage__grid">
             <article class="home-lineage__card">
-              <h3>What carries forward</h3>
+              <h3>What stays</h3>
               <ul class="home-list">
-                <li>Preset-driven feedback visuals and fast visual iteration.</li>
-                <li>Browser-native access to preset browsing, editing, import, and export.</li>
+                <li>Preset-driven visuals and fast iteration.</li>
+                <li>Browser-native preset browsing, editing, import, and export.</li>
                 <li>Clear credit to MilkDrop, Winamp-era context, and preset authors.</li>
               </ul>
             </article>
             <article class="home-lineage__card">
-              <h3>What changed</h3>
+              <h3>What changes</h3>
               <ul class="home-list">
-                <li>The browser is the platform, so compatibility, permissions, and performance settings are explicit.</li>
-                <li>The homepage explains the product before you launch it.</li>
+                <li>The browser is the platform, so compatibility and performance controls are explicit.</li>
                 <li><code>/milkdrop/</code> is the dedicated place for audio setup, presets, and editing.</li>
               </ul>
             </article>
           </div>
         </section>
 
-        <section class="home-source" aria-labelledby="source-title">
-          <div class="section-heading">
-            <p class="eyebrow">Open source</p>
-            <h2 id="source-title">See how the visualizer works.</h2>
-            <p class="section-description">
-              The runtime, preset system, docs, and release history all live in the open.
-            </p>
-          </div>
-          <div class="home-source__grid">
-            <article class="home-source__card">
-              <h3>Read the code</h3>
-              <p>Inspect the visualizer engine, loader, preset system, and docs in the repo.</p>
-              <a
-                href="https://github.com/zz-plant/stims"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="cta-button primary"
-              >
-                Open GitHub
-              </a>
-            </article>
-            <article class="home-source__card">
-              <h3>Launch the product</h3>
-              <p>Go straight to <code>/milkdrop/</code> for audio setup, presets, compatibility checks, and editing.</p>
-              <a href="/milkdrop/" class="cta-button ghost">Open the visualizer</a>
-            </article>
-          </div>
-        </section>
       </main>
 
       <footer class="home-footer" id="site-footer">
@@ -293,9 +250,16 @@
           <span aria-hidden="true">·</span>
           <a href="#presets" class="text-link">Presets</a>
           <span aria-hidden="true">·</span>
-          <a href="#lineage" class="text-link">Lineage</a>
-          <span aria-hidden="true">·</span>
           <a href="/milkdrop/" class="text-link">Launch</a>
+          <span aria-hidden="true">·</span>
+          <a
+            href="https://github.com/zz-plant/stims"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-link"
+          >
+            GitHub
+          </a>
         </p>
       </footer>
     </div>


### PR DESCRIPTION
### Motivation
- Simplify the homepage copy to make the primary launch path clearer and reduce marketing fluff. 
- Ensure the homepage directs users to the canonical `/milkdrop/` launch route and aligns with product docs that keep deeper controls on that route.

### Description
- Shortened and reworded hero headline and tagline to focus on quick demo launch and point to `/milkdrop/` for advanced controls. 
- Tightened the hero support summary and checklist, adjusted the aside to a concise "Launch first. Tweak later." message, and shortened the "After launch" cards. 
- Condensed the lineage section, removed the “Open source” section from the homepage, and updated footer links to include GitHub. 
- All changes are contained in `index.html` (content-only edits).

### Testing
- Ran `bun run check` (format/lint/typecheck + full test suite) which completed but the full suite surfaced an existing unrelated failure in `tests/system-controls-tv-mode.test.ts`. 
- Ran targeted tests with `bun run test tests/app-shell.test.js tests/init-milkdrop-showcase.test.ts` and they passed (4 tests, 0 failures). 
- Docs: `None`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be459a58548332967508ee599a3c8b)