### PR TITLE
Add WebGPU per-pixel field program lowering and descriptor-driven procedural mesh/motion-vector path

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -42,6 +42,9 @@ import type {
   MilkdropFeedbackPostEffectDescriptorPlan,
   MilkdropFidelityClass,
   MilkdropGpuDescriptorUnsupportedMarker,
+  MilkdropGpuFieldExpression,
+  MilkdropGpuFieldProgramDescriptor,
+  MilkdropGpuFieldStatement,
   MilkdropParityReport,
   MilkdropPresetAST,
   MilkdropPresetField,
@@ -471,6 +474,216 @@ function buildSupportedExpressionIdentifierSet() {
     'thickoutline',
   ]);
   return supported;
+}
+
+const GPU_FIELD_STATE_IDENTIFIERS = new Set([
+  'x',
+  'y',
+  'rad',
+  'ang',
+  'zoom',
+  'zoomexp',
+  'rot',
+  'warp',
+  'cx',
+  'cy',
+  'sx',
+  'sy',
+  'dx',
+  'dy',
+]);
+
+const GPU_FIELD_SIGNAL_ALIAS_MAP = new Map<string, string>([
+  ['time', 'time'],
+  ['frame', 'frame'],
+  ['fps', 'fps'],
+  ['bass', 'bass'],
+  ['mid', 'mid'],
+  ['mids', 'mids'],
+  ['treb', 'treble'],
+  ['treble', 'treble'],
+  ['bass_att', 'bassAtt'],
+  ['bassatt', 'bassAtt'],
+  ['mid_att', 'midAtt'],
+  ['mids_att', 'midsAtt'],
+  ['midsatt', 'midsAtt'],
+  ['treb_att', 'trebleAtt'],
+  ['treble_att', 'trebleAtt'],
+  ['trebleatt', 'trebleAtt'],
+  ['beat', 'beat'],
+  ['beat_pulse', 'beatPulse'],
+  ['beatpulse', 'beatPulse'],
+  ['rms', 'rms'],
+  ['vol', 'vol'],
+  ['music', 'music'],
+  ['weighted_energy', 'weightedEnergy'],
+]);
+
+const GPU_FIELD_FUNCTIONS = new Set([
+  'sin',
+  'cos',
+  'tan',
+  'asin',
+  'acos',
+  'atan',
+  'abs',
+  'sqrt',
+  'pow',
+  'mod',
+  'fmod',
+  'min',
+  'max',
+  'mix',
+  'lerp',
+  'floor',
+  'int',
+  'ceil',
+  'sqr',
+  'clamp',
+  'step',
+  'smoothstep',
+  'log',
+  'exp',
+  'sigmoid',
+  'sign',
+  'bor',
+  'band',
+  'bnot',
+  'atan2',
+  'frac',
+  'if',
+  'above',
+  'below',
+  'equal',
+]);
+
+function isGpuFieldTemporary(identifier: string) {
+  return /^q\d+$/u.test(identifier) || /^t\d+$/u.test(identifier);
+}
+
+function lowerGpuFieldIdentifier(identifier: string) {
+  const normalized = identifier.toLowerCase();
+  if (normalized === 'pi' || normalized === 'e') {
+    return normalized;
+  }
+  if (GPU_FIELD_SIGNAL_ALIAS_MAP.has(normalized)) {
+    return GPU_FIELD_SIGNAL_ALIAS_MAP.get(normalized) ?? normalized;
+  }
+  return normalized;
+}
+
+function isSupportedGpuFieldTarget(identifier: string) {
+  return (
+    GPU_FIELD_STATE_IDENTIFIERS.has(identifier) ||
+    isGpuFieldTemporary(identifier)
+  );
+}
+
+function lowerGpuFieldExpression(
+  expression: MilkdropExpressionNode,
+  allowedIdentifiers: Set<string>,
+): MilkdropGpuFieldExpression | null {
+  switch (expression.type) {
+    case 'literal':
+      return expression;
+    case 'identifier': {
+      const identifier = lowerGpuFieldIdentifier(expression.name);
+      return allowedIdentifiers.has(identifier)
+        ? { type: 'identifier', name: identifier }
+        : null;
+    }
+    case 'unary': {
+      const operand = lowerGpuFieldExpression(
+        expression.operand,
+        allowedIdentifiers,
+      );
+      return operand
+        ? {
+            type: 'unary',
+            operator: expression.operator,
+            operand,
+          }
+        : null;
+    }
+    case 'binary': {
+      const left = lowerGpuFieldExpression(expression.left, allowedIdentifiers);
+      const right = lowerGpuFieldExpression(
+        expression.right,
+        allowedIdentifiers,
+      );
+      return left && right
+        ? {
+            type: 'binary',
+            operator: expression.operator,
+            left,
+            right,
+          }
+        : null;
+    }
+    case 'call': {
+      const name = expression.name.toLowerCase();
+      if (!GPU_FIELD_FUNCTIONS.has(name)) {
+        return null;
+      }
+      const args = expression.args
+        .map((arg) => lowerGpuFieldExpression(arg, allowedIdentifiers))
+        .filter((arg): arg is MilkdropGpuFieldExpression => arg !== null);
+      if (args.length !== expression.args.length) {
+        return null;
+      }
+      return { type: 'call', name, args };
+    }
+    default:
+      return null;
+  }
+}
+
+function lowerGpuFieldProgram(
+  program: MilkdropProgramBlock,
+): MilkdropGpuFieldProgramDescriptor | null {
+  if (program.statements.length === 0) {
+    return null;
+  }
+
+  const allowedIdentifiers = new Set<string>([
+    ...GPU_FIELD_STATE_IDENTIFIERS,
+    ...GPU_FIELD_SIGNAL_ALIAS_MAP.values(),
+    'pi',
+    'e',
+  ]);
+  const temporaries = new Set<string>();
+  const statements: MilkdropGpuFieldStatement[] = [];
+
+  for (const statement of program.statements) {
+    const target = lowerGpuFieldIdentifier(statement.target);
+    if (!isSupportedGpuFieldTarget(target)) {
+      return null;
+    }
+
+    const expression = lowerGpuFieldExpression(
+      statement.expression,
+      allowedIdentifiers,
+    );
+    if (!expression) {
+      return null;
+    }
+
+    statements.push({ target, expression });
+    allowedIdentifiers.add(target);
+    if (isGpuFieldTemporary(target)) {
+      temporaries.add(target);
+    }
+  }
+
+  return {
+    kind: 'gpu-field-program',
+    statements,
+    temporaries: [...temporaries].sort(),
+    signature: JSON.stringify({
+      temporaries: [...temporaries].sort(),
+      statements,
+    }),
+  };
 }
 
 function hasLegacyMotionVectorControls(
@@ -5431,13 +5644,15 @@ function buildWebGpuDescriptorPlan({
       ),
   ];
 
+  const loweredPerPixelProgram = lowerGpuFieldProgram(programs.perPixel);
   const proceduralMesh: MilkdropProceduralMeshDescriptorPlan | null =
-    programs.perPixel.statements.length === 0
+    programs.perPixel.statements.length === 0 || loweredPerPixelProgram
       ? {
           kind: 'procedural-mesh',
-          requiresPerPixelProgram: false,
+          requiresPerPixelProgram: programs.perPixel.statements.length > 0,
           supportsMotionVectors:
             featureAnalysis.featuresUsed.includes('motion-vectors'),
+          fieldProgram: loweredPerPixelProgram,
         }
       : null;
 

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -33,6 +33,9 @@ import type {
   MilkdropFeedbackCompositeState,
   MilkdropFeedbackManager,
   MilkdropFeedbackSetRenderTarget,
+  MilkdropGpuFieldExpression,
+  MilkdropGpuFieldProgramDescriptor,
+  MilkdropGpuFieldSignalInputs,
   MilkdropGpuGeometryHints,
   MilkdropGpuInteractionTransform,
   MilkdropProceduralCustomWaveVisual,
@@ -192,7 +195,29 @@ type ProceduralFieldUniformState = {
   trebleAtt: { value: number };
   tint: { value: Color };
   alpha: { value: number };
+  signalTime: { value: number };
+  signalFrame: { value: number };
+  signalFps: { value: number };
+  signalBass: { value: number };
+  signalMid: { value: number };
+  signalMids: { value: number };
+  signalTreble: { value: number };
+  signalBassAtt: { value: number };
+  signalMidAtt: { value: number };
+  signalMidsAtt: { value: number };
+  signalTrebleAtt: { value: number };
+  signalBeat: { value: number };
+  signalBeatPulse: { value: number };
+  signalRms: { value: number };
+  signalVol: { value: number };
+  signalMusic: { value: number };
+  signalWeightedEnergy: { value: number };
 };
+
+type ProceduralFieldVisualWithSignals =
+  MilkdropProceduralFieldTransformVisual & {
+    signals: MilkdropGpuFieldSignalInputs;
+  };
 
 type ProceduralInteractionUniformState = {
   interactionOffsetX: { value: number };
@@ -219,6 +244,23 @@ function createProceduralFieldUniformState() {
     trebleAtt: { value: 0 },
     tint: { value: new Color(1, 1, 1) },
     alpha: { value: 1 },
+    signalTime: { value: 0 },
+    signalFrame: { value: 0 },
+    signalFps: { value: 60 },
+    signalBass: { value: 0 },
+    signalMid: { value: 0 },
+    signalMids: { value: 0 },
+    signalTreble: { value: 0 },
+    signalBassAtt: { value: 0 },
+    signalMidAtt: { value: 0 },
+    signalMidsAtt: { value: 0 },
+    signalTrebleAtt: { value: 0 },
+    signalBeat: { value: 0 },
+    signalBeatPulse: { value: 0 },
+    signalRms: { value: 0 },
+    signalVol: { value: 0 },
+    signalMusic: { value: 0 },
+    signalWeightedEnergy: { value: 0 },
   } satisfies ProceduralFieldUniformState;
 }
 
@@ -244,41 +286,376 @@ const PROCEDURAL_INTERACTION_SHADER_CHUNK = `
   }
 `;
 
-const PROCEDURAL_FIELD_SHADER_CHUNK = `
-  vec2 milkdropTransformPoint(vec2 source) {
-    float radius = length(source);
-    float angle = atan(source.y, source.x) + rotation;
-    float transformedX = (source.x - centerX) * scaleX + centerX + translateX;
-    float transformedY = (source.y - centerY) * scaleY + centerY + translateY;
-    float ripple = sin(
-      radius * 12.0 +
-      time * (0.6 + trebleAtt) * (0.35 + warpAnimSpeed)
-    ) * warp * 0.08;
-    float radiusNormalized = clamp(radius / 1.41421356237, 0.0, 1.0);
-    float zoomScale = pow(
-      max(zoom, 0.0001),
-      pow(max(zoomExponent, 0.0001), radiusNormalized * 2.0 - 1.0)
-    );
-    vec2 warped = vec2(
-      (transformedX + cos(angle * 3.0) * ripple) * zoomScale,
-      (transformedY + sin(angle * 4.0) * ripple) * zoomScale
-    );
-    float cosRot = cos(rotation);
-    float sinRot = sin(rotation);
-    return vec2(
-      warped.x * cosRot - warped.y * sinRot,
-      warped.x * sinRot + warped.y * cosRot
-    );
+const PROCEDURAL_FIELD_PROGRAM_SIGNAL_PARAMETERS = `
+  float signalTimeValue,
+  float signalFrameValue,
+  float signalFpsValue,
+  float signalBassValue,
+  float signalMidValue,
+  float signalMidsValue,
+  float signalTrebleValue,
+  float signalBassAttValue,
+  float signalMidAttValue,
+  float signalMidsAttValue,
+  float signalTrebleAttValue,
+  float signalBeatValue,
+  float signalBeatPulseValue,
+  float signalRmsValue,
+  float signalVolValue,
+  float signalMusicValue,
+  float signalWeightedEnergyValue
+`;
+
+const PROCEDURAL_FIELD_PROGRAM_SHADER_HELPERS = `
+  float milkdropBool(float value) {
+    return abs(value) > 0.000001 ? 1.0 : 0.0;
+  }
+
+  float milkdropSelect(bool condition, float whenTrue, float whenFalse) {
+    return condition ? whenTrue : whenFalse;
+  }
+
+  float milkdropBitOr(float left, float right) {
+    return float(int(left) | int(right));
+  }
+
+  float milkdropBitAnd(float left, float right) {
+    return float(int(left) & int(right));
+  }
+
+  float milkdropBitNot(float value) {
+    return float(~int(value));
+  }
+
+  float milkdropFrac(float value) {
+    return value - floor(value);
+  }
+
+  float milkdropSigmoid(float value, float slope) {
+    return 1.0 / (1.0 + exp(-value * slope));
+  }
+
+  float milkdropIf(float condition, float whenTrue, float whenFalse) {
+    return abs(condition) > 0.000001 ? whenTrue : whenFalse;
+  }
+
+  float milkdropAbove(float left, float right) {
+    return left > right ? 1.0 : 0.0;
+  }
+
+  float milkdropBelow(float left, float right) {
+    return left < right ? 1.0 : 0.0;
+  }
+
+  float milkdropEqual(float left, float right) {
+    return abs(left - right) <= 0.000001 ? 1.0 : 0.0;
   }
 `;
 
-function createProceduralMeshMaterial() {
+function gpuFieldVarName(name: string) {
+  switch (name) {
+    case 'zoom':
+      return 'fieldZoom';
+    case 'zoomexp':
+      return 'fieldZoomExponent';
+    case 'rot':
+      return 'fieldRotation';
+    case 'warp':
+      return 'fieldWarp';
+    case 'cx':
+      return 'fieldCenterX';
+    case 'cy':
+      return 'fieldCenterY';
+    case 'sx':
+      return 'fieldScaleX';
+    case 'sy':
+      return 'fieldScaleY';
+    case 'dx':
+      return 'fieldTranslateX';
+    case 'dy':
+      return 'fieldTranslateY';
+    default:
+      return `field_${name}`;
+  }
+}
+
+function gpuFieldIdentifierToShaderSource(name: string) {
+  switch (name) {
+    case 'pi':
+      return '3.141592653589793';
+    case 'e':
+      return '2.718281828459045';
+    case 'time':
+      return 'signalTimeValue';
+    case 'frame':
+      return 'signalFrameValue';
+    case 'fps':
+      return 'signalFpsValue';
+    case 'bass':
+      return 'signalBassValue';
+    case 'mid':
+      return 'signalMidValue';
+    case 'mids':
+      return 'signalMidsValue';
+    case 'treble':
+      return 'signalTrebleValue';
+    case 'bassAtt':
+      return 'signalBassAttValue';
+    case 'midAtt':
+      return 'signalMidAttValue';
+    case 'midsAtt':
+      return 'signalMidsAttValue';
+    case 'trebleAtt':
+      return 'signalTrebleAttValue';
+    case 'beat':
+      return 'signalBeatValue';
+    case 'beatPulse':
+      return 'signalBeatPulseValue';
+    case 'rms':
+      return 'signalRmsValue';
+    case 'vol':
+      return 'signalVolValue';
+    case 'music':
+      return 'signalMusicValue';
+    case 'weightedEnergy':
+      return 'signalWeightedEnergyValue';
+    default:
+      return gpuFieldVarName(name);
+  }
+}
+
+function buildGpuFieldExpressionShaderSource(
+  expression: MilkdropGpuFieldExpression,
+): string {
+  switch (expression.type) {
+    case 'literal':
+      return Number.isFinite(expression.value)
+        ? expression.value.toString()
+        : '0.0';
+    case 'identifier':
+      return gpuFieldIdentifierToShaderSource(expression.name);
+    case 'unary': {
+      const operand = buildGpuFieldExpressionShaderSource(expression.operand);
+      if (expression.operator === '!') {
+        return `(milkdropBool(${operand}) > 0.5 ? 0.0 : 1.0)`;
+      }
+      return `(${expression.operator}${operand})`;
+    }
+    case 'binary': {
+      const left = buildGpuFieldExpressionShaderSource(expression.left);
+      const right = buildGpuFieldExpressionShaderSource(expression.right);
+      switch (expression.operator) {
+        case '^':
+          return `pow(${left}, ${right})`;
+        case '%':
+          return `(abs(${right}) <= 0.000001 ? 0.0 : mod(${left}, ${right}))`;
+        case '|':
+          return `milkdropBitOr(${left}, ${right})`;
+        case '&':
+          return `milkdropBitAnd(${left}, ${right})`;
+        case '<':
+        case '<=':
+        case '>':
+        case '>=':
+        case '==':
+        case '!=':
+          return `(${left} ${expression.operator} ${right} ? 1.0 : 0.0)`;
+        case '&&':
+          return `((milkdropBool(${left}) > 0.5 && milkdropBool(${right}) > 0.5) ? 1.0 : 0.0)`;
+        case '||':
+          return `((milkdropBool(${left}) > 0.5 || milkdropBool(${right}) > 0.5) ? 1.0 : 0.0)`;
+        default:
+          return `(${left} ${expression.operator} ${right})`;
+      }
+    }
+    case 'call': {
+      const args = expression.args.map(buildGpuFieldExpressionShaderSource);
+      switch (expression.name) {
+        case 'mod':
+        case 'fmod':
+          return `(abs(${args[1]}) <= 0.000001 ? 0.0 : mod(${args[0]}, ${args[1]}))`;
+        case 'mix':
+        case 'lerp':
+          return `mix(${args[0]}, ${args[1]}, ${args[2]})`;
+        case 'int':
+          return `floor(${args[0]})`;
+        case 'sqr':
+          return `((${args[0]}) * (${args[0]}))`;
+        case 'sigmoid':
+          return `milkdropSigmoid(${args[0]}, ${args[1]})`;
+        case 'sign':
+          return `sign(${args[0]})`;
+        case 'bor':
+          return `milkdropBitOr(${args[0]}, ${args[1]})`;
+        case 'band':
+          return `milkdropBitAnd(${args[0]}, ${args[1]})`;
+        case 'bnot':
+          return `milkdropBitNot(${args[0]})`;
+        case 'atan2':
+          return `atan(${args[0]}, ${args[1]})`;
+        case 'frac':
+          return `milkdropFrac(${args[0]})`;
+        case 'if':
+          return `milkdropIf(${args[0]}, ${args[1]}, ${args[2]})`;
+        case 'above':
+          return `milkdropAbove(${args[0]}, ${args[1]})`;
+        case 'below':
+          return `milkdropBelow(${args[0]}, ${args[1]})`;
+        case 'equal':
+          return `milkdropEqual(${args[0]}, ${args[1]})`;
+        default:
+          return `${expression.name}(${args.join(', ')})`;
+      }
+    }
+  }
+}
+
+function buildProceduralFieldProgramShaderChunk(
+  program: MilkdropGpuFieldProgramDescriptor | null | undefined,
+) {
+  if (!program) {
+    return `
+      ${PROCEDURAL_FIELD_PROGRAM_SHADER_HELPERS}
+
+      vec2 milkdropTransformPointWithParams(
+        vec2 source,
+        float paramZoom,
+        float paramZoomExponent,
+        float paramRotation,
+        float paramWarp,
+        float paramWarpAnimSpeed,
+        float paramCenterX,
+        float paramCenterY,
+        float paramScaleX,
+        float paramScaleY,
+        float paramTranslateX,
+        float paramTranslateY,
+        ${PROCEDURAL_FIELD_PROGRAM_SIGNAL_PARAMETERS}
+      ) {
+        float radius = length(source);
+        float angle = atan(source.y, source.x) + paramRotation;
+        float transformedX =
+          (source.x - paramCenterX) * paramScaleX + paramCenterX + paramTranslateX;
+        float transformedY =
+          (source.y - paramCenterY) * paramScaleY + paramCenterY + paramTranslateY;
+        float ripple = sin(
+          radius * 12.0 +
+          signalTimeValue * (0.6 + signalTrebleAttValue) * (0.35 + paramWarpAnimSpeed)
+        ) * paramWarp * 0.08;
+        float radiusNormalized = clamp(radius / 1.41421356237, 0.0, 1.0);
+        float zoomScale = pow(
+          max(paramZoom, 0.0001),
+          pow(max(paramZoomExponent, 0.0001), radiusNormalized * 2.0 - 1.0)
+        );
+        vec2 warped = vec2(
+          (transformedX + cos(angle * 3.0) * ripple) * zoomScale,
+          (transformedY + sin(angle * 4.0) * ripple) * zoomScale
+        );
+        float cosRot = cos(paramRotation);
+        float sinRot = sin(paramRotation);
+        return vec2(
+          warped.x * cosRot - warped.y * sinRot,
+          warped.x * sinRot + warped.y * cosRot
+        );
+      }
+    `;
+  }
+
+  const temporaryDeclarations = program.temporaries
+    .map((temporary) => `float ${gpuFieldVarName(temporary)} = 0.0;`)
+    .join('\n        ');
+  const statementCode = program.statements
+    .map(
+      (statement) =>
+        `${gpuFieldVarName(statement.target)} = ${buildGpuFieldExpressionShaderSource(
+          statement.expression,
+        )};`,
+    )
+    .join('\n        ');
+  return `
+    ${PROCEDURAL_FIELD_PROGRAM_SHADER_HELPERS}
+
+    float milkdropNormalizeTransformCenter(float value) {
+      return value >= 0.0 && value <= 1.0 ? value * 2.0 - 1.0 : value;
+    }
+
+    vec2 milkdropTransformPointWithParams(
+      vec2 source,
+      float paramZoom,
+      float paramZoomExponent,
+      float paramRotation,
+      float paramWarp,
+      float paramWarpAnimSpeed,
+      float paramCenterX,
+      float paramCenterY,
+      float paramScaleX,
+      float paramScaleY,
+      float paramTranslateX,
+      float paramTranslateY,
+      ${PROCEDURAL_FIELD_PROGRAM_SIGNAL_PARAMETERS}
+    ) {
+      float field_x = source.x;
+      float field_y = source.y;
+      float field_rad = length(source);
+      float field_ang = atan(source.y, source.x);
+      float fieldZoom = paramZoom;
+      float fieldZoomExponent = paramZoomExponent;
+      float fieldRotation = paramRotation;
+      float fieldWarp = paramWarp;
+      float fieldCenterX = paramCenterX;
+      float fieldCenterY = paramCenterY;
+      float fieldScaleX = paramScaleX;
+      float fieldScaleY = paramScaleY;
+      float fieldTranslateX = paramTranslateX * 0.5;
+      float fieldTranslateY = paramTranslateY * 0.5;
+      ${temporaryDeclarations}
+      ${statementCode}
+
+      float angle = field_ang + fieldRotation;
+      float normalizedCenterX = milkdropNormalizeTransformCenter(fieldCenterX);
+      float normalizedCenterY = milkdropNormalizeTransformCenter(fieldCenterY);
+      float translatedX =
+        (field_x - normalizedCenterX) * fieldScaleX +
+        normalizedCenterX +
+        fieldTranslateX * 2.0;
+      float translatedY =
+        (field_y - normalizedCenterY) * fieldScaleY +
+        normalizedCenterY +
+        fieldTranslateY * 2.0;
+      float ripple = sin(
+        field_rad * 12.0 +
+        signalTimeValue * (0.6 + signalTrebleAttValue) * (0.35 + paramWarpAnimSpeed)
+      ) * fieldWarp * 0.08;
+      float radiusNormalized = clamp(field_rad / 1.41421356237, 0.0, 1.0);
+      float zoomScale = pow(
+        max(fieldZoom, 0.0001),
+        pow(max(fieldZoomExponent, 0.0001), radiusNormalized * 2.0 - 1.0)
+      );
+      float px = (translatedX + cos(angle * 3.0) * ripple) * zoomScale;
+      float py = (translatedY + sin(angle * 4.0) * ripple) * zoomScale;
+      float cosRot = cos(fieldRotation);
+      float sinRot = sin(fieldRotation);
+      return vec2(
+        px * cosRot - py * sinRot,
+        px * sinRot + py * cosRot
+      );
+    }
+  `;
+}
+
+function createProceduralMeshMaterial(
+  program?: MilkdropGpuFieldProgramDescriptor | null,
+) {
   const uniforms = {
     ...createProceduralFieldUniformState(),
     ...createProceduralInteractionUniformState(),
   };
+  const fieldProgramShader = buildProceduralFieldProgramShaderChunk(program);
   return new ShaderMaterial({
     uniforms,
+    userData: {
+      fieldProgramSignature: program?.signature ?? 'default',
+    },
     transparent: true,
     vertexShader: `
       attribute vec3 sourcePosition;
@@ -293,12 +670,59 @@ function createProceduralMeshMaterial() {
       uniform float interactionOffsetY;
       uniform float interactionRotation;
       uniform float interactionScale;
-      ${PROCEDURAL_FIELD_SHADER_CHUNK}
+      uniform float signalTime;
+      uniform float signalFrame;
+      uniform float signalFps;
+      uniform float signalBass;
+      uniform float signalMid;
+      uniform float signalMids;
+      uniform float signalTreble;
+      uniform float signalBassAtt;
+      uniform float signalMidAtt;
+      uniform float signalMidsAtt;
+      uniform float signalTrebleAtt;
+      uniform float signalBeat;
+      uniform float signalBeatPulse;
+      uniform float signalRms;
+      uniform float signalVol;
+      uniform float signalMusic;
+      uniform float signalWeightedEnergy;
+      ${fieldProgramShader}
       ${PROCEDURAL_INTERACTION_SHADER_CHUNK}
 
       void main() {
         vec2 transformed = applyMilkdropInteraction(
-          milkdropTransformPoint(sourcePosition.xy)
+          milkdropTransformPointWithParams(
+            sourcePosition.xy,
+            zoom,
+            zoomExponent,
+            rotation,
+            warp,
+            warpAnimSpeed,
+            centerX,
+            centerY,
+            scaleX,
+            scaleY,
+            translateX,
+            translateY,
+            signalTime,
+            signalFrame,
+            signalFps,
+            signalBass,
+            signalMid,
+            signalMids,
+            signalTreble,
+            signalBassAtt,
+            signalMidAtt,
+            signalMidsAtt,
+            signalTrebleAtt,
+            signalBeat,
+            signalBeatPulse,
+            signalRms,
+            signalVol,
+            signalMusic,
+            signalWeightedEnergy
+          )
         );
         gl_Position = projectionMatrix * modelViewMatrix * vec4(
           transformed.xy,
@@ -319,7 +743,9 @@ function createProceduralMeshMaterial() {
   });
 }
 
-function createProceduralMotionVectorMaterial() {
+function createProceduralMotionVectorMaterial(
+  program?: MilkdropGpuFieldProgramDescriptor | null,
+) {
   const uniforms = {
     ...createProceduralFieldUniformState(),
     ...createProceduralInteractionUniformState(),
@@ -342,9 +768,30 @@ function createProceduralMotionVectorMaterial() {
     previousSourceOffsetY: { value: 0 },
     previousExplicitLength: { value: 0 },
     blendMix: { value: 1 },
+    previousSignalTime: { value: 0 },
+    previousSignalFrame: { value: 0 },
+    previousSignalFps: { value: 60 },
+    previousSignalBass: { value: 0 },
+    previousSignalMid: { value: 0 },
+    previousSignalMids: { value: 0 },
+    previousSignalTreble: { value: 0 },
+    previousSignalBassAtt: { value: 0 },
+    previousSignalMidAtt: { value: 0 },
+    previousSignalMidsAtt: { value: 0 },
+    previousSignalTrebleAtt: { value: 0 },
+    previousSignalBeat: { value: 0 },
+    previousSignalBeatPulse: { value: 0 },
+    previousSignalRms: { value: 0 },
+    previousSignalVol: { value: 0 },
+    previousSignalMusic: { value: 0 },
+    previousSignalWeightedEnergy: { value: 0 },
   };
+  const fieldProgramShader = buildProceduralFieldProgramShaderChunk(program);
   return new ShaderMaterial({
     uniforms,
+    userData: {
+      fieldProgramSignature: program?.signature ?? 'default',
+    },
     transparent: true,
     vertexShader: `
       attribute vec3 sourcePosition;
@@ -386,53 +833,42 @@ function createProceduralMotionVectorMaterial() {
       uniform float previousExplicitLength;
       uniform float blendMix;
       varying float vAlpha;
-      ${PROCEDURAL_FIELD_SHADER_CHUNK}
+      uniform float signalTime;
+      uniform float signalFrame;
+      uniform float signalFps;
+      uniform float signalBass;
+      uniform float signalMid;
+      uniform float signalMids;
+      uniform float signalTreble;
+      uniform float signalBassAtt;
+      uniform float signalMidAtt;
+      uniform float signalMidsAtt;
+      uniform float signalTrebleAtt;
+      uniform float signalBeat;
+      uniform float signalBeatPulse;
+      uniform float signalRms;
+      uniform float signalVol;
+      uniform float signalMusic;
+      uniform float signalWeightedEnergy;
+      uniform float previousSignalTime;
+      uniform float previousSignalFrame;
+      uniform float previousSignalFps;
+      uniform float previousSignalBass;
+      uniform float previousSignalMid;
+      uniform float previousSignalMids;
+      uniform float previousSignalTreble;
+      uniform float previousSignalBassAtt;
+      uniform float previousSignalMidAtt;
+      uniform float previousSignalMidsAtt;
+      uniform float previousSignalTrebleAtt;
+      uniform float previousSignalBeat;
+      uniform float previousSignalBeatPulse;
+      uniform float previousSignalRms;
+      uniform float previousSignalVol;
+      uniform float previousSignalMusic;
+      uniform float previousSignalWeightedEnergy;
+      ${fieldProgramShader}
       ${PROCEDURAL_INTERACTION_SHADER_CHUNK}
-
-      vec2 milkdropTransformPointWithParams(
-        vec2 source,
-        float paramZoom,
-        float paramZoomExponent,
-        float paramRotation,
-        float paramWarp,
-        float paramWarpAnimSpeed,
-        float paramCenterX,
-        float paramCenterY,
-        float paramScaleX,
-        float paramScaleY,
-        float paramTranslateX,
-        float paramTranslateY
-      ) {
-        float radius = length(source);
-        float angle = atan(source.y, source.x) + paramRotation;
-        float transformedX =
-          (source.x - paramCenterX) * paramScaleX +
-          paramCenterX +
-          paramTranslateX;
-        float transformedY =
-          (source.y - paramCenterY) * paramScaleY +
-          paramCenterY +
-          paramTranslateY;
-        float ripple = sin(
-          radius * 12.0 +
-          time * (0.6 + trebleAtt) * (0.35 + paramWarpAnimSpeed)
-        ) * paramWarp * 0.08;
-        float radiusNormalized = clamp(radius / 1.41421356237, 0.0, 1.0);
-        float zoomScale = pow(
-          max(paramZoom, 0.0001),
-          pow(max(paramZoomExponent, 0.0001), radiusNormalized * 2.0 - 1.0)
-        );
-        vec2 warped = vec2(
-          (transformedX + cos(angle * 3.0) * ripple) * zoomScale,
-          (transformedY + sin(angle * 4.0) * ripple) * zoomScale
-        );
-        float cosRot = cos(paramRotation);
-        float sinRot = sin(paramRotation);
-        return vec2(
-          warped.x * cosRot - warped.y * sinRot,
-          warped.x * sinRot + warped.y * cosRot
-        );
-      }
 
       void main() {
         vec2 currentSource = clamp(
@@ -457,7 +893,24 @@ function createProceduralMotionVectorMaterial() {
           scaleX,
           scaleY,
           translateX,
-          translateY
+          translateY,
+          signalTime,
+          signalFrame,
+          signalFps,
+          signalBass,
+          signalMid,
+          signalMids,
+          signalTreble,
+          signalBassAtt,
+          signalMidAtt,
+          signalMidsAtt,
+          signalTrebleAtt,
+          signalBeat,
+          signalBeatPulse,
+          signalRms,
+          signalVol,
+          signalMusic,
+          signalWeightedEnergy
         );
         vec2 previous = milkdropTransformPointWithParams(
           previousSource,
@@ -471,7 +924,24 @@ function createProceduralMotionVectorMaterial() {
           previousScaleX,
           previousScaleY,
           previousTranslateX,
-          previousTranslateY
+          previousTranslateY,
+          previousSignalTime,
+          previousSignalFrame,
+          previousSignalFps,
+          previousSignalBass,
+          previousSignalMid,
+          previousSignalMids,
+          previousSignalTreble,
+          previousSignalBassAtt,
+          previousSignalMidAtt,
+          previousSignalMidsAtt,
+          previousSignalTrebleAtt,
+          previousSignalBeat,
+          previousSignalBeatPulse,
+          previousSignalRms,
+          previousSignalVol,
+          previousSignalMusic,
+          previousSignalWeightedEnergy
         );
         vec2 blendedCurrent = mix(previous, current, blendMix);
         vec2 blendedSource = mix(previousSource, currentSource, blendMix);
@@ -1203,9 +1673,10 @@ function syncProceduralFieldUniforms(
     translateY,
     time,
     trebleAtt,
+    signals,
     tint,
     alpha,
-  }: MilkdropProceduralFieldTransformVisual & {
+  }: ProceduralFieldVisualWithSignals & {
     time: number;
     trebleAtt: number;
     tint: { r: number; g: number; b: number };
@@ -1227,6 +1698,23 @@ function syncProceduralFieldUniforms(
   material.uniforms.trebleAtt.value = trebleAtt;
   material.uniforms.tint.value.setRGB(tint.r, tint.g, tint.b);
   material.uniforms.alpha.value = alpha;
+  material.uniforms.signalTime.value = signals.time;
+  material.uniforms.signalFrame.value = signals.frame;
+  material.uniforms.signalFps.value = signals.fps;
+  material.uniforms.signalBass.value = signals.bass;
+  material.uniforms.signalMid.value = signals.mid;
+  material.uniforms.signalMids.value = signals.mids;
+  material.uniforms.signalTreble.value = signals.treble;
+  material.uniforms.signalBassAtt.value = signals.bassAtt;
+  material.uniforms.signalMidAtt.value = signals.midAtt;
+  material.uniforms.signalMidsAtt.value = signals.midsAtt;
+  material.uniforms.signalTrebleAtt.value = signals.trebleAtt;
+  material.uniforms.signalBeat.value = signals.beat;
+  material.uniforms.signalBeatPulse.value = signals.beatPulse;
+  material.uniforms.signalRms.value = signals.rms;
+  material.uniforms.signalVol.value = signals.vol;
+  material.uniforms.signalMusic.value = signals.music;
+  material.uniforms.signalWeightedEnergy.value = signals.weightedEnergy;
 }
 
 function syncProceduralInteractionUniforms(
@@ -1264,22 +1752,9 @@ function lerpNumber(previous: number, current: number, mix: number) {
   return previous + (current - previous) * mix;
 }
 
-function lerpColor(
-  previous: MilkdropColor,
-  current: MilkdropColor,
-  mix: number,
-) {
-  return {
-    r: lerpNumber(previous.r, current.r, mix),
-    g: lerpNumber(previous.g, current.g, mix),
-    b: lerpNumber(previous.b, current.b, mix),
-    a: lerpNumber(previous.a ?? 1, current.a ?? 1, mix),
-  };
-}
-
 function syncPreviousProceduralFieldUniforms(
   material: ShaderMaterial,
-  field: MilkdropProceduralFieldTransformVisual,
+  field: ProceduralFieldVisualWithSignals,
 ) {
   material.uniforms.previousZoom.value = field.zoom;
   material.uniforms.previousZoomExponent.value = field.zoomExponent;
@@ -1292,6 +1767,24 @@ function syncPreviousProceduralFieldUniforms(
   material.uniforms.previousScaleY.value = field.scaleY;
   material.uniforms.previousTranslateX.value = field.translateX;
   material.uniforms.previousTranslateY.value = field.translateY;
+  material.uniforms.previousSignalTime.value = field.signals.time;
+  material.uniforms.previousSignalFrame.value = field.signals.frame;
+  material.uniforms.previousSignalFps.value = field.signals.fps;
+  material.uniforms.previousSignalBass.value = field.signals.bass;
+  material.uniforms.previousSignalMid.value = field.signals.mid;
+  material.uniforms.previousSignalMids.value = field.signals.mids;
+  material.uniforms.previousSignalTreble.value = field.signals.treble;
+  material.uniforms.previousSignalBassAtt.value = field.signals.bassAtt;
+  material.uniforms.previousSignalMidAtt.value = field.signals.midAtt;
+  material.uniforms.previousSignalMidsAtt.value = field.signals.midsAtt;
+  material.uniforms.previousSignalTrebleAtt.value = field.signals.trebleAtt;
+  material.uniforms.previousSignalBeat.value = field.signals.beat;
+  material.uniforms.previousSignalBeatPulse.value = field.signals.beatPulse;
+  material.uniforms.previousSignalRms.value = field.signals.rms;
+  material.uniforms.previousSignalVol.value = field.signals.vol;
+  material.uniforms.previousSignalMusic.value = field.signals.music;
+  material.uniforms.previousSignalWeightedEnergy.value =
+    field.signals.weightedEnergy;
 }
 
 function syncProceduralWaveObject(
@@ -1418,93 +1911,6 @@ function syncProceduralCustomWaveObject(
   material.uniforms.alpha.value = wave.alpha;
   syncProceduralInteractionUniforms(material, interaction);
   material.blending = wave.additive ? AdditiveBlending : NormalBlending;
-  return next;
-}
-
-function syncInterpolatedProceduralWaveObject(
-  object: Line | undefined,
-  previousWave: MilkdropProceduralWaveVisual,
-  currentWave: MilkdropProceduralWaveVisual,
-  mix: number,
-  alphaMultiplier: number,
-  interaction: MilkdropGpuInteractionTransform | null | undefined,
-) {
-  const next = syncProceduralWaveObject(object, currentWave, interaction);
-  setOrUpdateScalarAttribute(next.geometry, 'sampleValue', currentWave.samples);
-  setOrUpdateScalarAttribute(
-    next.geometry,
-    'previousSampleValue',
-    previousWave.samples,
-  );
-  setOrUpdateScalarAttribute(
-    next.geometry,
-    'sampleVelocity',
-    currentWave.velocities,
-  );
-  setOrUpdateScalarAttribute(
-    next.geometry,
-    'previousSampleVelocity',
-    previousWave.velocities,
-  );
-  const material = next.material as ShaderMaterial;
-  material.uniforms.previousCenterX.value = previousWave.centerX;
-  material.uniforms.previousCenterY.value = previousWave.centerY;
-  material.uniforms.previousScale.value = previousWave.scale;
-  material.uniforms.previousMystery.value = previousWave.mystery;
-  material.uniforms.previousSignalTime.value = previousWave.time;
-  material.uniforms.previousBeatPulse.value = previousWave.beatPulse;
-  material.uniforms.previousTrebleAtt.value = previousWave.trebleAtt;
-  material.uniforms.blendMix.value = mix;
-  material.uniforms.tint.value.setRGB(
-    lerpNumber(previousWave.color.r, currentWave.color.r, mix),
-    lerpNumber(previousWave.color.g, currentWave.color.g, mix),
-    lerpNumber(previousWave.color.b, currentWave.color.b, mix),
-  );
-  material.uniforms.alpha.value =
-    lerpNumber(previousWave.alpha, currentWave.alpha, mix) * alphaMultiplier;
-  material.blending =
-    previousWave.additive || currentWave.additive
-      ? AdditiveBlending
-      : NormalBlending;
-  syncProceduralInteractionUniforms(material, interaction);
-  return next;
-}
-
-function syncInterpolatedProceduralCustomWaveObject(
-  object: Line | undefined,
-  previousWave: MilkdropProceduralCustomWaveVisual,
-  currentWave: MilkdropProceduralCustomWaveVisual,
-  mix: number,
-  alphaMultiplier: number,
-  interaction: MilkdropGpuInteractionTransform | null | undefined,
-) {
-  const next = syncProceduralCustomWaveObject(object, currentWave, interaction);
-  setOrUpdateScalarAttribute(next.geometry, 'sampleValue', currentWave.samples);
-  setOrUpdateScalarAttribute(
-    next.geometry,
-    'previousSampleValue',
-    previousWave.samples,
-  );
-  const material = next.material as ShaderMaterial;
-  material.uniforms.previousCenterX.value = previousWave.centerX;
-  material.uniforms.previousCenterY.value = previousWave.centerY;
-  material.uniforms.previousScaling.value = previousWave.scaling;
-  material.uniforms.previousMystery.value = previousWave.mystery;
-  material.uniforms.previousSignalTime.value = previousWave.time;
-  material.uniforms.previousSpectrum.value = previousWave.spectrum ? 1 : 0;
-  material.uniforms.blendMix.value = mix;
-  material.uniforms.tint.value.setRGB(
-    lerpNumber(previousWave.color.r, currentWave.color.r, mix),
-    lerpNumber(previousWave.color.g, currentWave.color.g, mix),
-    lerpNumber(previousWave.color.b, currentWave.color.b, mix),
-  );
-  material.uniforms.alpha.value =
-    lerpNumber(previousWave.alpha, currentWave.alpha, mix) * alphaMultiplier;
-  material.blending =
-    previousWave.additive || currentWave.additive
-      ? AdditiveBlending
-      : NormalBlending;
-  syncProceduralInteractionUniforms(material, interaction);
   return next;
 }
 
@@ -2536,74 +2942,6 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     trimGroupChildren(group, waves.length);
   }
 
-  private renderInterpolatedProceduralWaveGroup(
-    group: Group,
-    waves: Array<{
-      previous: MilkdropProceduralWaveVisual;
-      current: MilkdropProceduralWaveVisual;
-    }>,
-    mix: number,
-    alphaMultiplier: number,
-    interaction?: MilkdropGpuInteractionTransform | null,
-  ) {
-    for (let index = 0; index < waves.length; index += 1) {
-      const wave = waves[index];
-      if (!wave) {
-        continue;
-      }
-      const existing = group.children[index] as Line | undefined;
-      const synced = syncInterpolatedProceduralWaveObject(
-        existing,
-        wave.previous,
-        wave.current,
-        mix,
-        alphaMultiplier,
-        interaction,
-      );
-      if (!existing) {
-        group.add(synced);
-      } else if (synced !== existing) {
-        group.remove(existing);
-        group.add(synced);
-      }
-    }
-    trimGroupChildren(group, waves.length);
-  }
-
-  private renderInterpolatedProceduralCustomWaveGroup(
-    group: Group,
-    waves: Array<{
-      previous: MilkdropProceduralCustomWaveVisual;
-      current: MilkdropProceduralCustomWaveVisual;
-    }>,
-    mix: number,
-    alphaMultiplier: number,
-    interaction?: MilkdropGpuInteractionTransform | null,
-  ) {
-    for (let index = 0; index < waves.length; index += 1) {
-      const wave = waves[index];
-      if (!wave) {
-        continue;
-      }
-      const existing = group.children[index] as Line | undefined;
-      const synced = syncInterpolatedProceduralCustomWaveObject(
-        existing,
-        wave.previous,
-        wave.current,
-        mix,
-        alphaMultiplier,
-        interaction,
-      );
-      if (!existing) {
-        group.add(synced);
-      } else if (synced !== existing) {
-        group.remove(existing);
-        group.add(synced);
-      }
-    }
-    trimGroupChildren(group, waves.length);
-  }
-
   private renderShapeGroup(
     target: 'shapes' | 'blend-shapes',
     group: Group,
@@ -2633,38 +2971,6 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       }
     }
     trimGroupChildren(group, shapes.length);
-  }
-
-  private renderInterpolatedShapeGroup(
-    group: Group,
-    previousShapes: MilkdropShapeVisual[],
-    currentShapes: MilkdropShapeVisual[],
-    mix: number,
-    alphaMultiplier = 1,
-  ) {
-    const currentByKey = new Map(
-      currentShapes.map((shape) => [shape.key, shape] as const),
-    );
-    const interpolatedShapes = previousShapes.map((shape) => {
-      const current = currentByKey.get(shape.key);
-      if (!current) {
-        return shape;
-      }
-      return {
-        ...shape,
-        x: lerpNumber(shape.x, current.x, mix),
-        y: lerpNumber(shape.y, current.y, mix),
-        radius: lerpNumber(shape.radius, current.radius, mix),
-        rotation: lerpNumber(shape.rotation, current.rotation, mix),
-        color: lerpColor(shape.color, current.color, mix),
-        secondaryColor:
-          shape.secondaryColor && current.secondaryColor
-            ? lerpColor(shape.secondaryColor, current.secondaryColor, mix)
-            : (current.secondaryColor ?? shape.secondaryColor),
-        borderColor: lerpColor(shape.borderColor, current.borderColor, mix),
-      };
-    });
-    this.renderShapeGroup(group, interpolatedShapes, alphaMultiplier);
   }
 
   private renderBorderGroup(
@@ -2760,9 +3066,17 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         ? gpuGeometry.meshField
         : null;
     if (proceduralMesh) {
-      if (!(this.meshLines.material instanceof ShaderMaterial)) {
+      const fieldProgramSignature =
+        proceduralMesh.program?.signature ?? 'default';
+      if (
+        !(this.meshLines.material instanceof ShaderMaterial) ||
+        this.meshLines.material.userData.fieldProgramSignature !==
+          fieldProgramSignature
+      ) {
         disposeMaterial(this.meshLines.material);
-        this.meshLines.material = createProceduralMeshMaterial();
+        this.meshLines.material = createProceduralMeshMaterial(
+          proceduralMesh.program,
+        );
       }
       this.meshLines.geometry = getProceduralMeshGeometry(
         proceduralMesh.density,
@@ -2816,9 +3130,17 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     if (proceduralField) {
       clearGroup(cpuGroup);
       proceduralObject.visible = true;
-      if (!(proceduralObject.material instanceof ShaderMaterial)) {
+      const fieldProgramSignature =
+        proceduralField.program?.signature ?? 'default';
+      if (
+        !(proceduralObject.material instanceof ShaderMaterial) ||
+        proceduralObject.material.userData.fieldProgramSignature !==
+          fieldProgramSignature
+      ) {
         disposeMaterial(proceduralObject.material);
-        proceduralObject.material = createProceduralMotionVectorMaterial();
+        proceduralObject.material = createProceduralMotionVectorMaterial(
+          proceduralField.program,
+        );
       }
       proceduralObject.geometry = getProceduralMotionVectorGeometry(
         proceduralField.countX,
@@ -3065,34 +3387,35 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     this.renderMotionVectors(payload.frameState);
 
     const blend = payload.blendState;
+    const cpuBlend = blend?.mode === 'cpu' ? blend : null;
     this.renderWaveGroup(
       'blend-main-wave',
       this.blendWaveGroup,
-      blend ? [blend.mainWave] : [],
+      cpuBlend ? [cpuBlend.mainWave] : [],
       blend?.alpha ?? 0,
     );
     this.renderWaveGroup(
       'blend-custom-wave',
       this.blendCustomWaveGroup,
-      blend?.customWaves ?? [],
+      cpuBlend?.customWaves ?? [],
       blend?.alpha ?? 0,
     );
     this.renderShapeGroup(
       'blend-shapes',
       this.blendShapeGroup,
-      blend?.shapes ?? [],
+      cpuBlend?.shapes ?? [],
       blend?.alpha ?? 0,
     );
     this.renderBorderGroup(
       'blend-borders',
       this.blendBorderGroup,
-      blend?.borders ?? [],
+      cpuBlend?.borders ?? [],
       blend?.alpha ?? 0,
     );
     this.renderLineVisualGroup(
       'blend-motion-vectors',
       this.blendMotionVectorGroup,
-      blend?.motionVectors ?? [],
+      cpuBlend?.motionVectors ?? [],
       blend?.alpha ?? 0,
     );
 

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -224,10 +224,59 @@ export type MilkdropProceduralWaveDescriptorPlan = {
   sampleSource: 'waveform' | 'spectrum';
 };
 
+export type MilkdropGpuFieldExpression =
+  | { type: 'literal'; value: number }
+  | { type: 'identifier'; name: string }
+  | {
+      type: 'unary';
+      operator: '+' | '-' | '!';
+      operand: MilkdropGpuFieldExpression;
+    }
+  | {
+      type: 'binary';
+      operator:
+        | '+'
+        | '-'
+        | '*'
+        | '/'
+        | '%'
+        | '^'
+        | '|'
+        | '&'
+        | '<'
+        | '<='
+        | '>'
+        | '>='
+        | '=='
+        | '!='
+        | '&&'
+        | '||';
+      left: MilkdropGpuFieldExpression;
+      right: MilkdropGpuFieldExpression;
+    }
+  | {
+      type: 'call';
+      name: string;
+      args: MilkdropGpuFieldExpression[];
+    };
+
+export type MilkdropGpuFieldStatement = {
+  target: string;
+  expression: MilkdropGpuFieldExpression;
+};
+
+export type MilkdropGpuFieldProgramDescriptor = {
+  kind: 'gpu-field-program';
+  statements: MilkdropGpuFieldStatement[];
+  temporaries: string[];
+  signature: string;
+};
+
 export type MilkdropProceduralMeshDescriptorPlan = {
   kind: 'procedural-mesh';
   requiresPerPixelProgram: boolean;
   supportsMotionVectors: boolean;
+  fieldProgram: MilkdropGpuFieldProgramDescriptor | null;
 };
 
 export type MilkdropFeedbackPostEffectDescriptorPlan = {
@@ -638,9 +687,31 @@ export type MilkdropProceduralFieldTransformVisual = {
   translateY: number;
 };
 
+export type MilkdropGpuFieldSignalInputs = {
+  time: number;
+  frame: number;
+  fps: number;
+  bass: number;
+  mid: number;
+  mids: number;
+  treble: number;
+  bassAtt: number;
+  midAtt: number;
+  midsAtt: number;
+  trebleAtt: number;
+  beat: number;
+  beatPulse: number;
+  rms: number;
+  vol: number;
+  music: number;
+  weightedEnergy: number;
+};
+
 export type MilkdropProceduralMeshFieldVisual =
   MilkdropProceduralFieldTransformVisual & {
     density: number;
+    program: MilkdropGpuFieldProgramDescriptor | null;
+    signals: MilkdropGpuFieldSignalInputs;
   };
 
 export type MilkdropProceduralWaveVisual = {
@@ -681,6 +752,8 @@ export type MilkdropProceduralMotionVectorFieldVisual =
     sourceOffsetY: number;
     explicitLength: number;
     legacyControls: boolean;
+    program: MilkdropGpuFieldProgramDescriptor | null;
+    signals: MilkdropGpuFieldSignalInputs;
   };
 
 export type MilkdropGpuGeometryHints = {

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -8,12 +8,14 @@ import type {
   MilkdropColor,
   MilkdropCompiledPreset,
   MilkdropFrameState,
+  MilkdropGpuFieldSignalInputs,
   MilkdropGpuGeometryHints,
   MilkdropMeshVisual,
   MilkdropMotionVectorVisual,
   MilkdropPolyline,
   MilkdropPostVisual,
   MilkdropProceduralCustomWaveVisual,
+  MilkdropProceduralMeshDescriptorPlan,
   MilkdropProceduralMeshFieldVisual,
   MilkdropProceduralMotionVectorFieldVisual,
   MilkdropProceduralWaveVisual,
@@ -296,6 +298,8 @@ type MeshFieldPoint = {
 type MeshField = {
   density: number;
   points: MeshFieldPoint[];
+  program: MilkdropProceduralMeshDescriptorPlan['fieldProgram'];
+  signals: MilkdropGpuFieldSignalInputs | null;
 };
 
 type MotionVectorDescriptorContext = {
@@ -619,11 +623,10 @@ class MilkdropPresetVM implements MilkdropVM {
     );
   }
 
-  private supportsProceduralFieldGeometry() {
-    return (
-      this.renderBackend === 'webgpu' &&
-      this.preset.ir.programs.perPixel.statements.length === 0
-    );
+  private getProceduralMeshDescriptorPlan() {
+    return this.renderBackend === 'webgpu'
+      ? this.preset.ir.compatibility.gpuDescriptorPlans.webgpu.proceduralMesh
+      : null;
   }
 
   private buildProceduralFieldTransform() {
@@ -639,6 +642,30 @@ class MilkdropPresetVM implements MilkdropVM {
       scaleY: this.state.sy ?? 1,
       translateX: (this.state.dx ?? 0) * 2,
       translateY: (this.state.dy ?? 0) * 2,
+    };
+  }
+
+  private buildProceduralFieldSignals(
+    signals: MilkdropRuntimeSignals,
+  ): MilkdropGpuFieldSignalInputs {
+    return {
+      time: signals.time,
+      frame: signals.frame,
+      fps: signals.fps,
+      bass: signals.bass,
+      mid: signals.mid,
+      mids: signals.mids,
+      treble: signals.treble,
+      bassAtt: signals.bassAtt,
+      midAtt: signals.mid_att,
+      midsAtt: signals.midsAtt,
+      trebleAtt: signals.trebleAtt,
+      beat: signals.beat,
+      beatPulse: signals.beatPulse,
+      rms: signals.rms,
+      vol: signals.vol,
+      music: signals.music,
+      weightedEnergy: signals.weightedEnergy,
     };
   }
 
@@ -1128,8 +1155,14 @@ class MilkdropPresetVM implements MilkdropVM {
 
   private buildMeshField(signals: MilkdropRuntimeSignals): MeshField {
     const density = this.getMeshDensity();
-    if (this.supportsProceduralFieldGeometry()) {
-      return { density, points: [] };
+    const proceduralMeshPlan = this.getProceduralMeshDescriptorPlan();
+    if (proceduralMeshPlan) {
+      return {
+        density,
+        points: [],
+        program: proceduralMeshPlan.fieldProgram,
+        signals: this.buildProceduralFieldSignals(signals),
+      };
     }
 
     const points = new Array<MeshFieldPoint>(density * density);
@@ -1148,7 +1181,7 @@ class MilkdropPresetVM implements MilkdropVM {
       }
     }
 
-    return { density, points };
+    return { density, points, program: null, signals: null };
   }
 
   private buildMesh(meshField: MeshField): MilkdropMeshVisual {
@@ -1216,19 +1249,25 @@ class MilkdropPresetVM implements MilkdropVM {
     };
   }
 
-  private getProceduralMeshFieldVisual(): MilkdropProceduralMeshFieldVisual | null {
-    if (!this.supportsProceduralFieldGeometry()) {
+  private getProceduralMeshFieldVisual(
+    meshField: MeshField,
+  ): MilkdropProceduralMeshFieldVisual | null {
+    if (!meshField.signals) {
       return null;
     }
 
     return {
-      density: this.getMeshDensity(),
+      density: meshField.density,
+      program: meshField.program,
+      signals: meshField.signals,
       ...this.buildProceduralFieldTransform(),
     };
   }
 
-  private getProceduralMotionVectorFieldVisual(): MilkdropProceduralMotionVectorFieldVisual | null {
-    if (!this.supportsProceduralFieldGeometry()) {
+  private getProceduralMotionVectorFieldVisual(
+    meshField: MeshField,
+  ): MilkdropProceduralMotionVectorFieldVisual | null {
+    if (!meshField.signals) {
       return null;
     }
 
@@ -1256,17 +1295,21 @@ class MilkdropPresetVM implements MilkdropVM {
       explicitLength:
         legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale,
       legacyControls: motionVectorContext.legacyControls,
+      program: meshField.program,
+      signals: meshField.signals,
       ...this.buildProceduralFieldTransform(),
     };
   }
 
-  private buildGpuGeometryHints(): MilkdropGpuGeometryHints {
+  private buildGpuGeometryHints(
+    meshField: MeshField,
+  ): MilkdropGpuGeometryHints {
     return {
       mainWave: null,
       trailWaves: this.proceduralTrailWaves.slice(),
       customWaves: [],
-      meshField: this.getProceduralMeshFieldVisual(),
-      motionVectorField: this.getProceduralMotionVectorFieldVisual(),
+      meshField: this.getProceduralMeshFieldVisual(meshField),
+      motionVectorField: this.getProceduralMotionVectorFieldVisual(meshField),
     };
   }
 
@@ -1279,7 +1322,7 @@ class MilkdropPresetVM implements MilkdropVM {
       return [];
     }
 
-    if (this.getProceduralMotionVectorFieldVisual()) {
+    if (meshField.signals) {
       return [];
     }
 
@@ -1583,11 +1626,10 @@ class MilkdropPresetVM implements MilkdropVM {
     this.lastWaveform = mainWave;
     this.lastProceduralWave = proceduralMainWave;
 
-    const gpuGeometry = this.buildGpuGeometryHints();
+    const meshField = this.buildMeshField(signals);
+    const gpuGeometry = this.buildGpuGeometryHints(meshField);
     gpuGeometry.mainWave = proceduralMainWave;
     const customWaves = this.buildCustomWaves(signals);
-
-    const meshField = this.buildMeshField(signals);
     const mesh = this.buildMesh(meshField);
     const motionVectors = this.buildMotionVectors(signals, meshField);
     this.lastMeshField = meshField;

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -32,7 +32,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -49,11 +50,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -90,7 +91,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -107,11 +109,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -148,7 +150,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -165,11 +168,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -206,7 +209,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -223,11 +227,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -268,7 +272,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -285,11 +290,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -330,7 +335,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -347,11 +353,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -388,7 +394,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -405,11 +412,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -446,7 +453,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -463,11 +471,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -510,7 +518,41 @@
             "sampleSource": "waveform"
           }
         ],
-        "proceduralMesh": null,
+        "proceduralMesh": {
+          "kind": "procedural-mesh",
+          "requiresPerPixelProgram": true,
+          "supportsMotionVectors": false,
+          "fieldProgram": {
+            "kind": "gpu-field-program",
+            "statements": [
+              {
+                "target": "zoom",
+                "expression": {
+                  "type": "binary",
+                  "operator": "-",
+                  "left": {
+                    "type": "literal",
+                    "value": 0.9615
+                  },
+                  "right": {
+                    "type": "binary",
+                    "operator": "*",
+                    "left": {
+                      "type": "identifier",
+                      "name": "rad"
+                    },
+                    "right": {
+                      "type": "literal",
+                      "value": 0.1
+                    }
+                  }
+                }
+              }
+            ],
+            "temporaries": [],
+            "signature": "{\"temporaries\":[],\"statements\":[{\"target\":\"zoom\",\"expression\":{\"type\":\"binary\",\"operator\":\"-\",\"left\":{\"type\":\"literal\",\"value\":0.9615},\"right\":{\"type\":\"binary\",\"operator\":\"*\",\"left\":{\"type\":\"identifier\",\"name\":\"rad\"},\"right\":{\"type\":\"literal\",\"value\":0.1}}}}]}"
+          }
+        },
         "feedback": null,
         "unsupported": []
       },
@@ -526,11 +568,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -567,7 +609,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -584,11 +627,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -625,7 +668,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -642,11 +686,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -683,7 +727,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -700,11 +745,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -741,7 +786,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -758,11 +804,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -799,7 +845,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -816,11 +863,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -857,7 +904,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -874,11 +922,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -915,7 +963,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -932,11 +981,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -973,7 +1022,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -990,11 +1040,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1031,7 +1081,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1048,11 +1099,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1089,7 +1140,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1106,11 +1158,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1147,7 +1199,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1164,11 +1217,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1205,7 +1258,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1222,11 +1276,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1263,7 +1317,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1280,11 +1335,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1321,7 +1376,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1338,11 +1394,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1379,7 +1435,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1396,11 +1453,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1437,7 +1494,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1454,11 +1512,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1502,7 +1560,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1519,11 +1578,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1567,7 +1626,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1584,11 +1644,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1632,7 +1692,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1649,11 +1710,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1697,7 +1758,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1714,11 +1776,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1762,7 +1824,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1779,11 +1842,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1827,7 +1890,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1844,11 +1908,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1892,7 +1956,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1909,11 +1974,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -1963,7 +2028,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -1980,11 +2046,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -2049,7 +2115,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -2066,11 +2133,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   },
@@ -2109,7 +2176,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -2123,24 +2191,24 @@
           "status": "partial",
           "evidence": [
             {
-              "scope": "backend",
               "status": "partial",
               "code": "supported-shader-text-gap",
-              "feature": null
+              "feature": null,
+              "scope": "backend"
             }
           ]
         }
       },
       "parity": {
         "fidelityClass": "near-exact",
+        "blockedConstructs": [],
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
         "backendDivergence": [
           "status:webgl=supported,webgpu=partial",
           "webgpu:supported-shader-text-gap"
         ],
-        "ignoredFields": [],
-        "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "approximatedShaderLines": []
       }
     }
   },
@@ -2179,7 +2247,8 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false
+          "supportsMotionVectors": false,
+          "fieldProgram": null
         },
         "feedback": null,
         "unsupported": []
@@ -2193,24 +2262,24 @@
           "status": "partial",
           "evidence": [
             {
-              "scope": "backend",
               "status": "partial",
               "code": "supported-shader-text-gap",
-              "feature": null
+              "feature": null,
+              "scope": "backend"
             }
           ]
         }
       },
       "parity": {
         "fidelityClass": "near-exact",
+        "blockedConstructs": [],
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
         "backendDivergence": [
           "status:webgl=supported,webgpu=partial",
           "webgpu:supported-shader-text-gap"
         ],
-        "ignoredFields": [],
-        "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "approximatedShaderLines": []
       }
     }
   },
@@ -2263,7 +2332,25 @@
             "sampleSource": "waveform"
           }
         ],
-        "proceduralMesh": null,
+        "proceduralMesh": {
+          "kind": "procedural-mesh",
+          "requiresPerPixelProgram": true,
+          "supportsMotionVectors": false,
+          "fieldProgram": {
+            "kind": "gpu-field-program",
+            "statements": [
+              {
+                "target": "cx",
+                "expression": {
+                  "type": "identifier",
+                  "name": "x"
+                }
+              }
+            ],
+            "temporaries": [],
+            "signature": "{\"temporaries\":[],\"statements\":[{\"target\":\"cx\",\"expression\":{\"type\":\"identifier\",\"name\":\"x\"}}]}"
+          }
+        },
         "feedback": null,
         "unsupported": []
       },
@@ -2279,11 +2366,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "backendDivergence": [],
-        "ignoredFields": [],
         "blockedConstructs": [],
-        "approximatedShaderLines": [],
-        "missingAliasesOrFunctions": []
+        "ignoredFields": [],
+        "missingAliasesOrFunctions": [],
+        "backendDivergence": [],
+        "approximatedShaderLines": []
       }
     }
   }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -1420,9 +1420,35 @@ motion_vectors_y=5
         kind: 'procedural-mesh',
         requiresPerPixelProgram: false,
         supportsMotionVectors: true,
+        fieldProgram: null,
       },
       feedback: null,
       unsupported: [],
+    });
+  });
+
+  test('lowers a supported per-pixel subset into the WebGPU descriptor plan', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Descriptor Plan Per Pixel
+per_pixel_1=q1=sin(time*0.5+x*2);
+per_pixel_2=x=x+q1*0.05;
+per_pixel_3=zoom=zoom+abs(y)*0.1;
+      `.trim(),
+      { id: 'descriptor-plan-per-pixel' },
+    );
+
+    expect(
+      compiled.ir.compatibility.gpuDescriptorPlans.webgpu.proceduralMesh,
+    ).toMatchObject({
+      kind: 'procedural-mesh',
+      requiresPerPixelProgram: true,
+      supportsMotionVectors: false,
+      fieldProgram: {
+        kind: 'gpu-field-program',
+        temporaries: ['q1'],
+        statements: [{ target: 'q1' }, { target: 'x' }, { target: 'zoom' }],
+      },
     });
   });
 

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -46,7 +46,9 @@ function getGeometryInstanceCount(node: RenderTreeNode | undefined) {
   )?.instanceCount;
 }
 
-function makeSignals(): MilkdropRuntimeSignals {
+function makeSignals(
+  overrides: Partial<MilkdropRuntimeSignals> = {},
+): MilkdropRuntimeSignals {
   const frequencyData = new Uint8Array(64);
   frequencyData.fill(160);
   const waveformData = new Uint8Array(64);
@@ -166,6 +168,7 @@ function makeSignals(): MilkdropRuntimeSignals {
     motion_strength: 0,
     frequencyData,
     waveformData,
+    ...overrides,
   };
 }
 
@@ -202,6 +205,7 @@ shapecode_0_thickoutline=1
       scene,
       camera,
       backend: 'webgpu',
+      preset,
     });
 
     adapter.attach();
@@ -244,6 +248,7 @@ shapecode_1_sides=6
       scene,
       camera,
       backend: 'webgpu',
+      preset,
     });
 
     adapter.attach();
@@ -518,6 +523,52 @@ warpanimspeed=1.4
 
     expect(meshLines.material).toBeInstanceOf(ShaderMaterial);
     expect(meshLines.geometry).toBeDefined();
+  });
+
+  test('renders lowered per-pixel mesh programs directly on webgpu', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Procedural Mesh Per Pixel
+mesh_density=10
+per_pixel_1=q1=sin(time+x*2.5);
+per_pixel_2=x=x+q1*0.04;
+per_pixel_3=zoom=zoom+abs(y)*0.08;
+      `.trim(),
+      { id: 'procedural-mesh-per-pixel' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const frameState = vm.step(makeSignals({ time: 0.75 }));
+
+    expect(frameState.mesh.positions).toHaveLength(0);
+    expect(frameState.gpuGeometry.meshField?.program).not.toBeNull();
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const root = scene.children[0] as {
+      children: Array<{ material?: unknown }>;
+    };
+    const meshLines = root.children[1] as {
+      material?: ShaderMaterial;
+    };
+
+    expect(meshLines.material).toBeInstanceOf(ShaderMaterial);
+    expect(meshLines.material?.userData.fieldProgramSignature).toBe(
+      frameState.gpuGeometry.meshField?.program?.signature,
+    );
   });
 
   test('renders motion vectors directly on webgpu when per-pixel VM work is absent', () => {

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -466,6 +466,36 @@ warpanimspeed=1.5
     expect(frameState.gpuGeometry.motionVectorField?.countX).toBe(6);
   });
 
+  test('emits lowered per-pixel field descriptors on supported webgpu presets', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Procedural GPU Per Pixel
+motion_vectors=1
+motion_vectors_x=5
+motion_vectors_y=3
+mesh_density=12
+per_pixel_1=q1=sin(time+x*3);
+per_pixel_2=x=x+q1*0.04;
+per_pixel_3=warp=warp+abs(y)*0.1;
+      `.trim(),
+      { id: 'procedural-gpu-per-pixel' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const frameState = vm.step(makeSignals({ frame: 7, time: 1.25 }));
+
+    expect(frameState.mesh.positions).toHaveLength(0);
+    expect(frameState.motionVectors).toHaveLength(0);
+    expect(frameState.gpuGeometry.meshField?.program?.temporaries).toEqual([
+      'q1',
+    ]);
+    expect(frameState.gpuGeometry.meshField?.signals.time).toBeCloseTo(1.25, 6);
+    expect(
+      frameState.gpuGeometry.motionVectorField?.program?.statements,
+    ).toHaveLength(3);
+  });
+
   test('keeps waveform-driven main-wave geometry on webgpu line-wave presets', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Enable WebGPU to handle a supported subset of `programs.perPixel` by lowering those statements into a WGSL-friendly field program descriptor instead of requiring an empty per-pixel program.
- Let the VM emit lightweight GPU field descriptors (mesh + motion-vector) and let the WebGPU renderer consume those descriptors directly to evaluate displaced positions and motion vectors on the GPU.

### Description
- Add GPU field AST/types and a lowering pass in `compiler.ts` that validates and lowers a supported subset of MilkDrop per-pixel expressions into `MilkdropGpuFieldProgramDescriptor` payloads and attaches them to the WebGPU descriptor plan when possible.
- Extend `types.ts` with `MilkdropGpuFieldExpression`, `MilkdropGpuFieldStatement`, `MilkdropGpuFieldProgramDescriptor`, and `MilkdropGpuFieldSignalInputs`, and add `fieldProgram`/`program`/`signals` fields to procedural mesh/motion-vector descriptor types.
- Update `vm.ts` so `buildMeshField()` can return a lightweight `program` + `signals` descriptor for WebGPU-capable presets and added helpers to produce the signal input bag for GPU evaluation; preserve CPU point arrays for unsupported presets.
- Rework `renderer-adapter.ts` to accept a field program on the procedural materials, generate a WGSL-friendly shader chunk from the descriptor, feed runtime signal uniforms into the procedural vertex logic, and pick/create shader materials by field-program signature so GPU procedural paths render displaced mesh coordinates and motion-vector directions directly.
- Add/adjust unit tests and snapshot data: extend compiler/VM/renderer adapter tests to assert lowering, VM descriptor emission, and renderer material selection; refresh the projectM compatibility snapshot to include the new descriptor shape.

### Testing
- Ran targeted tests: `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-vm.test.ts tests/milkdrop-renderer-adapter.test.ts` and they passed (all assertions in those suites succeeded).
- Ran compatibility corpus tests: `bun run test tests/milkdrop-projectm-compat.test.ts` and the updated snapshot matched the generated compatibility metadata.
- Ran the repository quality gate: `bun run check` (Biome formatting/lint + TypeScript typecheck + full test sweep) and it succeeded with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef605bfc48332ab423c9771c08b04)