### PR TITLE
Embed system 'Tune' controls into milkdrop launch panel and add embedded panel variant

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1061,6 +1061,7 @@ body {
 }
 
 .control-panel--inline,
+.control-panel--embedded,
 .shell-panel[data-audio-controls] > .control-panel,
 .shell-panel[data-settings-panel] > .control-panel,
 .shell-panel > [data-audio-controls] > .control-panel,
@@ -1074,6 +1075,23 @@ body {
   width: 100%;
   max-height: min(42dvh, 360px);
   overflow: auto;
+}
+
+.control-panel--embedded {
+  margin-top: 12px;
+  padding: 12px 0 0;
+  border: 0;
+  border-top: 1px solid rgba(255, 239, 214, 0.12);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  clip-path: none;
+  max-height: none;
+}
+
+.control-panel--embedded::before,
+.control-panel--embedded::after {
+  display: none;
 }
 
 .control-panel::before,
@@ -2014,6 +2032,7 @@ body {
   }
 
   .control-panel--inline,
+  .control-panel--embedded,
   .shell-panel[data-audio-controls] > .control-panel,
   .shell-panel[data-settings-panel] > .control-panel,
   .shell-panel > [data-audio-controls] > .control-panel,

--- a/assets/js/bootstrap/toy-page.ts
+++ b/assets/js/bootstrap/toy-page.ts
@@ -135,6 +135,10 @@ export function isPresetFirstToySession(toySlug: string | null) {
   return (toySlug ?? 'milkdrop') === 'milkdrop';
 }
 
+export function shouldCombineFocusedSessionPanels(toySlug: string | null) {
+  return isPresetFirstToySession(toySlug);
+}
+
 export function bootToyPage({
   router,
   loadFromQuery,
@@ -178,7 +182,7 @@ export function bootToyPage({
     }
     return null;
   })();
-  const shouldCollapseShellPanelsAfterAudio = isPresetFirstToySession(toySlug);
+  const shouldCombineLaunchPanels = shouldCombineFocusedSessionPanels(toySlug);
   const toyTitle = resolveToyTitle(toySlug, toyManifest as Toy[]);
   document.title = `${toyTitle} · Stims`;
 
@@ -187,7 +191,7 @@ export function bootToyPage({
   }
 
   const collapseFocusedSessionPanels = () => {
-    if (!shouldCollapseShellPanelsAfterAudio) {
+    if (!shouldCombineLaunchPanels) {
       return;
     }
     if (audioControlsContainer) {
@@ -294,14 +298,33 @@ export function bootToyPage({
   };
 
   const setupSystemControls = (result: CapabilityPreflightResult | null) => {
-    if (!settingsContainer || settingsContainer.childElementCount > 0) return;
-    initSystemControls(settingsContainer, {
+    const host = shouldCombineLaunchPanels
+      ? audioControlsContainer
+      : settingsContainer;
+
+    if (!host) {
+      return;
+    }
+
+    const existingPanel = host.querySelector('.control-panel--embedded');
+    if (shouldCombineLaunchPanels && existingPanel) {
+      return;
+    }
+    if (!shouldCombineLaunchPanels && host.childElementCount > 0) {
+      return;
+    }
+
+    initSystemControls(host, {
       title: 'Tune',
       description: 'Keep the visualizer comfortable and responsive.',
       defaultPresetId:
         result?.performance.recommendedQualityPresetId ?? undefined,
-      variant: 'inline',
+      variant: shouldCombineLaunchPanels ? 'embedded' : 'inline',
     });
+
+    if (shouldCombineLaunchPanels && settingsContainer) {
+      settingsContainer.hidden = true;
+    }
   };
 
   const handlePreflightReady = (result: CapabilityPreflightResult) => {

--- a/assets/js/ui/system-controls.ts
+++ b/assets/js/ui/system-controls.ts
@@ -33,7 +33,7 @@ type SystemControlOptions = {
   description?: string;
   qualityPresets?: QualityPreset[];
   defaultPresetId?: string;
-  variant?: 'floating' | 'inline';
+  variant?: 'floating' | 'inline' | 'embedded';
   includeAdvancedControls?: boolean;
   showDetailedQualitySummary?: boolean;
   onQualityPresetChange?: (preset: QualityPreset) => void;
@@ -178,6 +178,8 @@ export function initSystemControls(
   const panelElement = panel.getElement();
   if (variant === 'inline') {
     panelElement.classList.add('control-panel--inline');
+  } else if (variant === 'embedded') {
+    panelElement.classList.add('control-panel--embedded');
   }
   panel.configure({ title, description });
 

--- a/tests/control-panel.test.js
+++ b/tests/control-panel.test.js
@@ -69,4 +69,20 @@ describe('control panel mobile affordances', () => {
     expect(checkboxes[0].checked).toBe(true);
     expect(checkboxes[2].checked).toBe(false);
   });
+
+  test('supports embedding system controls inside another panel', async () => {
+    const { initSystemControls } = await freshImport();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const panel = initSystemControls(host, {
+      variant: 'embedded',
+    });
+
+    expect(panel.element.classList.contains('control-panel--embedded')).toBe(
+      true,
+    );
+    expect(panel.element.classList.contains('control-panel--inline')).toBe(
+      false,
+    );
+  });
 });

--- a/tests/milkdrop-corpus-compat.test.ts
+++ b/tests/milkdrop-corpus-compat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
+import type { MilkdropFidelityClass } from '../assets/js/milkdrop/types.ts';
 
 type CompatibilityStatus = 'supported' | 'partial' | 'unsupported';
 
@@ -15,7 +16,7 @@ type ShapeCorpusExpectation = {
   diagnostics: readonly string[];
   webgl: CompatibilityStatus;
   webgpu: CompatibilityStatus;
-  fidelityClass: string;
+  fidelityClass: MilkdropFidelityClass;
   unsupportedKeys: readonly string[];
   warnings: readonly string[];
   blockedConstructs: readonly string[];

--- a/tests/toy-page-bootstrap.test.ts
+++ b/tests/toy-page-bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import {
   isPresetFirstToySession,
+  shouldCombineFocusedSessionPanels,
   shouldPreferDemoAudio,
 } from '../assets/js/bootstrap/toy-page.ts';
 
@@ -41,6 +42,12 @@ describe('toy page demo-audio preference', () => {
   test('treats milkdrop as a preset-first session', () => {
     expect(isPresetFirstToySession('milkdrop')).toBe(true);
     expect(isPresetFirstToySession(null)).toBe(true);
+  });
+
+  test('combines focused session panels for milkdrop only', () => {
+    expect(shouldCombineFocusedSessionPanels('milkdrop')).toBe(true);
+    expect(shouldCombineFocusedSessionPanels(null)).toBe(true);
+    expect(shouldCombineFocusedSessionPanels('seary')).toBe(false);
   });
 });
 
@@ -122,5 +129,71 @@ describe('toy page query-driven startup', () => {
 
     expect(receivedAudioOptions?.autoStartSource).toBe('demo');
     expect(receivedAudioOptions?.preferDemoAudio).toBe(true);
+  });
+
+  test('embeds tune controls into the start panel for the focused milkdrop session', async () => {
+    const initSystemControls = mock();
+
+    mock.module('../assets/js/core/capability-preflight.ts', () => ({
+      attachCapabilityPreflight: ({
+        onComplete,
+      }: {
+        onComplete: (result: {
+          canProceed: boolean;
+          performance: { recommendedQualityPresetId: string };
+        }) => void;
+      }) => ({
+        open: mock(),
+        run: async () => {
+          onComplete({
+            canProceed: true,
+            performance: { recommendedQualityPresetId: 'balanced' },
+          });
+        },
+      }),
+    }));
+    mock.module('../assets/js/ui/audio-controls.ts', () => ({
+      initAudioControls: mock(),
+    }));
+    mock.module('../assets/js/ui/system-controls.ts', () => ({
+      initSystemControls,
+    }));
+    mock.module('../assets/js/milkdrop/overlay-intent.ts', () => ({
+      requestMilkdropOverlayTab: mock(),
+    }));
+    mock.module('../assets/js/milkdrop/preset-selection.ts', () => ({
+      requestMilkdropPresetSelection: mock(),
+    }));
+
+    const { bootToyPage } = await freshImport();
+    (
+      window as Window & { happyDOM?: { setURL?: (url: string) => void } }
+    ).happyDOM?.setURL?.('https://example.com/milkdrop/');
+    document.body.innerHTML = `
+      <button data-open-preflight type="button">Run quick check</button>
+      <section data-audio-controls></section>
+      <section data-settings-panel></section>
+    `;
+
+    bootToyPage({
+      router: {
+        getCurrentRoute: () => ({ view: 'toy' as const, slug: 'milkdrop' }),
+        getLibraryHref: () => '/',
+      },
+      loadFromQuery: mock(async () => {}),
+      initNavigation: mock(),
+      audioControlsContainer: document.querySelector('[data-audio-controls]'),
+      settingsContainer: document.querySelector('[data-settings-panel]'),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(initSystemControls).toHaveBeenCalledTimes(1);
+    expect(initSystemControls.mock.calls[0]?.[0]).toBe(
+      document.querySelector('[data-audio-controls]'),
+    );
+    expect(initSystemControls.mock.calls[0]?.[1]).toMatchObject({
+      variant: 'embedded',
+    });
   });
 });


### PR DESCRIPTION
### Motivation

- Make the system "Tune" controls optionally embed inside the audio/start panel for the focused milkdrop session so launch UX is more compact and cohesive.

### Description

- Add a new CSS panel variant `.control-panel--embedded` with tailored layout, borders, and clipping adjustments in `assets/css/base.css` to support embedded appearance.
- Introduce `shouldCombineFocusedSessionPanels` and use it in `bootToyPage` to decide when to embed system controls into the audio/start panel for preset-first sessions (milkdrop), and hide the standalone settings container when embedding.
- Change `initSystemControls` to accept a new `variant: 'embedded'` option and apply the `control-panel--embedded` class when requested in `assets/js/ui/system-controls.ts`.
- Update boot logic in `assets/js/bootstrap/toy-page.ts` to select the correct host and `variant` when initializing system controls and to avoid double-initialization when embedding.
- Small test/type adjustments: import `MilkdropFidelityClass` in `tests/milkdrop-corpus-compat.test.ts` for a stronger type on `fidelityClass`.

### Testing

- Ran `tests/control-panel.test.js` which now includes a test that `initSystemControls(..., { variant: 'embedded' })` adds `.control-panel--embedded`, and it passed.
- Ran `tests/toy-page-bootstrap.test.ts` which covers `shouldCombineFocusedSessionPanels` behavior and verifies that boot embeds the tune controls into the audio container for milkdrop, and it passed.
- Ran `tests/milkdrop-corpus-compat.test.ts` after the type import tweak and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee22e9c74833296f147275fea7f0a)