### PR TITLE
Preserve darken_center when formatting compiled presets

### DIFF
--- a/assets/js/milkdrop/formatter.ts
+++ b/assets/js/milkdrop/formatter.ts
@@ -56,6 +56,7 @@ const borderOrder = [
 const postOrder = [
   'brighten',
   'darken',
+  'darken_center',
   'solarize',
   'invert',
   'video_echo_enabled',
@@ -126,6 +127,9 @@ function canonicalKey(key: string) {
   }
   if (key === 'darken') {
     return 'bDarken';
+  }
+  if (key === 'darken_center') {
+    return 'bDarkenCenter';
   }
   if (key === 'solarize') {
     return 'bSolarize';

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -204,6 +204,14 @@ bDarkenCenter=1
     expect(compiled.ir.numericFields.darken_center).toBe(1);
     expect(compiled.ir.post.textureWrap).toBe(true);
     expect(compiled.ir.post.darkenCenter).toBe(true);
+    expect(compiled.formattedSource).toContain('bDarkenCenter=1');
+
+    const recompiled = compileMilkdropPresetSource(compiled.formattedSource, {
+      id: 'rovastar-feedback-aliases-roundtrip',
+    });
+
+    expect(recompiled.ir.numericFields.darken_center).toBe(1);
+    expect(recompiled.ir.post.darkenCenter).toBe(true);
     expect(compiled.ir.compatibility.featureAnalysis.featuresUsed).toContain(
       'post-effects',
     );


### PR DESCRIPTION
### Motivation
- Compiled presets containing the `darken_center` runtime flag were dropped during formatting, causing save/export/reload flows to silently lose the effect.

### Description
- Add `darken_center` to the formatter `postOrder` so serialized numeric sections include the field (`assets/js/milkdrop/formatter.ts`).
- Emit the canonical legacy key `bDarkenCenter` when formatting `darken_center` via `canonicalKey` so formatted presets round-trip (`assets/js/milkdrop/formatter.ts`).
- Add a round-trip regression to assert `formattedSource` contains `bDarkenCenter=1` and that re-compiling the formatted output preserves `darken_center` and `post.darkenCenter` (`tests/milkdrop-compiler.test.ts`).

### Testing
- Ran targeted tests with `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-vm.test.ts`, which passed. 
- Ran the full quality gate with `bun run check` (Biome checks, `tsc --noEmit`, and test suite), which completed successfully (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee9468bf08332a81aacfe1f1ff893)