### PR TITLE
Improve MilkDrop mobile touch guidance and gesture responses

### DIFF
--- a/assets/data/toys.json
+++ b/assets/data/toys.json
@@ -11,11 +11,16 @@
     "moods": ["immersive", "psychedelic"],
     "tags": ["feedback", "warp", "visualizer", "retro", "presets", "editor"],
     "controls": [
-      "Preset browser + favorites/recent",
-      "Blend duration + autoplay/random",
-      "Live source editor + diagnostics",
-      "Import/export preset files",
-      "Quality presets"
+      "Browse, favorite, and revisit standout presets",
+      "Blend between looks with autoplay or random runs",
+      "Edit preset code and see the scene respond live",
+      "Import or export preset files",
+      "Tune quality for smoother or richer playback"
+    ],
+    "touchHints": [
+      "Drag to bend the scene and shove the feedback trail.",
+      "Pinch to swell or compress the depth and intensity.",
+      "Rotate with two fingers to twist the whole image."
     ],
     "firstRunHint": "Start with the curated preset browser, then toggle autoplay to hear smooth blend transitions.",
     "starterPreset": {

--- a/assets/js/bootstrap/toy-page.ts
+++ b/assets/js/bootstrap/toy-page.ts
@@ -36,6 +36,45 @@ const resolveToyTitle = (slug: string | null, toys: Toy[]) => {
   return toys.find((toy) => toy.slug === slug)?.title ?? slug;
 };
 
+const DEFAULT_TOUCH_HINTS = [
+  'Drag to bend the scene.',
+  'Pinch to swell or compress the depth.',
+  'Rotate with two fingers to twist the image.',
+];
+
+function supportsTouchLikeInput() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (typeof window.matchMedia === 'function') {
+    if (
+      window.matchMedia('(pointer: coarse)').matches ||
+      window.matchMedia('(hover: none)').matches
+    ) {
+      return true;
+    }
+  }
+
+  return navigator.maxTouchPoints > 0;
+}
+
+function normalizeHints(hints: string[] | undefined, limit = 3) {
+  return (hints ?? [])
+    .map((hint) => hint.trim())
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function resolveTouchHints(toyMeta: ToyWithControls | null) {
+  const explicitHints = normalizeHints(toyMeta?.touchHints);
+  if (explicitHints.length > 0) {
+    return explicitHints;
+  }
+
+  return DEFAULT_TOUCH_HINTS;
+}
+
 function buildAudioInitState(result: CapabilityPreflightResult | null) {
   if (isSmartTvDevice()) {
     return {
@@ -179,9 +218,7 @@ export function bootToyPage({
         : []),
     ];
     const firstRunHint = toyMeta?.firstRunHint ?? starterTips[0];
-    const touchHints = (toyMeta?.touchHints ?? starterTips).filter((tip) =>
-      /touch|drag|pinch|swipe|gesture|tap|rotate/i.test(tip),
-    );
+    const touchHints = resolveTouchHints(toyMeta ?? null);
     const desktopHints = (
       toyMeta?.desktopHints ?? [
         'Move to steer the scene.',
@@ -229,7 +266,10 @@ export function bootToyPage({
       starterPresetId,
       starterPresetLabel,
       wowControl: toyMeta?.wowControl,
-      recommendedCapability: toyMeta?.recommendedCapability,
+      recommendedCapability:
+        supportsTouchLikeInput() && !isSmartTvDevice() && touchHints.length > 0
+          ? 'touch'
+          : toyMeta?.recommendedCapability,
       initialShortcut:
         requestedAudioSource === 'tab' || requestedAudioSource === 'youtube'
           ? requestedAudioSource

--- a/assets/js/data/toy-manifest.ts
+++ b/assets/js/data/toy-manifest.ts
@@ -24,11 +24,16 @@ export const toyManifest: ToyManifest = [
       "editor"
     ],
     "controls": [
-      "Preset browser + favorites/recent",
-      "Blend duration + autoplay/random",
-      "Live source editor + diagnostics",
-      "Import/export preset files",
-      "Quality presets"
+      "Browse, favorite, and revisit standout presets",
+      "Blend between looks with autoplay or random runs",
+      "Edit preset code and see the scene respond live",
+      "Import or export preset files",
+      "Tune quality for smoother or richer playback"
+    ],
+    "touchHints": [
+      "Drag to bend the scene and shove the feedback trail.",
+      "Pinch to swell or compress the depth and intensity.",
+      "Rotate with two fingers to twist the whole image."
     ],
     "firstRunHint": "Start with the curated preset browser, then toggle autoplay to hear smooth blend transitions.",
     "starterPreset": {

--- a/assets/js/data/toy-schema.ts
+++ b/assets/js/data/toy-schema.ts
@@ -12,6 +12,7 @@ const recommendedCapabilitySchema = z.enum([
   'microphone',
   'demoAudio',
   'motion',
+  'touch',
 ]);
 
 const starterPresetSchema = z.object({

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -36,6 +36,8 @@ import type {
   MilkdropCatalogEntry,
   MilkdropCompiledPreset,
   MilkdropFrameState,
+  MilkdropGpuGeometryHints,
+  MilkdropPostVisual,
   MilkdropPresetSource,
   MilkdropRuntimeSignals,
 } from './types';
@@ -128,6 +130,267 @@ shape_0_per_frame1=rad = 0.14 + beat_pulse * 0.08
 function sanitizeRuntimeSignals(signals: MilkdropRuntimeSignals) {
   const { frequencyData: _frequencyData, ...rest } = signals;
   return rest;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+function normalizeSceneTranslation(value: number) {
+  return clamp(value, -0.22, 0.22);
+}
+
+function transformScenePositions(
+  positions: number[],
+  {
+    offsetX,
+    offsetY,
+    rotation,
+    scale,
+  }: { offsetX: number; offsetY: number; rotation: number; scale: number },
+) {
+  if (
+    positions.length === 0 ||
+    (Math.abs(offsetX) < 0.0001 &&
+      Math.abs(offsetY) < 0.0001 &&
+      Math.abs(rotation) < 0.0001 &&
+      Math.abs(scale - 1) < 0.0001)
+  ) {
+    return positions;
+  }
+
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  const transformed = [...positions];
+
+  for (let index = 0; index < transformed.length; index += 3) {
+    const x = transformed[index] ?? 0;
+    const y = transformed[index + 1] ?? 0;
+    const scaledX = x * scale;
+    const scaledY = y * scale;
+    transformed[index] = scaledX * cos - scaledY * sin + offsetX;
+    transformed[index + 1] = scaledX * sin + scaledY * cos + offsetY;
+  }
+
+  return transformed;
+}
+
+function nudgeCenter(value: number, offset: number) {
+  return clamp(value + offset * 0.5, 0, 1);
+}
+
+function enhancePostEffects(
+  post: MilkdropPostVisual,
+  {
+    offsetX,
+    offsetY,
+    rotation,
+    pinchDelta,
+    dragBoost,
+  }: {
+    offsetX: number;
+    offsetY: number;
+    rotation: number;
+    pinchDelta: number;
+    dragBoost: number;
+  },
+): MilkdropPostVisual {
+  return {
+    ...post,
+    warp: clamp(
+      post.warp + dragBoost * 0.28 + Math.abs(pinchDelta) * 0.12,
+      0,
+      1,
+    ),
+    videoEchoZoom: clamp(post.videoEchoZoom + pinchDelta * 0.12, 0.85, 1.35),
+    shaderControls: {
+      ...post.shaderControls,
+      offsetX: clamp(post.shaderControls.offsetX + offsetX * 0.5, -0.3, 0.3),
+      offsetY: clamp(post.shaderControls.offsetY + offsetY * 0.5, -0.3, 0.3),
+      rotation: clamp(
+        post.shaderControls.rotation + rotation * 0.85,
+        -1.6,
+        1.6,
+      ),
+      zoom: clamp(post.shaderControls.zoom + pinchDelta * 0.3, 0.72, 1.45),
+      warpScale: clamp(
+        post.shaderControls.warpScale + pinchDelta * 0.24 + dragBoost * 0.16,
+        0,
+        2,
+      ),
+    },
+  };
+}
+
+function enhanceGpuGeometry(
+  gpuGeometry: MilkdropGpuGeometryHints,
+  {
+    offsetX,
+    offsetY,
+    rotation,
+    scale,
+    pinchDelta,
+  }: {
+    offsetX: number;
+    offsetY: number;
+    rotation: number;
+    scale: number;
+    pinchDelta: number;
+  },
+): MilkdropGpuGeometryHints {
+  return {
+    ...gpuGeometry,
+    mainWave: gpuGeometry.mainWave
+      ? {
+          ...gpuGeometry.mainWave,
+          centerX: nudgeCenter(gpuGeometry.mainWave.centerX, offsetX),
+          centerY: nudgeCenter(gpuGeometry.mainWave.centerY, -offsetY),
+          scale: clamp(gpuGeometry.mainWave.scale * scale, 0.45, 2.4),
+        }
+      : null,
+    trailWaves: gpuGeometry.trailWaves.map((wave) => ({
+      ...wave,
+      centerX: nudgeCenter(wave.centerX, offsetX),
+      centerY: nudgeCenter(wave.centerY, -offsetY),
+      scale: clamp(wave.scale * scale, 0.45, 2.4),
+    })),
+    customWaves: gpuGeometry.customWaves.map((wave) => ({
+      ...wave,
+      centerX: nudgeCenter(wave.centerX, offsetX),
+      centerY: nudgeCenter(wave.centerY, -offsetY),
+      scaling: clamp(wave.scaling * scale, 0.45, 2.4),
+    })),
+    meshField: gpuGeometry.meshField
+      ? {
+          ...gpuGeometry.meshField,
+          rotation: gpuGeometry.meshField.rotation + rotation * 0.9,
+          zoom: clamp(gpuGeometry.meshField.zoom - pinchDelta * 0.2, 0.5, 2.6),
+          warp: clamp(
+            gpuGeometry.meshField.warp + Math.abs(pinchDelta) * 0.1,
+            0,
+            1.4,
+          ),
+        }
+      : null,
+    motionVectorField: gpuGeometry.motionVectorField
+      ? {
+          ...gpuGeometry.motionVectorField,
+          rotation: gpuGeometry.motionVectorField.rotation + rotation * 0.9,
+          zoom: clamp(
+            gpuGeometry.motionVectorField.zoom - pinchDelta * 0.2,
+            0.5,
+            2.6,
+          ),
+          warp: clamp(
+            gpuGeometry.motionVectorField.warp + Math.abs(pinchDelta) * 0.1,
+            0,
+            1.4,
+          ),
+        }
+      : null,
+  };
+}
+
+export function applyMilkdropInteractionResponse(
+  frameState: MilkdropFrameState,
+  input: UnifiedInputState | null,
+): MilkdropFrameState {
+  if (!input) {
+    return frameState;
+  }
+
+  const gesture = input.gesture;
+  const dragBoost = clamp(input.performance.dragIntensity, 0, 1);
+  const pinchDelta = clamp((gesture?.scale ?? 1) - 1, -0.45, 0.7);
+  const rotation = clamp(gesture?.rotation ?? 0, -Math.PI / 2, Math.PI / 2);
+  const offsetX = normalizeSceneTranslation(
+    input.dragDelta.x * 0.9 + (gesture?.translation.x ?? 0) * 0.45,
+  );
+  const offsetY = normalizeSceneTranslation(
+    input.dragDelta.y * 0.9 + (gesture?.translation.y ?? 0) * 0.45,
+  );
+  const scale = clamp(1 + pinchDelta * 0.45, 0.7, 1.55);
+
+  if (
+    dragBoost < 0.001 &&
+    Math.abs(pinchDelta) < 0.001 &&
+    Math.abs(rotation) < 0.001 &&
+    Math.abs(offsetX) < 0.001 &&
+    Math.abs(offsetY) < 0.001
+  ) {
+    return frameState;
+  }
+
+  return {
+    ...frameState,
+    mainWave: {
+      ...frameState.mainWave,
+      positions: transformScenePositions(frameState.mainWave.positions, {
+        offsetX,
+        offsetY,
+        rotation,
+        scale,
+      }),
+      thickness: clamp(frameState.mainWave.thickness + dragBoost * 0.8, 1, 12),
+    },
+    customWaves: frameState.customWaves.map((wave) => ({
+      ...wave,
+      positions: transformScenePositions(wave.positions, {
+        offsetX,
+        offsetY,
+        rotation,
+        scale,
+      }),
+    })),
+    trails: frameState.trails.map((trail) => ({
+      ...trail,
+      positions: transformScenePositions(trail.positions, {
+        offsetX,
+        offsetY,
+        rotation,
+        scale,
+      }),
+    })),
+    mesh: {
+      ...frameState.mesh,
+      positions: transformScenePositions(frameState.mesh.positions, {
+        offsetX,
+        offsetY,
+        rotation,
+        scale,
+      }),
+      alpha: clamp(frameState.mesh.alpha + Math.abs(pinchDelta) * 0.12, 0, 1),
+    },
+    shapes: frameState.shapes.map((shape) => ({
+      ...shape,
+      x: nudgeCenter(shape.x, offsetX),
+      y: nudgeCenter(shape.y, -offsetY),
+      radius: clamp(shape.radius * scale, 0.02, 0.6),
+      rotation: shape.rotation + rotation,
+    })),
+    motionVectors: frameState.motionVectors.map((vector) => ({
+      ...vector,
+      positions: transformScenePositions(vector.positions, {
+        offsetX,
+        offsetY,
+        rotation,
+        scale,
+      }),
+    })),
+    post: enhancePostEffects(frameState.post, {
+      offsetX,
+      offsetY,
+      rotation,
+      pinchDelta,
+      dragBoost,
+    }),
+    gpuGeometry: enhanceGpuGeometry(frameState.gpuGeometry, {
+      offsetX,
+      offsetY,
+      rotation,
+      scale,
+      pinchDelta,
+    }),
+  };
 }
 
 export function getMilkdropDetailScale({
@@ -1230,7 +1493,10 @@ export function createMilkdropExperience({
         void selectRandomPreset();
       }
 
-      currentFrameState = vm.step(signals);
+      currentFrameState = applyMilkdropInteractionResponse(
+        vm.step(signals),
+        frame.input,
+      );
       updateAgentDebugSnapshot();
       const canBlendCurrentFrame =
         estimateFrameBlendWorkload(currentFrameState) < 900;

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -29,6 +29,33 @@ export interface AudioControlsOptions {
   initialShortcut?: 'tab' | 'youtube';
 }
 
+const DEFAULT_TOUCH_GESTURE_HINTS = [
+  'Drag to bend the scene.',
+  'Pinch to swell or compress the depth.',
+  'Rotate with two fingers to twist the image.',
+];
+
+function normalizeHints(hints: string[] | undefined, limit = 3) {
+  return (hints ?? [])
+    .map((hint) => hint.trim())
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+export function resolveTouchGestureHints(options: {
+  touchHints?: string[];
+  gestureHints?: string[];
+}) {
+  const explicitHints = normalizeHints(
+    options.touchHints ?? options.gestureHints,
+  );
+  if (explicitHints.length > 0) {
+    return explicitHints;
+  }
+
+  return DEFAULT_TOUCH_GESTURE_HINTS;
+}
+
 export function buildTryThisFirstRecommendation({
   recommendedCapability,
   starterPresetLabel,
@@ -46,6 +73,10 @@ export function buildTryThisFirstRecommendation({
     steps.push('Start with live mic for the most responsive visuals.');
   } else if (recommendedCapability === 'demoAudio') {
     steps.push('Start with demo audio for the quickest start.');
+  } else if (recommendedCapability === 'touch') {
+    steps.push(
+      'Start audio, then use touch gestures to bend, scale, and twist the scene.',
+    );
   }
 
   if (starterPresetLabel?.trim()) {
@@ -105,14 +136,7 @@ export function initAudioControls(
       window.matchMedia('(pointer: coarse)').matches) ||
     navigator.maxTouchPoints > 0;
   const firstRunHint = options.firstRunHint?.trim();
-  const touchHints = (
-    options.touchHints ??
-    options.gestureHints ??
-    options.starterTips ??
-    []
-  )
-    .filter((tip) => /touch|drag|pinch|swipe|gesture|tap|rotate/i.test(tip))
-    .slice(0, 2);
+  const touchHints = resolveTouchGestureHints(options);
   const desktopHints = (options.desktopHints ?? [])
     .map((tip) => tip.trim())
     .filter(Boolean)
@@ -682,7 +706,7 @@ function renderPostStartGuidance({
         <div class="control-panel__first-steps-header">
           <span class="control-panel__label">Desktop controls</span>
         </div>
-        <p class="control-panel__microcopy">On desktop, try these controls:</p>
+        <p class="control-panel__microcopy">On desktop, try these controls to steer the picture quickly:</p>
         <ul class="control-panel__tips control-panel__tips--compact">
           ${desktopHints.map((tip) => `<li>${tip}</li>`).join('')}
         </ul>
@@ -698,7 +722,7 @@ function renderPostStartGuidance({
           <span class="control-panel__label">Touch gestures</span>
           <button type="button" class="control-panel__dismiss" data-dismiss-gesture-hints>Got it</button>
         </div>
-        <p class="control-panel__microcopy">Once audio starts, try these quick moves:</p>
+        <p class="control-panel__microcopy">Once audio starts, use these gestures to reshape the scene fast:</p>
         <ul class="control-panel__tips control-panel__tips--compact">
           ${touchHints.map((tip) => `<li>${tip}</li>`).join('')}
         </ul>

--- a/public/toys.json
+++ b/public/toys.json
@@ -21,11 +21,16 @@
       "editor"
     ],
     "controls": [
-      "Preset browser + favorites/recent",
-      "Blend duration + autoplay/random",
-      "Live source editor + diagnostics",
-      "Import/export preset files",
-      "Quality presets"
+      "Browse, favorite, and revisit standout presets",
+      "Blend between looks with autoplay or random runs",
+      "Edit preset code and see the scene respond live",
+      "Import or export preset files",
+      "Tune quality for smoother or richer playback"
+    ],
+    "touchHints": [
+      "Drag to bend the scene and shove the feedback trail.",
+      "Pinch to swell or compress the depth and intensity.",
+      "Rotate with two fingers to twist the whole image."
     ],
     "firstRunHint": "Start with the curated preset browser, then toggle autoplay to hear smooth blend transitions.",
     "starterPreset": {

--- a/tests/agent-integration.test.ts
+++ b/tests/agent-integration.test.ts
@@ -32,6 +32,25 @@ async function waitForServer(url: string, timeoutMs = 20000) {
   throw new Error(`Timed out waiting for dev server at ${url}`);
 }
 
+async function createMobilePage() {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 430, height: 932 },
+    isMobile: true,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  return {
+    browser,
+    context,
+    page,
+    close: async () => {
+      await context.close();
+      await browser.close();
+    },
+  };
+}
+
 beforeAll(async () => {
   if (!hasChromium) return;
 
@@ -92,6 +111,83 @@ integrationTest(
     });
 
     expect(result.success).toBe(false);
+  },
+  { timeout: 45000 },
+);
+
+integrationTest(
+  'milkdrop shows touch onboarding after audio starts on a coarse-pointer viewport',
+  async () => {
+    const mobile = await createMobilePage();
+
+    try {
+      await mobile.page.goto(`http://127.0.0.1:${TEST_PORT}/?toy=milkdrop`);
+      await mobile.page.locator('#use-demo-audio').click();
+      await mobile.page.waitForFunction(
+        () => document.body.dataset.audioActive === 'true',
+      );
+
+      await mobile.page.waitForSelector('[data-gesture-hints]:not([hidden])');
+      const gestureText =
+        (await mobile.page.textContent('[data-gesture-hints]')) ?? '';
+      expect(gestureText).toContain('Touch gestures');
+      expect(gestureText).toContain(
+        'Drag to bend the scene and shove the feedback trail.',
+      );
+      expect(gestureText).toContain(
+        'Pinch to swell or compress the depth and intensity.',
+      );
+      expect(gestureText).not.toContain('Press Q/E');
+      expect(gestureText).not.toContain('Desktop controls');
+    } finally {
+      await mobile.close();
+    }
+  },
+  { timeout: 45000 },
+);
+
+integrationTest(
+  'browser-backed audio controls use mobile fallback gestures without desktop shortcut copy',
+  async () => {
+    const mobile = await createMobilePage();
+
+    try {
+      await mobile.page.goto(`http://127.0.0.1:${TEST_PORT}/`);
+      await mobile.page.evaluate(async () => {
+        document.body.innerHTML = '<section id="audio-controls"></section>';
+        const moduleUrl = new URL(
+          '/assets/js/ui/audio-controls.ts',
+          window.location.origin,
+        ).href;
+        const { initAudioControls } = await import(
+          /* @vite-ignore */ moduleUrl
+        );
+        const container = document.querySelector('#audio-controls');
+        if (!(container instanceof HTMLElement)) {
+          throw new Error('Audio controls container missing.');
+        }
+        initAudioControls(container, {
+          onRequestMicrophone: async () => {},
+          onRequestDemoAudio: async () => {},
+          starterTips: ['Press Q/E for mode changes', 'Import preset files'],
+          desktopHints: [
+            'Move to steer the scene.',
+            'Press Space for an accent burst.',
+          ],
+        });
+      });
+
+      await mobile.page.locator('#use-demo-audio').click();
+      await mobile.page.waitForSelector('[data-gesture-hints]:not([hidden])');
+      const gestureText =
+        (await mobile.page.textContent('[data-gesture-hints]')) ?? '';
+      expect(gestureText).toContain('Drag to bend the scene.');
+      expect(gestureText).toContain('Pinch to swell or compress the depth.');
+      expect(gestureText).not.toContain('Press Q/E');
+      expect(gestureText).not.toContain('Press Space');
+    } finally {
+      await mobile.close();
+    }
   },
   { timeout: 45000 },
 );

--- a/tests/audio-controls.test.ts
+++ b/tests/audio-controls.test.ts
@@ -8,6 +8,7 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 let initAudioControls: typeof import('../assets/js/ui/audio-controls.ts').initAudioControls;
 let buildTryThisFirstRecommendation: typeof import('../assets/js/ui/audio-controls.ts').buildTryThisFirstRecommendation;
+let resolveTouchGestureHints: typeof import('../assets/js/ui/audio-controls.ts').resolveTouchGestureHints;
 
 const baselineNavigator = globalThis.navigator;
 const baselineNavigatorPermissions = baselineNavigator.permissions;
@@ -68,6 +69,7 @@ describe('audio controls primary emphasis', () => {
     initAudioControls = audioControlsModule.initAudioControls;
     buildTryThisFirstRecommendation =
       audioControlsModule.buildTryThisFirstRecommendation;
+    resolveTouchGestureHints = audioControlsModule.resolveTouchGestureHints;
   });
 
   test('highlights demo row when preferDemoAudio is true', () => {
@@ -240,6 +242,32 @@ describe('audio controls primary emphasis', () => {
     expect(hintPanel.textContent).toContain('Pinch/rotate gestures');
   });
 
+  test('falls back to shared touch gestures instead of filtering starter tips', async () => {
+    const container = document.createElement('section');
+
+    initAudioControls(container, {
+      onRequestMicrophone: async () => {},
+      onRequestDemoAudio: async () => {},
+      starterTips: ['Press Q/E for mode changes', 'Import preset files'],
+    });
+
+    const demoButton = container.querySelector(
+      '#use-demo-audio',
+    ) as HTMLButtonElement;
+    demoButton.click();
+    await flush();
+
+    const hintPanel = container.querySelector(
+      '[data-gesture-hints]',
+    ) as HTMLElement;
+    expect(hintPanel.hidden).toBe(false);
+    expect(hintPanel.textContent).toContain('Drag to bend the scene.');
+    expect(hintPanel.textContent).toContain(
+      'Pinch to swell or compress the depth.',
+    );
+    expect(hintPanel.textContent).not.toContain('Press Q/E');
+  });
+
   test('shows desktop control legend by default on laptop-like devices', () => {
     window.matchMedia = ((query: string) =>
       ({
@@ -396,6 +424,31 @@ describe('audio controls primary emphasis', () => {
       detail:
         'Try Aurora starter once the toy opens. Then explore Q/E mood cycling.',
     });
+  });
+
+  test('builds touch-first recommendation when mobile guidance is preferred', () => {
+    expect(
+      buildTryThisFirstRecommendation({
+        recommendedCapability: 'touch',
+        firstRunHint: 'Open the preset browser after the first gesture burst.',
+      }),
+    ).toEqual({
+      summary:
+        'Start audio, then use touch gestures to bend, scale, and twist the scene.',
+      detail: 'Open the preset browser after the first gesture burst.',
+    });
+  });
+
+  test('keeps explicit touch hints ahead of shared fallback hints', () => {
+    expect(
+      resolveTouchGestureHints({
+        touchHints: [
+          'Drag to bend the scene hard.',
+          'Rotate to twist the image.',
+        ],
+        gestureHints: ['Pinch to change scale'],
+      }),
+    ).toEqual(['Drag to bend the scene hard.', 'Rotate to twist the image.']);
   });
 
   test('keeps a single visible start-here prompt instead of stacked quick-start tips', () => {

--- a/tests/milkdrop-input-signals.test.ts
+++ b/tests/milkdrop-input-signals.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { buildMilkdropInputSignalOverrides } from '../assets/js/milkdrop/runtime.ts';
+import {
+  applyMilkdropInteractionResponse,
+  buildMilkdropInputSignalOverrides,
+} from '../assets/js/milkdrop/runtime.ts';
+import type { MilkdropFrameState } from '../assets/js/milkdrop/types.ts';
 import type { UnifiedInputState } from '../assets/js/utils/unified-input.ts';
 
 describe('milkdrop input signal overrides', () => {
@@ -119,5 +123,205 @@ describe('milkdrop input signal overrides', () => {
     expect(overrides).toBe(target);
     expect(overrides.inputSpeed).toBeCloseTo(0.5, 6);
     expect(overrides.input_speed).toBeCloseTo(0.5, 6);
+  });
+
+  test('maps drag, pinch, and rotation into visible frame adjustments', () => {
+    const input: UnifiedInputState = {
+      time: 100,
+      deltaMs: 16,
+      pointers: [],
+      pointerCount: 2,
+      centroid: { x: 0, y: 0 },
+      normalizedCentroid: { x: 0.2, y: -0.1 },
+      primary: null,
+      isPressed: true,
+      justPressed: false,
+      justReleased: false,
+      dragDelta: { x: 0.18, y: -0.12 },
+      source: 'pointer',
+      gesture: {
+        pointerCount: 2,
+        scale: 1.35,
+        rotation: Math.PI / 7,
+        translation: { x: 0.12, y: -0.08 },
+      },
+      mic: { level: 0.4, available: true },
+      performance: {
+        hoverActive: false,
+        hover: null,
+        wheelDelta: 0,
+        wheelAccum: 0,
+        dragIntensity: 0.42,
+        dragAngle: 0,
+        accentPulse: 0,
+        sourceFlags: {
+          pointer: true,
+          keyboard: false,
+          gamepad: false,
+          mouse: false,
+          touch: true,
+          pen: false,
+        },
+        actions: {
+          accent: 0,
+          modeNext: 0,
+          modePrevious: 0,
+          presetNext: 0,
+          presetPrevious: 0,
+          quickLook1: 0,
+          quickLook2: 0,
+          quickLook3: 0,
+          remix: 0,
+        },
+      },
+    };
+
+    const frameState = {
+      presetId: 'test-preset',
+      title: 'Test',
+      background: { r: 0, g: 0, b: 0 },
+      waveform: {
+        positions: [0, 0, 0, 0.2, 0.1, 0],
+        color: { r: 1, g: 1, b: 1 },
+        alpha: 1,
+        thickness: 1,
+        drawMode: 'line',
+        additive: false,
+        pointSize: 1,
+      },
+      mainWave: {
+        positions: [0, 0, 0, 0.2, 0.1, 0],
+        color: { r: 1, g: 1, b: 1 },
+        alpha: 1,
+        thickness: 1,
+        drawMode: 'line',
+        additive: false,
+        pointSize: 1,
+      },
+      customWaves: [],
+      trails: [],
+      mesh: {
+        positions: [-0.5, -0.5, 0, 0.5, 0.5, 0],
+        color: { r: 1, g: 1, b: 1 },
+        alpha: 0.2,
+      },
+      shapes: [
+        {
+          key: 'shape',
+          x: 0.5,
+          y: 0.5,
+          radius: 0.2,
+          sides: 6,
+          rotation: 0,
+          color: { r: 1, g: 1, b: 1 },
+          borderColor: { r: 1, g: 1, b: 1 },
+          additive: false,
+          thickOutline: false,
+        },
+      ],
+      borders: [],
+      motionVectors: [],
+      post: {
+        shaderEnabled: true,
+        textureWrap: false,
+        feedbackTexture: true,
+        outerBorderStyle: false,
+        innerBorderStyle: false,
+        shaderControls: {
+          zoom: 1,
+          warpScale: 0.3,
+          offsetX: 0,
+          offsetY: 0,
+          rotation: 0,
+          saturation: 1,
+          contrast: 1,
+          hueShift: 0,
+          brightenBoost: 0,
+          invertBoost: 0,
+          solarizeBoost: 0,
+          colorScale: { r: 1, g: 1, b: 1 },
+          tint: { r: 0, g: 0, b: 0 },
+          textureLayer: {
+            source: 'none',
+            mode: 'add',
+            sampleDimension: '2d',
+            amount: 0,
+            scaleX: 1,
+            scaleY: 1,
+            offsetX: 0,
+            offsetY: 0,
+          },
+          warpTexture: {
+            source: 'none',
+            sampleDimension: '2d',
+            amount: 0,
+            scaleX: 1,
+            scaleY: 1,
+            offsetX: 0,
+            offsetY: 0,
+          },
+        },
+        brighten: false,
+        darken: false,
+        solarize: false,
+        invert: false,
+        gammaAdj: 1,
+        videoEchoEnabled: true,
+        videoEchoAlpha: 0.2,
+        videoEchoZoom: 1,
+        videoEchoOrientation: 0,
+        warp: 0.1,
+      },
+      signals: {
+        time: 0,
+      },
+      variables: {},
+      compatibility: {
+        supported: true,
+        needsWebGLFallback: false,
+        warnings: [],
+        unsupportedFeatures: [],
+      },
+      gpuGeometry: {
+        mainWave: {
+          samples: [0, 0],
+          velocities: [0, 0],
+          mode: 0,
+          centerX: 0.5,
+          centerY: 0.5,
+          scale: 1,
+          mystery: 0,
+          time: 0,
+          beatPulse: 0,
+          trebleAtt: 0,
+          color: { r: 1, g: 1, b: 1 },
+          alpha: 1,
+          additive: false,
+          thickness: 1,
+        },
+        trailWaves: [],
+        customWaves: [],
+        meshField: {
+          density: 12,
+          zoom: 1,
+          zoomExponent: 1,
+          rotation: 0,
+          warp: 0.1,
+          warpAnimSpeed: 1,
+        },
+        motionVectorField: null,
+      },
+    } as unknown as MilkdropFrameState;
+
+    const adjusted = applyMilkdropInteractionResponse(frameState, input);
+
+    expect(adjusted.post.shaderControls.offsetX).toBeGreaterThan(0);
+    expect(adjusted.post.shaderControls.rotation).toBeGreaterThan(0);
+    expect(adjusted.post.videoEchoZoom).toBeGreaterThan(1);
+    expect(adjusted.mainWave.positions[0]).not.toBe(
+      frameState.mainWave.positions[0],
+    );
+    expect(adjusted.shapes[0]?.rotation).toBeGreaterThan(0);
+    expect(adjusted.gpuGeometry.meshField?.rotation).toBeGreaterThan(0);
   });
 });

--- a/tests/system-controls-tv-mode.test.ts
+++ b/tests/system-controls-tv-mode.test.ts
@@ -6,7 +6,9 @@ import {
   resetRenderPreferencesState,
 } from '../assets/js/core/render-preferences.ts';
 import { resetSettingsPanelState } from '../assets/js/core/settings-panel.ts';
-import { initSystemControls } from '../assets/js/ui/system-controls.ts';
+
+const freshImport = async <T>(path: string): Promise<T> =>
+  import(`${path}?t=${Date.now()}-${Math.random()}`) as Promise<T>;
 
 type NavSnapshot = {
   userAgent: string;
@@ -18,6 +20,7 @@ const TV_UA =
   'Mozilla/5.0 (SMART-TV; Linux; Tizen 7.0) AppleWebKit/537.36 (KHTML, like Gecko)';
 
 let snapshot: NavSnapshot;
+let initSystemControls: typeof import('../assets/js/ui/system-controls.ts').initSystemControls;
 
 const setUserAgent = (userAgent: string) => {
   Object.defineProperty(navigator, 'userAgent', {
@@ -27,7 +30,7 @@ const setUserAgent = (userAgent: string) => {
 };
 
 describe('system controls tv defaults', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     snapshot = {
       userAgent: navigator.userAgent,
     };
@@ -35,6 +38,10 @@ describe('system controls tv defaults', () => {
     document.body.innerHTML = '';
     resetRenderPreferencesState();
     resetSettingsPanelState({ removePanel: true });
+    const systemControlsModule = await freshImport<
+      typeof import('../assets/js/ui/system-controls.ts')
+    >('../assets/js/ui/system-controls.ts');
+    initSystemControls = systemControlsModule.initSystemControls;
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Motivation
- Make mobile/coarse-pointer onboarding explicit and outcome-focused so users see a short set of high-value touch gestures (drag, pinch, rotate) that map to visible scene changes. 
- Keep desktop guidance separate to avoid leaking keyboard/shortcut copy into mobile hint panels. 
- Ensure metadata, generated manifests, and runtime behavior stay in sync after updating the MilkDrop toy metadata. 

### Description
- Added `touchHints` for the `milkdrop` entry in `assets/data/toys.json` and allowed `recommendedCapability` to include `touch` by updating `assets/js/data/toy-schema.ts`. 
- Regenerated derived artifacts (`assets/js/data/toy-manifest.ts` and `public/toys.json`) to match the updated toy metadata. 
- Reworked `assets/js/bootstrap/toy-page.ts` to pick device-aware touch guidance via `supportsTouchLikeInput`, `resolveTouchHints`, and a small shared `DEFAULT_TOUCH_HINTS`; it also sets `recommendedCapability: 'touch'` for coarse-pointer mobile sessions where appropriate. 
- Updated `assets/js/ui/audio-controls.ts` to deterministically resolve touch gesture hints with `resolveTouchGestureHints`, surface concise outcome-oriented copy in the post-start panel, and add `touch` to the `recommendedCapability` options. 
- Added a shared interaction-response layer in `assets/js/milkdrop/runtime.ts` (`applyMilkdropInteractionResponse` and helpers) to map drag/pinch/rotate into visible frame adjustments (geometry transforms, shader/post tweaks, GPU geometry nudges), and applied it to VM output just before rendering. 
- Added and updated tests to cover touch onboarding and interaction mapping (unit and browser-backed integration tests), and fixed a test import pattern to use fresh imports for TV/system-controls coverage. 

### Testing
- Ran manifest regeneration with `bun run generate:toys` and confirmed the derived `assets/js/data/toy-manifest.ts` and `public/toys.json` were updated successfully. 
- Ran targeted tests: `bun run test tests/audio-controls.test.ts tests/milkdrop-input-signals.test.ts tests/agent-integration.test.ts` where unit tests passed and browser-backed agent integration cases were skipped when Chromium was unavailable. 
- Ran `bun run test tests/system-controls-tv-mode.test.ts tests/toy-page-bootstrap.test.ts` and the targeted integration/unit checks passed. 
- Ran the repo quality gate with `bun run check` (Biome, typecheck, and test sweep) and the checks completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec180b59c8332a4ad9e7c1b65f334)