### PR TITLE
Follow up: preserve WebGPU wave depth in compact segment uploads

### DIFF
--- a/assets/js/milkdrop/renderer-adapter-webgpu.ts
+++ b/assets/js/milkdrop/renderer-adapter-webgpu.ts
@@ -268,15 +268,16 @@ class CompactSegmentUploadBuffer {
   }
 
   getControlData() {
-    return this.controlData.subarray(0, this.count * 2);
+    return this.controlData.subarray(0, this.count * 3);
   }
 
   appendSegment(
     startX: number,
     startY: number,
+    startZ: number,
     endX: number,
     endY: number,
-    z: number,
+    endZ: number,
     color: MilkdropColor,
     alpha: number,
     width: number,
@@ -294,9 +295,10 @@ class CompactSegmentUploadBuffer {
     this.styleData[styleOffset + 2] = color.b;
     this.styleData[styleOffset + 3] = alpha;
 
-    const controlOffset = this.count * 2;
-    this.controlData[controlOffset] = z;
-    this.controlData[controlOffset + 1] = width * 0.5;
+    const controlOffset = this.count * 3;
+    this.controlData[controlOffset] = startZ;
+    this.controlData[controlOffset + 1] = endZ;
+    this.controlData[controlOffset + 2] = width * 0.5;
     this.count += 1;
   }
 
@@ -311,9 +313,10 @@ class CompactSegmentUploadBuffer {
       this.appendSegment(
         positions[index] ?? 0,
         positions[index + 1] ?? 0,
+        positions[index + 2] ?? 0.24,
         positions[index + 3] ?? 0,
         positions[index + 4] ?? 0,
-        positions[index + 2] ?? 0.24,
+        positions[index + 5] ?? 0.24,
         color,
         alpha,
         width,
@@ -326,9 +329,10 @@ class CompactSegmentUploadBuffer {
     this.appendSegment(
       positions[lastPointIndex] ?? 0,
       positions[lastPointIndex + 1] ?? 0,
+      positions[lastPointIndex + 2] ?? 0.24,
       positions[0] ?? 0,
       positions[1] ?? 0,
-      positions[lastPointIndex + 2] ?? 0.24,
+      positions[2] ?? 0.24,
       color,
       alpha,
       width,
@@ -352,6 +356,7 @@ class CompactSegmentUploadBuffer {
         this.appendSegment(
           previousX,
           previousY,
+          0.24,
           point.x,
           point.y,
           0.24,
@@ -387,6 +392,7 @@ class CompactSegmentUploadBuffer {
         this.appendSegment(
           previousX,
           previousY,
+          0.28,
           x,
           pointY,
           0.28,
@@ -404,7 +410,7 @@ class CompactSegmentUploadBuffer {
   private ensureCapacity(count: number) {
     this.lineData = ensureFloat32Capacity(this.lineData, count * 4);
     this.styleData = ensureFloat32Capacity(this.styleData, count * 4);
-    this.controlData = ensureFloat32Capacity(this.controlData, count * 2);
+    this.controlData = ensureFloat32Capacity(this.controlData, count * 3);
   }
 }
 
@@ -539,7 +545,7 @@ class InstancedSegmentBatch {
           attribute vec2 segmentCoord;
           attribute vec4 instanceLine;
           attribute vec4 instanceColorAlpha;
-          attribute vec2 instanceControl;
+          attribute vec3 instanceControl;
           varying vec4 vColor;
 
           void main() {
@@ -548,8 +554,8 @@ class InstancedSegmentBatch {
             vec2 direction = lengthDelta > 0.000001 ? delta / lengthDelta : vec2(1.0, 0.0);
             vec2 normal = vec2(-direction.y, direction.x);
             vec2 base = instanceLine.xy + delta * segmentCoord.x;
-            vec2 point = base + normal * segmentCoord.y * instanceControl.y;
-            float z = instanceControl.x;
+            vec2 point = base + normal * segmentCoord.y * instanceControl.z;
+            float z = mix(instanceControl.x, instanceControl.y, segmentCoord.x);
             vColor = instanceColorAlpha;
             gl_Position = projectionMatrix * modelViewMatrix * vec4(point, z, 1.0);
           }
@@ -591,7 +597,7 @@ class InstancedSegmentBatch {
     const control = ensureInstancedAttribute(
       geometry,
       'instanceControl',
-      2,
+      3,
       instances.count,
     );
     (line.array as Float32Array).set(instances.getLineData());

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -1020,9 +1020,10 @@ wave_a=0.7
         (positions[4] ?? 0) - (positions[1] ?? 0),
       ]),
     );
-    expect(controlArray?.slice(0, 2)).toEqual(
+    expect(controlArray?.slice(0, 3)).toEqual(
       Float32Array.from([
         positions[2] ?? 0.24,
+        positions[5] ?? 0.24,
         0.0025 * Math.max(1, frameState.mainWave.thickness) * 0.5,
       ]),
     );
@@ -1032,6 +1033,64 @@ wave_a=0.7
         frameState.mainWave.color.g,
         frameState.mainWave.color.b,
         frameState.mainWave.alpha,
+      ]),
+    );
+  });
+
+  test('preserves per-point depth across compact WebGPU wave uploads', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Compact Wave Depth
+wave_mode=0
+wave_usedots=0
+wave_additive=0
+wave_a=0.7
+      `.trim(),
+      { id: 'compact-wave-depth' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    const positions = frameState.mainWave.positions;
+    const segmentIndex = Array.from(
+      { length: Math.max(0, positions.length / 3 - 1) },
+      (_, index) => index,
+    ).find((index) => {
+      const startZ = positions[index * 3 + 2] ?? 0;
+      const endZ = positions[index * 3 + 5] ?? 0;
+      return Math.abs(endZ - startZ) > 1e-6;
+    });
+
+    expect(segmentIndex).toBeDefined();
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgpu',
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: null,
+    });
+
+    const root = scene.children[0] as RenderTreeNode;
+    const waveMesh = flattenRenderTree(root).find(
+      (child) =>
+        isWebGPUSegmentBatchNode(child) &&
+        getGeometryInstanceCount(child) ===
+          frameState.mainWave.positions.length / 3,
+    );
+    const controlArray = getFloat32AttributeArray(waveMesh, 'instanceControl');
+    const controlOffset = (segmentIndex ?? 0) * 3;
+
+    expect(controlArray?.slice(controlOffset, controlOffset + 3)).toEqual(
+      Float32Array.from([
+        positions[(segmentIndex ?? 0) * 3 + 2] ?? 0.24,
+        positions[(segmentIndex ?? 0) * 3 + 5] ?? 0.24,
+        0.0025 * Math.max(1, frameState.mainWave.thickness) * 0.5,
       ]),
     );
   });


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where batched WebGPU main-wave segments flattened per-sample depth because the compact upload only carried a single `z` value and the vertex shader read only a single endpoint. 
- Preserve prior non-batched/WebGL semantics so WebGPU line-mode rendering matches existing depth interpolation for adjacent samples with different `z` values. 

### Description
- Expand the compact segment upload format by changing `CompactSegmentUploadBuffer` control data to carry `startZ`, `endZ`, and `halfWidth` (3 floats) instead of a 2-float `(z, halfWidth)`. 
- Wire the new start/end `z` through `appendSegment` and all callers (`appendPolyline`, procedural wave paths, and custom wave uploads) so each segment records both endpoint depths. 
- Update the instanced segment vertex shader to use `attribute vec3 instanceControl` and compute `z = mix(instanceControl.x, instanceControl.y, segmentCoord.x)` while using `instanceControl.z` for the half-width, and update the instanced attribute `itemSize` to `3` when syncing. 
- Add/adjust tests in `tests/milkdrop-renderer-adapter.test.ts` to expect the expanded `instanceControl` layout and a new regression test `preserves per-point depth across compact WebGPU wave uploads`. 

### Testing
- Ran the targeted adapter tests with `bun run test tests/milkdrop-renderer-adapter.test.ts` and observed the file-level suite pass (31 passed, 0 failed). 
- Ran the full quality gate with `bun run check` (Biome, `tsc --noEmit`, and the test suite) and observed completion with all tests green (`432 passed`, `4 skipped`, `0 failed`). 
- Docs touched: `None`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf166c81708332bc880a34f2226813)