### PR TITLE
Preserve lowered field center normalization in GPU shaders

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -350,6 +350,22 @@ const PROCEDURAL_FIELD_PROGRAM_SHADER_HELPERS = `
   float milkdropEqual(float left, float right) {
     return abs(left - right) <= 0.000001 ? 1.0 : 0.0;
   }
+
+  float milkdropNormalizeTransformCenterX(float value) {
+    return (value - 0.5) * 2.0;
+  }
+
+  float milkdropNormalizeTransformCenterY(float value) {
+    return (0.5 - value) * 2.0;
+  }
+
+  float milkdropDenormalizeTransformCenterX(float value) {
+    return value * 0.5 + 0.5;
+  }
+
+  float milkdropDenormalizeTransformCenterY(float value) {
+    return 0.5 - value * 0.5;
+  }
 `;
 
 function gpuFieldVarName(name: string) {
@@ -598,8 +614,8 @@ function buildProceduralFieldProgramShaderChunk(
       float fieldZoomExponent = paramZoomExponent;
       float fieldRotation = paramRotation;
       float fieldWarp = paramWarp;
-      float fieldCenterX = paramCenterX;
-      float fieldCenterY = paramCenterY;
+      float fieldCenterX = milkdropDenormalizeTransformCenterX(paramCenterX);
+      float fieldCenterY = milkdropDenormalizeTransformCenterY(paramCenterY);
       float fieldScaleX = paramScaleX;
       float fieldScaleY = paramScaleY;
       float fieldTranslateX = paramTranslateX * 0.5;
@@ -607,14 +623,16 @@ function buildProceduralFieldProgramShaderChunk(
       ${temporaryDeclarations}
       ${statementCode}
 
+      float normalizedCenterX = milkdropNormalizeTransformCenterX(fieldCenterX);
+      float normalizedCenterY = milkdropNormalizeTransformCenterY(fieldCenterY);
       float angle = field_ang + fieldRotation;
       float translatedX =
-        (field_x - fieldCenterX) * fieldScaleX +
-        fieldCenterX +
+        (field_x - normalizedCenterX) * fieldScaleX +
+        normalizedCenterX +
         fieldTranslateX * 2.0;
       float translatedY =
-        (field_y - fieldCenterY) * fieldScaleY +
-        fieldCenterY +
+        (field_y - normalizedCenterY) * fieldScaleY +
+        normalizedCenterY +
         fieldTranslateY * 2.0;
       float ripple = sin(
         field_rad * 12.0 +

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -574,15 +574,14 @@ per_pixel_3=zoom=zoom+abs(y)*0.08;
     );
   });
 
-  test('keeps lowered field shader centers in clip space without renormalizing', () => {
+  test('normalizes lowered field shader centers after per-pixel programs run', () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Procedural Mesh Center
 mesh_density=10
-sx=1.15
-sy=0.9
-per_pixel_1=q1=sin(time+x*2.5);
-per_pixel_2=x=x+q1*0.04;
+per_pixel_1=cx=0.75;
+per_pixel_2=cy=0.25;
+per_pixel_3=sx=2;
       `.trim(),
       { id: 'procedural-mesh-center' },
     );
@@ -616,14 +615,23 @@ per_pixel_2=x=x+q1*0.04;
     };
 
     expect(meshLines.material).toBeInstanceOf(ShaderMaterial);
-    expect(meshLines.material?.vertexShader).not.toContain(
-      'milkdropNormalizeTransformCenter',
+    expect(meshLines.material?.vertexShader).toContain(
+      'float fieldCenterX = milkdropDenormalizeTransformCenterX(paramCenterX);',
     );
     expect(meshLines.material?.vertexShader).toContain(
-      '(field_x - fieldCenterX) * fieldScaleX',
+      'float fieldCenterY = milkdropDenormalizeTransformCenterY(paramCenterY);',
     );
     expect(meshLines.material?.vertexShader).toContain(
-      '(field_y - fieldCenterY) * fieldScaleY',
+      'float normalizedCenterX = milkdropNormalizeTransformCenterX(fieldCenterX);',
+    );
+    expect(meshLines.material?.vertexShader).toContain(
+      'float normalizedCenterY = milkdropNormalizeTransformCenterY(fieldCenterY);',
+    );
+    expect(meshLines.material?.vertexShader).toContain(
+      '(field_x - normalizedCenterX) * fieldScaleX',
+    );
+    expect(meshLines.material?.vertexShader).toContain(
+      '(field_y - normalizedCenterY) * fieldScaleY',
     );
   });
 


### PR DESCRIPTION
### Motivation
- Lowered per-pixel field programs were treating `cx`/`cy` values as clip-space directly, causing WebGPU-lowered meshes and motion vectors to diverge from the VM/WebGL path when presets wrote `cx`/`cy` in MilkDrop's 0..1 space.
- The intent is to preserve the VM semantics where `cx`/`cy` are normalized in the VM and then mapped to clip space only after per-pixel programs run so GPU lowering matches CPU/WebGL behavior.

### Description
- Add shader helper functions to denormalize/renormalize transform centers (`milkdropDenormalizeTransformCenterX/Y` and `milkdropNormalizeTransformCenterX/Y`) inside the procedural field shader helpers in `assets/js/milkdrop/renderer-adapter.ts`.
- Change the lowered procedural field program generation so descriptor-provided `paramCenterX/paramCenterY` are first denormalized into `fieldCenterX/fieldCenterY`, run through the lowered per-pixel statements, then renormalized before the translation/scale math (`normalizedCenterX/normalizedCenterY`) to match VM/WebGL semantics.
- Replace the prior renderer-adapter regression test with a new targeted test `normalizes lowered field shader centers after per-pixel programs run` in `tests/milkdrop-renderer-adapter.test.ts` that asserts the emitted vertex shader contains the denormalize/renormalize sequence and the translation math uses the normalized centers.

### Testing
- Ran targeted unit suites with `bun run test tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-vm.test.ts` and the suites passed including the new regression test.
- Ran the repository quality gate with `bun run check` (Biome checks + `tsc --noEmit` + full test sweep) and it completed with all tests passing.
- Verified emitted shader snippets in `ShaderMaterial.vertexShader` include the denormalize/normalize helpers and the translation expressions use `normalizedCenterX`/`normalizedCenterY` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1574fa708332866ef3aed3f2d305)