### PR TITLE
Flatten launch panel mount points

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -419,6 +419,8 @@ body {
   pointer-events: auto;
 }
 
+.shell-panel[data-audio-controls]:empty,
+.shell-panel[data-settings-panel]:empty,
 .shell-panel > [data-audio-controls]:empty,
 .shell-panel > [data-settings-panel]:empty {
   display: none;
@@ -1059,6 +1061,8 @@ body {
 }
 
 .control-panel--inline,
+.shell-panel[data-audio-controls] > .control-panel,
+.shell-panel[data-settings-panel] > .control-panel,
 .shell-panel > [data-audio-controls] > .control-panel,
 .shell-panel > [data-settings-panel] > .control-panel {
   position: relative;
@@ -2010,6 +2014,8 @@ body {
   }
 
   .control-panel--inline,
+  .shell-panel[data-audio-controls] > .control-panel,
+  .shell-panel[data-settings-panel] > .control-panel,
   .shell-panel > [data-audio-controls] > .control-panel,
   .shell-panel > [data-settings-panel] > .control-panel {
     max-height: min(28svh, calc(100dvh - env(safe-area-inset-bottom) - 12px));

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -5760,12 +5760,15 @@ body[data-page="home"] .content {
   top: clamp(1rem, 2vw, 1.4rem);
 }
 
+.shell-header--launch .shell-panel[data-audio-controls] > .control-panel,
+.shell-header--launch .shell-panel[data-settings-panel] > .control-panel,
 .shell-header--launch .shell-panel > [data-audio-controls] > .control-panel,
 .shell-header--launch .shell-panel > [data-settings-panel] > .control-panel {
   max-height: none;
   overflow: visible;
 }
 
+.shell-header--launch .shell-panel[data-settings-panel] > .control-panel,
 .shell-header--launch .shell-panel > [data-settings-panel] > .control-panel {
   min-height: 100%;
 }

--- a/milkdrop/index.html
+++ b/milkdrop/index.html
@@ -134,12 +134,16 @@
         <section class="shell-header shell-header--launch">
           <div data-top-nav-container hidden></div>
           <div class="shell-panels">
-            <section class="shell-panel shell-panel--start" aria-label="Audio">
-              <div data-audio-controls></div>
-            </section>
-            <section class="shell-panel shell-panel--tune" aria-label="Tune">
-              <div data-settings-panel></div>
-            </section>
+            <section
+              class="shell-panel shell-panel--start"
+              aria-label="Audio"
+              data-audio-controls
+            ></section>
+            <section
+              class="shell-panel shell-panel--tune"
+              aria-label="Tune"
+              data-settings-panel
+            ></section>
           </div>
         </section>
       </main>


### PR DESCRIPTION
### Motivation
- The `/milkdrop/` launch workspace used an extra nested wrapper for the audio and tune panels which created a doubly-nested UI and made the layout feel awkward. 
- The change aims to simplify the DOM structure while preserving existing runtime mount semantics so the shell still wires audio and settings correctly.

### Description
- Mount points in `milkdrop/index.html` were flattened so the audio and tune shell columns now expose `data-audio-controls` and `data-settings-panel` directly on the visible `.shell-panel` sections. 
- `assets/css/base.css` was extended to recognize `.shell-panel[data-audio-controls]` and `.shell-panel[data-settings-panel]` variants for empty-state hiding and inline control-panel styling so both direct and legacy nested mount approaches behave the same. 
- `assets/css/index.css` launch-specific rules were updated to include the direct-mounted selectors so the panels retain full-height, non-clipped behavior in the `/milkdrop/` workspace.

### Testing
- Ran the repository quality gate with `bun run check` (Biome lint/format, TypeScript `tsc --noEmit`, and the automated test suite) and it completed successfully. 
- The test run completed with all tests passing in CI-style sweep: `398` passed, `4` skipped, and `0` failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becd87aa248332a02fa7cc48d356d5)