### PR TITLE
Normalize legacy shapecode suffixes

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -3388,6 +3388,8 @@ function buildShaderProgramPayload({
       statementTargets: statements.map((statement) => statement.target),
     },
   };
+}
+
 function isUnsupportedParsedShaderStatement({
   statement,
   shaderEnv,
@@ -4602,6 +4604,14 @@ const legacyCustomWaveSuffixMap: Record<string, string | null> = {
   badditive: 'additive',
 };
 
+const legacyCustomShapeSuffixMap: Record<string, string | null> = {
+  badditive: 'additive',
+  thickoutline: 'thickoutline',
+  thick_outline: 'thickoutline',
+  bthickoutline: 'thickoutline',
+  bthick_outline: 'thickoutline',
+};
+
 function defaultSourceId(rawTitle: string) {
   return (
     rawTitle
@@ -4639,6 +4649,14 @@ function normalizeLegacyCustomWaveSuffix(value: string) {
   const normalized = normalizeFieldSuffix(value);
   if (normalized in legacyCustomWaveSuffixMap) {
     return legacyCustomWaveSuffixMap[normalized];
+  }
+  return normalized;
+}
+
+function normalizeLegacyCustomShapeSuffix(value: string) {
+  const normalized = normalizeFieldSuffix(value);
+  if (normalized in legacyCustomShapeSuffixMap) {
+    return legacyCustomShapeSuffixMap[normalized];
   }
   return normalized;
 }
@@ -4855,7 +4873,10 @@ function normalizeFieldKey(field: MilkdropPresetField) {
       MAX_CUSTOM_SHAPES,
     );
     if (index !== null) {
-      return `shape_${index}_${normalizeFieldSuffix(shapecodeMatch[2] ?? '')}`;
+      const suffix = normalizeLegacyCustomShapeSuffix(shapecodeMatch[2] ?? '');
+      if (suffix !== null) {
+        return `shape_${index}_${suffix}`;
+      }
     }
   }
 

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -98,6 +98,36 @@ wavecode_0_a=1
     });
   });
 
+  test('normalizes legacy projectm shapecode booleans onto canonical shape fields', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+[preset00]
+shapecode_0_enabled=1
+shapecode_0_sides=5
+shapecode_0_bAdditive=1
+shapecode_0_bThickOutline=1
+      `.trim(),
+      { id: 'legacy-projectm-shapecode' },
+    );
+
+    expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
+    expect(compiled.ir.numericFields.shape_1_additive).toBe(1);
+    expect(compiled.ir.numericFields.shape_1_thickoutline).toBe(1);
+    expect(compiled.ir.customShapes[0]?.fields).toMatchObject({
+      enabled: 1,
+      sides: 5,
+      additive: 1,
+      thickoutline: 1,
+    });
+    expect(compiled.ir.customShapes[0]).toMatchObject({
+      index: 1,
+      fields: expect.objectContaining({
+        additive: 1,
+        thickoutline: 1,
+      }),
+    });
+  });
+
   test('keeps zoom and fZoomExponent distinct in compiled numeric fields', () => {
     const compiled = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation

- Imported legacy `shapecode_*` fields from MilkDrop2/projectM use legacy boolean names (for example `bAdditive`, `bThickOutline`) that should map to canonical `shape_<n>_*` keys before validation and compilation.

### Description

- Add a shape-specific legacy suffix map `legacyCustomShapeSuffixMap` and helper `normalizeLegacyCustomShapeSuffix()` to `assets/js/milkdrop/compiler.ts` to normalize common legacy shape suffixes (for example mapping `bAdditive` -> `additive` and multiple thick-outline spellings -> `thickoutline`).
- Wire the new normalization into the `shapecode_*` branch in `normalizeFieldKey()` so legacy `shapecode_<i>_*` fields become canonical `shape_<i>_*` keys prior to validation.
- Restore the missing `}` closure for `buildShaderProgramPayload()` so `compiler.ts` remains parseable by the tooling.
- Add a focused regression test in `tests/milkdrop-compiler.test.ts` that imports `shapecode_0_bAdditive` and `shapecode_0_bThickOutline` and asserts no `unsupportedKeys`, that canonical `shape_1_additive` / `shape_1_thickoutline` numeric fields are set, and that the compiled `customShapes[0]` reflects the expected values.

### Testing

- Ran the focused test file with `bun run test tests/milkdrop-compiler.test.ts` and the new shapecode regression passed (the modified compiler tests in that file succeeded).
- Ran the full quality gate with `bun run check`; Biome formatting/lint and `tsc --noEmit` typecheck completed, but the repo-wide test run reported unrelated existing failures in shader-program coverage and VM/renderer adapter expectations (failing tests included: `milkdrop compiler > keeps tex3D inversion mixes attached to the selected aux sample`, `milkdrop vm > preserves richer shader program payloads in post visuals`, and `milkdrop renderer adapter > prefers richer shader program payloads on supported backends`).
- Docs: None changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedb66a14c8332947b84eee52e059e)