### PR TITLE
Fix lowered field shader center handling

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -575,10 +575,6 @@ function buildProceduralFieldProgramShaderChunk(
   return `
     ${PROCEDURAL_FIELD_PROGRAM_SHADER_HELPERS}
 
-    float milkdropNormalizeTransformCenter(float value) {
-      return value >= 0.0 && value <= 1.0 ? value * 2.0 - 1.0 : value;
-    }
-
     vec2 milkdropTransformPointWithParams(
       vec2 source,
       float paramZoom,
@@ -612,15 +608,13 @@ function buildProceduralFieldProgramShaderChunk(
       ${statementCode}
 
       float angle = field_ang + fieldRotation;
-      float normalizedCenterX = milkdropNormalizeTransformCenter(fieldCenterX);
-      float normalizedCenterY = milkdropNormalizeTransformCenter(fieldCenterY);
       float translatedX =
-        (field_x - normalizedCenterX) * fieldScaleX +
-        normalizedCenterX +
+        (field_x - fieldCenterX) * fieldScaleX +
+        fieldCenterX +
         fieldTranslateX * 2.0;
       float translatedY =
-        (field_y - normalizedCenterY) * fieldScaleY +
-        normalizedCenterY +
+        (field_y - fieldCenterY) * fieldScaleY +
+        fieldCenterY +
         fieldTranslateY * 2.0;
       float ripple = sin(
         field_rad * 12.0 +

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -571,6 +571,59 @@ per_pixel_3=zoom=zoom+abs(y)*0.08;
     );
   });
 
+  test('keeps lowered field shader centers in clip space without renormalizing', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Procedural Mesh Center
+mesh_density=10
+sx=1.15
+sy=0.9
+per_pixel_1=q1=sin(time+x*2.5);
+per_pixel_2=x=x+q1*0.04;
+      `.trim(),
+      { id: 'procedural-mesh-center' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const frameState = vm.step(makeSignals({ time: 0.75 }));
+
+    expect(frameState.gpuGeometry.meshField?.centerX).toBeCloseTo(0, 6);
+    expect(frameState.gpuGeometry.meshField?.centerY).toBeCloseTo(0, 6);
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const root = scene.children[0] as {
+      children: Array<{ material?: unknown }>;
+    };
+    const meshLines = root.children[1] as {
+      material?: ShaderMaterial;
+    };
+
+    expect(meshLines.material).toBeInstanceOf(ShaderMaterial);
+    expect(meshLines.material?.vertexShader).not.toContain(
+      'milkdropNormalizeTransformCenter',
+    );
+    expect(meshLines.material?.vertexShader).toContain(
+      '(field_x - fieldCenterX) * fieldScaleX',
+    );
+    expect(meshLines.material?.vertexShader).toContain(
+      '(field_y - fieldCenterY) * fieldScaleY',
+    );
+  });
+
   test('renders motion vectors directly on webgpu when per-pixel VM work is absent', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Ensure lowered WebGPU procedural field shaders use the VM-provided `centerX`/`centerY` values (already in clip space) directly so GPU-displaced meshes and motion vectors match VM/WebGL behavior.
- Prevent a second normalization pass that caused incorrect scaling centers for lowered per-pixel programs when using default or already-normalized centers.

### Description
- Stop re-normalizing transform centers in the WGSL/GLSL shader chunk by removing the extra `milkdropNormalizeTransformCenter` usage and use `fieldCenterX`/`fieldCenterY` directly in translation math in `assets/js/milkdrop/renderer-adapter.ts`.
- Update the procedural vertex transform to compute translated coordinates from `fieldCenterX`/`fieldCenterY` without remapping the descriptor-provided values.
- Add a regression test `keeps lowered field shader centers in clip space without renormalizing` in `tests/milkdrop-renderer-adapter.test.ts` that verifies the GPU descriptor centers remain clip-space and the emitted vertex shader does not contain the normalization helper.

### Testing
- Ran targeted unit tests with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-vm.test.ts` and all tests in those suites passed (including the new regression test).
- Ran the repository quality gate with `bun run check` (Biome formatting/lint + TypeScript typecheck + full test sweep) and it completed with no failures.
- Verified the change preserves prior VM/WebGL parity for lowered per-pixel field descriptors and WebGPU procedural rendering paths by the test-suite assertions that exercise mesh/motion-vector lowering and material codegen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69befe88374c83328a45c8504514c51b)