### PR TITLE
Reduce WebGPU segment upload churn

### DIFF
--- a/assets/js/milkdrop/renderer-adapter-webgpu.ts
+++ b/assets/js/milkdrop/renderer-adapter-webgpu.ts
@@ -35,18 +35,6 @@ export type MilkdropWebGPURendererAdapterConfig = Omit<
   'backend'
 >;
 
-type SegmentInstance = {
-  startX: number;
-  startY: number;
-  startZ: number;
-  endX: number;
-  endY: number;
-  endZ: number;
-  color: MilkdropColor;
-  alpha: number;
-  width: number;
-};
-
 type ShapeFillInstance = {
   x: number;
   y: number;
@@ -261,42 +249,176 @@ function getShapeFillFallbackColor(shape: MilkdropShapeVisual) {
   };
 }
 
-function appendPolylineSegments(
-  target: SegmentInstance[],
-  positions: number[],
-  color: MilkdropColor,
-  alpha: number,
-  width: number,
-  closeLoop = false,
-) {
-  for (let index = 0; index + 5 < positions.length; index += 3) {
-    target.push({
-      startX: positions[index] ?? 0,
-      startY: positions[index + 1] ?? 0,
-      startZ: positions[index + 2] ?? 0.24,
-      endX: positions[index + 3] ?? 0,
-      endY: positions[index + 4] ?? 0,
-      endZ: positions[index + 5] ?? 0.24,
+class CompactSegmentUploadBuffer {
+  private lineData: Float32Array<ArrayBufferLike> = new Float32Array(0);
+  private styleData: Float32Array<ArrayBufferLike> = new Float32Array(0);
+  private controlData: Float32Array<ArrayBufferLike> = new Float32Array(0);
+  count = 0;
+
+  reset() {
+    this.count = 0;
+  }
+
+  getLineData() {
+    return this.lineData.subarray(0, this.count * 4);
+  }
+
+  getStyleData() {
+    return this.styleData.subarray(0, this.count * 4);
+  }
+
+  getControlData() {
+    return this.controlData.subarray(0, this.count * 2);
+  }
+
+  appendSegment(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    z: number,
+    color: MilkdropColor,
+    alpha: number,
+    width: number,
+  ) {
+    this.ensureCapacity(this.count + 1);
+    const lineOffset = this.count * 4;
+    this.lineData[lineOffset] = startX;
+    this.lineData[lineOffset + 1] = startY;
+    this.lineData[lineOffset + 2] = endX - startX;
+    this.lineData[lineOffset + 3] = endY - startY;
+
+    const styleOffset = this.count * 4;
+    this.styleData[styleOffset] = color.r;
+    this.styleData[styleOffset + 1] = color.g;
+    this.styleData[styleOffset + 2] = color.b;
+    this.styleData[styleOffset + 3] = alpha;
+
+    const controlOffset = this.count * 2;
+    this.controlData[controlOffset] = z;
+    this.controlData[controlOffset + 1] = width * 0.5;
+    this.count += 1;
+  }
+
+  appendPolyline(
+    positions: number[],
+    color: MilkdropColor,
+    alpha: number,
+    width: number,
+    closeLoop = false,
+  ) {
+    for (let index = 0; index + 5 < positions.length; index += 3) {
+      this.appendSegment(
+        positions[index] ?? 0,
+        positions[index + 1] ?? 0,
+        positions[index + 3] ?? 0,
+        positions[index + 4] ?? 0,
+        positions[index + 2] ?? 0.24,
+        color,
+        alpha,
+        width,
+      );
+    }
+    if (!closeLoop || positions.length < 6) {
+      return;
+    }
+    const lastPointIndex = positions.length - 3;
+    this.appendSegment(
+      positions[lastPointIndex] ?? 0,
+      positions[lastPointIndex + 1] ?? 0,
+      positions[0] ?? 0,
+      positions[1] ?? 0,
+      positions[lastPointIndex + 2] ?? 0.24,
       color,
       alpha,
       width,
-    });
+    );
   }
-  if (!closeLoop || positions.length < 6) {
-    return;
+
+  appendProceduralWave(wave: MilkdropProceduralWaveVisual) {
+    let previousX = 0;
+    let previousY = 0;
+    let hasPrevious = false;
+    const width = 0.0025 * Math.max(1, wave.thickness);
+    for (let index = 0; index < wave.samples.length; index += 1) {
+      const sampleT = index / Math.max(1, wave.samples.length - 1);
+      const point = buildProceduralWavePoint(
+        wave,
+        sampleT,
+        wave.samples[index] ?? 0,
+        wave.velocities[index] ?? 0,
+      );
+      if (hasPrevious) {
+        this.appendSegment(
+          previousX,
+          previousY,
+          point.x,
+          point.y,
+          0.24,
+          wave.color,
+          wave.alpha,
+          width,
+        );
+      }
+      previousX = point.x;
+      previousY = point.y;
+      hasPrevious = true;
+    }
   }
-  const lastPointIndex = positions.length - 3;
-  target.push({
-    startX: positions[lastPointIndex] ?? 0,
-    startY: positions[lastPointIndex + 1] ?? 0,
-    startZ: positions[lastPointIndex + 2] ?? 0.24,
-    endX: positions[0] ?? 0,
-    endY: positions[1] ?? 0,
-    endZ: positions[2] ?? 0.24,
-    color,
-    alpha,
-    width,
-  });
+
+  appendProceduralCustomWave(wave: MilkdropProceduralCustomWaveVisual) {
+    let previousX = 0;
+    let previousY = 0;
+    let hasPrevious = false;
+    for (let index = 0; index < wave.samples.length; index += 1) {
+      const sampleT = index / Math.max(1, wave.samples.length - 1);
+      const sampleValue = wave.samples[index] ?? 0;
+      const x = wave.centerX + (-1 + sampleT * 2) * 0.85;
+      const baseY =
+        wave.centerY +
+        (sampleValue - 0.5) * 0.55 * wave.scaling * (1 + wave.mystery * 0.25);
+      const orbitalY =
+        wave.centerY +
+        Math.sin(sampleT * Math.PI * 2 * (1 + wave.mystery) + wave.time) *
+          0.18 *
+          wave.scaling;
+      const pointY = wave.spectrum ? baseY : orbitalY;
+      if (hasPrevious) {
+        this.appendSegment(
+          previousX,
+          previousY,
+          x,
+          pointY,
+          0.28,
+          wave.color,
+          wave.alpha,
+          0.003,
+        );
+      }
+      previousX = x;
+      previousY = pointY;
+      hasPrevious = true;
+    }
+  }
+
+  private ensureCapacity(count: number) {
+    this.lineData = ensureFloat32Capacity(this.lineData, count * 4);
+    this.styleData = ensureFloat32Capacity(this.styleData, count * 4);
+    this.controlData = ensureFloat32Capacity(this.controlData, count * 2);
+  }
+}
+
+function ensureFloat32Capacity(
+  source: Float32Array<ArrayBufferLike>,
+  requiredLength: number,
+) {
+  if (source.length >= requiredLength) {
+    return source;
+  }
+  const nextLength = Math.max(requiredLength, Math.max(4, source.length * 2));
+  const resized = new Float32Array(nextLength);
+  resized.set(source);
+  return resized;
 }
 
 function buildProceduralWavePoint(
@@ -393,75 +515,6 @@ function buildProceduralWavePoint(
   return { x, y };
 }
 
-function appendProceduralWaveSegments(
-  target: SegmentInstance[],
-  wave: MilkdropProceduralWaveVisual,
-) {
-  let previous: { x: number; y: number } | null = null;
-  const width = 0.0025 * Math.max(1, wave.thickness);
-  for (let index = 0; index < wave.samples.length; index += 1) {
-    const sampleT = index / Math.max(1, wave.samples.length - 1);
-    const point = buildProceduralWavePoint(
-      wave,
-      sampleT,
-      wave.samples[index] ?? 0,
-      wave.velocities[index] ?? 0,
-    );
-    if (previous) {
-      target.push({
-        startX: previous.x,
-        startY: previous.y,
-        startZ: 0.24,
-        endX: point.x,
-        endY: point.y,
-        endZ: 0.24,
-        color: wave.color,
-        alpha: wave.alpha,
-        width,
-      });
-    }
-    previous = point;
-  }
-}
-
-function appendProceduralCustomWaveSegments(
-  target: SegmentInstance[],
-  wave: MilkdropProceduralCustomWaveVisual,
-) {
-  let previous: { x: number; y: number } | null = null;
-  for (let index = 0; index < wave.samples.length; index += 1) {
-    const sampleT = index / Math.max(1, wave.samples.length - 1);
-    const sampleValue = wave.samples[index] ?? 0;
-    const x = wave.centerX + (-1 + sampleT * 2) * 0.85;
-    const baseY =
-      wave.centerY +
-      (sampleValue - 0.5) * 0.55 * wave.scaling * (1 + wave.mystery * 0.25);
-    const orbitalY =
-      wave.centerY +
-      Math.sin(sampleT * Math.PI * 2 * (1 + wave.mystery) + wave.time) *
-        0.18 *
-        wave.scaling;
-    const point = {
-      x,
-      y: wave.spectrum ? baseY : orbitalY,
-    };
-    if (previous) {
-      target.push({
-        startX: previous.x,
-        startY: previous.y,
-        startZ: 0.28,
-        endX: point.x,
-        endY: point.y,
-        endZ: 0.28,
-        color: wave.color,
-        alpha: wave.alpha,
-        width: 0.003,
-      });
-    }
-    previous = point;
-  }
-}
-
 class InstancedSegmentBatch {
   readonly group = new Group();
   private readonly normalMesh = this.createMesh(NormalBlending);
@@ -484,20 +537,19 @@ class InstancedSegmentBatch {
         blending,
         vertexShader: `
           attribute vec2 segmentCoord;
-          attribute vec3 instanceStart;
-          attribute vec3 instanceEnd;
+          attribute vec4 instanceLine;
           attribute vec4 instanceColorAlpha;
-          attribute float instanceHalfWidth;
+          attribute vec2 instanceControl;
           varying vec4 vColor;
 
           void main() {
-            vec2 delta = instanceEnd.xy - instanceStart.xy;
+            vec2 delta = instanceLine.zw;
             float lengthDelta = length(delta);
             vec2 direction = lengthDelta > 0.000001 ? delta / lengthDelta : vec2(1.0, 0.0);
             vec2 normal = vec2(-direction.y, direction.x);
-            vec2 base = mix(instanceStart.xy, instanceEnd.xy, segmentCoord.x);
-            vec2 point = base + normal * segmentCoord.y * instanceHalfWidth;
-            float z = mix(instanceStart.z, instanceEnd.z, segmentCoord.x);
+            vec2 base = instanceLine.xy + delta * segmentCoord.x;
+            vec2 point = base + normal * segmentCoord.y * instanceControl.y;
+            float z = instanceControl.x;
             vColor = instanceColorAlpha;
             gl_Position = projectionMatrix * modelViewMatrix * vec4(point, z, 1.0);
           }
@@ -513,59 +565,41 @@ class InstancedSegmentBatch {
   }
 
   syncSplit(
-    normalInstances: SegmentInstance[],
-    additiveInstances: SegmentInstance[],
+    normalInstances: CompactSegmentUploadBuffer,
+    additiveInstances: CompactSegmentUploadBuffer,
   ) {
     this.syncMesh(this.normalMesh, normalInstances);
     this.syncMesh(this.additiveMesh, additiveInstances);
   }
 
-  private syncMesh(mesh: Mesh, instances: SegmentInstance[]) {
+  private syncMesh(mesh: Mesh, instances: CompactSegmentUploadBuffer) {
     const geometry = mesh.geometry as InstancedBufferGeometry;
-    geometry.instanceCount = instances.length;
-    mesh.visible = instances.length > 0;
-    const start = ensureInstancedAttribute(
+    geometry.instanceCount = instances.count;
+    mesh.visible = instances.count > 0;
+    const line = ensureInstancedAttribute(
       geometry,
-      'instanceStart',
-      3,
-      instances.length,
-    );
-    const end = ensureInstancedAttribute(
-      geometry,
-      'instanceEnd',
-      3,
-      instances.length,
+      'instanceLine',
+      4,
+      instances.count,
     );
     const colorAlpha = ensureInstancedAttribute(
       geometry,
       'instanceColorAlpha',
       4,
-      instances.length,
+      instances.count,
     );
-    const halfWidth = ensureInstancedAttribute(
+    const control = ensureInstancedAttribute(
       geometry,
-      'instanceHalfWidth',
-      1,
-      instances.length,
+      'instanceControl',
+      2,
+      instances.count,
     );
-
-    for (let index = 0; index < instances.length; index += 1) {
-      const instance = instances[index] as SegmentInstance;
-      start.setXYZ(index, instance.startX, instance.startY, instance.startZ);
-      end.setXYZ(index, instance.endX, instance.endY, instance.endZ);
-      colorAlpha.setXYZW(
-        index,
-        instance.color.r,
-        instance.color.g,
-        instance.color.b,
-        instance.alpha,
-      );
-      halfWidth.setX(index, instance.width * 0.5);
-    }
-    start.needsUpdate = true;
-    end.needsUpdate = true;
+    (line.array as Float32Array).set(instances.getLineData());
+    (colorAlpha.array as Float32Array).set(instances.getStyleData());
+    (control.array as Float32Array).set(instances.getControlData());
+    line.needsUpdate = true;
     colorAlpha.needsUpdate = true;
-    halfWidth.needsUpdate = true;
+    control.needsUpdate = true;
   }
 
   dispose() {
@@ -1005,6 +1039,13 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
   private readonly waveTargets = new Map<string, InstancedSegmentBatch>();
   private readonly shapeTargets = new Map<string, ShapeBatchTarget>();
   private readonly borderTargets = new Map<string, InstancedBorderBatch>();
+  private readonly normalSegmentUploads = new CompactSegmentUploadBuffer();
+  private readonly additiveSegmentUploads = new CompactSegmentUploadBuffer();
+
+  private resetSegmentUploads() {
+    this.normalSegmentUploads.reset();
+    this.additiveSegmentUploads.reset();
+  }
 
   attach(root: Group) {
     root.add(this.root);
@@ -1049,12 +1090,12 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
     if (waves.some((wave) => wave.drawMode === 'dots')) {
       return false;
     }
-    const normal: SegmentInstance[] = [];
-    const additive: SegmentInstance[] = [];
+    this.resetSegmentUploads();
     for (const wave of waves) {
-      const destination = wave.additive ? additive : normal;
-      appendPolylineSegments(
-        destination,
+      const destination = wave.additive
+        ? this.additiveSegmentUploads
+        : this.normalSegmentUploads;
+      destination.appendPolyline(
         wave.positions,
         wave.color,
         wave.alpha * alphaMultiplier,
@@ -1062,7 +1103,10 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
         wave.closed,
       );
     }
-    this.getWaveTarget(`wave:${target}`).syncSplit(normal, additive);
+    this.getWaveTarget(`wave:${target}`).syncSplit(
+      this.normalSegmentUploads,
+      this.additiveSegmentUploads,
+    );
     return true;
   }
 
@@ -1071,12 +1115,17 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
     _group: Group,
     waves: MilkdropProceduralWaveVisual[],
   ) {
-    const normal: SegmentInstance[] = [];
-    const additive: SegmentInstance[] = [];
+    this.resetSegmentUploads();
     for (const wave of waves) {
-      appendProceduralWaveSegments(wave.additive ? additive : normal, wave);
+      (wave.additive
+        ? this.additiveSegmentUploads
+        : this.normalSegmentUploads
+      ).appendProceduralWave(wave);
     }
-    this.getWaveTarget(`procedural-wave:${target}`).syncSplit(normal, additive);
+    this.getWaveTarget(`procedural-wave:${target}`).syncSplit(
+      this.normalSegmentUploads,
+      this.additiveSegmentUploads,
+    );
     return true;
   }
 
@@ -1084,15 +1133,17 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
     _group: Group,
     waves: MilkdropProceduralCustomWaveVisual[],
   ) {
-    const normal: SegmentInstance[] = [];
-    const additive: SegmentInstance[] = [];
+    this.resetSegmentUploads();
     for (const wave of waves) {
-      appendProceduralCustomWaveSegments(
-        wave.additive ? additive : normal,
-        wave,
-      );
+      (wave.additive
+        ? this.additiveSegmentUploads
+        : this.normalSegmentUploads
+      ).appendProceduralCustomWave(wave);
     }
-    this.getWaveTarget('procedural-custom-wave').syncSplit(normal, additive);
+    this.getWaveTarget('procedural-custom-wave').syncSplit(
+      this.normalSegmentUploads,
+      this.additiveSegmentUploads,
+    );
     return true;
   }
 
@@ -1127,18 +1178,22 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
     }>,
     alphaMultiplier: number,
   ) {
-    const normal: SegmentInstance[] = [];
-    const additive: SegmentInstance[] = [];
+    this.resetSegmentUploads();
     for (const line of lines) {
-      appendPolylineSegments(
-        (line.additive ?? false) ? additive : normal,
+      ((line.additive ?? false)
+        ? this.additiveSegmentUploads
+        : this.normalSegmentUploads
+      ).appendPolyline(
         line.positions,
         line.color,
         line.alpha * alphaMultiplier,
         0.0025,
       );
     }
-    this.getWaveTarget(`line:${target}`).syncSplit(normal, additive);
+    this.getWaveTarget(`line:${target}`).syncSplit(
+      this.normalSegmentUploads,
+      this.additiveSegmentUploads,
+    );
     return true;
   }
 

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -49,6 +49,25 @@ function getGeometryInstanceCount(node: RenderTreeNode | undefined) {
   )?.instanceCount;
 }
 
+function isWebGPUSegmentBatchNode(node: RenderTreeNode) {
+  return node.geometry?.getAttribute?.('instanceLine') !== undefined;
+}
+
+function getFloat32AttributeArray(
+  node: RenderTreeNode | undefined,
+  name: string,
+): Float32Array | null {
+  const attribute = node?.geometry?.getAttribute?.(name) as
+    | {
+        array?: ArrayLike<number>;
+      }
+    | undefined;
+  if (!attribute?.array) {
+    return null;
+  }
+  return Float32Array.from(attribute.array);
+}
+
 function makeSignals(
   overrides: Partial<MilkdropRuntimeSignals> = {},
 ): MilkdropRuntimeSignals {
@@ -314,7 +333,7 @@ ob_size=0.03
 
     const root = scene.children[0] as RenderTreeNode;
     const firstWaveObject = flattenRenderTree(root).find(
-      (child) => child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      isWebGPUSegmentBatchNode,
     );
     const firstBorderObject = flattenRenderTree(root).find(
       (child) => child.geometry?.getAttribute?.('instanceInsets') !== undefined,
@@ -326,7 +345,7 @@ ob_size=0.03
     });
 
     const secondWaveObject = flattenRenderTree(root).find(
-      (child) => child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      isWebGPUSegmentBatchNode,
     );
     const secondBorderObject = flattenRenderTree(root).find(
       (child) => child.geometry?.getAttribute?.('instanceInsets') !== undefined,
@@ -366,10 +385,10 @@ shapecode_0_thickoutline=1
 
     const root = scene.children[0] as RenderTreeNode;
     const firstWaveMesh = flattenRenderTree(root).find(
-      (child) => child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      isWebGPUSegmentBatchNode,
     );
     const firstWaveAttribute =
-      firstWaveMesh?.geometry?.getAttribute?.('instanceStart');
+      firstWaveMesh?.geometry?.getAttribute?.('instanceLine');
     const firstShapeMesh = flattenRenderTree(root).find(
       (child) =>
         child.geometry?.getAttribute?.('instanceTransform') !== undefined,
@@ -381,10 +400,10 @@ shapecode_0_thickoutline=1
     });
 
     const secondWaveMesh = flattenRenderTree(root).find(
-      (child) => child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      isWebGPUSegmentBatchNode,
     );
     const secondWaveAttribute =
-      secondWaveMesh?.geometry?.getAttribute?.('instanceStart');
+      secondWaveMesh?.geometry?.getAttribute?.('instanceLine');
     const secondShapeMesh = flattenRenderTree(root).find(
       (child) =>
         child.geometry?.getAttribute?.('instanceTransform') !== undefined,
@@ -475,7 +494,7 @@ per_pixel_1=zoom=1.08; rot=0.15; warp=0.3;
     const root = scene.children[0] as RenderTreeNode;
     const matchingMotionVectorMesh = flattenRenderTree(root).find(
       (child) =>
-        child.geometry?.getAttribute?.('instanceStart') !== undefined &&
+        isWebGPUSegmentBatchNode(child) &&
         getGeometryInstanceCount(child) === frameState.motionVectors.length,
     );
 
@@ -898,7 +917,7 @@ mesh_density=16
 
     const root = scene.children[0] as RenderTreeNode;
     const batchedSegmentMeshes = flattenRenderTree(root).filter(
-      (child) => child.geometry?.getAttribute?.('instanceStart') !== undefined,
+      isWebGPUSegmentBatchNode,
     );
 
     expect(firstFrame.gpuGeometry.mainWave).toBeNull();
@@ -947,14 +966,74 @@ modwavealphaend=0.6
     const expectedSegmentCount = frameState.mainWave.positions.length / 3;
     const root = scene.children[0] as RenderTreeNode;
     const segmentCounts = flattenRenderTree(root)
-      .filter(
-        (child) =>
-          child.geometry?.getAttribute?.('instanceStart') !== undefined,
-      )
+      .filter(isWebGPUSegmentBatchNode)
       .map((child) => getGeometryInstanceCount(child) ?? 0);
 
     expect(frameState.mainWave.closed).toBe(true);
     expect(segmentCounts).toContain(expectedSegmentCount);
+  });
+
+  test('uploads compact line and control attributes for batched webgpu waves', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Compact Batched Wave Upload
+wave_mode=0
+wave_usedots=0
+wave_additive=0
+wave_a=0.7
+      `.trim(),
+      { id: 'compact-batched-wave-upload' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const root = scene.children[0] as RenderTreeNode;
+    const waveMesh = flattenRenderTree(root).find(
+      (child) =>
+        isWebGPUSegmentBatchNode(child) &&
+        getGeometryInstanceCount(child) ===
+          frameState.mainWave.positions.length / 3,
+    );
+    const lineArray = getFloat32AttributeArray(waveMesh, 'instanceLine');
+    const controlArray = getFloat32AttributeArray(waveMesh, 'instanceControl');
+    const colorArray = getFloat32AttributeArray(waveMesh, 'instanceColorAlpha');
+    const positions = frameState.mainWave.positions;
+
+    expect(lineArray?.slice(0, 4)).toEqual(
+      Float32Array.from([
+        positions[0] ?? 0,
+        positions[1] ?? 0,
+        (positions[3] ?? 0) - (positions[0] ?? 0),
+        (positions[4] ?? 0) - (positions[1] ?? 0),
+      ]),
+    );
+    expect(controlArray?.slice(0, 2)).toEqual(
+      Float32Array.from([
+        positions[2] ?? 0.24,
+        0.0025 * Math.max(1, frameState.mainWave.thickness) * 0.5,
+      ]),
+    );
+    expect(colorArray?.slice(0, 4)).toEqual(
+      Float32Array.from([
+        frameState.mainWave.color.r,
+        frameState.mainWave.color.g,
+        frameState.mainWave.color.b,
+        frameState.mainWave.alpha,
+      ]),
+    );
   });
 
   test('keeps additive wave materials transparent when alpha exceeds 1', () => {
@@ -990,7 +1069,7 @@ modwavealphaend=0.4
     const root = scene.children[0] as RenderTreeNode;
     const additiveWaveMesh = flattenRenderTree(root).find(
       (child) =>
-        child.geometry?.getAttribute?.('instanceStart') !== undefined &&
+        isWebGPUSegmentBatchNode(child) &&
         child.material instanceof ShaderMaterial &&
         child.material.blending === AdditiveBlending,
     );


### PR DESCRIPTION
### Motivation
- Reduce adapter-side allocation churn when preparing line/wave segments by avoiding per-segment temporary JS object arrays and prepare a compact upload format that is easier to evolve toward a GPU-backed expansion pass.
- Keep existing batching semantics (batch keys and normal/additive split) and preserve shape and border batching behavior so other rendering code remains unchanged.

### Description
- Introduce `CompactSegmentUploadBuffer` to accumulate compact per-segment line (`instanceLine`), style (`instanceColorAlpha`), and control (`instanceControl`) Float32 arrays with reusable capacity growth instead of building `SegmentInstance[]` objects in JS.
- Update `InstancedSegmentBatch` vertex shader to consume `instanceLine` (start.xy, delta.xy) and `instanceControl` (z, half-width) attributes and update the mesh sync path to bulk-copy the compact buffers into instanced attributes.
- Wire `WebGPUBatchingLayer` to reuse two upload buffers (`normal` and `additive`) across `renderWaveGroup`, `renderProceduralWaveGroup`, `renderProceduralCustomWaveGroup`, and `renderLineVisualGroup` while preserving batching keys and the additive/normal split.
- Add deterministic adapter-level assertions and helpers in `tests/milkdrop-renderer-adapter.test.ts` that verify the new `instanceLine` / `instanceControl` / `instanceColorAlpha` uploads; shape and border tests remain in place to confirm unchanged batching for those paths.

### Testing
- Ran targeted adapter tests: `bun run test tests/milkdrop-renderer-adapter.test.ts` and observed all tests in that file pass (30 passed, 0 failed in local run).
- Ran full quality gate: `bun run check` (Biome formatting/lint, `tsc --noEmit`, test suite) and observed the full test suite and typecheck succeed (431 passed, 4 skipped, 0 failed across the suite in local run).
- Docs touched: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf12c0b3a88332a5d936ea115bbdc4)