### PR TITLE
Use dynamic draw usage for per-frame Three.js buffers

### DIFF
--- a/assets/js/library-view/three-library-effects.ts
+++ b/assets/js/library-view/three-library-effects.ts
@@ -6,6 +6,7 @@ import {
   ClampToEdgeWrapping,
   Color,
   DirectionalLight,
+  DynamicDrawUsage,
   Float32BufferAttribute,
   Group,
   IcosahedronGeometry,
@@ -493,6 +494,7 @@ export function createLibraryThreeEffects() {
       }),
       count,
     );
+    mesh.instanceMatrix.setUsage(DynamicDrawUsage);
     const dummy = new Object3D();
     const states: AmbientShardState[] = [];
     for (let index = 0; index < count; index += 1) {

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -4,6 +4,7 @@ import {
   BufferGeometry,
   Color,
   DoubleSide,
+  DynamicDrawUsage,
   Float32BufferAttribute,
   Group,
   Line,
@@ -783,10 +784,9 @@ function syncProceduralWaveObject(
       sampleValueAttribute.array.length === wave.samples.length
     )
   ) {
-    next.geometry.setAttribute(
-      'sampleValue',
-      new Float32BufferAttribute(wave.samples, 1),
-    );
+    const attribute = new Float32BufferAttribute(wave.samples, 1);
+    attribute.setUsage(DynamicDrawUsage);
+    next.geometry.setAttribute('sampleValue', attribute);
   } else {
     sampleValueAttribute.array.set(wave.samples);
     sampleValueAttribute.needsUpdate = true;
@@ -799,10 +799,9 @@ function syncProceduralWaveObject(
       sampleVelocityAttribute.array.length === wave.velocities.length
     )
   ) {
-    next.geometry.setAttribute(
-      'sampleVelocity',
-      new Float32BufferAttribute(wave.velocities, 1),
-    );
+    const attribute = new Float32BufferAttribute(wave.velocities, 1);
+    attribute.setUsage(DynamicDrawUsage);
+    next.geometry.setAttribute('sampleVelocity', attribute);
   } else {
     sampleVelocityAttribute.array.set(wave.velocities);
     sampleVelocityAttribute.needsUpdate = true;
@@ -847,10 +846,9 @@ function syncProceduralCustomWaveObject(
       sampleValueAttribute.array.length === wave.samples.length
     )
   ) {
-    next.geometry.setAttribute(
-      'sampleValue',
-      new Float32BufferAttribute(wave.samples, 1),
-    );
+    const attribute = new Float32BufferAttribute(wave.samples, 1);
+    attribute.setUsage(DynamicDrawUsage);
+    next.geometry.setAttribute('sampleValue', attribute);
   } else {
     sampleValueAttribute.array.set(wave.samples);
     sampleValueAttribute.needsUpdate = true;
@@ -901,7 +899,9 @@ function ensureGeometryPositions(
     existing.array.set(positions);
     existing.needsUpdate = true;
   } else {
-    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    const attribute = new Float32BufferAttribute(positions, 3);
+    attribute.setUsage(DynamicDrawUsage);
+    geometry.setAttribute('position', attribute);
   }
 
   if (!geometry.boundingSphere) {


### PR DESCRIPTION
### Motivation
- Per-frame-updated Three.js buffer attributes should be created with a dynamic usage hint so the renderer and GPU drivers can optimize repeated CPU-side writes instead of assuming static data; this change applies `DynamicDrawUsage` to those attributes.

### Description
- Mark `position` attributes created by `ensureGeometryPositions()` with `DynamicDrawUsage` in `assets/js/milkdrop/renderer-adapter.ts`.
- Mark `sampleValue` and `sampleVelocity` attributes created in `syncProceduralWaveObject()` and `sampleValue` in `syncProceduralCustomWaveObject()` with `DynamicDrawUsage` in `assets/js/milkdrop/renderer-adapter.ts`.
- Mark the ambient shard instanced mesh matrix as dynamic via `mesh.instanceMatrix.setUsage(DynamicDrawUsage)` immediately after `InstancedMesh` creation in `createAmbientShards()` in `assets/js/library-view/three-library-effects.ts`.
- Preserve existing per-frame steady-state behavior so matching buffers are updated in place via `array.set(...)` + `needsUpdate = true` (and `setMatrixAt(...)` + `instanceMatrix.needsUpdate = true`) rather than reallocating every frame.

### Testing
- Ran the project quality gate with `bun run check`, which runs Biome formatting/linting, TypeScript typecheck, and the test suite, and the command completed successfully.
- Test results: full suite executed with 407 tests run, `403` passed, `4` skipped, and `0` failed.
- No documentation files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed8d30640833290ab409693e9b629)