### PR TITLE
Tone down homepage Winamp homage

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -6811,11 +6811,16 @@ section.intro,
 .winamp-deck {
   display: grid;
   gap: 0;
+  width: min(100%, 26rem);
+  justify-self: end;
   border-radius: 8px;
   border: 1px solid rgba(220, 231, 255, 0.38);
   overflow: hidden;
   background: linear-gradient(180deg, #6e7ea2 0%, #445476 18%, #23314f 100%);
-  box-shadow: var(--shadow-panel);
+  box-shadow: 0 12px 28px rgba(4, 8, 18, 0.24);
+  opacity: 0.82;
+  filter: saturate(0.72) brightness(0.94);
+  transform: translateX(0.6rem);
 }
 
 .winamp-deck__titlebar {
@@ -6969,6 +6974,8 @@ section.intro,
     linear-gradient(180deg, #516285, #26324e 10%, #121a2e 100%);
   border: 1px solid rgba(213, 224, 255, 0.32);
   box-shadow: var(--shadow-panel);
+  position: relative;
+  z-index: 1;
 }
 
 .milkdrop-stage__frame {
@@ -7040,6 +7047,12 @@ section.intro,
 }
 
 @media (max-width: 760px) {
+  .winamp-deck {
+    width: 100%;
+    justify-self: stretch;
+    transform: none;
+  }
+
   .winamp-deck__body {
     grid-template-columns: 1fr;
   }
@@ -7161,6 +7174,9 @@ section.intro,
     var(--winamp-metal-mid) 20%,
     var(--winamp-metal-low) 100%
   );
+  opacity: 0.7;
+  filter: saturate(0.55) brightness(0.92);
+  transform: translate(0.85rem, 0.45rem) scale(0.97);
 }
 
 .winamp-deck__titlebar,
@@ -7370,6 +7386,8 @@ section.intro,
 
 .milkdrop-stage {
   padding: 0.55rem;
+  margin-top: -1.6rem;
+  margin-left: 1.25rem;
 }
 
 .home-proof-card,
@@ -7382,6 +7400,11 @@ section.intro,
 }
 
 @media (max-width: 760px) {
+  .milkdrop-stage {
+    margin-top: -0.8rem;
+    margin-left: 0.35rem;
+  }
+
   .winamp-deck__stack {
     gap: 0.45rem;
   }

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           <div class="home-hero__grid">
             <div class="home-hero__copy">
               <p class="eyebrow">Independent browser-native visualizer</p>
-              <h1>MilkDrop energy, remixed with Winamp-era chrome.</h1>
+              <h1>MilkDrop energy, tuned for the browser.</h1>
               <p class="tagline">
                 Start with demo audio now. Use <code>/milkdrop/</code> for mic or tab audio,
                 presets, and editing.
@@ -125,8 +125,8 @@
               </div>
               <div class="home-hero__focus" aria-label="Launch flow summary">
                 <p class="home-hero__support">
-                  The homepage keeps the classic player feel on the surface, then hands you the
-                  deeper controls inside <code>/milkdrop/</code> when you want them.
+                  The homepage nods to the desktop-visualizer lineage, then hands you the deeper
+                  controls inside <code>/milkdrop/</code> when you want them.
                 </p>
                 <ul class="home-hero__checklist">
                   <li>Boot the visualizer fast with bundled demo audio.</li>
@@ -220,7 +220,7 @@
               </div>
               <aside class="home-hero__aside" aria-label="What opens in MilkDrop">
                 <p class="home-hero__aside-label">Inside <code>/milkdrop/</code></p>
-                <h2>Classic desktop feel, modern browser flow.</h2>
+                <h2>Preset-first launch, modern browser flow.</h2>
                 <p>Audio setup, presets, and editing live inside <code>/milkdrop/</code>.</p>
               </aside>
             </div>


### PR DESCRIPTION
### Motivation
- Make the homepage hero and visual treatment less explicitly Winamp-like so the flagship message emphasizes a browser-native MilkDrop lineage rather than overt desktop nostalgia.

### Description
- Updated homepage copy in `index.html` to soften Winamp-era language by changing the main headline, the supporting launch summary, and the `/milkdrop/` aside heading.
- Adjusted `.winamp-deck` styles in `assets/css/index.css` to reduce visual prominence by capping width, lowering saturation/opacity, offsetting and scaling the element, and adding responsive fallbacks.
- Elevated and offset the `.milkdrop-stage` with z-index and negative margin so the MilkDrop stage reads as the primary focal element above the retro mockup.
- Files modified: `index.html`, `assets/css/index.css`.

### Testing
- `bun run check` (quality gate + tests) was executed and the build/test sweep ran, but the run reported failing assertions in pre-existing parity/renderer tests (`tests/milkdrop-parity.test.ts` and `tests/milkdrop-renderer-adapter.test.ts`); failures appear unrelated to the HTML/CSS-only changes.
- `bun run build` completed successfully and produced the production artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beeafa9a848332abe25761958a6b89)