### PR TITLE
Fix periodic tex3D atlas wrapping for feedback sampling

### DIFF
--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -18,6 +18,10 @@ import {
   WebGLRenderTarget,
 } from 'three';
 import { disposeMaterial } from '../utils/three-dispose';
+import {
+  AUX_TEXTURE_ATLAS_GRID_SIZE,
+  AUX_TEXTURE_ATLAS_SLICE_COUNT,
+} from './feedback-volume-sampling.ts';
 import type {
   FeedbackBackendProfile,
   MilkdropBackendBehavior,
@@ -42,10 +46,6 @@ const MILKDROP_TEXTURE_FILES = {
   pattern: 'circuit_board_pattern.png',
   fractal: 'crystal_fractal.png',
 } as const;
-const AUX_TEXTURE_ATLAS_GRID_SIZE = 8;
-const AUX_TEXTURE_ATLAS_SLICE_COUNT =
-  AUX_TEXTURE_ATLAS_GRID_SIZE * AUX_TEXTURE_ATLAS_GRID_SIZE;
-
 function resolveTextureUrl(fileName: string) {
   const baseUrl =
     typeof import.meta.env.BASE_URL === 'string'
@@ -376,13 +376,11 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
             return sampleAuxTexture2d(source, wrappedUv);
           }
           float sliceCount = ${AUX_TEXTURE_ATLAS_SLICE_COUNT.toFixed(1)};
-          bool sliceInRange = sliceZ >= 0.0 && sliceZ <= 1.0;
-          float wrappedSliceZ = sliceInRange ? sliceZ : fract(sliceZ);
-          // Keep the original 0..1 mapping for in-range phases, but let wrapped cycles span the
-          // full atlas count so the last segment blends the final slice back to slice 0.
-          float sliceScale = sliceInRange ? (sliceCount - 1.0) : sliceCount;
-          float scaledSlice = wrappedSliceZ * sliceScale;
-          float sliceIndexA = floor(scaledSlice);
+          // Keep tex3D phases fully periodic so modulo-equivalent values stay aligned while the
+          // last atlas segment blends the final slice back to slice 0.
+          float wrappedSliceZ = fract(sliceZ);
+          float scaledSlice = wrappedSliceZ * sliceCount;
+          float sliceIndexA = mod(floor(scaledSlice), sliceCount);
           float sliceIndexB = mod(sliceIndexA + 1.0, sliceCount);
           float sliceBlend = fract(scaledSlice);
           vec4 sliceA = sampleAuxTexture2d(source, atlasSliceUv(wrappedUv, sliceIndexA));

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -17,6 +17,10 @@ import {
 // @ts-expect-error - 'three/tsl' requires moduleResolution: "bundler" or "nodenext", but project uses "node".
 import { NodeMaterial, RenderTarget, TSL } from 'three/webgpu';
 import { disposeMaterial } from '../utils/three-dispose';
+import {
+  AUX_TEXTURE_ATLAS_GRID_SIZE,
+  AUX_TEXTURE_ATLAS_SLICE_COUNT,
+} from './feedback-volume-sampling.ts';
 import { WEBGPU_MILKDROP_BACKEND_BEHAVIOR } from './renderer-adapter.ts';
 import type {
   MilkdropFeedbackCompositeState,
@@ -62,10 +66,6 @@ const MILKDROP_TEXTURE_FILES = {
   pattern: 'circuit_board_pattern.png',
   fractal: 'crystal_fractal.png',
 } as const;
-const AUX_TEXTURE_ATLAS_GRID_SIZE = 8;
-const AUX_TEXTURE_ATLAS_SLICE_COUNT =
-  AUX_TEXTURE_ATLAS_GRID_SIZE * AUX_TEXTURE_ATLAS_GRID_SIZE;
-
 type FeedbackRendererLike = {
   render: (scene: Scene, camera: Camera) => void;
   setRenderTarget: (target: RenderTarget | null) => void;
@@ -226,15 +226,13 @@ function createSampleAuxTextureNode(
     ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
       const wrappedUv = fract(sampleUv);
       const sliceCount = float(AUX_TEXTURE_ATLAS_SLICE_COUNT);
-      const sliceInRange = sliceZ
-        .greaterThanEqual(0)
-        .and(sliceZ.lessThanEqual(1));
-      const wrappedSliceZ = select(sliceInRange, sliceZ, fract(sliceZ));
-      // Keep the original 0..1 mapping for in-range phases, but let wrapped cycles span the
-      // full atlas count so the last segment blends the final slice back to slice 0.
-      const sliceScale = select(sliceInRange, sliceCount.sub(1), sliceCount);
-      const scaledSlice = wrappedSliceZ.mul(sliceScale);
-      const sliceIndexA = floor(scaledSlice);
+      // Keep tex3D phases fully periodic so modulo-equivalent values stay aligned while the
+      // last atlas segment blends the final slice back to slice 0.
+      const wrappedSliceZ = fract(sliceZ);
+      const scaledSlice = wrappedSliceZ.mul(sliceCount);
+      const sliceIndexA = fract(floor(scaledSlice).div(sliceCount)).mul(
+        sliceCount,
+      );
       const sliceIndexB = fract(sliceIndexA.add(1).div(sliceCount)).mul(
         sliceCount,
       );

--- a/assets/js/milkdrop/feedback-volume-sampling.ts
+++ b/assets/js/milkdrop/feedback-volume-sampling.ts
@@ -1,0 +1,23 @@
+export const AUX_TEXTURE_ATLAS_GRID_SIZE = 8;
+export const AUX_TEXTURE_ATLAS_SLICE_COUNT =
+  AUX_TEXTURE_ATLAS_GRID_SIZE * AUX_TEXTURE_ATLAS_GRID_SIZE;
+
+export function wrapTex3DSlicePhase(sliceZ: number) {
+  return ((sliceZ % 1) + 1) % 1;
+}
+
+export function getWrappedAtlasSliceSample(
+  sliceZ: number,
+  sliceCount = AUX_TEXTURE_ATLAS_SLICE_COUNT,
+) {
+  const wrappedSliceZ = wrapTex3DSlicePhase(sliceZ);
+  const scaledSlice = wrappedSliceZ * sliceCount;
+  const sliceIndexA = Math.floor(scaledSlice) % sliceCount;
+  return {
+    wrappedSliceZ,
+    scaledSlice,
+    sliceIndexA,
+    sliceIndexB: (sliceIndexA + 1) % sliceCount,
+    sliceBlend: scaledSlice - Math.floor(scaledSlice),
+  };
+}

--- a/tests/milkdrop-feedback-volume-sampling.test.ts
+++ b/tests/milkdrop-feedback-volume-sampling.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AUX_TEXTURE_ATLAS_SLICE_COUNT,
+  getWrappedAtlasSliceSample,
+} from '../assets/js/milkdrop/feedback-volume-sampling.ts';
+
+describe('milkdrop feedback volume atlas sampling', () => {
+  test('keeps modulo-equivalent tex3D phases on the same atlas position', () => {
+    const inRange = getWrappedAtlasSliceSample(0.2);
+    const wrapped = getWrappedAtlasSliceSample(1.2);
+    const negativeWrapped = getWrappedAtlasSliceSample(-0.8);
+
+    expect(inRange.scaledSlice).toBeCloseTo(12.8, 6);
+    expect(wrapped.scaledSlice).toBeCloseTo(inRange.scaledSlice, 6);
+    expect(negativeWrapped.scaledSlice).toBeCloseTo(inRange.scaledSlice, 6);
+    expect(wrapped.sliceIndexA).toBe(inRange.sliceIndexA);
+    expect(wrapped.sliceIndexB).toBe(inRange.sliceIndexB);
+    expect(wrapped.sliceBlend).toBeCloseTo(inRange.sliceBlend, 6);
+  });
+
+  test('blends the last atlas slice back to slice zero before the phase wraps', () => {
+    const nearWrap = getWrappedAtlasSliceSample(0.99);
+    const wrapped = getWrappedAtlasSliceSample(1);
+
+    expect(nearWrap.sliceIndexA).toBe(AUX_TEXTURE_ATLAS_SLICE_COUNT - 1);
+    expect(nearWrap.sliceIndexB).toBe(0);
+    expect(nearWrap.sliceBlend).toBeGreaterThan(0);
+    expect(wrapped.scaledSlice).toBe(0);
+    expect(wrapped.sliceIndexA).toBe(0);
+    expect(wrapped.sliceIndexB).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix a regression where out-of-range `tex3D` slice phases (e.g. `time / 10.0` > 1.0) switched atlas scaling and caused modulo-equivalent phases to map to different atlas positions, producing a visible seam on wrap.
- Keep sampling semantics consistent between the WebGL/shared shader path and the WebGPU TSL path so wrapped phases remain periodic across backends.

### Description
- Add a small shared helper module `assets/js/milkdrop/feedback-volume-sampling.ts` that centralizes atlas grid constants and provides helper utilities for wrapping and sampling slice phases. 
- Update `assets/js/milkdrop/feedback-manager-shared.ts` to wrap `sliceZ` with `fract(sliceZ)`, scale by the full `sliceCount`, and wrap atlas indices with `mod(floor(...), sliceCount)` so modulo-equivalent phases stay aligned while the last segment still blends the final slice back to slice 0. 
- Mirror the same periodic wrapping logic in `assets/js/milkdrop/feedback-manager-webgpu.ts` TSL node graph so both backends preserve periodic sampling semantics. 
- Add focused regression tests in `tests/milkdrop-feedback-volume-sampling.test.ts` that assert modulo-equivalent phases map to identical atlas positions and that the last atlas slice blends back to slice 0 before wrap. 

### Testing
- Ran `bun run test tests/milkdrop-feedback-volume-sampling.test.ts` and the new regression tests passed. 
- Ran `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-shader-sampler-aliases.test.ts` and all targeted MilkDrop tests passed. 
- Ran the full quality gate with `bun run check` and the typecheck, Biome checks, and test suite completed successfully. 

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be469fb75c83328083203f7706b7c1)