### PR TITLE
Fix runtime renderScale propagation for pooled renderers

### DIFF
--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -96,18 +96,18 @@ export function resolveRendererSettings(
   return {
     maxPixelRatio:
       options.maxPixelRatio ??
-      info?.maxPixelRatio ??
       defaults.maxPixelRatio ??
+      info?.maxPixelRatio ??
       BASE_RENDERER_SETTINGS.maxPixelRatio,
     renderScale:
       options.renderScale ??
-      info?.renderScale ??
       defaults.renderScale ??
+      info?.renderScale ??
       BASE_RENDERER_SETTINGS.renderScale,
     exposure:
       options.exposure ??
-      info?.exposure ??
       defaults.exposure ??
+      info?.exposure ??
       BASE_RENDERER_SETTINGS.exposure,
     antialias:
       options.antialias ??

--- a/assets/js/core/services/render-service.ts
+++ b/assets/js/core/services/render-service.ts
@@ -65,7 +65,8 @@ function getRenderDefaults(): Partial<RendererInitConfig> {
     maxPixelRatio:
       activeRenderPreferences.maxPixelRatio ?? activeQuality.maxPixelRatio,
     renderScale:
-      activeRenderPreferences.renderScale ?? activeQuality.renderScale ?? 1,
+      activeRuntimeControls.renderScale *
+      (activeRenderPreferences.renderScale ?? activeQuality.renderScale ?? 1),
   };
 }
 
@@ -196,6 +197,7 @@ export function setRendererRuntimeControls(
     overrides,
     activeRuntimeControls,
   );
+  forEachActiveRenderer((entry) => entry.handle.applySettings());
   runtimeControlSubscribers.forEach((subscriber) =>
     subscriber(activeRuntimeControls),
   );
@@ -204,6 +206,7 @@ export function setRendererRuntimeControls(
 
 export function resetRendererRuntimeControls() {
   activeRuntimeControls = DEFAULT_RENDERER_RUNTIME_CONTROLS;
+  forEachActiveRenderer((entry) => entry.handle.applySettings());
   runtimeControlSubscribers.forEach((subscriber) =>
     subscriber(activeRuntimeControls),
   );

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -21,15 +21,18 @@ import { DEFAULT_MICROPHONE_CONSTRAINTS } from '../assets/js/utils/audio-handler
 
 describe('render-service pooling', () => {
   const setPixelRatioMock = mock();
+  const setSizeMock = mock();
   const fakeRenderer = {
     setPixelRatio: setPixelRatioMock,
-    setSize: mock(),
+    setSize: setSizeMock,
     setAnimationLoop: mock(),
     dispose: mock(),
     toneMappingExposure: 1,
   } as unknown as WebGLRenderer;
 
   afterEach(() => {
+    setPixelRatioMock.mockReset();
+    setSizeMock.mockReset();
     document.body.innerHTML = '';
     resetRendererPool({ dispose: true });
     window.localStorage.clear();
@@ -87,6 +90,39 @@ describe('render-service pooling', () => {
     expect(getRendererRuntimeControls()).toEqual(next);
 
     unsubscribe();
+  });
+
+  test('applies runtime renderScale overrides to new and pooled renderers', async () => {
+    const initRendererImpl = mock(async () => ({
+      renderer: fakeRenderer,
+      backend: 'webgl' as const,
+      adapter: null,
+      device: null,
+      maxPixelRatio: 2,
+      renderScale: 1,
+      exposure: 1,
+    }));
+
+    setRendererRuntimeControls({ renderScale: 0.5 });
+
+    const first = await requestRenderer({ initRendererImpl });
+
+    expect(initRendererImpl).toHaveBeenCalledWith(
+      first.canvas,
+      expect.objectContaining({ renderScale: 0.5 }),
+    );
+
+    first.release();
+    setPixelRatioMock.mockClear();
+
+    const second = await requestRenderer({ initRendererImpl });
+
+    expect(second).toBe(first);
+    expect(setPixelRatioMock).toHaveBeenCalled();
+
+    setRendererRuntimeControls({ renderScale: 0.25 });
+
+    expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.25);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Runtime renderer controls (notably the `renderScale` multiplier) should apply to all renderers so runtime-optimization overrides actually reduce GPU work for both newly created and pooled renderers.
- Current flow only updated the in-memory runtime object and subscribers, but `initRenderer()` / pooled renderer settings resolution still sourced `renderScale` from cached quality/prefs, making the runtime control effectively a no-op for the main optimization path.

### Description
- Fold the shared runtime `renderScale` multiplier into renderer defaults by updating `getRenderDefaults()` in `assets/js/core/services/render-service.ts` so new renderers inherit the runtime override when created via `initRenderer`.
- Reapply settings to active pooled renderers when runtime controls change or are reset by invoking `forEachActiveRenderer(...applySettings())` inside `setRendererRuntimeControls()` and `resetRendererRuntimeControls()` in `assets/js/core/services/render-service.ts`.
- Prefer the current defaults over cached renderer `info` when resolving settings by changing precedence in `resolveRendererSettings()` in `assets/js/core/renderer-settings.ts` so reusing renderers picks up updated default-backed values like `renderScale`.
- Add a regression test in `tests/services-pool.test.ts` that validates `renderScale` from `setRendererRuntimeControls()` flows into both newly initialized renderers and pooled/reused renderers.

### Testing
- Ran targeted tests with `bun run test tests/services-pool.test.ts tests/renderer-settings.test.ts` and both passed.
- Ran the full quality gate with `bun run check` (Biome lint/format, `tsc` typecheck, and the test suite) and it completed successfully with no failures. 
- The change includes the added/updated test `tests/services-pool.test.ts` that covers the regression for runtime `renderScale` propagation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf166b931083329e12ee3fcbf378e6)