### PR TITLE
Preserve inverted aux shader texture mixes

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -943,6 +943,7 @@ function createDefaultShaderControls(): MilkdropShaderControls {
       source: 'none',
       mode: 'none',
       sampleDimension: '2d',
+      inverted: false,
       amount: 0,
       scaleX: 1,
       scaleY: 1,
@@ -2003,10 +2004,12 @@ function applyTextureLayerSample(
   controls: MilkdropShaderControls,
   expressions: MilkdropShaderControlExpressions,
   sample: MilkdropExtractedShaderSampleMetadata,
+  options: { inverted?: boolean } = {},
 ) {
   const coordinate = analyzeShaderSampleCoordinate(sample);
   controls.textureLayer.source = sample.source as MilkdropShaderTextureSampler;
   controls.textureLayer.sampleDimension = sample.sampleDimension;
+  controls.textureLayer.inverted = options.inverted ?? false;
   controls.textureLayer.volumeSliceZ = coordinate.volumeSlice.value;
   expressions.textureLayer.sampleDimension = sample.sampleDimension;
   expressions.textureLayer.volumeSliceZ = coordinate.volumeSlice.expression;
@@ -2583,7 +2586,9 @@ function applyShaderAstStatement({
           controls.textureLayer.mode = 'mix';
           controls.textureLayer.amount = amount.value;
           expressions.textureLayer.amount = amount.expression;
-          applyTextureLayerSample(controls, expressions, invertedSample);
+          applyTextureLayerSample(controls, expressions, invertedSample, {
+            inverted: true,
+          });
           return true;
         }
         if (isShaderSolarizeSampleExpression(targetNode)) {
@@ -4533,6 +4538,7 @@ function mergeShaderControlAnalysis(
             : warpAnalysis.controls.textureLayer.mode,
         sampleDimension:
           textureLayerSample.controls.textureLayer.sampleDimension,
+        inverted: textureLayerSample.controls.textureLayer.inverted,
         amount: textureLayerAmount.value,
         scaleX: textureLayerScaleX.value,
         scaleY: textureLayerScaleY.value,

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -272,6 +272,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         overlayTextureSource: { value: 0 },
         overlayTextureMode: { value: 0 },
         overlayTextureSampleDimension: { value: 0 },
+        overlayTextureInvert: { value: 0 },
         overlayTextureAmount: { value: 0 },
         overlayTextureScale: { value: new Vector2(1, 1) },
         overlayTextureOffset: { value: new Vector2(0, 0) },
@@ -340,6 +341,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform float overlayTextureSource;
         uniform float overlayTextureMode;
         uniform float overlayTextureSampleDimension;
+        uniform float overlayTextureInvert;
         uniform float overlayTextureAmount;
         uniform vec2 overlayTextureScale;
         uniform vec2 overlayTextureOffset;
@@ -544,6 +546,9 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
               overlayUv,
               overlayTextureVolumeSliceZ
             ).rgb;
+            if (overlayTextureInvert > 0.5) {
+              overlayColor = 1.0 - overlayColor;
+            }
             float amount = clamp(overlayTextureAmount, 0.0, 1.5);
             if (overlayTextureMode < 1.5) {
               color = mix(color, overlayColor, clamp(amount, 0.0, 1.0));
@@ -622,6 +627,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.overlayTextureMode.value = state.overlayTextureMode;
     uniforms.overlayTextureSampleDimension.value =
       state.overlayTextureSampleDimension;
+    uniforms.overlayTextureInvert.value = state.overlayTextureInvert;
     uniforms.overlayTextureAmount.value = state.overlayTextureAmount;
     uniforms.overlayTextureScale.value.set(
       state.overlayTextureScale.x,

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -302,6 +302,7 @@ function createCompositeUniforms(
     overlayTextureSource: uniform(0),
     overlayTextureMode: uniform(0),
     overlayTextureSampleDimension: uniform(0),
+    overlayTextureInvert: uniform(0),
     overlayTextureAmount: uniform(0),
     overlayTextureScale: uniform(new Vector2(1, 1)),
     overlayTextureOffset: uniform(new Vector2(0, 0)),
@@ -526,12 +527,17 @@ function createCompositeOutputNode(uniforms: CompositeUniformBag) {
     const overlayUv = baseUv
       .mul(uniforms.overlayTextureScale)
       .add(uniforms.overlayTextureOffset);
-    const overlayColor = sampleAuxTextureNode(
+    const overlaySample = sampleAuxTextureNode(
       uniforms.overlayTextureSource,
       uniforms.overlayTextureSampleDimension,
       overlayUv,
       uniforms.overlayTextureVolumeSliceZ,
     ).rgb;
+    const overlayColor = mix(
+      overlaySample,
+      vec3(1).sub(overlaySample),
+      step(0.5, uniforms.overlayTextureInvert),
+    );
     const overlayAmount = clamp(uniforms.overlayTextureAmount, 0, 1.5);
     const overlayMixAmount = clamp(overlayAmount, 0, 1);
     const overlayMix = mix(color, overlayColor, overlayMixAmount);
@@ -735,6 +741,8 @@ class WebGPUMilkdropFeedbackManager {
       state.overlayTextureMode;
     this.compositeMaterial.uniforms.overlayTextureSampleDimension.value =
       state.overlayTextureSampleDimension;
+    this.compositeMaterial.uniforms.overlayTextureInvert.value =
+      state.overlayTextureInvert;
     this.compositeMaterial.uniforms.overlayTextureAmount.value =
       state.overlayTextureAmount;
     this.compositeMaterial.uniforms.overlayTextureScale.value.set(

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -2179,6 +2179,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       overlayTextureSampleDimension: getShaderSampleDimensionId(
         controls.textureLayer.sampleDimension,
       ),
+      overlayTextureInvert: controls.textureLayer.inverted ? 1 : 0,
       overlayTextureAmount: controls.textureLayer.amount,
       overlayTextureScale: {
         x: controls.textureLayer.scaleX,

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -300,6 +300,7 @@ export type MilkdropShaderTextureLayerControls = {
   source: MilkdropShaderTextureSampler;
   mode: MilkdropShaderTextureBlendMode;
   sampleDimension: MilkdropShaderSampleDimension;
+  inverted: boolean;
   amount: number;
   scaleX: number;
   scaleY: number;
@@ -843,6 +844,7 @@ export type MilkdropFeedbackCompositeState = {
   overlayTextureSource: number;
   overlayTextureMode: number;
   overlayTextureSampleDimension: number;
+  overlayTextureInvert: number;
   overlayTextureAmount: number;
   overlayTextureScale: {
     x: number;

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -748,6 +748,7 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     expect(compiled.ir.post.shaderControls.invertBoost).toBeCloseTo(0, 6);
     expect(compiled.ir.post.shaderControls.textureLayer.source).toBe('simplex');
     expect(compiled.ir.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(compiled.ir.post.shaderControls.textureLayer.inverted).toBe(true);
     expect(compiled.ir.post.shaderControls.textureLayer.sampleDimension).toBe(
       '3d',
     );

--- a/tests/milkdrop-input-signals.test.ts
+++ b/tests/milkdrop-input-signals.test.ts
@@ -249,6 +249,7 @@ describe('milkdrop input signal overrides', () => {
             source: 'none',
             mode: 'add',
             sampleDimension: '2d',
+            inverted: false,
             amount: 0,
             scaleX: 1,
             scaleY: 1,

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -607,6 +607,7 @@ video_echo=1
     frameState.post.shaderControls.textureLayer.source = 'simplex';
     frameState.post.shaderControls.textureLayer.mode = 'mix';
     frameState.post.shaderControls.textureLayer.sampleDimension = '3d';
+    frameState.post.shaderControls.textureLayer.inverted = true;
     frameState.post.shaderControls.textureLayer.volumeSliceZ = 0.25;
     frameState.post.shaderControls.warpTexture.source = 'aura';
     frameState.post.shaderControls.warpTexture.sampleDimension = '3d';
@@ -651,6 +652,7 @@ video_echo=1
 
     expect(compositeStates[0]).toMatchObject({
       overlayTextureSampleDimension: 1,
+      overlayTextureInvert: 1,
       overlayTextureVolumeSliceZ: 0.25,
       warpTextureSampleDimension: 1,
       warpTextureVolumeSliceZ: 0.75,

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -733,6 +733,7 @@ comp_shader=ret = mix(tex2d(sampler_main, uv).rgb, 1.0 - tex3D(sampler_fw_noisev
     expect(frameState.post.shaderPrograms.comp).toBeNull();
     expect(frameState.post.shaderControls.textureLayer.source).toBe('simplex');
     expect(frameState.post.shaderControls.textureLayer.mode).toBe('mix');
+    expect(frameState.post.shaderControls.textureLayer.inverted).toBe(true);
     expect(frameState.post.shaderControls.textureLayer.amount).toBeCloseTo(
       0.35,
       6,


### PR DESCRIPTION
### Motivation

- Fix the bug where compiler-marked "supported/translated" shader lines dropped inversion (e.g., `mix(main, 1.0 - aux, amount)`), causing translated playback to render `mix(main, aux, amount)` instead of the authored inverted mix. 
- Ensure translated shader-control playback preserves inversion metadata end-to-end so parity/fallback and translated-render paths match the authored shader behavior.

### Description

- Added an `inverted: boolean` field to `MilkdropShaderTextureLayerControls` and wired it through `createDefaultShaderControls()` and merged shader-control analysis so the flag is preserved when samples are extracted.  
- Taught `applyTextureLayerSample()` to accept `options:{ inverted?: boolean }` and set `inverted: true` when the compiler extracts `1.0 - tex*D(...)` aux samples.  
- Threaded the new inversion bit through the renderer adapter (`overlayTextureInvert`) and into both WebGL and WebGPU feedback managers so the overlay/aux sample is inverted before blending during translated/controls-mode rendering.  
- Updated tests and fixtures to assert the inversion flag is preserved in compiler output, VM post state, and renderer composite state (`tests/milkdrop-compiler.test.ts`, `tests/milkdrop-vm.test.ts`, `tests/milkdrop-renderer-adapter.test.ts`, `tests/milkdrop-input-signals.test.ts`).

### Testing

- Ran the focused suites with `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-vm.test.ts tests/milkdrop-renderer-adapter.test.ts` and observed all tests pass after the fix.  
- Ran the full quality gate with `bun run check` (Biome + TypeScript + tests) and observed the suite complete successfully (`405 pass, 4 skip, 0 fail`).  
- No docs were changed beyond test expectations; change is implementation + test coverage only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee30f754c8332b23b058f54f8592c)