### PR TITLE
Add local shape corpus fixtures and corpus-style compatibility checks

### DIFF
--- a/tests/fixtures/milkdrop/local-shape-corpus/README.md
+++ b/tests/fixtures/milkdrop/local-shape-corpus/README.md
@@ -1,0 +1,13 @@
+# Local custom-shape corpus
+
+These fixtures complement the vendored `projectm-upstream` regression slice.
+The upstream fixtures currently cover parser/compiler behavior for waves,
+shader text, and alias normalization, but they do not include presets that
+exercise custom shape slots.
+
+This local corpus keeps shape coverage in a corpus-style form by focusing on:
+
+- shape scalar fields,
+- shape init and per-frame programs,
+- legacy slot spellings such as `shapecode_32_*`,
+- border, thick outline, and additive flags.

--- a/tests/fixtures/milkdrop/local-shape-corpus/shape-legacy-max-slot-orbit.milk
+++ b/tests/fixtures/milkdrop/local-shape-corpus/shape-legacy-max-slot-orbit.milk
@@ -1,0 +1,40 @@
+MILKDROP_PRESET_VERSION=201
+TITLE=Shape Legacy Max Slot Orbit
+AUTHOR=Fixture
+zoom=1.015000
+rot=0.010000
+ob_border=1
+fOuterBorderSize=0.012000
+fOuterBorderA=0.650000
+fOuterBorderR=0.950000
+fOuterBorderG=0.850000
+fOuterBorderB=1.000000
+shapecode_32_enabled=1
+shapecode_32_sides=8
+shapecode_32_textured=1
+shapecode_32_x=0.500000
+shapecode_32_y=0.520000
+shapecode_32_rad=0.180000
+shapecode_32_ang=0.000000
+shapecode_32_tex_ang=0.150000
+shapecode_32_tex_zoom=1.100000
+shapecode_32_a=0.280000
+shapecode_32_r=0.800000
+shapecode_32_g=0.450000
+shapecode_32_b=1.000000
+shapecode_32_a2=0.050000
+shapecode_32_r2=0.200000
+shapecode_32_g2=0.100000
+shapecode_32_b2=0.600000
+shapecode_32_border_a=0.900000
+shapecode_32_border_r=1.000000
+shapecode_32_border_g=0.800000
+shapecode_32_border_b=1.000000
+shapecode_32_additive=1
+shapecode_32_thickoutline=1
+shape_32_init1=ang=0.08; x=0.50+q1*0.02; y=0.50-q2*0.02;
+shape_32_init2=tex_ang=0.12; border_a=0.84;
+shape_32_per_frame1=ang=ang+0.015+treb_att*0.01; rad=0.15+bass_att*0.05;
+shape_32_per_frame2=border_a=0.65+beat_pulse*0.25; tex_ang=tex_ang+0.02;
+per_frame_1=q1=sin(time*0.31);
+per_frame_2=q2=cos(time*0.27);

--- a/tests/fixtures/milkdrop/local-shape-corpus/shape-projectm-dual-lattice.milk
+++ b/tests/fixtures/milkdrop/local-shape-corpus/shape-projectm-dual-lattice.milk
@@ -1,0 +1,54 @@
+MILKDROP_PRESET_VERSION=201
+TITLE=Shape ProjectM Dual Lattice
+AUTHOR=Fixture
+warp=0.010000
+ib_size=0.006000
+ib_a=0.350000
+ib_r=0.600000
+ib_g=0.780000
+ib_b=1.000000
+shapecode_0_enabled=1
+shapecode_0_sides=6
+shapecode_0_textured=1
+shapecode_0_x=0.320000
+shapecode_0_y=0.720000
+shapecode_0_rad=0.120000
+shapecode_0_ang=0.250000
+shapecode_0_tex_zoom=0.900000
+shapecode_0_a=0.220000
+shapecode_0_r=1.000000
+shapecode_0_g=0.700000
+shapecode_0_b=0.200000
+shapecode_0_a2=0.020000
+shapecode_0_r2=0.300000
+shapecode_0_g2=0.200000
+shapecode_0_b2=0.000000
+shapecode_0_border_a=0.800000
+shapecode_0_border_r=1.000000
+shapecode_0_border_g=0.900000
+shapecode_0_border_b=0.400000
+shapecode_0_additive=1
+shapecode_0_thickoutline=1
+shape_0_init1=x=x+0.02*instance; y=y-0.01*instance; rad=rad+0.01*q3;
+shape_0_init2=ang=ang+instance*0.08;
+shape_0_per_frame1=ang=ang-0.020; x=0.32+0.12*sin(time*0.60);
+shape_0_per_frame2=y=0.72+0.05*cos(time*0.40); border_a=0.55+bass_att*0.20;
+shapecode_1_enabled=1
+shapecode_1_sides=4
+shapecode_1_x=0.680000
+shapecode_1_y=0.300000
+shapecode_1_rad=0.100000
+shapecode_1_ang=0.000000
+shapecode_1_a=0.180000
+shapecode_1_r=0.350000
+shapecode_1_g=0.700000
+shapecode_1_b=1.000000
+shapecode_1_border_a=0.700000
+shapecode_1_border_r=0.900000
+shapecode_1_border_g=1.000000
+shapecode_1_border_b=1.000000
+shape_1_init1=rad=rad+0.02*q4; ang=0.1+q4*0.2;
+shape_1_per_frame1=ang=ang+0.015; rad=0.09+mid_att*0.03;
+shape_1_per_frame2=x=0.68+0.04*cos(time*0.50); y=0.30+0.07*sin(time*0.70);
+per_frame_1=q3=0.5+0.5*sin(time*0.50);
+per_frame_2=q4=0.5+0.5*cos(time*0.33);

--- a/tests/fixtures/milkdrop/projectm-upstream/README.md
+++ b/tests/fixtures/milkdrop/projectm-upstream/README.md
@@ -14,9 +14,11 @@ upstream `projectM` regression preset corpus.
 - Upstream license context: projectM ships `COPYING` and `LICENSE.txt` under
   the GNU LGPL 2.1-or-later terms
 - Coverage note: the upstream regression corpus at this commit does not include
-  any presets that exercise custom shape slots; Stims keeps using dedicated
-  local shape fixtures for that gap while vendoring the full upstream wave/
-  shader-oriented suite here.
+  any presets that exercise custom shape slots; Stims closes that gap with the
+  dedicated local corpus under `tests/fixtures/milkdrop/local-shape-corpus/`,
+  where shape-heavy fixtures cover shape scalar fields, init/per-frame programs,
+  legacy slot spellings, and border/thick/additive metadata while this folder
+  remains the vendored upstream wave/shader-oriented suite.
 
 Selected fixture files and hashes:
 

--- a/tests/milkdrop-corpus-compat.test.ts
+++ b/tests/milkdrop-corpus-compat.test.ts
@@ -3,11 +3,51 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
 
+type CompatibilityStatus = 'supported' | 'partial' | 'unsupported';
+
 type BundledPresetExpectation = {
-  webgl: 'supported' | 'partial' | 'unsupported';
-  webgpu: 'supported' | 'partial' | 'unsupported';
+  webgl: CompatibilityStatus;
+  webgpu: CompatibilityStatus;
   forbiddenUnsupportedKeys?: readonly string[];
 };
+
+type ShapeCorpusExpectation = {
+  diagnostics: readonly string[];
+  webgl: CompatibilityStatus;
+  webgpu: CompatibilityStatus;
+  fidelityClass: string;
+  unsupportedKeys: readonly string[];
+  warnings: readonly string[];
+  blockedConstructs: readonly string[];
+  missingAliasesOrFunctions: readonly string[];
+  customShapeCount: number;
+};
+
+const LOCAL_SHAPE_CORPUS_EXPECTATIONS: Record<string, ShapeCorpusExpectation> =
+  {
+    'shape-legacy-max-slot-orbit.milk': {
+      diagnostics: [],
+      webgl: 'supported',
+      webgpu: 'supported',
+      fidelityClass: 'exact',
+      unsupportedKeys: [],
+      warnings: [],
+      blockedConstructs: [],
+      missingAliasesOrFunctions: [],
+      customShapeCount: 1,
+    },
+    'shape-projectm-dual-lattice.milk': {
+      diagnostics: [],
+      webgl: 'supported',
+      webgpu: 'supported',
+      fidelityClass: 'exact',
+      unsupportedKeys: [],
+      warnings: [],
+      blockedConstructs: [],
+      missingAliasesOrFunctions: [],
+      customShapeCount: 2,
+    },
+  };
 
 const BUNDLED_PRESET_EXPECTATIONS: Record<string, BundledPresetExpectation> = {
   'aurora-feedback-core.milk': { webgl: 'supported', webgpu: 'partial' },
@@ -88,6 +128,13 @@ function loadLegacyFixtureCorpus() {
   );
 }
 
+function loadLocalShapeFixtureCorpus() {
+  return loadPresetCorpus(
+    join(process.cwd(), 'tests', 'fixtures', 'milkdrop', 'local-shape-corpus'),
+    'user',
+  );
+}
+
 describe('milkdrop bundled preset corpus', () => {
   test('keeps the bundled preset corpus fully supported on both backends in compat mode', () => {
     const corpus = loadBundledPresetCorpus();
@@ -141,6 +188,53 @@ describe('milkdrop legacy fixture corpus', () => {
       expect(
         compiled.diagnostics.some((entry) => entry.severity === 'error'),
       ).toBe(false);
+    });
+  });
+});
+
+describe('milkdrop local shape fixture corpus', () => {
+  test('keeps dedicated custom-shape fixtures on stable compatibility metadata', () => {
+    const corpus = loadLocalShapeFixtureCorpus();
+
+    expect(corpus.length).toBe(2);
+    expect(corpus.map(({ file }) => file)).toEqual(
+      Object.keys(LOCAL_SHAPE_CORPUS_EXPECTATIONS),
+    );
+
+    corpus.forEach(({ file, compiled }) => {
+      const expected = LOCAL_SHAPE_CORPUS_EXPECTATIONS[file];
+      const actualDiagnosticCodes = compiled.diagnostics.map(
+        (entry) => entry.code,
+      );
+
+      expect(expected).toBeDefined();
+      expect(actualDiagnosticCodes).toEqual([...expected.diagnostics]);
+      expect(compiled.ir.compatibility.backends.webgl.status).toBe(
+        expected.webgl,
+      );
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+        expected.webgpu,
+      );
+      expect(compiled.ir.compatibility.parity.fidelityClass).toBe(
+        expected.fidelityClass,
+      );
+      expect(compiled.ir.compatibility.unsupportedKeys).toEqual([
+        ...expected.unsupportedKeys,
+      ]);
+      expect(compiled.ir.compatibility.warnings).toEqual([
+        ...expected.warnings,
+      ]);
+      expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([
+        ...expected.blockedConstructs,
+      ]);
+      expect(
+        compiled.ir.compatibility.parity.missingAliasesOrFunctions,
+      ).toEqual([...expected.missingAliasesOrFunctions]);
+      expect(compiled.ir.customShapes).toHaveLength(expected.customShapeCount);
+      compiled.ir.customShapes.forEach((shape) => {
+        expect(shape.programs.init.sourceLines.length).toBeGreaterThan(0);
+        expect(shape.programs.perFrame.sourceLines.length).toBeGreaterThan(0);
+      });
     });
   });
 });


### PR DESCRIPTION
### Motivation
- The vendored projectM regression fixtures do not exercise custom shape slots, leaving shapes validated only by ad-hoc unit tests; this change adds corpus-style coverage for custom shapes to improve compatibility/fidelity tracking.
- The goal is to validate shape scalar fields, init/per-frame programs, legacy alias spellings, and border/thick/additive metadata under the same compatibility expectations used for other fixture corpora.

### Description
- Add a dedicated local custom-shape fixture corpus under `tests/fixtures/milkdrop/local-shape-corpus/` containing `shape-legacy-max-slot-orbit.milk` and `shape-projectm-dual-lattice.milk` plus a README describing focus areas.
- Extend `tests/milkdrop-corpus-compat.test.ts` with `loadLocalShapeFixtureCorpus()` and `LOCAL_SHAPE_CORPUS_EXPECTATIONS` to assert per-fixture backend support, parity fidelity class, `unsupportedKeys`, `warnings`, `blockedConstructs`, `missingAliasesOrFunctions`, and presence of `customShapes` programs.
- Update `tests/fixtures/milkdrop/projectm-upstream/README.md` to document that the upstream corpus lacks shape fixtures and that the local corpus closes this coverage gap.

### Testing
- Ran `bun run test tests/milkdrop-corpus-compat.test.ts`, which failed to execute because the repository has a pre-existing parse/lint error in `assets/js/milkdrop/compiler.ts` (illegal export usage reported at compile time), so the new assertions did not run.
- Ran the main quality gate `bun run check`, which also failed due to the same `assets/js/milkdrop/compiler.ts` parse/lint issues and therefore the repo-level checks did not pass.
- Formatter/lint checks were invoked during the change process and the new fixture/README files were formatted; no new test assertions were observed to pass because the compiler parse error prevented test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedc1b1dec8332b5ac85b29a0e7d8c)