### PR TITLE
Fix premature direct shader support reporting

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -3388,6 +3388,8 @@ function buildShaderProgramPayload({
       statementTargets: statements.map((statement) => statement.target),
     },
   };
+}
+
 function isUnsupportedParsedShaderStatement({
   statement,
   shaderEnv,
@@ -3557,7 +3559,8 @@ function extractShaderControls(
         unsupportedLines.push(line);
         return;
       }
-      supportedLineCount += 1;
+      directProgramStatements.push(parsedStatement);
+      directProgramLines.push(line);
       return;
     }
 
@@ -5594,10 +5597,7 @@ function createIR(
           requiresControlFallback:
             shaderWarpAnalysis.directProgramStatements.length !==
             shaderWarpAnalysis.statements.length,
-          supportedBackends:
-            shaderWarpAnalysis.unsupportedLines.length === 0
-              ? ['webgl', 'webgpu']
-              : [],
+          supportedBackends: [],
         })
       : null;
   const compShaderProgram =
@@ -5609,18 +5609,20 @@ function createIR(
           requiresControlFallback:
             shaderCompAnalysis.directProgramStatements.length !==
             shaderCompAnalysis.statements.length,
-          supportedBackends:
-            shaderCompAnalysis.unsupportedLines.length === 0
-              ? ['webgl', 'webgpu']
-              : [],
+          supportedBackends: [],
         })
       : null;
+  const directProgramLines = [
+    ...shaderWarpAnalysis.directProgramLines,
+    ...shaderCompAnalysis.directProgramLines,
+  ].map(normalizeBlockedConstructValue);
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
   const approximatedShaderLines = [
     ...shaderWarpAnalysis.unsupportedLines,
     ...shaderCompAnalysis.unsupportedLines,
+    ...directProgramLines,
   ].map(normalizeBlockedConstructValue);
   const blockingConstructDetails = buildBlockingConstructDetails({
     sourceId: source.id,
@@ -5656,13 +5658,13 @@ function createIR(
     assignedTargets,
   );
   const hasShaderText = Boolean(warpShaderText || compShaderText);
+  const hasDirectShaderPrograms =
+    warpShaderProgram !== null || compShaderProgram !== null;
   const hasBlockingShaderApproximation = blockingConstructDetails.some(
     (construct) => construct.kind === 'shader' && !construct.allowlisted,
   );
   supportedShaderText =
-    shaderWarpAnalysis.supported ||
-    shaderCompAnalysis.supported ||
-    (hasShaderText && !hasBlockingShaderApproximation);
+    shaderWarpAnalysis.supported || shaderCompAnalysis.supported;
   unsupportedShaderText = hasBlockingShaderApproximation;
   if (unsupportedShaderText) {
     addDiagnostic(
@@ -5677,21 +5679,8 @@ function createIR(
       ? unsupportedShaderText
         ? { webgl: 'unsupported', webgpu: 'unsupported' }
         : {
-            webgl:
-              warpShaderProgram || compShaderProgram ? 'direct' : 'translated',
-            webgpu:
-              (warpShaderProgram === null ||
-                warpShaderProgram.execution.supportedBackends.includes(
-                  'webgpu',
-                )) &&
-              (compShaderProgram === null ||
-                compShaderProgram.execution.supportedBackends.includes(
-                  'webgpu',
-                ))
-                ? warpShaderProgram || compShaderProgram
-                  ? 'direct'
-                  : 'translated'
-                : 'translated',
+            webgl: hasDirectShaderPrograms ? 'unsupported' : 'translated',
+            webgpu: hasDirectShaderPrograms ? 'unsupported' : 'translated',
           }
       : { webgl: 'none', webgpu: 'none' };
   const featureAnalysis = buildFeatureAnalysis({

--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -5619,11 +5619,14 @@ function createIR(
   const ignoredFields = [
     ...new Set([...softUnknownKeys, ...hardUnsupportedFields.keys()]),
   ].sort();
-  const approximatedShaderLines = [
-    ...shaderWarpAnalysis.unsupportedLines,
-    ...shaderCompAnalysis.unsupportedLines,
-    ...directProgramLines,
-  ].map(normalizeBlockedConstructValue);
+  const shaderEnabled = (runtimeGlobals.shader ?? 1) > 0.5;
+  const approximatedShaderLines = shaderEnabled
+    ? [
+        ...shaderWarpAnalysis.unsupportedLines,
+        ...shaderCompAnalysis.unsupportedLines,
+        ...directProgramLines,
+      ].map(normalizeBlockedConstructValue)
+    : [];
   const blockingConstructDetails = buildBlockingConstructDetails({
     sourceId: source.id,
     ignoredFields,
@@ -5658,14 +5661,16 @@ function createIR(
     assignedTargets,
   );
   const hasShaderText = Boolean(warpShaderText || compShaderText);
+  const activeShaderText = hasShaderText && shaderEnabled;
   const hasDirectShaderPrograms =
     warpShaderProgram !== null || compShaderProgram !== null;
   const hasBlockingShaderApproximation = blockingConstructDetails.some(
     (construct) => construct.kind === 'shader' && !construct.allowlisted,
   );
   supportedShaderText =
-    shaderWarpAnalysis.supported || shaderCompAnalysis.supported;
-  unsupportedShaderText = hasBlockingShaderApproximation;
+    activeShaderText &&
+    (shaderWarpAnalysis.supported || shaderCompAnalysis.supported);
+  unsupportedShaderText = activeShaderText && hasBlockingShaderApproximation;
   if (unsupportedShaderText) {
     addDiagnostic(
       diagnostics,
@@ -5675,7 +5680,7 @@ function createIR(
     );
   }
   const shaderTextExecution: MilkdropFeatureAnalysis['shaderTextExecution'] =
-    hasShaderText
+    activeShaderText
       ? unsupportedShaderText
         ? { webgl: 'unsupported', webgpu: 'unsupported' }
         : {
@@ -5879,7 +5884,7 @@ function createIR(
       darken: (numericFields.darken ?? 0) > 0.5,
       solarize: (numericFields.solarize ?? 0) > 0.5,
       invert: (numericFields.invert ?? 0) > 0.5,
-      shaderEnabled: (numericFields.shader ?? 1) > 0.5,
+      shaderEnabled,
       textureWrap: (numericFields.texture_wrap ?? 0) > 0.5,
       feedbackTexture: (numericFields.feedback_texture ?? 0) > 0.5,
       outerBorderStyle: (numericFields.ob_border ?? 0) > 0.5,

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -271,6 +271,35 @@ wave_0_per_point2=y = value2;
     ).toMatchObject(['x = value + value1', 'y = value2']);
   });
 
+  test('ignores disabled shader text when grading backend support', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Disabled Direct Shader
+shader=0
+comp_shader=ret = tex2d(sampler_main, uv).rgb + vec3(0.1, 0.0, 0.0)
+      `.trim(),
+      { id: 'disabled-direct-shader' },
+    );
+
+    expect(compiled.ir.post.shaderEnabled).toBe(false);
+    expect(compiled.ir.shaderText.compProgram).not.toBeNull();
+    expect(
+      compiled.ir.compatibility.featureAnalysis.shaderTextExecution,
+    ).toEqual({
+      webgl: 'none',
+      webgpu: 'none',
+    });
+    expect(
+      compiled.ir.compatibility.featureAnalysis.unsupportedShaderText,
+    ).toBe(false);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.warnings).toEqual([]);
+    expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
+      [],
+    );
+  });
+
   test('supports shader-text subset and feedback-style flags', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -313,7 +313,6 @@ warp_shader=dx=0.08; dy=-0.04; rot=0.3; zoom=1.15
       `.trim(),
       { id: 'shader-transform' },
     );
-
     expect(compiled.ir.shaderText.supported).toBe(true);
     expect(compiled.ir.post.shaderControls.offsetX).toBeCloseTo(0.08, 6);
     expect(compiled.ir.post.shaderControls.offsetY).toBeCloseTo(-0.04, 6);
@@ -687,7 +686,7 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
       { id: 'shader-volume-invert-mix' },
     );
 
-    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.shaderText.supported).toBe(false);
     expect(compiled.ir.post.shaderControls.invertBoost).toBeCloseTo(0, 6);
     expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
     expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('mix');
@@ -702,20 +701,29 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     expect(
       compiled.ir.post.shaderControlExpressions.textureLayer.volumeSliceZ,
     ).not.toBeNull();
-    expect(compiled.diagnostics).toEqual([]);
-    expect(compiled.ir.compatibility.warnings).toEqual([]);
-    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
-    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
-    expect(compiled.ir.shaderText.compProgram).toEqual(
-      expect.objectContaining({
-        stage: 'comp',
-        execution: expect.objectContaining({
-          supportedBackends: ['webgl', 'webgpu'],
+    expect(compiled.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'preset_unsupported_shader_text',
+          severity: 'warning',
         }),
-      }),
+      ]),
+    );
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('partial');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe(
+      'unsupported',
+    );
+    expect(compiled.ir.shaderText.compProgram).toBeNull();
+    expect(compiled.ir.compatibility.warnings).toEqual(
+      expect.arrayContaining([
+        'This preset includes custom shader text outside the fully supported subset and will be approximated.',
+        'WebGPU cannot safely approximate unsupported shader-text lines and must fall back to WebGL.',
+      ]),
     );
     expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
-      [],
+      expect.arrayContaining([
+        'ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisevol_lq, float3(uv, time / 10.0)).xyz, 0.35)',
+      ]),
     );
   });
 

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -657,7 +657,7 @@ video_echo=1
     });
   });
 
-  test('prefers richer shader program payloads on supported backends', () => {
+  test('preserves richer shader program payloads but falls back to controls', () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Direct Shader Program Feedback
@@ -701,11 +701,11 @@ comp_shader=ret = tex2d(sampler_main, uv).rgb + vec3(0.1, 0.0, 0.0);
       }),
     ).toBe(true);
 
-    expect(compositeStates[0]?.shaderExecution).toBe('direct');
+    expect(compositeStates[0]?.shaderExecution).toBe('controls');
     expect(compositeStates[0]?.shaderPrograms.comp?.stage).toBe('comp');
     expect(
       compositeStates[0]?.shaderPrograms.comp?.execution.supportedBackends,
-    ).toEqual(['webgl', 'webgpu']);
+    ).toEqual([]);
   });
 
   test('renders main wave and trails directly on webgpu line-wave presets', () => {

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -730,14 +730,7 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     );
 
     expect(frameState.post.shaderPrograms.warp).toBeNull();
-    expect(frameState.post.shaderPrograms.comp).toEqual(
-      expect.objectContaining({
-        stage: 'comp',
-        execution: expect.objectContaining({
-          supportedBackends: ['webgl', 'webgpu'],
-        }),
-      }),
-    );
+    expect(frameState.post.shaderPrograms.comp).toBeNull();
   });
 
   test('renders ninth shape slot beyond the previous ceiling', () => {


### PR DESCRIPTION
### Motivation
- Prevent presets whose shader text parsed into direct program statements from being advertised as backend-`supported` when the renderer/feedback path does not actually execute those direct programs. 
- Keep compatibility reporting, warnings, and parity data accurate by treating preserved direct-program lines as approximations until render-side execution is implemented.

### Description
- Update shader extraction/classification in `assets/js/milkdrop/compiler.ts` to collect `directProgramStatements`/`directProgramLines` and preserve them as payloads while not claiming backend support by default.  
- Stop assigning non-empty `supportedBackends` for preserved direct-program payloads and fold those lines into the compiler `approximatedShaderLines` inventory so they are treated as approximation/blocked constructs.  
- Change `shaderTextExecution` classification so backends are reported as `translated` or `unsupported` (not `direct`) when preserved direct-program payloads exist, causing appropriate compatibility evidence/warnings to be emitted.  
- Update test expectations across the repo to reflect the corrected behavior: the renderer-adapter test now expects feedback composite state to prefer `controls` (fallback) and preserved program payloads to report empty `supportedBackends`, the VM/compiler tests expect approximations/warnings instead of claiming direct execution, and VM tests no longer expect compiled direct programs to appear as executable post payloads.

### Testing
- Ran focused unit tests: `bun run test tests/milkdrop-vm.test.ts tests/milkdrop-compiler.test.ts tests/milkdrop-renderer-adapter.test.ts`, and the updated assertions passed.  
- Ran the full project quality gate: `bun run check` (Biome + tsc + tests), which completed successfully with no failing tests.  
- Files changed: `assets/js/milkdrop/compiler.ts` and related test updates under `tests/*milkdrop*` to reflect the corrected compatibility/reporting behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedc4d300883328d9db87b05879633)