### PR TITLE
Follow-up: preserve active renderer overrides during runtime reapply

### DIFF
--- a/assets/js/core/services/render-service.ts
+++ b/assets/js/core/services/render-service.ts
@@ -116,15 +116,33 @@ async function createRendererHandle(
     throw new Error('Unable to initialize renderer.');
   }
 
+  let activeOptions = options;
+  let activeViewport: RendererViewport | undefined;
+
   const handle: RendererHandle = {
     renderer: initResult.renderer,
     backend: initResult.backend,
     info: initResult,
     canvas,
     getRuntimeControls: () => activeRuntimeControls,
-    applySettings: (nextOptions, viewport) =>
-      applyPoolSettings(initResult.renderer, initResult, nextOptions, viewport),
-    release: () => {},
+    applySettings: (nextOptions, viewport) => {
+      if (nextOptions) {
+        activeOptions = nextOptions;
+      }
+      if (viewport) {
+        activeViewport = viewport;
+      }
+      applyPoolSettings(
+        initResult.renderer,
+        initResult,
+        activeOptions,
+        activeViewport,
+      );
+    },
+    release: () => {
+      activeOptions = {};
+      activeViewport = undefined;
+    },
   };
 
   return handle;
@@ -176,7 +194,9 @@ export async function requestRenderer({
     inUse: true,
   };
 
+  const releaseHandle = handle.release;
   handle.release = () => {
+    releaseHandle();
     handle.renderer.setAnimationLoop?.(null);
     poolEntry.inUse = false;
     detachCanvas(handle.canvas);

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -124,6 +124,35 @@ describe('render-service pooling', () => {
 
     expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.25);
   });
+
+  test('preserves active renderer overrides when runtime controls reapply', async () => {
+    const initRendererImpl = mock(async () => ({
+      renderer: fakeRenderer,
+      backend: 'webgl' as const,
+      adapter: null,
+      device: null,
+      maxPixelRatio: 2,
+      renderScale: 1,
+      exposure: 1,
+    }));
+
+    const handle = await requestRenderer({
+      initRendererImpl,
+      options: { maxPixelRatio: 0.75, renderScale: 0.6 },
+    });
+
+    setPixelRatioMock.mockClear();
+    setRendererRuntimeControls({ renderScale: 0.25 });
+
+    expect(handle.getRuntimeControls()).toEqual({
+      renderScale: 0.25,
+      feedbackScale: 1,
+      meshDensityMultiplier: 1,
+      waveSampleMultiplier: 1,
+      motionVectorDensityMultiplier: 1,
+    });
+    expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.6);
+  });
 });
 
 describe('audio-service pooling', () => {


### PR DESCRIPTION
### Motivation
- A service-level reapply of runtime controls could overwrite per-toy renderer overrides for pooled renderers, causing active toys to snap back to global defaults for `maxPixelRatio`/`renderScale` instead of preserving explicit per-toy settings.
- The pool reapply path invoked `applySettings()` with no `nextOptions`, so pooled handles needed to remember their last-applied per-handle overrides and viewport to avoid losing those values.

### Description
- Make each pooled `RendererHandle` cache its last-applied `options` and `viewport` and use those cached values when `applySettings()` is called with no `nextOptions`, by updating `createRendererHandle()` in `assets/js/core/services/render-service.ts`.
- Clear the cached `activeOptions`/`activeViewport` on `release()` so state does not leak between uses of a pooled handle.
- Ensure the handle `release` wrapper in `requestRenderer()` preserves original release semantics when returning handles to the pool.
- Add a regression test `preserves active renderer overrides when runtime controls reapply` to `tests/services-pool.test.ts` that verifies per-handle overrides (like `renderScale`) are preserved when `setRendererRuntimeControls()` triggers a reapply.

### Testing
- Ran targeted tests with `bun run test tests/services-pool.test.ts tests/renderer-settings.test.ts` and the added test passed alongside existing cases.
- Ran the full quality gate with `bun run check` (Biome lint/format, `tsc` typecheck, and the test suite) and it completed successfully with all tests passing.
- Modified files: `assets/js/core/services/render-service.ts` and `tests/services-pool.test.ts`, with the new test covering the regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1e6b79b88332b04bbc474de5d6ea)