### PR TITLE
Align bundled preset catalog with compiled compatibility

### DIFF
--- a/assets/js/milkdrop/catalog-store.ts
+++ b/assets/js/milkdrop/catalog-store.ts
@@ -24,8 +24,6 @@ type BundledCatalogDocument =
   | {
       certification?: 'bundled' | 'certified' | 'exploratory';
       corpusTier?: 'bundled' | 'certified' | 'exploratory';
-      expectedFidelityClass?: MilkdropBundledCatalogEntry['expectedFidelityClass'];
-      visualEvidenceTier?: MilkdropBundledCatalogEntry['visualEvidenceTier'];
       presets?: Array<
         MilkdropBundledCatalogEntry & {
           order?: number;
@@ -190,6 +188,63 @@ function supportsFromCompiled(compiled: MilkdropCompiledPreset): {
   };
 }
 
+function supportFlagMatchesCompiled(
+  status: MilkdropBackendSupport['status'],
+  flag: boolean | undefined,
+) {
+  if (typeof flag !== 'boolean') {
+    return true;
+  }
+
+  return flag ? status === 'supported' : status !== 'supported';
+}
+
+function getValidatedCatalogOverrides(
+  entry: MilkdropBundledCatalogEntry,
+  compiled: MilkdropCompiledPreset,
+): {
+  expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
+  visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
+} {
+  const overrides: {
+    expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
+    visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
+  } = {};
+
+  if (
+    entry.expectedFidelityClass ===
+    compiled.ir.compatibility.parity.fidelityClass
+  ) {
+    overrides.expectedFidelityClass = entry.expectedFidelityClass;
+  }
+
+  if (
+    entry.visualEvidenceTier ===
+    compiled.ir.compatibility.parity.visualEvidenceTier
+  ) {
+    overrides.visualEvidenceTier = entry.visualEvidenceTier;
+  }
+
+  const catalogSupports = entry.supports;
+  if (catalogSupports) {
+    const compiledSupports = supportsFromCompiled(compiled);
+    const webglMatches = supportFlagMatchesCompiled(
+      compiledSupports.webgl.status,
+      catalogSupports.webgl,
+    );
+    const webgpuMatches = supportFlagMatchesCompiled(
+      compiledSupports.webgpu.status,
+      catalogSupports.webgpu,
+    );
+
+    if (!webglMatches || !webgpuMatches) {
+      return overrides;
+    }
+  }
+
+  return overrides;
+}
+
 function toCatalogEntry(
   source: MilkdropPresetSource,
   compiled: MilkdropCompiledPreset,
@@ -270,8 +325,6 @@ export function createMilkdropCatalogStore({
           }
           const defaultCertification = document.certification ?? 'bundled';
           const defaultCorpusTier = document.corpusTier ?? 'bundled';
-          const defaultFidelityClass = document.expectedFidelityClass;
-          const defaultVisualEvidenceTier = document.visualEvidenceTier;
           return (document.presets ?? []).map((entry) => ({
             id: entry.id,
             title: entry.title,
@@ -281,10 +334,8 @@ export function createMilkdropCatalogStore({
             curatedRank: entry.curatedRank ?? entry.order,
             certification: entry.certification ?? defaultCertification,
             corpusTier: entry.corpusTier ?? defaultCorpusTier,
-            expectedFidelityClass:
-              entry.expectedFidelityClass ?? defaultFidelityClass,
-            visualEvidenceTier:
-              entry.visualEvidenceTier ?? defaultVisualEvidenceTier,
+            expectedFidelityClass: entry.expectedFidelityClass,
+            visualEvidenceTier: entry.visualEvidenceTier,
             supports: entry.supports ?? entry.compatibility,
           }));
         })
@@ -363,6 +414,10 @@ export function createMilkdropCatalogStore({
           try {
             const source = await loadBundledSource(entry);
             const compiled = getCompiled(source);
+            const validatedOverrides = getValidatedCatalogOverrides(
+              entry,
+              compiled,
+            );
             return toCatalogEntry(
               source,
               compiled,
@@ -374,8 +429,7 @@ export function createMilkdropCatalogStore({
                 historyIndex: history.indexOf(entry.id),
                 certification: entry.certification ?? 'bundled',
                 corpusTier: entry.corpusTier ?? 'bundled',
-                expectedFidelityClass: entry.expectedFidelityClass,
-                visualEvidenceTier: entry.visualEvidenceTier,
+                ...validatedOverrides,
               },
             );
           } catch {
@@ -395,18 +449,14 @@ export function createMilkdropCatalogStore({
               warnings: ['Bundled preset could not be analyzed.'],
               supports: {
                 webgl: {
-                  status:
-                    entry.supports?.webgl === false ? 'unsupported' : 'partial',
+                  status: 'partial',
                   reasons: ['Bundled preset could not be analyzed.'],
                   evidence: [],
                   requiredFeatures: [],
                   unsupportedFeatures: [],
                 },
                 webgpu: {
-                  status:
-                    entry.supports?.webgpu === false
-                      ? 'unsupported'
-                      : 'partial',
+                  status: 'partial',
                   reasons: ['Bundled preset could not be analyzed.'],
                   evidence: [],
                   requiredFeatures: [],
@@ -414,8 +464,8 @@ export function createMilkdropCatalogStore({
                   recommendedFallback: 'webgl',
                 },
               },
-              fidelityClass: entry.expectedFidelityClass ?? 'fallback',
-              visualEvidenceTier: entry.visualEvidenceTier ?? 'none',
+              fidelityClass: 'fallback',
+              visualEvidenceTier: 'none',
               evidence: {
                 compile: 'issues',
                 runtime: 'not-run',
@@ -440,13 +490,13 @@ export function createMilkdropCatalogStore({
                     blocking: true,
                   },
                 ],
-                fidelityClass: entry.expectedFidelityClass ?? 'fallback',
+                fidelityClass: 'fallback',
                 evidence: {
                   compile: 'issues',
                   runtime: 'not-run',
                   visual: 'not-captured',
                 },
-                visualEvidenceTier: entry.visualEvidenceTier ?? 'none',
+                visualEvidenceTier: 'none',
               },
               bundledFile: entry.file,
             } satisfies MilkdropCatalogEntry;

--- a/public/milkdrop-presets/catalog.json
+++ b/public/milkdrop-presets/catalog.json
@@ -3,8 +3,6 @@
   "generatedAt": "2026-03-21",
   "certification": "bundled",
   "corpusTier": "bundled",
-  "expectedFidelityClass": "exact",
-  "visualEvidenceTier": "visual",
   "presets": [
     {
       "id": "aurora-feedback-core",
@@ -19,9 +17,11 @@
         "warp",
         "preset"
       ],
-      "compatibility": {
+      "expectedFidelityClass": "near-exact",
+      "visualEvidenceTier": "runtime",
+      "supports": {
         "webgl": true,
-        "webgpu": true
+        "webgpu": false
       }
     },
     {
@@ -38,9 +38,11 @@
         "original-pack",
         "preset"
       ],
-      "compatibility": {
-        "webgl": true,
-        "webgpu": true
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
+      "supports": {
+        "webgl": false,
+        "webgpu": false
       }
     },
     {
@@ -57,9 +59,11 @@
         "cream-of-the-crop",
         "preset"
       ],
-      "compatibility": {
-        "webgl": true,
-        "webgpu": true
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
+      "supports": {
+        "webgl": false,
+        "webgpu": false
       }
     },
     {
@@ -76,9 +80,11 @@
         "cream-of-the-crop",
         "preset"
       ],
-      "compatibility": {
-        "webgl": true,
-        "webgpu": true
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
+      "supports": {
+        "webgl": false,
+        "webgpu": false
       }
     },
     {
@@ -94,9 +100,11 @@
         "drums",
         "preset"
       ],
-      "compatibility": {
+      "expectedFidelityClass": "near-exact",
+      "visualEvidenceTier": "runtime",
+      "supports": {
         "webgl": true,
-        "webgpu": true
+        "webgpu": false
       }
     },
     {
@@ -113,9 +121,11 @@
         "cream-of-the-crop",
         "preset"
       ],
-      "compatibility": {
-        "webgl": true,
-        "webgpu": true
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
+      "supports": {
+        "webgl": false,
+        "webgpu": false
       }
     },
     {
@@ -131,9 +141,11 @@
         "reactive",
         "preset"
       ],
-      "compatibility": {
+      "expectedFidelityClass": "near-exact",
+      "visualEvidenceTier": "runtime",
+      "supports": {
         "webgl": true,
-        "webgpu": true
+        "webgpu": false
       }
     },
     {
@@ -149,9 +161,11 @@
         "halos",
         "preset"
       ],
-      "compatibility": {
+      "expectedFidelityClass": "near-exact",
+      "visualEvidenceTier": "runtime",
+      "supports": {
         "webgl": true,
-        "webgpu": true
+        "webgpu": false
       }
     }
   ]

--- a/tests/milkdrop-catalog-store.test.ts
+++ b/tests/milkdrop-catalog-store.test.ts
@@ -15,6 +15,57 @@ describe('milkdrop catalog store', () => {
     mock.restore();
   });
 
+  test('ignores optimistic catalog metadata when compiled analysis is weaker', async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/milkdrop-presets/catalog.json')) {
+        return {
+          ok: true,
+          json: async () => ({
+            presets: [
+              {
+                id: 'optimistic-pack',
+                title: 'Optimistic Pack',
+                author: 'Curated',
+                file: '/milkdrop-presets/optimistic-pack.milk',
+                tags: ['curated'],
+                order: 1,
+                expectedFidelityClass: 'exact',
+                visualEvidenceTier: 'visual',
+                supports: { webgl: true, webgpu: true },
+              },
+            ],
+          }),
+        };
+      }
+
+      if (url.endsWith('/milkdrop-presets/optimistic-pack.milk')) {
+        return {
+          ok: true,
+          text: async () =>
+            'title=Optimistic Pack\nvideo_echo=1\nwavecode_0_enabled=1\n',
+        };
+      }
+
+      return { ok: false };
+    }) as unknown as typeof fetch;
+
+    const store = createMilkdropCatalogStore({
+      dbName: 'milkdrop-catalog-store-optimistic-test',
+      catalogUrl: '/milkdrop-presets/catalog.json',
+    });
+
+    const entries = await store.listPresets();
+    const bundled = entries.find((entry) => entry.id === 'optimistic-pack');
+
+    expect(bundled).toBeDefined();
+    expect(bundled?.supports.webgl.status).toBe('supported');
+    expect(bundled?.supports.webgpu.status).toBe('partial');
+    expect(bundled?.fidelityClass).toBe('near-exact');
+    expect(bundled?.visualEvidenceTier).toBe('runtime');
+    expect(bundled?.evidence.visual).toBe('not-captured');
+  });
+
   test('derives backend support, favorites, ratings, and history from preset analysis', async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = String(input);


### PR DESCRIPTION
### Motivation
- The shipped catalog used blanket optimistic defaults (`expectedFidelityClass`, `visualEvidenceTier`, and compatibility flags) that overstated MilkDrop2 support compared with the compiler/runtime analysis, causing the catalog to advertise stronger support than actually compiled.
- Make the static catalog reflect the runtime/compiler truth so the overlay and browse UI do not mislead users about what backends or fidelity are supported.

### Description
- Replace document-level fidelity/evidence defaults in `public/milkdrop-presets/catalog.json` with per-preset metadata that matches the compiler analysis for each bundled preset and remove the blanket optimistic compatibility booleans.
- Update `assets/js/milkdrop/catalog-store.ts` to treat compiler-derived analysis as the source of truth and only accept catalog-provided `expectedFidelityClass` / `visualEvidenceTier` / `supports` overrides when they match validated compiled evidence, implemented via `getValidatedCatalogOverrides` and `supportFlagMatchesCompiled` helpers.
- Ensure a bundled preset that fails to be analyzed surfaces `partial` support (rather than being upgraded by optimistic metadata) and fall back to safe fidelity/evidence defaults on analysis failure.
- Add a regression test in `tests/milkdrop-catalog-store.test.ts` that asserts optimistic catalog metadata cannot make a compiled-partial preset appear as exact/visual/fully supported.

### Testing
- Ran targeted tests: `bun run test tests/milkdrop-catalog-store.test.ts tests/milkdrop-corpus-compat.test.ts` and both completed with all tests passing (5 pass, 0 fail across those specs).
- Ran the full quality gate: `bun run check` (Biome lint/format, TypeScript `tsc`, and test suite) and the test suite completed with no failures (406 tests across 71 files: 402 passed, 4 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed25004288332b39addf74cee5982)