### PR TITLE
Avoid shape gradient material reconfiguration

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -1188,7 +1188,6 @@ function syncShapeFillMaterial(
     material.uniforms.secondaryAlpha.value =
       (shape.secondaryColor?.a ?? 0) * alphaMultiplier;
     material.blending = shape.additive ? AdditiveBlending : NormalBlending;
-    material.needsUpdate = true;
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Reduce per-frame expensive material reconfiguration by letting Three.js upload cheap uniform changes for gradient shape fills instead of forcing a compile-like update every frame.

### Description
- In `assets/js/milkdrop/renderer-adapter.ts` inside `syncShapeFillMaterial()` stop setting `material.needsUpdate = true` after updating `primaryColor`, `secondaryColor`, `primaryAlpha`, and `secondaryAlpha`, while keeping `material.blending` in sync and continuing to recreate/reconfigure the material only when the material class actually changes.

### Testing
- Ran `bun run check` (Biome lint, TypeScript typecheck, and test suite) which completed successfully across the suite (`403` pass, `4` skip) and no docs were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed8d8a9788332acefa837b8ec8567)