### PR TITLE
Fix closed wave loop batching for WebGPU renderer batching layer

### DIFF
--- a/assets/js/milkdrop/renderer-adapter-webgpu.ts
+++ b/assets/js/milkdrop/renderer-adapter-webgpu.ts
@@ -267,6 +267,7 @@ function appendPolylineSegments(
   color: MilkdropColor,
   alpha: number,
   width: number,
+  closeLoop = false,
 ) {
   for (let index = 0; index + 5 < positions.length; index += 3) {
     target.push({
@@ -281,6 +282,21 @@ function appendPolylineSegments(
       width,
     });
   }
+  if (!closeLoop || positions.length < 6) {
+    return;
+  }
+  const lastPointIndex = positions.length - 3;
+  target.push({
+    startX: positions[lastPointIndex] ?? 0,
+    startY: positions[lastPointIndex + 1] ?? 0,
+    startZ: positions[lastPointIndex + 2] ?? 0.24,
+    endX: positions[0] ?? 0,
+    endY: positions[1] ?? 0,
+    endZ: positions[2] ?? 0.24,
+    color,
+    alpha,
+    width,
+  });
 }
 
 function buildProceduralWavePoint(
@@ -1043,6 +1059,7 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
         wave.color,
         wave.alpha * alphaMultiplier,
         0.0025 * Math.max(1, wave.thickness),
+        wave.closed,
       );
     }
     this.getWaveTarget(`wave:${target}`).syncSplit(normal, additive);

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -807,6 +807,49 @@ mesh_density=16
     });
   });
 
+  test('closes manually closed batched main waves on webgpu', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Closed Batched Wave
+wave_mode=0
+wave_usedots=0
+wave_additive=0
+wave_a=0.9
+bModWaveAlphaByVolume=1
+modwavealphastart=0.2
+modwavealphaend=0.6
+      `.trim(),
+      { id: 'closed-batched-wave' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const expectedSegmentCount = frameState.mainWave.positions.length / 3;
+    const root = scene.children[0] as RenderTreeNode;
+    const segmentCounts = flattenRenderTree(root)
+      .filter(
+        (child) =>
+          child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      )
+      .map((child) => getGeometryInstanceCount(child) ?? 0);
+
+    expect(frameState.mainWave.closed).toBe(true);
+    expect(segmentCounts).toContain(expectedSegmentCount);
+  });
+
   test('keeps additive wave materials transparent when alpha exceeds 1', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Close manually-closed main-wave polylines in the WebGPU batching path to match the non-batched WebGL behavior so closed wave modes do not show a visible gap.

### Description
- Added an optional `closeLoop` parameter to `appendPolylineSegments` and emit a final segment from the last point back to the first when `closeLoop` is true, preserving the closing edge for batched polylines (`assets/js/milkdrop/renderer-adapter-webgpu.ts`).
- Propagated `wave.closed` into the WebGPU batcher call-site so closed waves request loop-closing when packed into instanced segment batches (`renderWaveGroup` in `renderer-adapter-webgpu.ts`).
- Added a regression test that renders a closed main wave on the WebGPU adapter and asserts the batched instance counts include the closing edge (`tests/milkdrop-renderer-adapter.test.ts`).

### Testing
- Ran the focused adapter tests with `bun run test tests/milkdrop-renderer-adapter.test.ts`, which passed (25 tests, 0 failures, 89 assertions).
- Ran the project quality gate with `bun run check`; the WebGPU batching changes themselves typecheck, but the full gate surfaced pre-existing TypeScript errors in `assets/js/milkdrop/renderer-adapter.ts` that are unrelated to this fix and remain to be addressed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef6c6c77483329e762cc19b7089c0)