### PR TITLE
Refactor legacy motion vector generation

### DIFF
--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -972,21 +972,8 @@ class MilkdropPresetVM implements MilkdropVM {
     return null;
   }
 
-  private buildGpuGeometryHints(): MilkdropGpuGeometryHints {
-    return {
-      mainWave: null,
-      trailWaves: [],
-      customWaves: [],
-      meshField: this.getProceduralMeshFieldVisual(),
-      motionVectorField: this.getProceduralMotionVectorFieldVisual(),
-    };
-  }
-
-  private buildMotionVectors(
-    signals: MilkdropRuntimeSignals,
-    meshField: MeshField,
-  ): MilkdropMotionVectorVisual[] {
-    const hasLegacyMotionVectorControls =
+  private hasLegacyMotionVectorControls() {
+    return (
       Math.abs(this.state.mv_dx ?? 0) > 0.0001 ||
       Math.abs(this.state.mv_dy ?? 0) > 0.0001 ||
       Math.abs(this.state.mv_l ?? 0) > 0.0001 ||
@@ -999,25 +986,26 @@ class MilkdropPresetVM implements MilkdropVM {
         (statement) =>
           statement.target === 'motion_vectors_x' ||
           statement.target === 'motion_vectors_y',
-      );
-
-    if (
-      (this.state.motion_vectors ?? 0) < 0.5 &&
-      !hasLegacyMotionVectorControls
-    ) {
-      return [];
-    }
-
-    const countX = clamp(
-      Math.round(this.state.motion_vectors_x ?? 16),
-      1,
-      MAX_MOTION_VECTOR_COLUMNS,
+      )
     );
-    const countY = clamp(
-      Math.round(this.state.motion_vectors_y ?? 12),
-      1,
-      MAX_MOTION_VECTOR_ROWS,
-    );
+  }
+
+  private getMotionVectorGridCounts() {
+    return {
+      countX: clamp(
+        Math.round(this.state.motion_vectors_x ?? 16),
+        1,
+        MAX_MOTION_VECTOR_COLUMNS,
+      ),
+      countY: clamp(
+        Math.round(this.state.motion_vectors_y ?? 12),
+        1,
+        MAX_MOTION_VECTOR_ROWS,
+      ),
+    };
+  }
+
+  private getMotionVectorStyle(hasLegacyMotionVectorControls: boolean) {
     const colorValue = color(
       this.state.mv_r ?? 1,
       this.state.mv_g ?? 1,
@@ -1029,11 +1017,15 @@ class MilkdropPresetVM implements MilkdropVM {
       hasLegacyMotionVectorControls ? 0 : 0.02,
       1,
     );
-    const vectors: MilkdropMotionVectorVisual[] = [];
-    const previousField = this.lastMeshField;
-    const density = meshField.density;
-    const hasPerPixelPrograms =
-      this.preset.ir.programs.perPixel.statements.length > 0;
+
+    return { alpha, colorValue };
+  }
+
+  private buildLegacyMotionVectors(
+    signals: MilkdropRuntimeSignals,
+  ): MilkdropMotionVectorVisual[] {
+    const { countX, countY } = this.getMotionVectorGridCounts();
+    const { alpha, colorValue } = this.getMotionVectorStyle(true);
     const legacyOffsetX = clamp(this.state.mv_dx ?? 0, -1, 1);
     const legacyOffsetY = clamp(this.state.mv_dy ?? 0, -1, 1);
     const legacyLength = Math.max(0, this.state.mv_l ?? 0);
@@ -1041,17 +1033,72 @@ class MilkdropPresetVM implements MilkdropVM {
       Math.min(2 / Math.max(countX, 1), 2 / Math.max(countY, 1)) * 0.625;
     const explicitLegacyMagnitude =
       legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale;
+    const vectors: MilkdropMotionVectorVisual[] = [];
 
     for (let row = 0; row < countY; row += 1) {
       for (let col = 0; col < countX; col += 1) {
         const sourceBaseX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
         const sourceBaseY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
-        const sourceX = hasLegacyMotionVectorControls
-          ? clamp(sourceBaseX + legacyOffsetX, -1, 1)
-          : sourceBaseX;
-        const sourceY = hasLegacyMotionVectorControls
-          ? clamp(sourceBaseY + legacyOffsetY, -1, 1)
-          : sourceBaseY;
+        const sourceX = clamp(sourceBaseX + legacyOffsetX, -1, 1);
+        const sourceY = clamp(sourceBaseY + legacyOffsetY, -1, 1);
+        const currentPoint = this.transformMeshPoint(signals, sourceX, sourceY);
+        const baseDx = (currentPoint.x - sourceX) * 1.35;
+        const baseDy = (currentPoint.y - sourceY) * 1.35;
+        const baseMagnitude = Math.hypot(baseDx, baseDy);
+        let dx = clamp(baseDx, -0.24, 0.24);
+        let dy = clamp(baseDy, -0.24, 0.24);
+
+        if (explicitLegacyMagnitude > 0.0001) {
+          if (baseMagnitude < 0.0001) {
+            continue;
+          }
+          const normalizedX = baseDx / baseMagnitude;
+          const normalizedY = baseDy / baseMagnitude;
+          dx = normalizedX * explicitLegacyMagnitude;
+          dy = normalizedY * explicitLegacyMagnitude;
+        }
+
+        const magnitude = Math.hypot(dx, dy);
+        if (magnitude < 0.002) {
+          continue;
+        }
+
+        vectors.push({
+          positions: [
+            currentPoint.x - dx * 0.45,
+            currentPoint.y - dy * 0.45,
+            0.18,
+            currentPoint.x + dx,
+            currentPoint.y + dy,
+            0.18,
+          ],
+          color: colorValue,
+          alpha,
+          thickness: clamp(1 + magnitude * 10, 1, 4),
+          additive: false,
+        });
+      }
+    }
+
+    return vectors;
+  }
+
+  private buildDerivedMotionVectors(
+    signals: MilkdropRuntimeSignals,
+    meshField: MeshField,
+  ): MilkdropMotionVectorVisual[] {
+    const { countX, countY } = this.getMotionVectorGridCounts();
+    const { alpha, colorValue } = this.getMotionVectorStyle(false);
+    const vectors: MilkdropMotionVectorVisual[] = [];
+    const previousField = this.lastMeshField;
+    const density = meshField.density;
+    const hasPerPixelPrograms =
+      this.preset.ir.programs.perPixel.statements.length > 0;
+
+    for (let row = 0; row < countY; row += 1) {
+      for (let col = 0; col < countX; col += 1) {
+        const sourceX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
+        const sourceY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
         const fieldCol = Math.round((sourceX + 1) * 0.5 * (density - 1));
         const fieldRow = Math.round((sourceY + 1) * 0.5 * (density - 1));
         const index = fieldRow * density + fieldCol;
@@ -1070,26 +1117,14 @@ class MilkdropPresetVM implements MilkdropVM {
         const historyDy = hasPerPixelPrograms
           ? (currentPoint.y - previous.y) * 1.1
           : 0;
-        const baseDx = sourceDx + historyDx;
-        const baseDy = sourceDy + historyDy;
-        const baseMagnitude = Math.hypot(baseDx, baseDy);
-        let dx = clamp(baseDx, -0.24, 0.24);
-        let dy = clamp(baseDy, -0.24, 0.24);
-
-        if (hasLegacyMotionVectorControls && explicitLegacyMagnitude > 0.0001) {
-          if (baseMagnitude < 0.0001) {
-            continue;
-          }
-          const normalizedX = baseDx / baseMagnitude;
-          const normalizedY = baseDy / baseMagnitude;
-          dx = normalizedX * explicitLegacyMagnitude;
-          dy = normalizedY * explicitLegacyMagnitude;
-        }
-
+        const dx = clamp(sourceDx + historyDx, -0.24, 0.24);
+        const dy = clamp(sourceDy + historyDy, -0.24, 0.24);
         const magnitude = Math.hypot(dx, dy);
+
         if (magnitude < 0.002) {
           continue;
         }
+
         vectors.push({
           positions: [
             currentPoint.x - dx * 0.45,
@@ -1100,18 +1135,44 @@ class MilkdropPresetVM implements MilkdropVM {
             0.18,
           ],
           color: colorValue,
-          alpha: hasLegacyMotionVectorControls
-            ? alpha
-            : clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
-          thickness: hasLegacyMotionVectorControls
-            ? clamp(1 + magnitude * 10, 1, 4)
-            : clamp(1 + magnitude * 18, 1, 4),
+          alpha: clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
+          thickness: clamp(1 + magnitude * 18, 1, 4),
           additive: false,
         });
       }
     }
 
     return vectors;
+  }
+
+  private buildGpuGeometryHints(): MilkdropGpuGeometryHints {
+    return {
+      mainWave: null,
+      trailWaves: [],
+      customWaves: [],
+      meshField: this.getProceduralMeshFieldVisual(),
+      motionVectorField: this.getProceduralMotionVectorFieldVisual(),
+    };
+  }
+
+  private buildMotionVectors(
+    signals: MilkdropRuntimeSignals,
+    meshField: MeshField,
+  ): MilkdropMotionVectorVisual[] {
+    const hasLegacyMotionVectorControls = this.hasLegacyMotionVectorControls();
+
+    if (
+      (this.state.motion_vectors ?? 0) < 0.5 &&
+      !hasLegacyMotionVectorControls
+    ) {
+      return [];
+    }
+
+    if (hasLegacyMotionVectorControls) {
+      return this.buildLegacyMotionVectors(signals);
+    }
+
+    return this.buildDerivedMotionVectors(signals, meshField);
   }
 
   private buildShapes(signals: MilkdropRuntimeSignals): MilkdropShapeVisual[] {

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -10,11 +10,27 @@ function makeSignals({
   beatPulse = 0.1,
   frequencyValue = 160,
   time = frame / 60,
+  bass = 0.7,
+  bassAtt = 0.6,
+  mid = 0.5,
+  mids = 0.5,
+  midsAtt = 0.45,
+  treb = 0.4,
+  treble = 0.4,
+  trebleAtt = 0.35,
 }: {
   frame?: number;
   beatPulse?: number;
   frequencyValue?: number;
   time?: number;
+  bass?: number;
+  bassAtt?: number;
+  mid?: number;
+  mids?: number;
+  midsAtt?: number;
+  treb?: number;
+  treble?: number;
+  trebleAtt?: number;
 } = {}): MilkdropRuntimeSignals {
   const frequencyData = new Uint8Array(64);
   frequencyData.fill(frequencyValue);
@@ -24,19 +40,19 @@ function makeSignals({
     deltaMs: 16.67,
     frame,
     fps: 60,
-    bass: 0.7,
-    mid: 0.5,
-    mids: 0.5,
-    treb: 0.4,
-    treble: 0.4,
-    bassAtt: 0.6,
-    bass_att: 0.6,
-    mid_att: 0.45,
-    midsAtt: 0.45,
-    mids_att: 0.45,
-    treb_att: 0.35,
-    trebleAtt: 0.35,
-    treble_att: 0.35,
+    bass,
+    mid,
+    mids,
+    treb,
+    treble,
+    bassAtt,
+    bass_att: bassAtt,
+    mid_att: midsAtt,
+    midsAtt,
+    mids_att: midsAtt,
+    treb_att: trebleAtt,
+    trebleAtt,
+    treble_att: trebleAtt,
     rms: 0.5,
     vol: 0.5,
     music: 0.58,
@@ -533,6 +549,63 @@ per_pixel_1=zoom=1.06 + beat_pulse * 0.05; rot=rot + 0.04; warp=0.24 + bass_att 
     expect(second.motionVectors[0]?.positions).not.toEqual(
       first.motionVectors[0]?.positions,
     );
+  });
+
+  test('builds Rovastar legacy motion vectors from the declared lattice without mesh-history drift', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'public',
+        'milkdrop-presets',
+        'rovastar-parallel-universe.milk',
+      ),
+      'utf8',
+    );
+    const preset = compileMilkdropPresetSource(source, {
+      id: 'rovastar-parallel-universe',
+      title: 'Rovastar - Parallel Universe',
+      origin: 'bundled',
+    });
+
+    const warmedVm = createMilkdropVM(preset);
+    warmedVm.step(
+      makeSignals({
+        frame: 1,
+        bass: 0.2,
+        bassAtt: 0.2,
+      }),
+    );
+    const warmedFrame = warmedVm.step(
+      makeSignals({
+        frame: 2,
+        bass: 1.4,
+        bassAtt: 1.35,
+      }),
+    );
+
+    const freshFrame = createMilkdropVM(preset).step(
+      makeSignals({
+        frame: 2,
+        bass: 1.4,
+        bassAtt: 1.35,
+      }),
+    );
+
+    expect(warmedFrame.variables.motion_vectors_x).toBeCloseTo(12, 6);
+    expect(warmedFrame.variables.motion_vectors_y).toBeCloseTo(9, 6);
+    expect(warmedFrame.variables.mv_l).toBeCloseTo(4.4, 6);
+    expect(warmedFrame.motionVectors.length).toBeGreaterThan(100);
+    expect(warmedFrame.motionVectors).toEqual(freshFrame.motionVectors);
+
+    const sampleVector = warmedFrame.motionVectors[40];
+    expect(sampleVector?.color.r).toBeCloseTo(1, 6);
+    expect(sampleVector?.alpha).toBeCloseTo(0, 6);
+
+    const dx =
+      (sampleVector?.positions[3] ?? 0) - (sampleVector?.positions[0] ?? 0);
+    const dy =
+      (sampleVector?.positions[4] ?? 0) - (sampleVector?.positions[1] ?? 0);
+    expect(Math.hypot(dx, dy)).toBeGreaterThan(0.4);
   });
 
   test('warp animation speed changes per-pixel mesh deformation over time', () => {


### PR DESCRIPTION
### Motivation

- Prevent legacy `mv_*` presets from being approximated by mesh-history deltas and restore explicit lattice semantics for presets that declare motion-vector controls.
- Preserve the derived/mesh-history approach for newer procedural approximations while ensuring fidelity for Rovastar-style presets that rely on declared lattice and `mv_l` semantics.

### Description

- Split `buildMotionVectors()` into a small set of helpers and two paths: `buildLegacyMotionVectors()` for explicit `mv_*` / lattice controls and `buildDerivedMotionVectors()` for the mesh-history-derived approximation, with `hasLegacyMotionVectorControls()` routing between them (changes in `assets/js/milkdrop/vm.ts`).
- In the legacy path, compute the grid points directly from the declared motion-vector lattice and legacy offsets/length semantics using `transformMeshPoint()` instead of relying on `lastMeshField` deltas.
- Kept the derived mesh-history approach intact and only used when the preset does not explicitly set legacy `mv_*` controls.
- Added regression coverage in `tests/milkdrop-vm.test.ts` that loads `public/milkdrop-presets/rovastar-parallel-universe.milk` and asserts the Rovastar-style values (`nMotionVectorsX=12`, `nMotionVectorsY=9`, `mv_l=4.4`) and that warmed vs fresh runs produce identical legacy-vector output.

### Testing

- Ran targeted VM and corpus tests with `bun run test tests/milkdrop-vm.test.ts tests/milkdrop-corpus-compat.test.ts` and those tests passed.
- Ran the full quality gate via `bun run check`; the command completed but reported a single failing parity expectation in `tests/milkdrop-parity.test.ts` (the parity descriptor-plan / `fallbackToLegacyFeedback` expectation mismatch) that is unrelated to the motion-vector change.
- Updated and ran the modified VM tests locally and the new Rovastar regression passed as part of the VM test suite run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee90ab5a48332a093948ebfb09cb1)