### PR TITLE
Extend GPU blend snapshots to WebGL transitions

### DIFF
--- a/assets/js/milkdrop/renderer-adapter.ts
+++ b/assets/js/milkdrop/renderer-adapter.ts
@@ -3662,7 +3662,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     this.renderMotionVectors(payload.frameState);
 
     const blend = payload.blendState;
-    if (blend?.mode === 'gpu' && this.backend === 'webgpu') {
+    if (blend?.mode === 'gpu') {
       const previousFrame = blend.previousFrame;
       const blendMix = 1 - blend.alpha;
       if (

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -645,50 +645,13 @@ function downloadPresetFile(name: string, contents: string) {
 
 function cloneBlendState(
   frameState: MilkdropFrameState | null,
-  backend: 'webgl' | 'webgpu',
 ): MilkdropBlendState | null {
   if (!frameState) {
     return null;
   }
-  if (backend === 'webgpu') {
-    return {
-      mode: 'gpu',
-      previousFrame: frameState,
-      alpha: 1,
-    };
-  }
-  const waveform = {
-    ...frameState.mainWave,
-    positions: [...frameState.mainWave.positions],
-    color: { ...frameState.mainWave.color },
-  };
   return {
-    mode: 'cpu',
-    background: frameState.background,
-    waveform,
-    mainWave: waveform,
-    customWaves: frameState.customWaves.map((wave) => ({
-      ...wave,
-      positions: [...wave.positions],
-      color: { ...wave.color },
-    })),
-    trails: frameState.trails,
-    shapes: frameState.shapes.map((shape) => ({
-      ...shape,
-      color: { ...shape.color },
-      secondaryColor: shape.secondaryColor ? { ...shape.secondaryColor } : null,
-      borderColor: { ...shape.borderColor },
-    })),
-    borders: frameState.borders.map((border) => ({
-      ...border,
-      color: { ...border.color },
-    })),
-    motionVectors: frameState.motionVectors.map((vector) => ({
-      ...vector,
-      positions: [...vector.positions],
-      color: { ...vector.color },
-    })),
-    post: frameState.post,
+    mode: 'gpu',
+    previousFrame: frameState,
     alpha: 1,
   };
 }
@@ -821,7 +784,7 @@ export function createMilkdropExperience({
   let activePresetId = defaultPreset.source.id;
   let activeBackend: 'webgl' | 'webgpu' = 'webgl';
   let currentFrameState: MilkdropFrameState | null = null;
-  let blendState = cloneBlendState(currentFrameState, activeBackend);
+  let blendState = cloneBlendState(currentFrameState);
   let blendEndAtMs = 0;
   let autoplay = prefs.autoplay ?? false;
   let blendDuration =
@@ -1001,7 +964,7 @@ export function createMilkdropExperience({
       blendDuration > 0 &&
       estimateFrameBlendWorkload(currentFrameState) < 900
     ) {
-      blendState = cloneBlendState(currentFrameState, activeBackend);
+      blendState = cloneBlendState(currentFrameState);
       blendEndAtMs = performance.now() + blendDuration * 1000;
     } else {
       blendState = null;
@@ -1718,3 +1681,7 @@ export function createMilkdropExperience({
     },
   };
 }
+
+export const __milkdropRuntimeTestUtils = {
+  cloneBlendState,
+};

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -1392,6 +1392,53 @@ wavecode_0_a=0.35
     );
   });
 
+  test('renders GPU blend snapshots on webgl without requiring CPU-cloned wave state', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=WebGL GPU Blend
+wave_mode=0
+wave_a=1
+      `.trim(),
+      { id: 'webgl-gpu-blend' },
+    );
+    const vm = createMilkdropVM(preset);
+    const previousFrame = vm.step(makeSignals({ time: 0.1 }));
+    const frameState = vm.step(makeSignals({ time: 0.3 }));
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapter({
+      scene,
+      camera,
+      backend: 'webgl',
+      preset,
+    });
+
+    adapter.attach();
+    adapter.render({
+      frameState,
+      blendState: {
+        mode: 'gpu',
+        previousFrame,
+        alpha: 0.5,
+      },
+    });
+
+    const root = scene.children[0] as {
+      children: Array<{ children?: Array<{ material?: unknown }> }>;
+    };
+    const blendWaveGroup = root.children[8];
+
+    expect(blendWaveGroup?.children?.length ?? 0).toBeGreaterThan(0);
+    const renderedBlendWave = blendWaveGroup?.children?.[0] as
+      | {
+          material?: LineBasicMaterial;
+        }
+      | undefined;
+    expect(renderedBlendWave?.material).toBeInstanceOf(LineBasicMaterial);
+    expect(renderedBlendWave?.material?.opacity).toBeCloseTo(0.5, 6);
+  });
+
   test('keeps WebGL fallback on CPU geometry for descriptors that WebGPU synthesizes procedurally', () => {
     const preset = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-runtime.test.ts
+++ b/tests/milkdrop-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  __milkdropRuntimeTestUtils,
   applyMilkdropInteractionResponse,
   getMilkdropDetailScale,
 } from '../assets/js/milkdrop/runtime.ts';
@@ -64,6 +65,23 @@ describe('milkdrop runtime detail scale', () => {
         particleBudget: 2,
       }),
     ).toBe(2);
+  });
+});
+
+describe('milkdrop runtime blend state', () => {
+  test('reuses the frame reference for transition blends', () => {
+    const frameState = {
+      presetId: 'blend-state-reference',
+    } as MilkdropFrameState;
+
+    const blendState = __milkdropRuntimeTestUtils.cloneBlendState(frameState);
+
+    expect(blendState?.mode).toBe('gpu');
+    if (!blendState || blendState.mode !== 'gpu') {
+      throw new Error('Expected a GPU blend state.');
+    }
+    expect(blendState.alpha).toBe(1);
+    expect(blendState.previousFrame).toBe(frameState);
   });
 });
 


### PR DESCRIPTION
Summary
- reuse frame references for preset transitions so WebGL can use the existing GPU-style blend snapshot path instead of deep-cloning visual state on the CPU
- allow the renderer adapter to honor GPU blend snapshots on WebGL and cover the regression with targeted runtime and adapter tests

Tests
- bun test tests/milkdrop-runtime.test.ts --test-name-pattern "reuses the frame reference for transition blends"
- bun test tests/milkdrop-renderer-adapter.test.ts --test-name-pattern "renders GPU blend snapshots on webgl without requiring CPU-cloned wave state"
- bun run check *(fails in pre-existing TypeScript checks: tests/adaptive-quality-controller.test.ts is missing WebGPUCapabilitySummary.optimization, and tests/services-pool.test.ts mocks are missing RendererInitResult adaptive multiplier fields)*

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1f0f1a548332b2bfbc7e42f74267)