### PR TITLE
Clamp preserved maxPixelRatio on runtime reapply

### DIFF
--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -1,9 +1,12 @@
 import type * as THREE from 'three';
+import { isMobileDevice } from '../utils/device-detect';
 import type {
   RendererInitConfig,
   RendererInitResult,
 } from './renderer-setup.ts';
 import type { WebGPURenderer } from './webgpu-renderer.ts';
+
+const isMobileUserAgent = isMobileDevice();
 
 export function getRendererBackendMaxPixelRatioCap({
   backend,
@@ -147,9 +150,17 @@ export function applyRendererSettings(
     0.4,
     (merged.renderScale ?? 1) * (merged.adaptiveRenderScaleMultiplier ?? 1),
   );
+  const backendPixelRatioCap = getRendererBackendMaxPixelRatioCap({
+    backend: info.backend,
+    isMobile: isMobileUserAgent,
+  });
   const effectiveMaxPixelRatio = Math.max(
     0.5,
-    (merged.maxPixelRatio ?? 2) * (merged.adaptiveMaxPixelRatioMultiplier ?? 1),
+    Math.min(
+      (merged.maxPixelRatio ?? 2) *
+        (merged.adaptiveMaxPixelRatioMultiplier ?? 1),
+      backendPixelRatioCap,
+    ),
   );
   const effectivePixelRatio = Math.min(
     (window.devicePixelRatio || 1) * effectiveRenderScale,

--- a/tests/adaptive-quality-controller.test.ts
+++ b/tests/adaptive-quality-controller.test.ts
@@ -14,6 +14,15 @@ describe('createAdaptiveQualityController', () => {
           offscreenCanvas: true,
           transferControlToOffscreen: true,
         },
+        optimization: {
+          timestampQuery: false,
+          shaderF16: false,
+          subgroups: false,
+          workers: true,
+          offscreenCanvas: true,
+          transferControlToOffscreen: true,
+          workerOffscreenPipeline: true,
+        },
         features: {
           bgra8unormStorage: false,
           float32Blendable: false,
@@ -51,6 +60,15 @@ describe('createAdaptiveQualityController', () => {
           workers: true,
           offscreenCanvas: true,
           transferControlToOffscreen: true,
+        },
+        optimization: {
+          timestampQuery: true,
+          shaderF16: true,
+          subgroups: true,
+          workers: true,
+          offscreenCanvas: true,
+          transferControlToOffscreen: true,
+          workerOffscreenPipeline: true,
         },
         features: {
           bgra8unormStorage: true,

--- a/tests/renderer-settings.test.ts
+++ b/tests/renderer-settings.test.ts
@@ -73,6 +73,45 @@ describe('applyRendererSettings', () => {
     expect(pixelRatio).toBeGreaterThan(0);
   });
 
+  test('reapplies the backend max pixel-ratio cap for later settings updates', () => {
+    const originalDevicePixelRatio = window.devicePixelRatio;
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 2,
+    });
+
+    const pixelRatios: number[] = [];
+    const renderer = {
+      setPixelRatio: (value: number) => {
+        pixelRatios.push(value);
+      },
+      setSize: () => {},
+      toneMappingExposure: 1,
+    };
+    const info = {
+      renderer: renderer as never,
+      backend: 'webgl' as const,
+      maxPixelRatio: 2,
+      renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
+      exposure: 1,
+    };
+
+    applyRendererSettings(renderer as never, info, {
+      maxPixelRatio: 1.75,
+      renderScale: 1,
+    });
+
+    expect(pixelRatios[pixelRatios.length - 1]).toBeCloseTo(1.35, 6);
+
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: originalDevicePixelRatio,
+    });
+  });
+
   test('applies adaptive multipliers without overwriting the stored base settings', () => {
     const pixelRatios: number[] = [];
     const renderer = {

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -36,6 +36,10 @@ describe('render-service pooling', () => {
     document.body.innerHTML = '';
     resetRendererPool({ dispose: true });
     window.localStorage.clear();
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1,
+    });
   });
 
   test('reuses renderer handle between toys', async () => {
@@ -103,6 +107,9 @@ describe('render-service pooling', () => {
       device: null,
       maxPixelRatio: 2,
       renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
       exposure: 1,
     }));
 
@@ -110,10 +117,10 @@ describe('render-service pooling', () => {
 
     const first = await requestRenderer({ initRendererImpl });
 
-    expect(initRendererImpl).toHaveBeenCalledWith(
-      first.canvas,
-      expect.objectContaining({ renderScale: 0.5 }),
-    );
+    expect(initRendererImpl.mock.calls[0]?.[0]).toBe(first.canvas);
+    expect(initRendererImpl.mock.calls[0]?.[1]).toMatchObject({
+      renderScale: 0.5,
+    });
 
     first.release();
     setPixelRatioMock.mockClear();
@@ -125,10 +132,15 @@ describe('render-service pooling', () => {
 
     setRendererRuntimeControls({ renderScale: 0.25 });
 
-    expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.25);
+    expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.4);
   });
 
   test('preserves active renderer overrides when runtime controls reapply', async () => {
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 2,
+    });
+
     const initRendererImpl = mock(async () => ({
       renderer: fakeRenderer,
       backend: 'webgl' as const,
@@ -136,25 +148,28 @@ describe('render-service pooling', () => {
       device: null,
       maxPixelRatio: 2,
       renderScale: 1,
+      adaptiveMaxPixelRatioMultiplier: 1,
+      adaptiveRenderScaleMultiplier: 1,
+      adaptiveDensityMultiplier: 1,
       exposure: 1,
     }));
 
     const handle = await requestRenderer({
       initRendererImpl,
-      options: { maxPixelRatio: 0.75, renderScale: 0.6 },
+      options: { maxPixelRatio: 1.75, renderScale: 1 },
     });
 
     setPixelRatioMock.mockClear();
-    setRendererRuntimeControls({ renderScale: 0.25 });
+    setRendererRuntimeControls({ renderScale: 0.9 });
 
     expect(handle.getRuntimeControls()).toEqual({
-      renderScale: 0.25,
+      renderScale: 0.9,
       feedbackScale: 1,
       meshDensityMultiplier: 1,
       waveSampleMultiplier: 1,
       motionVectorDensityMultiplier: 1,
     });
-    expect(setPixelRatioMock).toHaveBeenLastCalledWith(0.6);
+    expect(setPixelRatioMock).toHaveBeenLastCalledWith(1.35);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Preserved per-toy `maxPixelRatio` overrides were being reused raw on runtime-control reapply, which can restore an uncapped pixel-ratio and bypass the backend GPU cap applied at initialization. 
- Enforce the backend-specific pixel-ratio cap when `applyRendererSettings()` runs later so pooled/active renderers cannot unintentionally exceed the device/driver safeguard.

### Description
- Reapply the backend max-pixel-ratio cap inside `applyRendererSettings()` by computing `backendPixelRatioCap` (via `getRendererBackendMaxPixelRatioCap`) and clamping the effective max-pixel-ratio with `Math.min(...)` before computing the final pixel ratio. (file: `assets/js/core/renderer-settings.ts`).
- Import `isMobileDevice` and use it to determine the mobile/desktop cap when reapplying settings so the same backend cap used at init is reapplied on subsequent updates. (file: `assets/js/core/renderer-settings.ts`).
- Add and adjust tests to cover the regression: new reapply-cap test in `tests/renderer-settings.test.ts`, updates to `tests/services-pool.test.ts` to validate preserved overrides and capped pixel-ratio behavior, and refresh `tests/adaptive-quality-controller.test.ts` fixtures to match the current capability shape. 
- Minor test/mock updates to align mocked `RendererInitResult` shape and window DPR in tests so expectations reflect the capped behavior.

### Testing
- Ran targeted tests with `bun run test tests/services-pool.test.ts tests/renderer-settings.test.ts tests/adaptive-quality-controller.test.ts`, and the targeted suites passed. 
- Executed the repo quality gate with `bun run check` (Biome lint/format, TypeScript typecheck, and tests); targeted changes and checks were validated, and the change is limited to renderer settings and tests. 
- Note: an unrelated existing test in the larger integration suite (`tests/milkdrop-renderer-adapter.test.ts`) was observed failing in one run of the full suite prior to the focused fixes; the change in this PR does not modify that area and the targeted tests covering this fix pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2127a91c8332b05efa1468b72f25)