### PR TITLE
Support legacy MilkDrop motion vector controls

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -293,6 +293,9 @@ export const DEFAULT_MILKDROP_STATE: Record<string, number> = {
   motion_vectors: 0,
   motion_vectors_x: 16,
   motion_vectors_y: 12,
+  mv_dx: 0,
+  mv_dy: 0,
+  mv_l: 0,
   mv_r: 1,
   mv_g: 1,
   mv_b: 1,
@@ -405,6 +408,7 @@ function toBlockedShaderConstruct(line: string) {
 function buildSupportedExpressionIdentifierSet() {
   const supported = new Set<string>([
     ...Object.keys(DEFAULT_MILKDROP_STATE),
+    ...Object.keys(aliasMap).filter((key) => aliasMap[key] !== null),
     ...MILKDROP_INTRINSIC_IDENTIFIERS,
     'time',
     'frame',
@@ -463,6 +467,31 @@ function buildSupportedExpressionIdentifierSet() {
     'thickoutline',
   ]);
   return supported;
+}
+
+function hasLegacyMotionVectorControls(
+  numericFields: Record<string, number>,
+  programs?: Pick<MilkdropPresetIR['programs'], 'init' | 'perFrame'>,
+) {
+  const hasLegacyFieldValues =
+    Math.abs(numericFields.mv_dx ?? 0) > 0.0001 ||
+    Math.abs(numericFields.mv_dy ?? 0) > 0.0001 ||
+    Math.abs(numericFields.mv_l ?? 0) > 0.0001;
+  if (hasLegacyFieldValues) {
+    return true;
+  }
+
+  if (!programs) {
+    return false;
+  }
+
+  return [programs.init, programs.perFrame].some((block) =>
+    block.statements.some(
+      (statement) =>
+        statement.target === 'motion_vectors_x' ||
+        statement.target === 'motion_vectors_y',
+    ),
+  );
 }
 
 function isSupportedExpressionIdentifier(
@@ -4831,7 +4860,13 @@ function buildFeatureAnalysis({
     features.add('borders');
   }
 
-  if ((numericFields.motion_vectors ?? 0) > 0.5) {
+  if (
+    (numericFields.motion_vectors ?? 0) > 0.5 ||
+    hasLegacyMotionVectorControls(numericFields, {
+      init: programs.init,
+      perFrame: programs.perFrame,
+    })
+  ) {
     features.add('motion-vectors');
   }
 

--- a/assets/js/milkdrop/field-normalization.ts
+++ b/assets/js/milkdrop/field-normalization.ts
@@ -45,6 +45,12 @@ const aliasMap: Record<string, string | null> = {
   finnerbordera: 'ib_a',
   video_echo: 'video_echo_enabled',
   echo_orient: 'video_echo_orientation',
+  motionvectorsx: 'motion_vectors_x',
+  motionvectorsy: 'motion_vectors_y',
+  nmotionvectorsx: 'motion_vectors_x',
+  nmotionvectorsy: 'motion_vectors_y',
+  mv_x: 'motion_vectors_x',
+  mv_y: 'motion_vectors_y',
 };
 
 export function normalizeFieldSuffix(value: string) {

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -26,6 +26,8 @@ import type {
 const MAX_TRAILS = 5;
 const MAX_CUSTOM_WAVE_SLOTS = 32;
 const MAX_CUSTOM_SHAPE_SLOTS = 32;
+const MAX_MOTION_VECTOR_COLUMNS = 96;
+const MAX_MOTION_VECTOR_ROWS = 72;
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
@@ -984,29 +986,72 @@ class MilkdropPresetVM implements MilkdropVM {
     signals: MilkdropRuntimeSignals,
     meshField: MeshField,
   ): MilkdropMotionVectorVisual[] {
-    if ((this.state.motion_vectors ?? 0) < 0.5) {
+    const hasLegacyMotionVectorControls =
+      Math.abs(this.state.mv_dx ?? 0) > 0.0001 ||
+      Math.abs(this.state.mv_dy ?? 0) > 0.0001 ||
+      Math.abs(this.state.mv_l ?? 0) > 0.0001 ||
+      this.preset.ir.programs.init.statements.some(
+        (statement) =>
+          statement.target === 'motion_vectors_x' ||
+          statement.target === 'motion_vectors_y',
+      ) ||
+      this.preset.ir.programs.perFrame.statements.some(
+        (statement) =>
+          statement.target === 'motion_vectors_x' ||
+          statement.target === 'motion_vectors_y',
+      );
+
+    if (
+      (this.state.motion_vectors ?? 0) < 0.5 &&
+      !hasLegacyMotionVectorControls
+    ) {
       return [];
     }
 
-    const countX = clamp(Math.round(this.state.motion_vectors_x ?? 16), 1, 40);
-    const countY = clamp(Math.round(this.state.motion_vectors_y ?? 12), 1, 32);
+    const countX = clamp(
+      Math.round(this.state.motion_vectors_x ?? 16),
+      1,
+      MAX_MOTION_VECTOR_COLUMNS,
+    );
+    const countY = clamp(
+      Math.round(this.state.motion_vectors_y ?? 12),
+      1,
+      MAX_MOTION_VECTOR_ROWS,
+    );
     const colorValue = color(
       this.state.mv_r ?? 1,
       this.state.mv_g ?? 1,
       this.state.mv_b ?? 1,
       this.state.mv_a ?? 0.35,
     );
-    const alpha = clamp(this.state.mv_a ?? 0.35, 0.02, 1);
+    const alpha = clamp(
+      this.state.mv_a ?? 0.35,
+      hasLegacyMotionVectorControls ? 0 : 0.02,
+      1,
+    );
     const vectors: MilkdropMotionVectorVisual[] = [];
     const previousField = this.lastMeshField;
     const density = meshField.density;
     const hasPerPixelPrograms =
       this.preset.ir.programs.perPixel.statements.length > 0;
+    const legacyOffsetX = clamp(this.state.mv_dx ?? 0, -1, 1);
+    const legacyOffsetY = clamp(this.state.mv_dy ?? 0, -1, 1);
+    const legacyLength = Math.max(0, this.state.mv_l ?? 0);
+    const legacyCellScale =
+      Math.min(2 / Math.max(countX, 1), 2 / Math.max(countY, 1)) * 0.625;
+    const explicitLegacyMagnitude =
+      legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale;
 
     for (let row = 0; row < countY; row += 1) {
       for (let col = 0; col < countX; col += 1) {
-        const sourceX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
-        const sourceY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
+        const sourceBaseX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
+        const sourceBaseY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
+        const sourceX = hasLegacyMotionVectorControls
+          ? clamp(sourceBaseX + legacyOffsetX, -1, 1)
+          : sourceBaseX;
+        const sourceY = hasLegacyMotionVectorControls
+          ? clamp(sourceBaseY + legacyOffsetY, -1, 1)
+          : sourceBaseY;
         const fieldCol = Math.round((sourceX + 1) * 0.5 * (density - 1));
         const fieldRow = Math.round((sourceY + 1) * 0.5 * (density - 1));
         const index = fieldRow * density + fieldCol;
@@ -1025,8 +1070,22 @@ class MilkdropPresetVM implements MilkdropVM {
         const historyDy = hasPerPixelPrograms
           ? (currentPoint.y - previous.y) * 1.1
           : 0;
-        const dx = clamp(sourceDx + historyDx, -0.24, 0.24);
-        const dy = clamp(sourceDy + historyDy, -0.24, 0.24);
+        const baseDx = sourceDx + historyDx;
+        const baseDy = sourceDy + historyDy;
+        const baseMagnitude = Math.hypot(baseDx, baseDy);
+        let dx = clamp(baseDx, -0.24, 0.24);
+        let dy = clamp(baseDy, -0.24, 0.24);
+
+        if (hasLegacyMotionVectorControls && explicitLegacyMagnitude > 0.0001) {
+          if (baseMagnitude < 0.0001) {
+            continue;
+          }
+          const normalizedX = baseDx / baseMagnitude;
+          const normalizedY = baseDy / baseMagnitude;
+          dx = normalizedX * explicitLegacyMagnitude;
+          dy = normalizedY * explicitLegacyMagnitude;
+        }
+
         const magnitude = Math.hypot(dx, dy);
         if (magnitude < 0.002) {
           continue;
@@ -1041,8 +1100,12 @@ class MilkdropPresetVM implements MilkdropVM {
             0.18,
           ],
           color: colorValue,
-          alpha: clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
-          thickness: clamp(1 + magnitude * 18, 1, 4),
+          alpha: hasLegacyMotionVectorControls
+            ? alpha
+            : clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
+          thickness: hasLegacyMotionVectorControls
+            ? clamp(1 + magnitude * 10, 1, 4)
+            : clamp(1 + magnitude * 18, 1, 4),
           additive: false,
         });
       }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -184,6 +184,44 @@ mv_a=0.3
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
   });
 
+  test('normalizes legacy motion vector aliases and keeps init aliases wired', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Legacy Motion Vectors
+nMotionVectorsX=3
+nMotionVectorsY=2
+mv_dx=0.02
+mv_dy=-0.02
+mv_l=0.15
+per_frame_init_1=mv_x=64;mv_y=48;q1=mv_x+mv_y;
+      `.trim(),
+      { id: 'legacy-motion-vectors' },
+    );
+
+    expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
+    expect(compiled.ir.numericFields.motion_vectors_x).toBe(3);
+    expect(compiled.ir.numericFields.motion_vectors_y).toBe(2);
+    expect(compiled.ir.numericFields.mv_dx).toBeCloseTo(0.02, 6);
+    expect(compiled.ir.numericFields.mv_dy).toBeCloseTo(-0.02, 6);
+    expect(compiled.ir.numericFields.mv_l).toBeCloseTo(0.15, 6);
+    expect(compiled.ir.programs.init.statements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ target: 'motion_vectors_x' }),
+        expect.objectContaining({ target: 'motion_vectors_y' }),
+        expect.objectContaining({ target: 'q1' }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
+      'motion-vectors',
+    );
+    expect(
+      compiled.ir.compatibility.parity.missingAliasesOrFunctions,
+    ).not.toContain('mv_x');
+    expect(
+      compiled.ir.compatibility.parity.missingAliasesOrFunctions,
+    ).not.toContain('mv_y');
+  });
+
   test('maps warp animation speed into numeric fields', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-corpus-compat.test.ts
+++ b/tests/milkdrop-corpus-compat.test.ts
@@ -3,19 +3,62 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
 
-const BUNDLED_PRESET_EXPECTATIONS = {
+type BundledPresetExpectation = {
+  webgl: 'supported' | 'partial' | 'unsupported';
+  webgpu: 'supported' | 'partial' | 'unsupported';
+  forbiddenUnsupportedKeys?: readonly string[];
+};
+
+const BUNDLED_PRESET_EXPECTATIONS: Record<string, BundledPresetExpectation> = {
   'aurora-feedback-core.milk': { webgl: 'supported', webgpu: 'partial' },
-  'eos-glowsticks-v2-03-music.milk': { webgl: 'partial', webgpu: 'partial' },
-  'eos-phat-cubetrace-v2.milk': { webgl: 'partial', webgpu: 'partial' },
+  'eos-glowsticks-v2-03-music.milk': {
+    webgl: 'partial',
+    webgpu: 'partial',
+    forbiddenUnsupportedKeys: [
+      'mv_dx',
+      'mv_dy',
+      'mv_l',
+      'nmotionvectorsx',
+      'nmotionvectorsy',
+    ],
+  },
+  'eos-phat-cubetrace-v2.milk': {
+    webgl: 'partial',
+    webgpu: 'partial',
+    forbiddenUnsupportedKeys: [
+      'mv_dx',
+      'mv_dy',
+      'mv_l',
+      'nmotionvectorsx',
+      'nmotionvectorsy',
+    ],
+  },
   'kinetic-grid-pulse.milk': { webgl: 'supported', webgpu: 'partial' },
   'krash-rovastar-cerebral-demons-stars.milk': {
     webgl: 'partial',
     webgpu: 'partial',
+    forbiddenUnsupportedKeys: [
+      'mv_dx',
+      'mv_dy',
+      'mv_l',
+      'nmotionvectorsx',
+      'nmotionvectorsy',
+    ],
   },
   'low-motion-halo-drift.milk': { webgl: 'supported', webgpu: 'partial' },
   'prism-drum-tunnel.milk': { webgl: 'supported', webgpu: 'partial' },
-  'rovastar-parallel-universe.milk': { webgl: 'partial', webgpu: 'partial' },
-} as const;
+  'rovastar-parallel-universe.milk': {
+    webgl: 'partial',
+    webgpu: 'partial',
+    forbiddenUnsupportedKeys: [
+      'mv_dx',
+      'mv_dy',
+      'mv_l',
+      'nmotionvectorsx',
+      'nmotionvectorsy',
+    ],
+  },
+};
 
 function loadPresetCorpus(dir: string, origin: 'bundled' | 'user' = 'bundled') {
   return readdirSync(dir)
@@ -77,6 +120,11 @@ describe('milkdrop bundled preset corpus', () => {
         expect(entry?.compiled.ir.compatibility.backends.webgpu.status).toBe(
           expectation.webgpu,
         );
+        expectation.forbiddenUnsupportedKeys?.forEach((key) => {
+          expect(
+            entry?.compiled.ir.compatibility.unsupportedKeys,
+          ).not.toContain(key);
+        });
       },
     );
   });

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
 import type { MilkdropRuntimeSignals } from '../assets/js/milkdrop/types.ts';
 import { createMilkdropVM } from '../assets/js/milkdrop/vm.ts';
@@ -248,6 +250,66 @@ per_pixel_1=zoom=1.08; rot=0.12; warp=0.35;
     expect(frameState.motionVectors[0]?.positions).toHaveLength(6);
     expect(frameState.motionVectors[0]?.color.b).toBeCloseTo(1, 6);
     expect(frameState.motionVectors[0]?.alpha).toBeGreaterThan(0.28);
+  });
+
+  test('uses legacy motion vector counts and spacing controls without canonical enable flags', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Legacy Motion Overlay
+nMotionVectorsX=3
+nMotionVectorsY=2
+mv_dx=0.1
+mv_dy=-0.05
+mv_l=0.15
+mv_r=0.4
+mv_g=0.8
+mv_b=1
+mv_a=0.5
+per_frame_init_1=mv_x=4;mv_y=3;
+per_pixel_1=zoom=1.1; rot=0.08; warp=0.2;
+      `.trim(),
+      { id: 'legacy-motion-overlay' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 2 }));
+
+    expect(frameState.variables.motion_vectors_x).toBeCloseTo(4, 6);
+    expect(frameState.variables.motion_vectors_y).toBeCloseTo(3, 6);
+    expect(frameState.motionVectors).toHaveLength(12);
+    expect(frameState.motionVectors[0]?.color.g).toBeCloseTo(0.8, 6);
+    expect(frameState.motionVectors[0]?.alpha).toBeCloseTo(0.5, 6);
+    expect(frameState.motionVectors[0]?.positions[0]).toBeGreaterThan(-0.95);
+    expect(frameState.motionVectors[0]?.positions[1]).toBeLessThan(0.95);
+    const firstVectorDx =
+      (frameState.motionVectors[0]?.positions[3] ?? 0) -
+      (frameState.motionVectors[0]?.positions[0] ?? 0);
+    const firstVectorDy =
+      (frameState.motionVectors[0]?.positions[4] ?? 0) -
+      (frameState.motionVectors[0]?.positions[1] ?? 0);
+    expect(Math.hypot(firstVectorDx, firstVectorDy)).toBeCloseTo(0.2175, 3);
+  });
+
+  test('applies bundled mv_x/mv_y init aliases for legacy motion-vector presets', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'public',
+        'milkdrop-presets',
+        'eos-glowsticks-v2-03-music.milk',
+      ),
+      'utf8',
+    );
+    const preset = compileMilkdropPresetSource(source, {
+      id: 'eos-glowsticks-v2-03-music',
+      title: 'eos-glowsticks-v2-03-music.milk',
+      origin: 'bundled',
+    });
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 2 }));
+
+    expect(frameState.variables.motion_vectors_x).toBeCloseTo(64, 6);
+    expect(frameState.variables.motion_vectors_y).toBeCloseTo(48, 6);
+    expect(frameState.motionVectors.length).toBeGreaterThan(0);
   });
 
   test('preserves prior frame wave samples for velocity-driven main wave animation', () => {


### PR DESCRIPTION
### Motivation
- Bundled MilkDrop2 presets use legacy motion-vector fields (`mv_dx`, `mv_dy`, `mv_l`, `mv_x`/`mv_y`, `nMotionVectorsX`/`nMotionVectorsY`) that were being dropped or approximated, causing mismatches versus shipped presets.
- The change preserves those legacy controls through parsing/compilation and makes the VM honor preset-provided spacing/count/offset/length controls when present while keeping the procedural fallback.

### Description
- Add legacy alias mappings in `assets/js/milkdrop/field-normalization.ts` so `mv_x`, `mv_y`, `nMotionVectorsX`/`nMotionVectorsY`, and normalized variants map to `motion_vectors_x`/`motion_vectors_y`.
- Extend `DEFAULT_MILKDROP_STATE` in `assets/js/milkdrop/compiler.ts` to include `mv_dx`, `mv_dy`, and `mv_l` and wire alias keys into the expression identifier set so legacy names survive compilation.
- Add `hasLegacyMotionVectorControls()` in `compiler.ts` and use it in feature analysis so legacy motion-vector usage is treated as the `motion-vectors` feature rather than unknown/unsupported.
- Update `assets/js/milkdrop/vm.ts` `buildMotionVectors()` to detect legacy controls and, when present, use preset-defined counts/offsets/length (`mv_dx`, `mv_dy`, `mv_l`, and `mv_x`/`mv_y` init aliases) to position and size vectors; preserve existing per-pixel / mesh-delta procedural path when legacy controls are absent; add safe ceiling constants for counts.
- Add and adjust tests: new/updated coverage in `tests/milkdrop-compiler.test.ts`, `tests/milkdrop-vm.test.ts`, and `tests/milkdrop-corpus-compat.test.ts` to assert preservation of `mv_dx`/`mv_dy`/`mv_l`, `mv_x`/`mv_y` init aliases, legacy count normalization, and tighten bundled corpus expectations so legacy fields are no longer reported as unsupported.

### Testing
- Ran targeted specs: `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-vm.test.ts tests/milkdrop-corpus-compat.test.ts` and all focused tests passed (no failures).
- Ran full project checks: `bun run check` (Biome format/lint, TypeScript typecheck, and full test suite) and the quality gate completed successfully with the test suite passing.
- Files touched: `assets/js/milkdrop/field-normalization.ts`, `assets/js/milkdrop/compiler.ts`, `assets/js/milkdrop/vm.ts`, and test updates in `tests/milkdrop-compiler.test.ts`, `tests/milkdrop-vm.test.ts`, `tests/milkdrop-corpus-compat.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becf33e18483328b02f254c707cd89)