### PR TITLE
Add mesh and motion vector descriptor plans

### DIFF
--- a/assets/js/milkdrop/compiler.ts
+++ b/assets/js/milkdrop/compiler.ts
@@ -51,6 +51,7 @@ import type {
   MilkdropPresetIR,
   MilkdropPresetSource,
   MilkdropProceduralMeshDescriptorPlan,
+  MilkdropProceduralMotionVectorDescriptorPlan,
   MilkdropProceduralWaveDescriptorPlan,
   MilkdropProgramBlock,
   MilkdropRenderBackend,
@@ -5562,13 +5563,18 @@ function buildBackendSupport({
 function buildWebGpuDescriptorPlan({
   featureAnalysis,
   webgpu,
+  numericFields,
   programs,
   customWaves,
   post,
 }: {
   featureAnalysis: MilkdropFeatureAnalysis;
   webgpu: MilkdropBackendSupport;
-  programs: Pick<MilkdropPresetIR['programs'], 'perPixel'>;
+  numericFields: Record<string, number>;
+  programs: Pick<
+    MilkdropPresetIR['programs'],
+    'init' | 'perFrame' | 'perPixel'
+  >;
   customWaves: MilkdropWaveDefinition[];
   post: Pick<
     MilkdropPresetIR['post'],
@@ -5612,6 +5618,7 @@ function buildWebGpuDescriptorPlan({
       routing: 'fallback-webgl',
       proceduralWaves: [],
       proceduralMesh: null,
+      proceduralMotionVectors: null,
       feedback: null,
       unsupported,
     };
@@ -5645,13 +5652,27 @@ function buildWebGpuDescriptorPlan({
   ];
 
   const loweredPerPixelProgram = lowerGpuFieldProgram(programs.perPixel);
+  const supportsProceduralFieldEvaluation =
+    programs.perPixel.statements.length === 0 ||
+    loweredPerPixelProgram !== null;
   const proceduralMesh: MilkdropProceduralMeshDescriptorPlan | null =
-    programs.perPixel.statements.length === 0 || loweredPerPixelProgram
+    supportsProceduralFieldEvaluation
       ? {
           kind: 'procedural-mesh',
           requiresPerPixelProgram: programs.perPixel.statements.length > 0,
-          supportsMotionVectors:
-            featureAnalysis.featuresUsed.includes('motion-vectors'),
+          fieldProgram: loweredPerPixelProgram,
+        }
+      : null;
+  const proceduralMotionVectors: MilkdropProceduralMotionVectorDescriptorPlan | null =
+    featureAnalysis.featuresUsed.includes('motion-vectors') &&
+    !hasLegacyMotionVectorControls(numericFields, {
+      init: programs.init,
+      perFrame: programs.perFrame,
+    }) &&
+    supportsProceduralFieldEvaluation
+      ? {
+          kind: 'procedural-motion-vectors',
+          requiresPerPixelProgram: programs.perPixel.statements.length > 0,
           fieldProgram: loweredPerPixelProgram,
         }
       : null;
@@ -5694,11 +5715,15 @@ function buildWebGpuDescriptorPlan({
 
   return {
     routing:
-      proceduralWaves.length > 0 || proceduralMesh || feedback
+      proceduralWaves.length > 0 ||
+      proceduralMesh ||
+      proceduralMotionVectors ||
+      feedback
         ? 'descriptor-plan'
         : 'generic-frame-payload',
     proceduralWaves,
     proceduralMesh,
+    proceduralMotionVectors,
     feedback,
     unsupported: [],
   };
@@ -6214,6 +6239,7 @@ function createIR(
     webgpu: buildWebGpuDescriptorPlan({
       featureAnalysis,
       webgpu: finalBackends.webgpu,
+      numericFields,
       programs,
       customWaves,
       post,

--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -3373,7 +3373,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
   ) {
     const proceduralField =
       this.backend === 'webgpu' &&
-      this.webgpuDescriptorPlan?.proceduralMesh?.supportsMotionVectors
+      this.webgpuDescriptorPlan?.proceduralMotionVectors !== null
         ? payload.gpuGeometry.motionVectorField
         : null;
     if (proceduralField) {

--- a/assets/js/milkdrop/types.ts
+++ b/assets/js/milkdrop/types.ts
@@ -275,7 +275,12 @@ export type MilkdropGpuFieldProgramDescriptor = {
 export type MilkdropProceduralMeshDescriptorPlan = {
   kind: 'procedural-mesh';
   requiresPerPixelProgram: boolean;
-  supportsMotionVectors: boolean;
+  fieldProgram: MilkdropGpuFieldProgramDescriptor | null;
+};
+
+export type MilkdropProceduralMotionVectorDescriptorPlan = {
+  kind: 'procedural-motion-vectors';
+  requiresPerPixelProgram: boolean;
   fieldProgram: MilkdropGpuFieldProgramDescriptor | null;
 };
 
@@ -300,6 +305,7 @@ export type MilkdropWebGpuDescriptorPlan = {
   routing: MilkdropGpuDescriptorRouting;
   proceduralWaves: MilkdropProceduralWaveDescriptorPlan[];
   proceduralMesh: MilkdropProceduralMeshDescriptorPlan | null;
+  proceduralMotionVectors: MilkdropProceduralMotionVectorDescriptorPlan | null;
   feedback: MilkdropFeedbackPostEffectDescriptorPlan | null;
   unsupported: MilkdropGpuDescriptorUnsupportedMarker[];
 };

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -302,6 +302,19 @@ type MeshField = {
   signals: MilkdropGpuFieldSignalInputs | null;
 };
 
+type MotionVectorHistoryPoint = {
+  sourceX: number;
+  sourceY: number;
+  x: number;
+  y: number;
+};
+
+type MotionVectorFieldHistory = {
+  countX: number;
+  countY: number;
+  points: MotionVectorHistoryPoint[];
+};
+
 type MotionVectorDescriptorContext = {
   legacyControls: boolean;
   countX: number;
@@ -330,7 +343,7 @@ class MilkdropPresetVM implements MilkdropVM {
   private customWaveState: MutableState[] = [];
   private proceduralTrailWaves: MilkdropProceduralWaveVisual[] = [];
   private customShapeState: MutableState[] = [];
-  private lastMeshField: MeshField | null = null;
+  private lastMotionVectorField: MotionVectorFieldHistory | null = null;
   private readonly waveBuffers: WaveFrameBuffers = {
     liveSamples: [],
     previousSamples: [],
@@ -383,7 +396,7 @@ class MilkdropPresetVM implements MilkdropVM {
       this.seedCustomShapeState(shape),
     );
     this.proceduralTrailWaves = [];
-    this.lastMeshField = null;
+    this.lastMotionVectorField = null;
     this.waveBuffers.liveSamples.length = 0;
     this.waveBuffers.previousSamples.length = 0;
     this.waveBuffers.smoothedSamples.length = 0;
@@ -626,6 +639,13 @@ class MilkdropPresetVM implements MilkdropVM {
   private getProceduralMeshDescriptorPlan() {
     return this.renderBackend === 'webgpu'
       ? this.preset.ir.compatibility.gpuDescriptorPlans.webgpu.proceduralMesh
+      : null;
+  }
+
+  private getProceduralMotionVectorDescriptorPlan() {
+    return this.renderBackend === 'webgpu'
+      ? this.preset.ir.compatibility.gpuDescriptorPlans.webgpu
+          .proceduralMotionVectors
       : null;
   }
 
@@ -1267,7 +1287,9 @@ class MilkdropPresetVM implements MilkdropVM {
   private getProceduralMotionVectorFieldVisual(
     meshField: MeshField,
   ): MilkdropProceduralMotionVectorFieldVisual | null {
-    if (!meshField.signals) {
+    const proceduralMotionVectorPlan =
+      this.getProceduralMotionVectorDescriptorPlan();
+    if (!meshField.signals || !proceduralMotionVectorPlan) {
       return null;
     }
 
@@ -1295,7 +1317,7 @@ class MilkdropPresetVM implements MilkdropVM {
       explicitLength:
         legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale,
       legacyControls: motionVectorContext.legacyControls,
-      program: meshField.program,
+      program: proceduralMotionVectorPlan.fieldProgram,
       signals: meshField.signals,
       ...this.buildProceduralFieldTransform(),
     };
@@ -1319,10 +1341,12 @@ class MilkdropPresetVM implements MilkdropVM {
   ): MilkdropMotionVectorVisual[] {
     const motionVectorContext = this.getMotionVectorDescriptorContext();
     if (!motionVectorContext) {
+      this.lastMotionVectorField = null;
       return [];
     }
 
-    if (meshField.signals) {
+    if (this.getProceduralMotionVectorDescriptorPlan() && meshField.signals) {
+      this.lastMotionVectorField = null;
       return [];
     }
 
@@ -1343,8 +1367,10 @@ class MilkdropPresetVM implements MilkdropVM {
       1,
     );
     const vectors: MilkdropMotionVectorVisual[] = [];
-    const previousField = this.lastMeshField;
-    const density = meshField.density;
+    const nextHistoryPoints = new Array<MotionVectorHistoryPoint>(
+      countX * countY,
+    );
+    const previousField = this.lastMotionVectorField;
     const hasPerPixelPrograms =
       this.preset.ir.programs.perPixel.statements.length > 0;
     const legacyOffsetX = clamp(this.state.mv_dx ?? 0, -1, 1);
@@ -1365,10 +1391,14 @@ class MilkdropPresetVM implements MilkdropVM {
         const sourceY = hasLegacyMotionVectorControls
           ? clamp(sourceBaseY + legacyOffsetY, -1, 1)
           : sourceBaseY;
-        const fieldCol = Math.round((sourceX + 1) * 0.5 * (density - 1));
-        const fieldRow = Math.round((sourceY + 1) * 0.5 * (density - 1));
-        const index = fieldRow * density + fieldCol;
+        const index = row * countX + col;
         const currentPoint = this.transformMeshPoint(signals, sourceX, sourceY);
+        nextHistoryPoints[index] = {
+          sourceX,
+          sourceY,
+          x: currentPoint.x,
+          y: currentPoint.y,
+        };
         const previous = previousField?.points[index] ?? {
           sourceX,
           sourceY,
@@ -1424,6 +1454,11 @@ class MilkdropPresetVM implements MilkdropVM {
       }
     }
 
+    this.lastMotionVectorField = {
+      countX,
+      countY,
+      points: nextHistoryPoints,
+    };
     return vectors;
   }
 
@@ -1632,7 +1667,6 @@ class MilkdropPresetVM implements MilkdropVM {
     const customWaves = this.buildCustomWaves(signals);
     const mesh = this.buildMesh(meshField);
     const motionVectors = this.buildMotionVectors(signals, meshField);
-    this.lastMeshField = meshField;
 
     const frameState: MilkdropFrameState = {
       presetId: this.preset.source.id,

--- a/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
+++ b/tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json
@@ -32,9 +32,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -50,11 +50,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -91,9 +91,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -109,11 +109,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -150,9 +150,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -168,11 +168,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -209,9 +209,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -227,11 +227,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -272,9 +272,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -290,11 +290,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -335,9 +335,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -353,11 +353,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -394,9 +394,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -412,11 +412,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -453,9 +453,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -471,11 +471,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -521,7 +521,6 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": true,
-          "supportsMotionVectors": false,
           "fieldProgram": {
             "kind": "gpu-field-program",
             "statements": [
@@ -553,6 +552,7 @@
             "signature": "{\"temporaries\":[],\"statements\":[{\"target\":\"zoom\",\"expression\":{\"type\":\"binary\",\"operator\":\"-\",\"left\":{\"type\":\"literal\",\"value\":0.9615},\"right\":{\"type\":\"binary\",\"operator\":\"*\",\"left\":{\"type\":\"identifier\",\"name\":\"rad\"},\"right\":{\"type\":\"literal\",\"value\":0.1}}}}]}"
           }
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -568,11 +568,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -609,9 +609,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -627,11 +627,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -668,9 +668,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -686,11 +686,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -727,9 +727,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -745,11 +745,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -786,9 +786,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -804,11 +804,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -845,9 +845,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -863,11 +863,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -904,9 +904,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -922,11 +922,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -963,9 +963,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -981,11 +981,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1022,9 +1022,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1040,11 +1040,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1081,9 +1081,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1099,11 +1099,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1140,9 +1140,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1158,11 +1158,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1199,9 +1199,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1217,11 +1217,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1258,9 +1258,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1276,11 +1276,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1317,9 +1317,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1335,11 +1335,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1376,9 +1376,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1394,11 +1394,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1435,9 +1435,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1453,11 +1453,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1494,9 +1494,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1512,11 +1512,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1560,9 +1560,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1578,11 +1578,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1626,9 +1626,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1644,11 +1644,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1692,9 +1692,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1710,11 +1710,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1758,9 +1758,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1776,11 +1776,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1824,9 +1824,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1842,11 +1842,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1890,9 +1890,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1908,11 +1908,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -1956,9 +1956,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -1974,11 +1974,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -2028,9 +2028,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -2046,11 +2046,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -2115,9 +2115,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -2133,11 +2133,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -2176,9 +2176,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -2191,24 +2191,24 @@
           "status": "partial",
           "evidence": [
             {
+              "scope": "backend",
               "status": "partial",
               "code": "supported-shader-text-gap",
-              "feature": null,
-              "scope": "backend"
+              "feature": null
             }
           ]
         }
       },
       "parity": {
         "fidelityClass": "near-exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [
           "status:webgl=supported,webgpu=partial",
           "webgpu:supported-shader-text-gap"
         ],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -2247,9 +2247,9 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": false,
-          "supportsMotionVectors": false,
           "fieldProgram": null
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -2262,24 +2262,24 @@
           "status": "partial",
           "evidence": [
             {
+              "scope": "backend",
               "status": "partial",
               "code": "supported-shader-text-gap",
-              "feature": null,
-              "scope": "backend"
+              "feature": null
             }
           ]
         }
       },
       "parity": {
         "fidelityClass": "near-exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [
           "status:webgl=supported,webgpu=partial",
           "webgpu:supported-shader-text-gap"
         ],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   },
@@ -2335,7 +2335,6 @@
         "proceduralMesh": {
           "kind": "procedural-mesh",
           "requiresPerPixelProgram": true,
-          "supportsMotionVectors": false,
           "fieldProgram": {
             "kind": "gpu-field-program",
             "statements": [
@@ -2351,6 +2350,7 @@
             "signature": "{\"temporaries\":[],\"statements\":[{\"target\":\"cx\",\"expression\":{\"type\":\"identifier\",\"name\":\"x\"}}]}"
           }
         },
+        "proceduralMotionVectors": null,
         "feedback": null,
         "unsupported": []
       },
@@ -2366,11 +2366,11 @@
       },
       "parity": {
         "fidelityClass": "exact",
-        "blockedConstructs": [],
-        "ignoredFields": [],
-        "missingAliasesOrFunctions": [],
         "backendDivergence": [],
-        "approximatedShaderLines": []
+        "ignoredFields": [],
+        "blockedConstructs": [],
+        "approximatedShaderLines": [],
+        "missingAliasesOrFunctions": []
       }
     }
   }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -1419,7 +1419,11 @@ motion_vectors_y=5
       proceduralMesh: {
         kind: 'procedural-mesh',
         requiresPerPixelProgram: false,
-        supportsMotionVectors: true,
+        fieldProgram: null,
+      },
+      proceduralMotionVectors: {
+        kind: 'procedural-motion-vectors',
+        requiresPerPixelProgram: false,
         fieldProgram: null,
       },
       feedback: null,
@@ -1431,6 +1435,9 @@ motion_vectors_y=5
     const compiled = compileMilkdropPresetSource(
       `
 title=Descriptor Plan Per Pixel
+motion_vectors=1
+motion_vectors_x=5
+motion_vectors_y=3
 per_pixel_1=q1=sin(time*0.5+x*2);
 per_pixel_2=x=x+q1*0.05;
 per_pixel_3=zoom=zoom+abs(y)*0.1;
@@ -1443,7 +1450,18 @@ per_pixel_3=zoom=zoom+abs(y)*0.1;
     ).toMatchObject({
       kind: 'procedural-mesh',
       requiresPerPixelProgram: true,
-      supportsMotionVectors: false,
+      fieldProgram: {
+        kind: 'gpu-field-program',
+        temporaries: ['q1'],
+        statements: [{ target: 'q1' }, { target: 'x' }, { target: 'zoom' }],
+      },
+    });
+    expect(
+      compiled.ir.compatibility.gpuDescriptorPlans.webgpu
+        .proceduralMotionVectors,
+    ).toMatchObject({
+      kind: 'procedural-motion-vectors',
+      requiresPerPixelProgram: true,
       fieldProgram: {
         kind: 'gpu-field-program',
         temporaries: ['q1'],
@@ -1465,6 +1483,7 @@ warp_shader=unsupported(shader)
       routing: 'fallback-webgl',
       proceduralWaves: [],
       proceduralMesh: null,
+      proceduralMotionVectors: null,
       feedback: null,
       unsupported: [
         {
@@ -1476,5 +1495,31 @@ warp_shader=unsupported(shader)
         },
       ],
     });
+  });
+
+  test('keeps legacy motion-vector controls on the CPU path while retaining mesh descriptors', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Descriptor Plan Legacy Motion Vectors
+motion_vectors=1
+motion_vectors_x=7
+motion_vectors_y=5
+mv_l=0.4
+      `.trim(),
+      { id: 'descriptor-plan-legacy-motion-vectors' },
+    );
+
+    expect(compiled.ir.compatibility.gpuDescriptorPlans.webgpu).toEqual(
+      expect.objectContaining({
+        routing: 'descriptor-plan',
+        proceduralMesh: {
+          kind: 'procedural-mesh',
+          requiresPerPixelProgram: false,
+          fieldProgram: null,
+        },
+        proceduralMotionVectors: null,
+        unsupported: [],
+      }),
+    );
   });
 });

--- a/tests/milkdrop-projectm-compat.test.ts
+++ b/tests/milkdrop-projectm-compat.test.ts
@@ -359,6 +359,9 @@ function buildCompatibilitySnapshot(
           compiled.ir.compatibility.gpuDescriptorPlans.webgpu.proceduralWaves,
         proceduralMesh:
           compiled.ir.compatibility.gpuDescriptorPlans.webgpu.proceduralMesh,
+        proceduralMotionVectors:
+          compiled.ir.compatibility.gpuDescriptorPlans.webgpu
+            .proceduralMotionVectors,
         feedback: compiled.ir.compatibility.gpuDescriptorPlans.webgpu.feedback
           ? {
               kind: compiled.ir.compatibility.gpuDescriptorPlans.webgpu.feedback

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -669,7 +669,7 @@ warpanimspeed=1.25
         children?: Array<{ type?: string; material?: unknown }>;
       }>;
     };
-    const motionVectorGroup = root.children[7] as {
+    const motionVectorGroup = root.children?.[7] as {
       children: Array<{
         type?: string;
         visible?: boolean;
@@ -685,6 +685,61 @@ warpanimspeed=1.25
     expect(cpuMotionVectors?.children).toHaveLength(0);
     expect(proceduralMotionVectors).toBeInstanceOf(LineSegments);
     expect(motionVectorGroup.children[1]?.material).toBeDefined();
+  });
+
+  test('falls back to CPU motion-vector overlays on webgpu for legacy controls', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Legacy Motion Vector Overlay
+motion_vectors=1
+motion_vectors_x=6
+motion_vectors_y=4
+mv_l=0.2
+zoom=1.05
+rot=0.12
+warp=0.26
+warpanimspeed=1.25
+      `.trim(),
+      { id: 'legacy-motion-vector-overlay' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const frameState = vm.step(makeSignals());
+
+    expect(frameState.motionVectors.length).toBeGreaterThan(0);
+    expect(frameState.gpuGeometry.motionVectorField).toBeNull();
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const root = scene.children[0] as RenderTreeNode;
+    const motionVectorGroup = root.children?.[7] as {
+      children: Array<{
+        type?: string;
+        visible?: boolean;
+      }>;
+    };
+
+    const matchingMotionVectorMesh = flattenRenderTree(root).find(
+      (child) =>
+        child.geometry?.getAttribute?.('instanceStart') !== undefined &&
+        getGeometryInstanceCount(child) === frameState.motionVectors.length,
+    );
+
+    expect(matchingMotionVectorMesh).toBeDefined();
+    expect(motionVectorGroup.children[1]?.visible).toBe(false);
   });
 
   test('passes semantic feedback state to the feedback manager', () => {

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -496,6 +496,37 @@ per_pixel_3=warp=warp+abs(y)*0.1;
     ).toHaveLength(3);
   });
 
+  test('keeps legacy motion-vector controls on the CPU path even when mesh descriptors stay procedural', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Legacy Motion Vector CPU Fallback
+motion_vectors=1
+motion_vectors_x=5
+motion_vectors_y=3
+mv_l=0.18
+mesh_density=12
+zoom=1.08
+rot=0.1
+warp=0.2
+      `.trim(),
+      { id: 'legacy-motion-vector-cpu-fallback' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const first = vm.step(makeSignals({ frame: 1, time: 0.2 }));
+    const second = vm.step(makeSignals({ frame: 2, time: 0.4 }));
+
+    expect(first.mesh.positions).toHaveLength(0);
+    expect(first.gpuGeometry.meshField).not.toBeNull();
+    expect(first.gpuGeometry.motionVectorField).toBeNull();
+    expect(first.motionVectors.length).toBeGreaterThan(0);
+    expect(second.motionVectors.length).toBeGreaterThan(0);
+    expect(second.motionVectors[0]?.positions).not.toEqual(
+      first.motionVectors[0]?.positions,
+    );
+  });
+
   test('keeps waveform-driven main-wave geometry on webgpu line-wave presets', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Allow WebGPU to evaluate mesh and motion-vector fields from compact descriptor plans so the renderer can avoid allocating JS point arrays each frame while preserving CPU fallbacks for legacy or unsupported controls.
- Keep the minimum VM-side CPU state required for correct legacy motion-vector overlays and reuse the procedural signal/uniform packing used for waves for consistent shader input.

### Description
- Add a dedicated `MilkdropProceduralMotionVectorDescriptorPlan` and change procedural mesh plans to carry a `fieldProgram` in `types.ts`, and expose `proceduralMotionVectors` in the WebGPU descriptor plan output.
- Update the compiler (`buildWebGpuDescriptorPlan`) to emit a `proceduralMotionVectors` plan only when the preset uses motion-vectors, has no legacy motion-vector controls, and the per-pixel program lowers to the supported GPU subset, while still emitting `proceduralMesh` where appropriate.
- Change the VM to emit procedural mesh/motion-vector visuals (with `fieldProgram` and packed `signals`) when descriptor plans are available, and retain a minimal `lastMotionVectorField` history for CPU fallback rendering instead of full mesh point arrays.
- Update the renderer (`renderer-adapter.ts`) to select the WebGPU procedural motion-vector shader path when the `proceduralMotionVectors` plan is present and to fall back to the CPU overlays when legacy controls require it, keeping existing CPU paths for unsupported `perPixel` cases.
- Refresh the projectM compatibility snapshot and extend unit tests to cover descriptor-plan compilation, backend support classification, and legacy CPU fallback correctness.

### Testing
- Ran the focused milkdrop tests with `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-vm.test.ts tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-projectm-compat.test.ts`, and the suite passed (all tests in those files succeeded).
- Ran the project quality gate `bun run check` (Biome, TypeScript typecheck, and tests) and it completed successfully.
- Updated `tests/fixtures/milkdrop/projectm-upstream/compatibility-metadata.snapshot.json` to reflect the new descriptor-plan shape (no visual behavior regressions observed in the test corpus).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf12bfdcb483329c7390904dd6751f)