### PR TITLE
Fix WebGPU procedural wave blend alpha and previous-buffer sizing

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -1212,6 +1212,35 @@ function setOrUpdateScalarAttribute(
   geometry.setAttribute(name, attribute);
 }
 
+function resampleScalarValues(values: number[], targetLength: number) {
+  if (values.length === targetLength) {
+    return values;
+  }
+  if (targetLength <= 0) {
+    return [];
+  }
+  if (values.length === 0) {
+    return new Array<number>(targetLength).fill(0);
+  }
+  if (values.length === 1) {
+    return new Array<number>(targetLength).fill(values[0] ?? 0);
+  }
+
+  const resampled = new Array<number>(targetLength);
+  const sourceMaxIndex = values.length - 1;
+  const targetMaxIndex = Math.max(1, targetLength - 1);
+  for (let index = 0; index < targetLength; index += 1) {
+    const position = (index / targetMaxIndex) * sourceMaxIndex;
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.min(sourceMaxIndex, lowerIndex + 1);
+    const mix = position - lowerIndex;
+    const lowerValue = values[lowerIndex] ?? 0;
+    const upperValue = values[upperIndex] ?? lowerValue;
+    resampled[index] = lerpNumber(lowerValue, upperValue, mix);
+  }
+  return resampled;
+}
+
 function lerpNumber(previous: number, current: number, mix: number) {
   return previous + (current - previous) * mix;
 }
@@ -1386,7 +1415,7 @@ function syncInterpolatedProceduralWaveObject(
   setOrUpdateScalarAttribute(
     next.geometry,
     'previousSampleValue',
-    previousWave.samples,
+    resampleScalarValues(previousWave.samples, currentWave.samples.length),
   );
   setOrUpdateScalarAttribute(
     next.geometry,
@@ -1396,7 +1425,10 @@ function syncInterpolatedProceduralWaveObject(
   setOrUpdateScalarAttribute(
     next.geometry,
     'previousSampleVelocity',
-    previousWave.velocities,
+    resampleScalarValues(
+      previousWave.velocities,
+      currentWave.velocities.length,
+    ),
   );
   const material = next.material as ShaderMaterial;
   material.uniforms.previousCenterX.value = previousWave.centerX;
@@ -1435,7 +1467,7 @@ function syncInterpolatedProceduralCustomWaveObject(
   setOrUpdateScalarAttribute(
     next.geometry,
     'previousSampleValue',
-    previousWave.samples,
+    resampleScalarValues(previousWave.samples, currentWave.samples.length),
   );
   const material = next.material as ShaderMaterial;
   material.uniforms.previousCenterX.value = previousWave.centerX;
@@ -2986,12 +3018,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
               payload.frameState.interaction?.waves.scale ?? 1,
               blendMix,
             ),
-            alphaMultiplier:
-              lerpNumber(
-                previousFrame.interaction?.waves.alphaMultiplier ?? 1,
-                payload.frameState.interaction?.waves.alphaMultiplier ?? 1,
-                blendMix,
-              ) * blend.alpha,
+            alphaMultiplier: lerpNumber(
+              previousFrame.interaction?.waves.alphaMultiplier ?? 1,
+              payload.frameState.interaction?.waves.alphaMultiplier ?? 1,
+              blendMix,
+            ),
           },
         );
       } else {
@@ -3038,12 +3069,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
               payload.frameState.interaction?.waves.scale ?? 1,
               blendMix,
             ),
-            alphaMultiplier:
-              lerpNumber(
-                previousFrame.interaction?.waves.alphaMultiplier ?? 1,
-                payload.frameState.interaction?.waves.alphaMultiplier ?? 1,
-                blendMix,
-              ) * blend.alpha,
+            alphaMultiplier: lerpNumber(
+              previousFrame.interaction?.waves.alphaMultiplier ?? 1,
+              payload.frameState.interaction?.waves.alphaMultiplier ?? 1,
+              blendMix,
+            ),
           },
         );
       } else {
@@ -3175,3 +3205,8 @@ export function createMilkdropRendererAdapterCore({
 }
 
 export const createMilkdropRendererAdapter = createMilkdropRendererAdapterCore;
+
+export const __milkdropRendererAdapterTestUtils = {
+  syncInterpolatedProceduralWaveObject,
+  syncInterpolatedProceduralCustomWaveObject,
+};

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -12,7 +12,10 @@ import {
   WebGLRenderer,
 } from 'three';
 import { compileMilkdropPresetSource } from '../assets/js/milkdrop/compiler.ts';
-import { createMilkdropRendererAdapterCore } from '../assets/js/milkdrop/renderer-adapter.ts';
+import {
+  __milkdropRendererAdapterTestUtils,
+  createMilkdropRendererAdapterCore,
+} from '../assets/js/milkdrop/renderer-adapter.ts';
 import { createMilkdropRendererAdapter } from '../assets/js/milkdrop/renderer-adapter-factory.ts';
 import type {
   MilkdropFeedbackCompositeState,
@@ -865,6 +868,146 @@ wavecode_0_a=0.35
 
     expect(frameState.gpuGeometry.customWaves).toHaveLength(1);
     expect(renderedWaveChildren.length).toBeGreaterThan(0);
+  });
+
+  test('keeps procedural blend interaction alpha separate from blend alpha on webgpu', () => {
+    const currentWave = {
+      samples: [0.2, -0.1, 0.3, -0.25, 0.15],
+      velocities: [0.04, -0.02, 0.01, -0.03, 0.02],
+      mode: 0,
+      centerX: 0,
+      centerY: 0,
+      scale: 1,
+      mystery: 0,
+      time: 0.3,
+      beatPulse: 0.2,
+      trebleAtt: 0.35,
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      alpha: 0.4,
+      additive: false,
+      thickness: 1,
+    };
+    const previousWave = {
+      ...currentWave,
+      time: 0.1,
+    };
+
+    const line =
+      __milkdropRendererAdapterTestUtils.syncInterpolatedProceduralWaveObject(
+        undefined,
+        previousWave,
+        currentWave,
+        0.75,
+        0.25,
+        {
+          offsetX: 0,
+          offsetY: 0,
+          rotation: 0,
+          scale: 1,
+          alphaMultiplier: 0.675,
+        },
+      );
+    const material = line.material as ShaderMaterial;
+
+    expect(material.uniforms.alpha.value).toBeCloseTo(0.1, 6);
+    expect(material.uniforms.interactionAlpha.value).toBeCloseTo(0.675, 6);
+    expect(material.uniforms.blendMix.value).toBeCloseTo(0.75, 6);
+  });
+
+  test('resamples previous procedural wave buffers to the current vertex count during webgpu blends', () => {
+    const interpolatedMainWave =
+      __milkdropRendererAdapterTestUtils.syncInterpolatedProceduralWaveObject(
+        undefined,
+        {
+          samples: [0.5, -0.4, 0.3],
+          velocities: [0.08, -0.06, 0.05],
+          mode: 0,
+          centerX: 0,
+          centerY: 0,
+          scale: 1,
+          mystery: 0,
+          time: 0.1,
+          beatPulse: 0.2,
+          trebleAtt: 0.35,
+          color: { r: 1, g: 1, b: 1, a: 1 },
+          alpha: 0.5,
+          additive: false,
+          thickness: 1,
+        },
+        {
+          samples: [0.2, -0.1, 0.3, -0.25, 0.15],
+          velocities: [0.04, -0.02, 0.01, -0.03, 0.02],
+          mode: 0,
+          centerX: 0,
+          centerY: 0,
+          scale: 1,
+          mystery: 0,
+          time: 0.3,
+          beatPulse: 0.2,
+          trebleAtt: 0.35,
+          color: { r: 1, g: 1, b: 1, a: 1 },
+          alpha: 0.5,
+          additive: false,
+          thickness: 1,
+        },
+        0.6,
+        0.4,
+        null,
+      );
+    const interpolatedCustomWave =
+      __milkdropRendererAdapterTestUtils.syncInterpolatedProceduralCustomWaveObject(
+        undefined,
+        {
+          samples: [0.25, -0.15, 0.05],
+          spectrum: false,
+          centerX: 0,
+          centerY: 0,
+          scaling: 1,
+          mystery: 0,
+          time: 0.1,
+          color: { r: 1, g: 0.8, b: 0.6, a: 1 },
+          alpha: 0.35,
+          additive: false,
+        },
+        {
+          samples: Array.from({ length: 40 }, (_, index) =>
+            Math.sin(index / 8),
+          ),
+          spectrum: false,
+          centerX: 0,
+          centerY: 0,
+          scaling: 1,
+          mystery: 0,
+          time: 0.3,
+          color: { r: 0.8, g: 0.4, b: 1, a: 1 },
+          alpha: 0.35,
+          additive: false,
+        },
+        0.6,
+        0.4,
+        null,
+      );
+
+    const mainPreviousSampleValues = interpolatedMainWave.geometry.getAttribute(
+      'previousSampleValue',
+    );
+    const mainPreviousSampleVelocities =
+      interpolatedMainWave.geometry.getAttribute('previousSampleVelocity');
+    const mainSampleT = interpolatedMainWave.geometry.getAttribute('sampleT');
+    const customPreviousSampleValues =
+      interpolatedCustomWave.geometry.getAttribute('previousSampleValue');
+    const customSampleT =
+      interpolatedCustomWave.geometry.getAttribute('sampleT');
+
+    expect(mainPreviousSampleValues.array.length).toBe(
+      mainSampleT.array.length,
+    );
+    expect(mainPreviousSampleVelocities.array.length).toBe(
+      mainSampleT.array.length,
+    );
+    expect(customPreviousSampleValues.array.length).toBe(
+      customSampleT.array.length,
+    );
   });
 
   test('keeps WebGL fallback on CPU geometry for descriptors that WebGPU synthesizes procedurally', () => {


### PR DESCRIPTION
### Motivation
- Fix two WebGPU blend regressions so procedural wave blends match CPU/WebGL behavior: (1) avoid applying `blend.alpha` twice to procedural-wave interaction alpha, and (2) ensure previous-frame procedural sample/velocity buffers match the current vertex count to prevent corrupted attribute reads. 

### Description
- Add `resampleScalarValues()` and use it when uploading `previousSampleValue` and `previousSampleVelocity` so previous-frame buffers are resampled to `currentWave.samples.length`/`currentWave.velocities.length` before setting attributes. (file: `assets/js/milkdrop/renderer-adapter.ts`)
- Stop multiplying the interpolated interaction `alphaMultiplier` by `blend.alpha` when building the interpolated interaction payload for procedural waves so shader opacity no longer falls off as `blend.alpha²`. (file: `assets/js/milkdrop/renderer-adapter.ts`)
- Expose small test helpers (`__milkdropRendererAdapterTestUtils`) to allow direct unit exercise of the interpolation helpers. (file: `assets/js/milkdrop/renderer-adapter.ts`)
- Add regression tests that assert the procedural blend interaction alpha is kept separate from blend alpha and that previous procedural buffers are resampled to the current vertex count. (file: `tests/milkdrop-renderer-adapter.test.ts`)

### Testing
- Ran the targeted renderer tests with `bun run test tests/milkdrop-renderer-adapter.test.ts` and the new/modified tests passed. 
- Ran the full project quality gate with `bun run check` (Biome format/lint, TypeScript typecheck, and test suite) and it completed successfully with all tests passing. 
- Files changed: `assets/js/milkdrop/renderer-adapter.ts`, `tests/milkdrop-renderer-adapter.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef652aa088332bcf3a7497b602f2d)