### PR TITLE
Restore translated WebGPU partial shader support

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -388,6 +388,8 @@ const BACKEND_SHADER_TEXT_GAPS: Record<
       'This preset includes custom shader text outside the fully supported subset and will be approximated.',
   },
   webgpu: {
+    supportedSubset:
+      'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
     unsupportedSubset:
       'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
   },
@@ -2582,7 +2584,7 @@ function applyShaderAstStatement({
           controls.textureLayer.amount = amount.value;
           expressions.textureLayer.amount = amount.expression;
           applyTextureLayerSample(controls, expressions, invertedSample);
-          return false;
+          return true;
         }
         if (isShaderSolarizeSampleExpression(targetNode)) {
           const next = applyShaderControlValue(
@@ -3386,6 +3388,8 @@ function buildShaderProgramPayload({
       statementTargets: statements.map((statement) => statement.target),
     },
   };
+}
+
 function isUnsupportedParsedShaderStatement({
   statement,
   shaderEnv,
@@ -3469,7 +3473,11 @@ function isUnsupportedParsedShaderStatement({
   }
 
   const invertedSample = extractShaderInvertedSampleExpression(targetNode);
-  return invertedSample !== null && invertedSample !== 'main';
+  if (!invertedSample || invertedSample === 'main') {
+    return false;
+  }
+
+  return !isAuxShaderSamplerName(invertedSample.source);
 }
 
 function extractShaderControls(

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -1274,7 +1274,9 @@
     },
     "compatibility": {
       "unsupportedKeys": [],
-      "warnings": [],
+      "warnings": [
+        "WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution."
+      ],
       "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
@@ -1282,13 +1284,23 @@
           "evidence": []
         },
         "webgpu": {
-          "status": "supported",
-          "evidence": []
+          "status": "partial",
+          "evidence": [
+            {
+              "scope": "backend",
+              "status": "partial",
+              "code": "supported-shader-text-gap",
+              "feature": null
+            }
+          ]
         }
       },
       "parity": {
-        "fidelityClass": "exact",
-        "backendDivergence": [],
+        "fidelityClass": "near-exact",
+        "backendDivergence": [
+          "status:webgl=supported,webgpu=partial",
+          "webgpu:supported-shader-text-gap"
+        ],
         "ignoredFields": [],
         "blockedConstructs": [],
         "approximatedShaderLines": [],
@@ -1308,7 +1320,9 @@
     },
     "compatibility": {
       "unsupportedKeys": [],
-      "warnings": [],
+      "warnings": [
+        "WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution."
+      ],
       "featuresUsed": ["base-globals"],
       "backends": {
         "webgl": {
@@ -1316,13 +1330,23 @@
           "evidence": []
         },
         "webgpu": {
-          "status": "supported",
-          "evidence": []
+          "status": "partial",
+          "evidence": [
+            {
+              "scope": "backend",
+              "status": "partial",
+              "code": "supported-shader-text-gap",
+              "feature": null
+            }
+          ]
         }
       },
       "parity": {
-        "fidelityClass": "exact",
-        "backendDivergence": [],
+        "fidelityClass": "near-exact",
+        "backendDivergence": [
+          "status:webgl=supported,webgpu=partial",
+          "webgpu:supported-shader-text-gap"
+        ],
         "ignoredFields": [],
         "blockedConstructs": [],
         "approximatedShaderLines": [],

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -286,7 +286,7 @@ ib_border=1
     );
 
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     expect(
       compiled.ir.compatibility.featureAnalysis.unsupportedShaderText,
     ).toBe(false);
@@ -297,7 +297,10 @@ ib_border=1
     expect(compiled.ir.post.innerBorderStyle).toBe(true);
     expect(compiled.ir.post.shaderControls.hueShift).toBeCloseTo(0.35, 6);
     expect(compiled.ir.post.shaderControls.mixAlpha).toBeCloseTo(0.25, 6);
-    expect(compiled.ir.compatibility.parity.backendDivergence).toEqual([]);
+    expect(compiled.ir.compatibility.parity.backendDivergence).toEqual([
+      'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
+    ]);
   });
 
   test('supports shader transform controls in the subset', () => {
@@ -409,7 +412,14 @@ comp_shader=ret = tex2d(sampler_fw_noise_lq, uv).rgb
     expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('noise');
     expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('replace');
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'supported-shader-text-gap',
+        }),
+      ]),
+    );
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
       [],
     );
@@ -533,6 +543,9 @@ comp_shader=ret=tex2d(sampler_main,uv).rgb*1.2;
       expect.arrayContaining([
         expect.objectContaining({
           code: 'supported-shader-text-gap',
+          status: 'partial',
+          message:
+            'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
         }),
       ]),
     );
@@ -684,6 +697,7 @@ comp_shader=float3 wash = float3(1.2, 0.9, 0.7); ret = tex2d(sampler_main, uv).r
     expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     expect(compiled.ir.compatibility.parity.backendDivergence).toEqual([
       'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
       'webgpu:video-echo-gap:video-echo',
     ]);
   });
@@ -710,11 +724,11 @@ comp_shader=ret = ${sampleCall}(sampler_fw_noisevol_lq, float3(uv, time / 10.0))
         compiled.ir.post.shaderControls.textureLayer.volumeSliceZ,
       ).toBeCloseTo(0, 6);
       expect(compiled.diagnostics).toEqual([]);
-      expect(compiled.ir.compatibility.warnings).toEqual([]);
+      expect(compiled.ir.compatibility.warnings).toEqual([
+        'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
+      ]);
       expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-        'supported',
-      );
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
       expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
         [],
       );
@@ -746,17 +760,12 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
       compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
     ).not.toBeNull();
     expect(compiled.diagnostics).toEqual([]);
-    expect(compiled.ir.compatibility.warnings).toEqual([]);
+    expect(compiled.ir.compatibility.warnings).toEqual([
+      'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
+    ]);
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
-    expect(compiled.ir.shaderText.compProgram).toEqual(
-      expect.objectContaining({
-        stage: 'comp',
-        execution: expect.objectContaining({
-          supportedBackends: ['webgl', 'webgpu'],
-        }),
-      }),
-    );
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.shaderText.compProgram).toBeNull();
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
       [],
     );
@@ -832,8 +841,10 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, tex3D(sampler_fw_noisevol_lq,
       '3d',
     );
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
-    expect(compiled.ir.compatibility.warnings).toEqual([]);
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
+    expect(compiled.ir.compatibility.warnings).toEqual([
+      'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
+    ]);
   });
 
   test('downgrades tex3D extraction for aux samplers without volume atlases', () => {
@@ -862,6 +873,7 @@ comp_shader=ret = tex3D(sampler_fw_noise_lq, float3(uv, time / 10.0)).xyz
     ]);
     expect(compiled.ir.compatibility.warnings).toEqual([
       'Texture layer shader control uses tex3D/texture3D with aux sampler "noise", but only "simplex" is backed by the runtime volume atlas; this lookup will be approximated from a 2D texture.',
+      'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
     ]);
     expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
     expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -84,14 +84,18 @@ const REPRESENTATIVE_BACKEND_EXPECTATIONS = {
   },
   'parity-shader-01': {
     webgl: 'supported',
-    webgpu: 'supported',
-    divergence: [],
+    webgpu: 'partial',
+    divergence: [
+      'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
+    ],
   },
   'parity-allowlisted-shader-gap': {
     webgl: 'supported',
     webgpu: 'partial',
     divergence: [
       'status:webgl=supported,webgpu=partial',
+      'webgpu:supported-shader-text-gap',
       'webgpu:video-echo-gap:video-echo',
     ],
   },
@@ -359,6 +363,7 @@ test('keeps former shader-gap parity fixtures out of the allowlist when only vid
   expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([]);
   expect(compiled.ir.compatibility.parity.backendDivergence).toEqual([
     'status:webgl=supported,webgpu=partial',
+    'webgpu:supported-shader-text-gap',
     'webgpu:video-echo-gap:video-echo',
   ]);
   expect(

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -81,6 +81,21 @@ const FULL_SUPPORT_EXPECTATION = {
   unsupportedKeys: [],
 } as const satisfies ProjectMFixtureExpectation;
 
+const TRANSLATED_WEBGPU_SUPPORT_EXPECTATION = {
+  diagnostics: [],
+  webgl: 'supported',
+  webgpu: 'partial',
+  divergence: [
+    'status:webgl=supported,webgpu=partial',
+    'webgpu:supported-shader-text-gap',
+  ],
+  warnings: [
+    'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
+  ],
+  blockedConstructs: [],
+  unsupportedKeys: [],
+} as const satisfies ProjectMFixtureExpectation;
+
 const PROJECTM_FIXTURE_EXPECTATIONS = {
   '000-empty.milk': FULL_SUPPORT_EXPECTATION,
   '001-line.milk': FULL_SUPPORT_EXPECTATION,
@@ -116,8 +131,8 @@ const PROJECTM_FIXTURE_EXPECTATIONS = {
   '250-wavecode.milk': FULL_SUPPORT_EXPECTATION,
   '251-wavecode-spectrum.milk': FULL_SUPPORT_EXPECTATION,
   '252-wavecode-spectrum2.milk': FULL_SUPPORT_EXPECTATION,
-  '260-compshader-noise_lq.milk': FULL_SUPPORT_EXPECTATION,
-  '261-compshader-noisevol_lq.milk': FULL_SUPPORT_EXPECTATION,
+  '260-compshader-noise_lq.milk': TRANSLATED_WEBGPU_SUPPORT_EXPECTATION,
+  '261-compshader-noisevol_lq.milk': TRANSLATED_WEBGPU_SUPPORT_EXPECTATION,
   '300-beatdetect-bassmidtreb.milk': FULL_SUPPORT_EXPECTATION,
 } as const satisfies Record<
   (typeof PROJECTM_PRESET_FILES)[number],

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -657,7 +657,7 @@ video_echo=1
     });
   });
 
-  test('prefers richer shader program payloads on supported backends', () => {
+  test('prefers translated shader controls when direct shader programs are unavailable', () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Direct Shader Program Feedback
@@ -701,11 +701,8 @@ comp_shader=ret = tex2d(sampler_main, uv).rgb + vec3(0.1, 0.0, 0.0);
       }),
     ).toBe(true);
 
-    expect(compositeStates[0]?.shaderExecution).toBe('direct');
-    expect(compositeStates[0]?.shaderPrograms.comp?.stage).toBe('comp');
-    expect(
-      compositeStates[0]?.shaderPrograms.comp?.execution.supportedBackends,
-    ).toEqual(['webgl', 'webgpu']);
+    expect(compositeStates[0]?.shaderExecution).toBe('controls');
+    expect(compositeStates[0]?.shaderPrograms.comp).toBeNull();
   });
 
   test('renders main wave and trails directly on webgpu line-wave presets', () => {

--- a/tests/milkdrop-shader-sampler-aliases.test.ts
+++ b/tests/milkdrop-shader-sampler-aliases.test.ts
@@ -174,11 +174,11 @@ describe('milkdrop shader sampler aliases', () => {
         compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
       ).not.toBeNull();
       expect(compiled.diagnostics).toEqual([]);
-      expect(compiled.ir.compatibility.warnings).toEqual([]);
+      expect(compiled.ir.compatibility.warnings).toEqual([
+        'WebGPU supports the extracted shader controls here, but still uses translated shader text instead of direct shader-program execution.',
+      ]);
       expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-      expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
-        'supported',
-      );
+      expect(compiled.ir.compatibility.backends.webgpu.status).toBe('partial');
     }
   });
 });

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -716,7 +716,7 @@ comp_shader=vec3 wash = vec3(1 + bass_att * 0.2, 0.8 + mid * 0.1, 0.6 + beat_pul
     expect(frameState.post.shaderControls.colorScale.b).toBeCloseTo(0.66, 6);
   });
 
-  test('preserves richer shader program payloads in post visuals', () => {
+  test('keeps translated shader controls available in post visuals', () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Direct Shader Program VM
@@ -730,13 +730,12 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     );
 
     expect(frameState.post.shaderPrograms.warp).toBeNull();
-    expect(frameState.post.shaderPrograms.comp).toEqual(
-      expect.objectContaining({
-        stage: 'comp',
-        execution: expect.objectContaining({
-          supportedBackends: ['webgl', 'webgpu'],
-        }),
-      }),
+    expect(frameState.post.shaderPrograms.comp).toBeNull();
+    expect(frameState.post.shaderControls.textureLayer.source).toBe('simplex');
+    expect(frameState.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(frameState.post.shaderControls.textureLayer.amount).toBeCloseTo(
+      0.35,
+      6,
     );
   });
 


### PR DESCRIPTION
### Motivation

- Restores explicit evidence for WebGPU "translation-only" shader paths so presets that are translated (not directly executed) are reported as `partial` instead of incorrectly reporting exact `supported` status.
- Preserves the control-extraction path (shader controls remain observable and exercised) while keeping translation-only cases visible to parity, cataloging, and fallback logic.

### Description

- Reintroduced the WebGPU `supportedSubset` message in `BACKEND_SHADER_TEXT_GAPS` so `buildBackendSupport()` emits a `supported-shader-text-gap` partial evidence when `shaderTextExecution` is `translated` (`assets/js/milkdrop/compiler.ts`).
- Fixed a parser/regression by closing the `buildShaderProgramPayload` function block and kept inverted aux-sample extraction on the supported control path (returning `true` when a valid inverted aux sample is applied) to avoid downgrading valid control extraction (`assets/js/milkdrop/compiler.ts`).
- Updated expectations across compiler, VM, renderer-adapter, parity, sampler-alias, and projectM compatibility tests to assert the restored translated-WebGPU partial evidence and warning, and refreshed the vendored ProjectM compatibility snapshot for the affected fixtures (`tests/*.test.ts`, `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json`).
- Minor formatting/typecheck cleanups applied so the repo quality gate passes (Biome/TypeScript). 

### Testing

- Ran targeted unit suites with `bun run test tests/milkdrop-compiler.test.ts`, `bun run test tests/milkdrop-vm.test.ts tests/milkdrop-projectm-compat.test.ts`, `bun run test tests/milkdrop-parity.test.ts`, `bun run test tests/milkdrop-renderer-adapter.test.ts`, and `bun run test tests/milkdrop-shader-sampler-aliases.test.ts`, all of which passed.
- Ran the full quality gate with `bun run check` (Biome + TypeScript + tests) and observed the test suite complete successfully (`405 pass, 4 skip, 0 fail`).
- Updated the ProjectM compatibility snapshot via the test-driven snapshot update so vendored expectations remain in sync (`tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedcd1b5f883329de78ee1ccf20869)