### PR TITLE
Apply recommended quality preset defaults

### DIFF
--- a/assets/js/core/settings-panel.ts
+++ b/assets/js/core/settings-panel.ts
@@ -82,6 +82,10 @@ export const QUALITY_STORAGE_KEY = 'stims:quality-preset';
 const DEFAULT_PRESET_ID = 'balanced';
 const DEFAULT_QUALITY_HINT = 'Adjust resolution and particle density.';
 
+function getStoredPresetId(storageKey: string) {
+  return getStorage()?.getItem(storageKey) ?? null;
+}
+
 const qualitySubscribers = new Set<QualitySubscriber>();
 let activeQualityPreset: QualityPreset | null = null;
 let activeQualityPresetStorageKey: string | null = null;
@@ -106,7 +110,7 @@ export function getStoredQualityPreset({
   defaultPresetId = DEFAULT_PRESET_ID,
   storageKey = QUALITY_STORAGE_KEY,
 }: StoredPresetOptions = {}): QualityPreset {
-  const storedId = getStorage()?.getItem(storageKey);
+  const storedId = getStoredPresetId(storageKey);
   const fromStorage = presets.find((preset) => preset.id === storedId);
   if (fromStorage) return fromStorage;
 
@@ -118,7 +122,13 @@ export function getActiveQualityPreset({
   defaultPresetId = DEFAULT_PRESET_ID,
   storageKey = QUALITY_STORAGE_KEY,
 }: StoredPresetOptions = {}): QualityPreset {
-  if (activeQualityPreset && activeQualityPresetStorageKey === storageKey) {
+  const storedId = getStoredPresetId(storageKey);
+
+  if (
+    activeQualityPreset &&
+    activeQualityPresetStorageKey === storageKey &&
+    storedId
+  ) {
     const match = presets.find(
       (preset) => preset.id === activeQualityPreset?.id,
     );
@@ -243,8 +253,7 @@ export class PersistentSettingsPanel {
       hint: qualityHint = DEFAULT_QUALITY_HINT,
     } = options;
 
-    const hadActivePreset =
-      !!activeQualityPreset && activeQualityPresetStorageKey === storageKey;
+    const hadActivePreset = getStoredPresetId(storageKey) !== null;
 
     this.qualityStorageKey = storageKey;
     this.qualityPresets = presets;

--- a/tests/settings-panel.test.ts
+++ b/tests/settings-panel.test.ts
@@ -57,6 +57,18 @@ describe('quality preset subscriptions', () => {
     expect(cached.id).toBe('hi-fi');
   });
 
+  test('getActiveQualityPreset honors a new default when no preset is stored', () => {
+    const initial = getActiveQualityPreset();
+    expect(initial.id).toBe('balanced');
+
+    localStorage.removeItem(QUALITY_STORAGE_KEY);
+
+    const resolved = getActiveQualityPreset({
+      defaultPresetId: 'performance',
+    });
+    expect(resolved.id).toBe('performance');
+  });
+
   test('getActiveQualityPreset falls back when cached preset is unavailable', () => {
     localStorage.setItem(QUALITY_STORAGE_KEY, 'hi-fi');
     getActiveQualityPreset();
@@ -71,6 +83,22 @@ describe('quality preset subscriptions', () => {
       defaultPresetId: 'low',
     });
     expect(resolved.id).toBe('low');
+  });
+
+  test('quality panels persist their default preset when no preset is stored yet', () => {
+    const panel = getSettingsPanel();
+
+    panel.setQualityPresets({
+      presets: DEFAULT_QUALITY_PRESETS,
+      defaultPresetId: 'performance',
+    });
+
+    const select = document.querySelector(
+      '.control-panel select',
+    ) as HTMLSelectElement | null;
+
+    expect(select?.value).toBe('performance');
+    expect(localStorage.getItem(QUALITY_STORAGE_KEY)).toBe('performance');
   });
 
   test('quality presets include global scope hint and impact summary', () => {


### PR DESCRIPTION
### Motivation
- Ensure the runtime applies a requested default quality preset when no explicit user selection has been stored so first-run low-power / performance recommendations actually take effect and reduce render cost.

### Description
- Add `getStoredPresetId` helper and use it to detect whether a stored preset exists before reusing an in-memory cached preset in `getActiveQualityPreset` (`assets/js/core/settings-panel.ts`).
- Change `PersistentSettingsPanel#setQualityPresets` to treat the presence of a stored preset as the signal to preserve prior quality, so the default preset is applied and persisted on first render (`assets/js/core/settings-panel.ts`).
- Add regression tests that cover honoring a new default when no preset is stored and that the panel persists the initial preset (`tests/settings-panel.test.ts`).
- No docs changed.

### Testing
- `bun test tests/settings-panel.test.ts` — ran the updated test file and all 11 tests passed.
- `bun run check` — ran the project quality gate (Biome formatting + typecheck + tests); Biome/formatting passed but the full check stopped on a pre-existing TypeScript error in `tests/milkdrop-corpus-compat.test.ts`, which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beddd8af208332b25f54158c5492b5)