### PR TITLE
Avoid redundant WebGPU renderer reconfiguration and preserve startup pixel-ratio caps

### DIFF
--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -1,4 +1,6 @@
 import type * as THREE from 'three';
+import { isMobileDevice } from '../utils/device-detect';
+import { getAdaptiveMaxPixelRatio } from './device-profile.ts';
 import type {
   RendererInitConfig,
   RendererInitResult,
@@ -23,6 +25,8 @@ export type RendererViewport = {
   width: number;
   height: number;
 };
+
+const isMobileUserAgent = isMobileDevice();
 
 const BASE_RENDERER_SETTINGS: Required<RendererInitConfig> = {
   maxPixelRatio: 1.5,
@@ -91,21 +95,45 @@ export function applyRendererSettings(
     0.4,
     (merged.renderScale ?? 1) * (merged.adaptiveRenderScaleMultiplier ?? 1),
   );
+  const adaptiveMaxPixelRatioCap = getAdaptiveMaxPixelRatio(
+    merged.maxPixelRatio ??
+      info.maxPixelRatio ??
+      BASE_RENDERER_SETTINGS.maxPixelRatio,
+  );
+  const backendMaxPixelRatioCap = getRendererBackendMaxPixelRatioCap({
+    backend: info.backend,
+    isMobile: isMobileUserAgent,
+  });
   const effectiveMaxPixelRatio = Math.max(
     0.5,
-    (merged.maxPixelRatio ?? 2) * (merged.adaptiveMaxPixelRatioMultiplier ?? 1),
+    Math.min(
+      (merged.maxPixelRatio ?? 2) *
+        (merged.adaptiveMaxPixelRatioMultiplier ?? 1),
+      adaptiveMaxPixelRatioCap,
+      backendMaxPixelRatioCap,
+    ),
   );
   const effectivePixelRatio = Math.min(
     (window.devicePixelRatio || 1) * effectiveRenderScale,
     effectiveMaxPixelRatio,
   );
+  const nextViewportWidth = viewport?.width ?? window.innerWidth;
+  const nextViewportHeight = viewport?.height ?? window.innerHeight;
 
-  renderer.setPixelRatio(effectivePixelRatio);
-  renderer.setSize(
-    viewport?.width ?? window.innerWidth,
-    viewport?.height ?? window.innerHeight,
-    false,
-  );
+  if (info.appliedPixelRatio !== effectivePixelRatio) {
+    renderer.setPixelRatio(effectivePixelRatio);
+    info.appliedPixelRatio = effectivePixelRatio;
+  }
+
+  if (
+    info.appliedViewportWidth !== nextViewportWidth ||
+    info.appliedViewportHeight !== nextViewportHeight
+  ) {
+    renderer.setSize(nextViewportWidth, nextViewportHeight, false);
+    info.appliedViewportWidth = nextViewportWidth;
+    info.appliedViewportHeight = nextViewportHeight;
+  }
+
   renderer.toneMappingExposure = merged.exposure ?? 1;
 
   info.maxPixelRatio = merged.maxPixelRatio ?? info.maxPixelRatio;

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -32,6 +32,9 @@ export type RendererInitResult = {
   adaptiveRenderScaleMultiplier: number;
   adaptiveDensityMultiplier: number;
   exposure: number;
+  appliedPixelRatio?: number;
+  appliedViewportWidth?: number;
+  appliedViewportHeight?: number;
 };
 
 export type RendererInitConfig = {
@@ -109,6 +112,9 @@ export async function initRenderer(
       adaptiveRenderScaleMultiplier,
       adaptiveDensityMultiplier,
       exposure,
+      appliedPixelRatio: effectivePixelRatio,
+      appliedViewportWidth: window.innerWidth,
+      appliedViewportHeight: window.innerHeight,
     };
   };
 

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -842,6 +842,12 @@ export function createMilkdropExperience({
   let adaptiveQualityController: AdaptiveQualityController | null = null;
   let adaptiveQualityState: AdaptiveQualityState | null = null;
   let adaptiveQualityUnsubscribe: (() => void) | null = null;
+  let lastAppliedAdaptiveQuality: {
+    renderScaleMultiplier: number;
+    maxPixelRatioMultiplier: number;
+    densityMultiplier: number;
+    feedbackResolutionMultiplier: number;
+  } | null = null;
   const mergedSignals: Partial<MilkdropRuntimeSignals> = {};
   const lowQualityPostOverride = {
     shaderEnabled: false,
@@ -1526,6 +1532,7 @@ export function createMilkdropExperience({
         adapter.attach();
         adaptiveQualityUnsubscribe?.();
         adaptiveQualityUnsubscribe = null;
+        lastAppliedAdaptiveQuality = null;
         adaptiveQualityController = createAdaptiveQualityController({
           backend: activeBackend,
           capabilities:
@@ -1540,14 +1547,40 @@ export function createMilkdropExperience({
               updateAgentDebugSnapshot();
               return;
             }
-            nextRuntime.toy.updateRendererSettings({
-              adaptiveRenderScaleMultiplier: state.renderScaleMultiplier,
-              adaptiveMaxPixelRatioMultiplier: state.maxPixelRatioMultiplier,
-              adaptiveDensityMultiplier: state.densityMultiplier,
-            });
-            adapter?.setAdaptiveQuality?.({
+
+            const nextAdaptiveQuality = {
+              renderScaleMultiplier: state.renderScaleMultiplier,
+              maxPixelRatioMultiplier: state.maxPixelRatioMultiplier,
+              densityMultiplier: state.densityMultiplier,
               feedbackResolutionMultiplier: state.feedbackResolutionMultiplier,
-            });
+            };
+            const adaptiveQualityChanged =
+              lastAppliedAdaptiveQuality === null ||
+              lastAppliedAdaptiveQuality.renderScaleMultiplier !==
+                nextAdaptiveQuality.renderScaleMultiplier ||
+              lastAppliedAdaptiveQuality.maxPixelRatioMultiplier !==
+                nextAdaptiveQuality.maxPixelRatioMultiplier ||
+              lastAppliedAdaptiveQuality.densityMultiplier !==
+                nextAdaptiveQuality.densityMultiplier ||
+              lastAppliedAdaptiveQuality.feedbackResolutionMultiplier !==
+                nextAdaptiveQuality.feedbackResolutionMultiplier;
+
+            if (adaptiveQualityChanged) {
+              nextRuntime.toy.updateRendererSettings({
+                adaptiveRenderScaleMultiplier:
+                  nextAdaptiveQuality.renderScaleMultiplier,
+                adaptiveMaxPixelRatioMultiplier:
+                  nextAdaptiveQuality.maxPixelRatioMultiplier,
+                adaptiveDensityMultiplier:
+                  nextAdaptiveQuality.densityMultiplier,
+              });
+              adapter?.setAdaptiveQuality?.({
+                feedbackResolutionMultiplier:
+                  nextAdaptiveQuality.feedbackResolutionMultiplier,
+              });
+              lastAppliedAdaptiveQuality = nextAdaptiveQuality;
+            }
+
             updateAgentDebugSnapshot();
           },
         );
@@ -1691,6 +1724,7 @@ export function createMilkdropExperience({
       adaptiveQualityUnsubscribe = null;
       adaptiveQualityController = null;
       adaptiveQualityState = null;
+      lastAppliedAdaptiveQuality = null;
       runtime = null;
       if (keyboardHandler) {
         document.removeEventListener('keydown', keyboardHandler);

--- a/tests/renderer-settings.test.ts
+++ b/tests/renderer-settings.test.ts
@@ -71,6 +71,107 @@ describe('applyRendererSettings', () => {
     expect(pixelRatio).toBeGreaterThan(0);
   });
 
+  test('reapplies startup caps during adaptive webgpu updates', () => {
+    const pixelRatios: number[] = [];
+    const renderer = {
+      setPixelRatio: (value: number) => {
+        pixelRatios.push(value);
+      },
+      setSize: () => {},
+      toneMappingExposure: 1,
+    };
+    const info = {
+      renderer: renderer as never,
+      backend: 'webgpu' as const,
+      maxPixelRatio: 2,
+      renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
+      exposure: 1,
+    };
+
+    const originalWindow = globalThis.window;
+    const originalNavigator = globalThis.navigator;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        ...originalWindow,
+        devicePixelRatio: 2,
+        innerWidth: 800,
+        innerHeight: 600,
+        matchMedia: () => ({ matches: false }),
+      },
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        ...originalNavigator,
+        deviceMemory: 4,
+        hardwareConcurrency: 4,
+      },
+    });
+
+    try {
+      applyRendererSettings(renderer as never, info, {
+        adaptiveMaxPixelRatioMultiplier: 1,
+      });
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: originalNavigator,
+      });
+    }
+
+    expect(pixelRatios[pixelRatios.length - 1]).toBe(1.25);
+  });
+
+  test('skips renderer reconfiguration when effective settings are unchanged', () => {
+    const pixelRatios: number[] = [];
+    const sizes: Array<[number, number, boolean?]> = [];
+    const renderer = {
+      setPixelRatio: (value: number) => {
+        pixelRatios.push(value);
+      },
+      setSize: (width: number, height: number, updateStyle?: boolean) => {
+        sizes.push([width, height, updateStyle]);
+      },
+      toneMappingExposure: 1,
+    };
+    const info = {
+      renderer: renderer as never,
+      backend: 'webgpu' as const,
+      maxPixelRatio: 1.5,
+      renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
+      exposure: 1,
+    };
+
+    applyRendererSettings(
+      renderer as never,
+      info,
+      {},
+      {},
+      { width: 640, height: 360 },
+    );
+    applyRendererSettings(
+      renderer as never,
+      info,
+      {},
+      {},
+      { width: 640, height: 360 },
+    );
+
+    expect(pixelRatios).toHaveLength(1);
+    expect(sizes).toEqual([[640, 360, false]]);
+  });
+
   test('applies adaptive multipliers without overwriting the stored base settings', () => {
     const pixelRatios: number[] = [];
     const renderer = {


### PR DESCRIPTION
### Motivation
- Prevent the adaptive quality controller from forcing the renderer to reconfigure every timing sample, which could cause frame drops on WebGPU runs. 
- Ensure the initial startup pixel-ratio caps (mobile / low-power safeguards) remain in effect when adaptive updates are applied so constrained devices are not prematurely bumped up.

### Description
- Stop noisy updates by caching the last applied adaptive multipliers in the MilkDrop runtime and only call `updateRendererSettings` / `setAdaptiveQuality` when the multipliers actually change, with the cache reset on attach and dispose (`assets/js/milkdrop/runtime.ts`).
- Preserve the startup pixel-ratio caps by reintroducing `getAdaptiveMaxPixelRatio` and backend caps into the adaptive update path and by clamping the computed `effectiveMaxPixelRatio` accordingly in `applyRendererSettings` (`assets/js/core/renderer-settings.ts`).
- Avoid redundant `renderer.setPixelRatio()` / `renderer.setSize()` calls by tracking the last-applied pixel ratio and viewport in the renderer info and only invoking the underlying renderer when those values change, and by wiring those tracking fields into the init result (`assets/js/core/renderer-setup.ts`).
- Add regression coverage for the capped adaptive path and idempotent reapplication behavior in `tests/renderer-settings.test.ts`.

### Testing
- Ran targeted unit tests with `bun run test tests/renderer-settings.test.ts tests/adaptive-quality-controller.test.ts` and all tests passed. 
- Ran the full quality gate with `bun run check` (Biome, typecheck, full test suite) and it completed with zero failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1d261900833295bb8d3a1493357e)