### PR TITLE
Add adaptive WebGPU quality controller

### DIFF
--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -27,6 +27,9 @@ export type RendererViewport = {
 const BASE_RENDERER_SETTINGS: Required<RendererInitConfig> = {
   maxPixelRatio: 1.5,
   renderScale: 1,
+  adaptiveMaxPixelRatioMultiplier: 1,
+  adaptiveRenderScaleMultiplier: 1,
+  adaptiveDensityMultiplier: 1,
   exposure: 1,
   antialias: true,
   alpha: false,
@@ -48,6 +51,21 @@ export function resolveRendererSettings(
       info?.renderScale ??
       defaults.renderScale ??
       BASE_RENDERER_SETTINGS.renderScale,
+    adaptiveMaxPixelRatioMultiplier:
+      options.adaptiveMaxPixelRatioMultiplier ??
+      info?.adaptiveMaxPixelRatioMultiplier ??
+      defaults.adaptiveMaxPixelRatioMultiplier ??
+      BASE_RENDERER_SETTINGS.adaptiveMaxPixelRatioMultiplier,
+    adaptiveRenderScaleMultiplier:
+      options.adaptiveRenderScaleMultiplier ??
+      info?.adaptiveRenderScaleMultiplier ??
+      defaults.adaptiveRenderScaleMultiplier ??
+      BASE_RENDERER_SETTINGS.adaptiveRenderScaleMultiplier,
+    adaptiveDensityMultiplier:
+      options.adaptiveDensityMultiplier ??
+      info?.adaptiveDensityMultiplier ??
+      defaults.adaptiveDensityMultiplier ??
+      BASE_RENDERER_SETTINGS.adaptiveDensityMultiplier,
     exposure:
       options.exposure ??
       info?.exposure ??
@@ -69,9 +87,17 @@ export function applyRendererSettings(
   viewport?: RendererViewport,
 ) {
   const merged = resolveRendererSettings(options, info, defaults);
+  const effectiveRenderScale = Math.max(
+    0.4,
+    (merged.renderScale ?? 1) * (merged.adaptiveRenderScaleMultiplier ?? 1),
+  );
+  const effectiveMaxPixelRatio = Math.max(
+    0.5,
+    (merged.maxPixelRatio ?? 2) * (merged.adaptiveMaxPixelRatioMultiplier ?? 1),
+  );
   const effectivePixelRatio = Math.min(
-    (window.devicePixelRatio || 1) * (merged.renderScale ?? 1),
-    merged.maxPixelRatio ?? 2,
+    (window.devicePixelRatio || 1) * effectiveRenderScale,
+    effectiveMaxPixelRatio,
   );
 
   renderer.setPixelRatio(effectivePixelRatio);
@@ -84,5 +110,12 @@ export function applyRendererSettings(
 
   info.maxPixelRatio = merged.maxPixelRatio ?? info.maxPixelRatio;
   info.renderScale = merged.renderScale ?? info.renderScale;
+  info.adaptiveMaxPixelRatioMultiplier =
+    merged.adaptiveMaxPixelRatioMultiplier ??
+    info.adaptiveMaxPixelRatioMultiplier;
+  info.adaptiveRenderScaleMultiplier =
+    merged.adaptiveRenderScaleMultiplier ?? info.adaptiveRenderScaleMultiplier;
+  info.adaptiveDensityMultiplier =
+    merged.adaptiveDensityMultiplier ?? info.adaptiveDensityMultiplier;
   info.exposure = merged.exposure ?? info.exposure;
 }

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -28,6 +28,9 @@ export type RendererInitResult = {
   device?: GPUDevice | null;
   maxPixelRatio: number;
   renderScale: number;
+  adaptiveMaxPixelRatioMultiplier: number;
+  adaptiveRenderScaleMultiplier: number;
+  adaptiveDensityMultiplier: number;
   exposure: number;
 };
 
@@ -37,6 +40,9 @@ export type RendererInitConfig = {
   maxPixelRatio?: number;
   alpha?: boolean;
   renderScale?: number;
+  adaptiveMaxPixelRatioMultiplier?: number;
+  adaptiveRenderScaleMultiplier?: number;
+  adaptiveDensityMultiplier?: number;
 };
 
 async function loadWebGPURenderer() {
@@ -66,6 +72,9 @@ export async function initRenderer(
     maxPixelRatio = isMobileUserAgent ? 1.1 : 1.5,
     alpha = false,
     renderScale = 1,
+    adaptiveMaxPixelRatioMultiplier = 1,
+    adaptiveRenderScaleMultiplier = 1,
+    adaptiveDensityMultiplier = 1,
   } = config;
 
   const finalize = (
@@ -96,6 +105,9 @@ export async function initRenderer(
       device,
       maxPixelRatio,
       renderScale,
+      adaptiveMaxPixelRatioMultiplier,
+      adaptiveRenderScaleMultiplier,
+      adaptiveDensityMultiplier,
       exposure,
     };
   };

--- a/assets/js/core/services/adaptive-quality-controller.ts
+++ b/assets/js/core/services/adaptive-quality-controller.ts
@@ -1,0 +1,367 @@
+import type {
+  RendererBackend,
+  WebGPUCapabilitySummary,
+} from '../renderer-capabilities.ts';
+
+export type AdaptiveQualityTimingMode = 'coarse-frame' | 'gpu-phase-timestamps';
+
+export type AdaptiveQualityPhaseTimings = Partial<{
+  simulationMs: number;
+  renderMs: number;
+  postprocessMs: number;
+  presentMs: number;
+}>;
+
+export type AdaptiveQualitySample = {
+  frameMs: number;
+  phases?: AdaptiveQualityPhaseTimings;
+};
+
+export type AdaptiveQualityMultipliers = {
+  renderScaleMultiplier: number;
+  maxPixelRatioMultiplier: number;
+  densityMultiplier: number;
+  feedbackResolutionMultiplier: number;
+};
+
+export type AdaptiveQualityState = AdaptiveQualityMultipliers & {
+  enabled: boolean;
+  backend: RendererBackend;
+  timingMode: AdaptiveQualityTimingMode;
+  supportsGpuTimestamps: boolean;
+  profile: string;
+  frameBudgetMs: number;
+  qualityStep: number;
+  qualityStepCount: number;
+  averageFrameMs: number | null;
+  averageRenderMs: number | null;
+  sampleCount: number;
+  adaptation: 'steady' | 'degraded' | 'recovering';
+  reasons: string[];
+};
+
+export type AdaptiveQualityController = {
+  getState: () => AdaptiveQualityState;
+  recordFrame: (sample: AdaptiveQualitySample) => AdaptiveQualityState;
+  subscribe: (subscriber: (state: AdaptiveQualityState) => void) => () => void;
+};
+
+type AdaptiveQualityControllerOptions = {
+  backend: RendererBackend;
+  capabilities: WebGPUCapabilitySummary | null;
+};
+
+type QualityStep = AdaptiveQualityMultipliers & {
+  id: string;
+};
+
+const QUALITY_STEPS: readonly QualityStep[] = [
+  {
+    id: 'full',
+    renderScaleMultiplier: 1,
+    maxPixelRatioMultiplier: 1,
+    densityMultiplier: 1,
+    feedbackResolutionMultiplier: 1,
+  },
+  {
+    id: 'balanced',
+    renderScaleMultiplier: 0.94,
+    maxPixelRatioMultiplier: 0.96,
+    densityMultiplier: 0.92,
+    feedbackResolutionMultiplier: 0.9,
+  },
+  {
+    id: 'reduced',
+    renderScaleMultiplier: 0.88,
+    maxPixelRatioMultiplier: 0.92,
+    densityMultiplier: 0.82,
+    feedbackResolutionMultiplier: 0.8,
+  },
+  {
+    id: 'low',
+    renderScaleMultiplier: 0.8,
+    maxPixelRatioMultiplier: 0.86,
+    densityMultiplier: 0.72,
+    feedbackResolutionMultiplier: 0.68,
+  },
+  {
+    id: 'minimal',
+    renderScaleMultiplier: 0.72,
+    maxPixelRatioMultiplier: 0.8,
+    densityMultiplier: 0.6,
+    feedbackResolutionMultiplier: 0.56,
+  },
+] as const;
+
+const EMA_ALPHA = 0.18;
+const MIN_WARMUP_SAMPLES = 12;
+const DEGRADE_THRESHOLD_SAMPLES = 6;
+const RECOVER_THRESHOLD_SAMPLES = 45;
+const RESET_THRESHOLD_SAMPLES = 3;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function updateEma(previous: number | null, next: number) {
+  if (!Number.isFinite(next)) {
+    return previous;
+  }
+  if (previous === null) {
+    return next;
+  }
+  return previous + (next - previous) * EMA_ALPHA;
+}
+
+function buildHeuristicProfile(capabilities: WebGPUCapabilitySummary | null) {
+  if (!capabilities) {
+    return {
+      frameBudgetMs: 16.7,
+      initialStep: 2,
+      profile: 'fallback-webgpu',
+      reasons: ['No WebGPU capability snapshot was available for adaptation.'],
+    };
+  }
+
+  const reasons: string[] = [];
+  let initialStep =
+    capabilities.performanceTier === 'high-end'
+      ? 0
+      : capabilities.performanceTier === 'enhanced'
+        ? 1
+        : 2;
+
+  if (!capabilities.features.float32Blendable) {
+    reasons.push('float32 blendable attachments are unavailable.');
+    initialStep += 1;
+  }
+  if (!capabilities.features.float32Filterable) {
+    reasons.push('float32 filterable textures are unavailable.');
+    initialStep += 1;
+  }
+  if (!capabilities.features.shaderF16) {
+    reasons.push('shader-f16 is unavailable.');
+    initialStep += 1;
+  }
+  if ((capabilities.limits.maxTextureDimension2D ?? 0) < 8_192) {
+    reasons.push('2D texture limits are below the high-end target.');
+    initialStep += 1;
+  }
+  if ((capabilities.limits.maxColorAttachments ?? 0) < 8) {
+    reasons.push('color-attachment headroom is limited.');
+    initialStep += 1;
+  }
+
+  initialStep = clamp(initialStep, 0, QUALITY_STEPS.length - 1);
+
+  return {
+    frameBudgetMs: 16.7,
+    initialStep,
+    profile: capabilities.performanceTier,
+    reasons,
+  };
+}
+
+function buildState({
+  backend,
+  timingMode,
+  supportsGpuTimestamps,
+  profile,
+  frameBudgetMs,
+  qualityStep,
+  averageFrameMs,
+  averageRenderMs,
+  sampleCount,
+  adaptation,
+  reasons,
+}: {
+  backend: RendererBackend;
+  timingMode: AdaptiveQualityTimingMode;
+  supportsGpuTimestamps: boolean;
+  profile: string;
+  frameBudgetMs: number;
+  qualityStep: number;
+  averageFrameMs: number | null;
+  averageRenderMs: number | null;
+  sampleCount: number;
+  adaptation: AdaptiveQualityState['adaptation'];
+  reasons: string[];
+}) {
+  const step = QUALITY_STEPS[qualityStep] as QualityStep;
+  return {
+    enabled: backend === 'webgpu',
+    backend,
+    timingMode,
+    supportsGpuTimestamps,
+    profile,
+    frameBudgetMs,
+    qualityStep,
+    qualityStepCount: QUALITY_STEPS.length,
+    averageFrameMs,
+    averageRenderMs,
+    sampleCount,
+    adaptation,
+    reasons,
+    renderScaleMultiplier: step.renderScaleMultiplier,
+    maxPixelRatioMultiplier: step.maxPixelRatioMultiplier,
+    densityMultiplier: step.densityMultiplier,
+    feedbackResolutionMultiplier: step.feedbackResolutionMultiplier,
+  } satisfies AdaptiveQualityState;
+}
+
+export function createAdaptiveQualityController({
+  backend,
+  capabilities,
+}: AdaptiveQualityControllerOptions): AdaptiveQualityController {
+  const subscribers = new Set<(state: AdaptiveQualityState) => void>();
+  const timingMode: AdaptiveQualityTimingMode = 'coarse-frame';
+  const supportsGpuTimestamps =
+    backend === 'webgpu' && Boolean(capabilities?.features.timestampQuery);
+  const heuristic = buildHeuristicProfile(
+    backend === 'webgpu' ? capabilities : null,
+  );
+
+  let qualityStep = backend === 'webgpu' ? heuristic.initialStep : 0;
+  let averageFrameMs: number | null = null;
+  let averageRenderMs: number | null = null;
+  let sampleCount = 0;
+  let consecutiveOverBudget = 0;
+  let consecutiveUnderBudget = 0;
+  let adaptation: AdaptiveQualityState['adaptation'] = 'steady';
+
+  let state = buildState({
+    backend,
+    timingMode,
+    supportsGpuTimestamps,
+    profile: heuristic.profile,
+    frameBudgetMs: heuristic.frameBudgetMs,
+    qualityStep,
+    averageFrameMs,
+    averageRenderMs,
+    sampleCount,
+    adaptation,
+    reasons:
+      backend === 'webgpu'
+        ? [
+            ...heuristic.reasons,
+            supportsGpuTimestamps
+              ? 'timestamp-query is available for future GPU timing upgrades.'
+              : 'Falling back to coarse CPU frame timing for now.',
+          ]
+        : ['Adaptive quality is disabled outside the WebGPU backend.'],
+  });
+
+  const publish = () => {
+    state = buildState({
+      backend,
+      timingMode,
+      supportsGpuTimestamps,
+      profile: heuristic.profile,
+      frameBudgetMs: heuristic.frameBudgetMs,
+      qualityStep,
+      averageFrameMs,
+      averageRenderMs,
+      sampleCount,
+      adaptation,
+      reasons: state.reasons,
+    });
+    subscribers.forEach((subscriber) => subscriber(state));
+    return state;
+  };
+
+  return {
+    getState: () => state,
+    recordFrame: ({ frameMs, phases }: AdaptiveQualitySample) => {
+      if (backend !== 'webgpu' || !Number.isFinite(frameMs)) {
+        return state;
+      }
+
+      sampleCount += 1;
+      averageFrameMs = updateEma(averageFrameMs, frameMs);
+      const renderMs = phases?.renderMs;
+      if (typeof renderMs === 'number' && Number.isFinite(renderMs)) {
+        averageRenderMs = updateEma(averageRenderMs, renderMs);
+      }
+
+      if (sampleCount < MIN_WARMUP_SAMPLES) {
+        return publish();
+      }
+
+      const renderPressure =
+        averageRenderMs !== null &&
+        averageRenderMs > heuristic.frameBudgetMs * 0.82;
+      const framePressure =
+        averageFrameMs !== null &&
+        averageFrameMs > heuristic.frameBudgetMs * 1.08;
+      const hasHeadroom =
+        averageFrameMs !== null &&
+        averageFrameMs < heuristic.frameBudgetMs * 0.72 &&
+        (averageRenderMs === null ||
+          averageRenderMs < heuristic.frameBudgetMs * 0.55);
+
+      if (renderPressure || framePressure) {
+        consecutiveOverBudget += 1;
+        consecutiveUnderBudget = 0;
+      } else if (hasHeadroom) {
+        consecutiveUnderBudget += 1;
+        consecutiveOverBudget = 0;
+      } else {
+        consecutiveOverBudget = Math.max(0, consecutiveOverBudget - 1);
+        consecutiveUnderBudget = Math.max(0, consecutiveUnderBudget - 1);
+      }
+
+      if (
+        consecutiveOverBudget >= DEGRADE_THRESHOLD_SAMPLES &&
+        qualityStep < QUALITY_STEPS.length - 1
+      ) {
+        qualityStep += 1;
+        adaptation = 'degraded';
+        consecutiveOverBudget = 0;
+        consecutiveUnderBudget = 0;
+        state = {
+          ...state,
+          reasons: [
+            ...heuristic.reasons,
+            'Coarse frame timing pushed the controller below the baseline budget.',
+          ],
+        };
+        return publish();
+      }
+
+      if (
+        consecutiveUnderBudget >= RECOVER_THRESHOLD_SAMPLES &&
+        qualityStep > heuristic.initialStep
+      ) {
+        qualityStep -= 1;
+        adaptation = 'recovering';
+        consecutiveOverBudget = 0;
+        consecutiveUnderBudget = 0;
+        state = {
+          ...state,
+          reasons: [
+            ...heuristic.reasons,
+            'Frame headroom allowed the controller to restore quality.',
+          ],
+        };
+        return publish();
+      }
+
+      if (
+        adaptation !== 'steady' &&
+        consecutiveOverBudget < RESET_THRESHOLD_SAMPLES &&
+        consecutiveUnderBudget < RESET_THRESHOLD_SAMPLES
+      ) {
+        adaptation = 'steady';
+      }
+
+      return publish();
+    },
+    subscribe: (subscriber) => {
+      subscribers.add(subscriber);
+      subscriber(state);
+      return () => {
+        subscribers.delete(subscriber);
+      };
+    },
+  };
+}

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -1301,6 +1301,7 @@ class WebGPUMilkdropFeedbackManager {
   readonly sceneResolutionScale = this.profile.sceneResolutionScale;
   readonly feedbackResolutionScale = this.profile.feedbackResolutionScale;
   readonly auxTextures: Record<string, Texture>;
+  adaptiveFeedbackResolutionMultiplier = 1;
   currentCompositeKey = '';
   currentFeedbackResolutionScale = this.feedbackResolutionScale;
   viewportWidth: number;
@@ -1407,7 +1408,8 @@ class WebGPUMilkdropFeedbackManager {
       Math.abs(state.gammaAdj - 1) > 0.0001;
     const nextResolutionScale = needsSceneResolution
       ? this.sceneResolutionScale
-      : this.feedbackResolutionScale;
+      : this.feedbackResolutionScale *
+        this.adaptiveFeedbackResolutionMultiplier;
     if (
       Math.abs(nextResolutionScale - this.currentFeedbackResolutionScale) >
       0.0001
@@ -1492,6 +1494,29 @@ class WebGPUMilkdropFeedbackManager {
     this.compositeMaterial.uniforms.signalBeat.value = state.signalBeat;
     this.compositeMaterial.uniforms.signalEnergy.value = state.signalEnergy;
     this.compositeMaterial.uniforms.signalTime.value = state.signalTime;
+  }
+
+  setAdaptiveQuality({
+    feedbackResolutionMultiplier,
+  }: Partial<{
+    feedbackResolutionMultiplier: number;
+  }>) {
+    const nextMultiplier = Math.min(
+      1,
+      Math.max(0.45, feedbackResolutionMultiplier ?? 1),
+    );
+    if (
+      Math.abs(nextMultiplier - this.adaptiveFeedbackResolutionMultiplier) <
+      0.0001
+    ) {
+      return;
+    }
+    this.adaptiveFeedbackResolutionMultiplier = nextMultiplier;
+    this.currentFeedbackResolutionScale = Math.min(
+      this.currentFeedbackResolutionScale,
+      this.feedbackResolutionScale * this.adaptiveFeedbackResolutionMultiplier,
+    );
+    this.resize(this.viewportWidth, this.viewportHeight);
   }
 
   render(renderer: FeedbackRendererLike, scene: Scene, camera: Camera) {

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -3009,6 +3009,14 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     this.feedback?.resize(width, height);
   }
 
+  setAdaptiveQuality(
+    multipliers: Partial<{
+      feedbackResolutionMultiplier: number;
+    }>,
+  ) {
+    this.feedback?.setAdaptiveQuality?.(multipliers);
+  }
+
   private renderWaveGroup(
     target:
       | 'main-wave'

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -8,6 +8,12 @@ import {
   isCompatibilityModeEnabled,
   setCompatibilityMode,
 } from '../core/render-preferences';
+import { getCachedRendererCapabilities } from '../core/renderer-capabilities.ts';
+import {
+  type AdaptiveQualityController,
+  type AdaptiveQualityState,
+  createAdaptiveQualityController,
+} from '../core/services/adaptive-quality-controller.ts';
 import {
   type QualityPreset,
   setQualityPresetById,
@@ -571,16 +577,19 @@ function buildAgentMilkdropDebugSnapshot({
   compiledPreset,
   frameState,
   status,
+  adaptiveQuality,
 }: {
   activePresetId: string | null;
   compiledPreset: MilkdropCompiledPreset | null;
   frameState: MilkdropFrameState | null;
   status: string | null;
+  adaptiveQuality?: AdaptiveQualityState | null;
 }) {
   if (!frameState) {
     return {
       activePresetId,
       status,
+      adaptiveQuality,
       frameState: null,
       title: compiledPreset?.title ?? null,
     };
@@ -589,6 +598,7 @@ function buildAgentMilkdropDebugSnapshot({
   return {
     activePresetId,
     status,
+    adaptiveQuality,
     title: compiledPreset?.title ?? frameState.title,
     frameState: {
       presetId: frameState.presetId,
@@ -829,6 +839,9 @@ export function createMilkdropExperience({
   let catalogSyncPromise: Promise<void> | null = null;
   let catalogSyncFrameId: number | null = null;
   let lastInspectorOverlaySyncAt = 0;
+  let adaptiveQualityController: AdaptiveQualityController | null = null;
+  let adaptiveQualityState: AdaptiveQualityState | null = null;
+  let adaptiveQualityUnsubscribe: (() => void) | null = null;
   const mergedSignals: Partial<MilkdropRuntimeSignals> = {};
   const lowQualityPostOverride = {
     shaderEnabled: false,
@@ -846,6 +859,7 @@ export function createMilkdropExperience({
         compiledPreset: activeCompiled,
         frameState: currentFrameState,
         status: lastStatusMessage,
+        adaptiveQuality: adaptiveQualityState,
       }),
     );
   };
@@ -1510,6 +1524,33 @@ export function createMilkdropExperience({
           preset: activeCompiled,
         });
         adapter.attach();
+        adaptiveQualityUnsubscribe?.();
+        adaptiveQualityUnsubscribe = null;
+        adaptiveQualityController = createAdaptiveQualityController({
+          backend: activeBackend,
+          capabilities:
+            activeBackend === 'webgpu'
+              ? (getCachedRendererCapabilities()?.webgpu ?? null)
+              : null,
+        });
+        adaptiveQualityUnsubscribe = adaptiveQualityController.subscribe(
+          (state) => {
+            adaptiveQualityState = state;
+            if (activeBackend !== 'webgpu') {
+              updateAgentDebugSnapshot();
+              return;
+            }
+            nextRuntime.toy.updateRendererSettings({
+              adaptiveRenderScaleMultiplier: state.renderScaleMultiplier,
+              adaptiveMaxPixelRatioMultiplier: state.maxPixelRatioMultiplier,
+              adaptiveDensityMultiplier: state.densityMultiplier,
+            });
+            adapter?.setAdaptiveQuality?.({
+              feedbackResolutionMultiplier: state.feedbackResolutionMultiplier,
+            });
+            updateAgentDebugSnapshot();
+          },
+        );
         if (shouldFallbackToWebgl(activeCompiled)) {
           triggerWebglFallback({
             presetId: activeCompiled.source.id,
@@ -1532,6 +1573,7 @@ export function createMilkdropExperience({
       }
 
       const now = performance.now();
+      const frameStartAt = now;
 
       const detailScale = getMilkdropDetailScale({
         backend: activeBackend,
@@ -1539,7 +1581,11 @@ export function createMilkdropExperience({
         particleBudget: frame.performance.particleBudget,
         shaderQuality: frame.performance.shaderQuality,
       });
-      vm.setDetailScale(detailScale);
+      const adaptiveDensityMultiplier =
+        activeBackend === 'webgpu'
+          ? (runtime.toy.rendererInfo?.adaptiveDensityMultiplier ?? 1)
+          : 1;
+      vm.setDetailScale(detailScale * adaptiveDensityMultiplier);
       const baseSignals = signalTracker.update({
         time: frame.time,
         deltaMs: frame.deltaMs,
@@ -1606,6 +1652,7 @@ export function createMilkdropExperience({
             }
           : currentFrameState;
 
+      const renderStartAt = performance.now();
       const adapterPresentedFrame = adapter.render({
         frameState: renderFrameState,
         blendState: activeBlendState,
@@ -1613,6 +1660,14 @@ export function createMilkdropExperience({
       if (!adapterPresentedFrame) {
         runtime.toy.render();
       }
+      const frameEndAt = performance.now();
+      adaptiveQualityController?.recordFrame({
+        frameMs: frameEndAt - frameStartAt,
+        phases: {
+          simulationMs: renderStartAt - frameStartAt,
+          renderMs: frameEndAt - renderStartAt,
+        },
+      });
       if (
         overlay.shouldRenderInspectorMetrics() &&
         now - lastInspectorOverlaySyncAt >= 180
@@ -1632,6 +1687,10 @@ export function createMilkdropExperience({
       session.dispose();
       adapter?.dispose();
       adapter = null;
+      adaptiveQualityUnsubscribe?.();
+      adaptiveQualityUnsubscribe = null;
+      adaptiveQualityController = null;
+      adaptiveQualityState = null;
       runtime = null;
       if (keyboardHandler) {
         document.removeEventListener('keydown', keyboardHandler);

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -1038,6 +1038,11 @@ export type MilkdropFeedbackSetRenderTarget = {
 
 export interface MilkdropFeedbackManager {
   applyCompositeState(state: MilkdropFeedbackCompositeState): void;
+  setAdaptiveQuality?(
+    multipliers: Partial<{
+      feedbackResolutionMultiplier: number;
+    }>,
+  ): void;
   render(
     renderer: {
       render(scene: Scene, camera: Camera): void;
@@ -1064,6 +1069,11 @@ export interface MilkdropRendererAdapter {
   readonly backend: 'webgl' | 'webgpu';
   attach(): void;
   setPreset(preset: MilkdropCompiledPreset): void;
+  setAdaptiveQuality?(
+    multipliers: Partial<{
+      feedbackResolutionMultiplier: number;
+    }>,
+  ): void;
   render(payload: MilkdropRenderPayload): boolean;
   resize(width: number, height: number): void;
   dispose(): void;

--- a/tests/adaptive-quality-controller.test.ts
+++ b/tests/adaptive-quality-controller.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { createAdaptiveQualityController } from '../assets/js/core/services/adaptive-quality-controller.ts';
+
+describe('createAdaptiveQualityController', () => {
+  test('starts from capability heuristics for baseline webgpu devices', () => {
+    const controller = createAdaptiveQualityController({
+      backend: 'webgpu',
+      capabilities: {
+        preferredCanvasFormat: 'bgra8unorm',
+        performanceTier: 'baseline',
+        recommendedQualityPreset: 'balanced',
+        workers: {
+          workers: true,
+          offscreenCanvas: true,
+          transferControlToOffscreen: true,
+        },
+        features: {
+          bgra8unormStorage: false,
+          float32Blendable: false,
+          float32Filterable: false,
+          shaderF16: false,
+          subgroups: false,
+          timestampQuery: false,
+        },
+        limits: {
+          maxColorAttachments: 4,
+          maxComputeInvocationsPerWorkgroup: 256,
+          maxStorageBufferBindingSize: 268_435_456,
+          maxTextureDimension2D: 4_096,
+        },
+      },
+    });
+
+    const state = controller.getState();
+    expect(state.enabled).toBe(true);
+    expect(state.profile).toBe('baseline');
+    expect(state.qualityStep).toBeGreaterThan(1);
+    expect(state.renderScaleMultiplier).toBeLessThan(1);
+    expect(state.feedbackResolutionMultiplier).toBeLessThan(1);
+    expect(state.timingMode).toBe('coarse-frame');
+  });
+
+  test('degrades quickly under sustained pressure and recovers with headroom', () => {
+    const controller = createAdaptiveQualityController({
+      backend: 'webgpu',
+      capabilities: {
+        preferredCanvasFormat: 'bgra8unorm',
+        performanceTier: 'high-end',
+        recommendedQualityPreset: 'hi-fi',
+        workers: {
+          workers: true,
+          offscreenCanvas: true,
+          transferControlToOffscreen: true,
+        },
+        features: {
+          bgra8unormStorage: true,
+          float32Blendable: true,
+          float32Filterable: true,
+          shaderF16: true,
+          subgroups: true,
+          timestampQuery: true,
+        },
+        limits: {
+          maxColorAttachments: 8,
+          maxComputeInvocationsPerWorkgroup: 1_024,
+          maxStorageBufferBindingSize: 1_073_741_824,
+          maxTextureDimension2D: 16_384,
+        },
+      },
+    });
+
+    for (let index = 0; index < 24; index += 1) {
+      controller.recordFrame({
+        frameMs: 24,
+        phases: { renderMs: 18 },
+      });
+    }
+
+    const degraded = controller.getState();
+    expect(degraded.qualityStep).toBeGreaterThan(0);
+    expect(degraded.renderScaleMultiplier).toBeLessThan(1);
+
+    for (let index = 0; index < 160; index += 1) {
+      controller.recordFrame({
+        frameMs: 8,
+        phases: { renderMs: 5 },
+      });
+    }
+
+    const recovered = controller.getState();
+    expect(recovered.qualityStep).toBe(0);
+    expect(recovered.feedbackResolutionMultiplier).toBe(1);
+    expect(recovered.supportsGpuTimestamps).toBe(true);
+    expect(['steady', 'recovering']).toContain(recovered.adaptation);
+  });
+
+  test('stays disabled for webgl backends', () => {
+    const controller = createAdaptiveQualityController({
+      backend: 'webgl',
+      capabilities: null,
+    });
+
+    controller.recordFrame({
+      frameMs: 40,
+      phases: { renderMs: 35 },
+    });
+
+    const state = controller.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.qualityStep).toBe(0);
+    expect(state.renderScaleMultiplier).toBe(1);
+  });
+});

--- a/tests/renderer-settings.test.ts
+++ b/tests/renderer-settings.test.ts
@@ -37,8 +37,11 @@ describe('applyRendererSettings', () => {
 
   test('applies explicit viewport dimensions when provided', () => {
     const calls: Array<[number, number, boolean?]> = [];
+    let pixelRatio = 0;
     const renderer = {
-      setPixelRatio: () => {},
+      setPixelRatio: (value: number) => {
+        pixelRatio = value;
+      },
       setSize: (width: number, height: number, updateStyle?: boolean) => {
         calls.push([width, height, updateStyle]);
       },
@@ -49,6 +52,9 @@ describe('applyRendererSettings', () => {
       backend: 'webgl' as const,
       maxPixelRatio: 2,
       renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
       exposure: 1,
     };
 
@@ -62,5 +68,42 @@ describe('applyRendererSettings', () => {
 
     expect(calls).toEqual([[640, 360, false]]);
     expect(renderer.toneMappingExposure).toBe(1.2);
+    expect(pixelRatio).toBeGreaterThan(0);
+  });
+
+  test('applies adaptive multipliers without overwriting the stored base settings', () => {
+    const pixelRatios: number[] = [];
+    const renderer = {
+      setPixelRatio: (value: number) => {
+        pixelRatios.push(value);
+      },
+      setSize: () => {},
+      toneMappingExposure: 1,
+    };
+    const info = {
+      renderer: renderer as never,
+      backend: 'webgpu' as const,
+      maxPixelRatio: 2,
+      renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
+      exposure: 1,
+    };
+
+    applyRendererSettings(renderer as never, info, {
+      renderScale: 0.9,
+      maxPixelRatio: 1.6,
+      adaptiveRenderScaleMultiplier: 0.8,
+      adaptiveMaxPixelRatioMultiplier: 0.75,
+      adaptiveDensityMultiplier: 0.7,
+    });
+
+    expect(info.renderScale).toBe(0.9);
+    expect(info.maxPixelRatio).toBe(1.6);
+    expect(info.adaptiveRenderScaleMultiplier).toBe(0.8);
+    expect(info.adaptiveMaxPixelRatioMultiplier).toBe(0.75);
+    expect(info.adaptiveDensityMultiplier).toBe(0.7);
+    expect(pixelRatios[pixelRatios.length - 1]).toBeCloseTo(0.72, 6);
   });
 });

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -43,6 +43,9 @@ describe('render-service pooling', () => {
       device: null,
       maxPixelRatio: 2,
       renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
       exposure: 1,
     }));
 


### PR DESCRIPTION
### Motivation
- Improve runtime frame pacing on capable WebGPU devices by adapting render scale, pixel ratio, density, and feedback resolution without restarting the toy. 
- Seed the controller from detected `RendererCapabilities.webgpu.performanceTier` and feature/limit bits so initial quality matches the GPU class. 
- Keep WebGL behavior unchanged and make the API amenable to later replacement with precise GPU timestamps or finer-phase timings.

### Description
- Add a new adaptive quality controller module `assets/js/core/services/adaptive-quality-controller.ts` that exposes a subscription API, capability-based heuristics, EMA sampling, degrade/recover logic, and quality multiplier steps. 
- Wire adaptive multipliers into renderer init/settings by extending `RendererInitResult`/`RendererInitConfig` and updating `assets/js/core/renderer-setup.ts` and `assets/js/core/renderer-settings.ts` so `renderScale`, `maxPixelRatio`, and density can be tuned at runtime. 
- Integrate controller into the MilkDrop runtime: create the controller after renderer startup, subscribe to its state, feed coarse per-frame timing samples each frame, apply density into `vm.setDetailScale`, and surface the active state in the existing debug snapshot (`assets/js/milkdrop/runtime.ts`). 
- Add dynamic feedback resolution control to the WebGPU feedback manager (`assets/js/milkdrop/feedback-manager-webgpu.ts`) and adapter/type plumbing so feedback targets can downshift/recover at runtime, and update `assets/js/milkdrop/renderer-adapter.ts` and `assets/js/milkdrop/types.ts` to expose `setAdaptiveQuality` hooks. 
- Add tests and small test updates: `tests/adaptive-quality-controller.test.ts` (controller heuristics + degrade/recover behavior) and updates to `tests/renderer-settings.test.ts` and `tests/services-pool.test.ts` to cover the new multipliers and expanded init metadata.

### Testing
- Ran targeted unit tests with `bun run test tests/adaptive-quality-controller.test.ts tests/renderer-settings.test.ts tests/services-pool.test.ts` and all targeted tests passed. 
- Ran full quality gate `bun run check` (Biome, typecheck, full test suite) and the test suite completed with zero failures after the changes. 

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf12bd276483329ede006504d7fa7f)