### PR TITLE
Add opt-in OffscreenCanvas/WebGPU renderer worker experiment

### DIFF
--- a/assets/js/core/renderer-worker-protocol.ts
+++ b/assets/js/core/renderer-worker-protocol.ts
@@ -1,0 +1,144 @@
+import type { RendererRuntimeControls } from './renderer-settings.ts';
+import type { RendererInitConfig } from './renderer-setup.ts';
+
+export const RENDERER_WORKER_MESSAGE_TYPES = {
+  init: 'renderer:init',
+  resize: 'renderer:resize',
+  quality: 'renderer:quality',
+  preset: 'renderer:preset',
+  frame: 'renderer:frame',
+  dispose: 'renderer:dispose',
+  ready: 'renderer:ready',
+  status: 'renderer:status',
+  error: 'renderer:error',
+} as const;
+
+export type RendererWorkerMessageType =
+  (typeof RENDERER_WORKER_MESSAGE_TYPES)[keyof typeof RENDERER_WORKER_MESSAGE_TYPES];
+
+export type RendererWorkerInitPayload = {
+  canvas: OffscreenCanvas;
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+  options?: Partial<RendererInitConfig>;
+};
+
+export type RendererWorkerResizePayload = {
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+};
+
+export type RendererWorkerQualityPayload = {
+  runtimeControls: RendererRuntimeControls;
+  options?: Partial<RendererInitConfig>;
+};
+
+export type RendererWorkerPresetPayload = {
+  id?: string | null;
+  title?: string | null;
+  source?: string | null;
+};
+
+export type RendererWorkerFramePayload = {
+  now: number;
+  deltaMs: number;
+  audioLevel?: number;
+  energy?: {
+    bass?: number;
+    mids?: number;
+    treble?: number;
+  };
+  pointer?: {
+    x?: number;
+    y?: number;
+    down?: boolean;
+  };
+};
+
+export type RendererWorkerInitMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.init;
+  payload: RendererWorkerInitPayload;
+};
+
+export type RendererWorkerResizeMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.resize;
+  payload: RendererWorkerResizePayload;
+};
+
+export type RendererWorkerQualityMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.quality;
+  payload: RendererWorkerQualityPayload;
+};
+
+export type RendererWorkerPresetMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.preset;
+  payload: RendererWorkerPresetPayload;
+};
+
+export type RendererWorkerFrameMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.frame;
+  payload: RendererWorkerFramePayload;
+};
+
+export type RendererWorkerDisposeMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.dispose;
+};
+
+export type RendererWorkerRequestMessage =
+  | RendererWorkerInitMessage
+  | RendererWorkerResizeMessage
+  | RendererWorkerQualityMessage
+  | RendererWorkerPresetMessage
+  | RendererWorkerFrameMessage
+  | RendererWorkerDisposeMessage;
+
+export type RendererWorkerReadyMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.ready;
+  payload: {
+    backend: 'webgpu';
+    width: number;
+    height: number;
+  };
+};
+
+export type RendererWorkerStatusMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.status;
+  payload: {
+    phase:
+      | 'initialized'
+      | 'resized'
+      | 'quality-updated'
+      | 'preset-applied'
+      | 'frame-submitted'
+      | 'disposed';
+  };
+};
+
+export type RendererWorkerErrorMessage = {
+  type: typeof RENDERER_WORKER_MESSAGE_TYPES.error;
+  payload: {
+    message: string;
+  };
+};
+
+export type RendererWorkerResponseMessage =
+  | RendererWorkerReadyMessage
+  | RendererWorkerStatusMessage
+  | RendererWorkerErrorMessage;
+
+export function isRendererWorkerResponseMessage(
+  value: unknown,
+): value is RendererWorkerResponseMessage {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as { type?: unknown };
+  return (
+    candidate.type === RENDERER_WORKER_MESSAGE_TYPES.ready ||
+    candidate.type === RENDERER_WORKER_MESSAGE_TYPES.status ||
+    candidate.type === RENDERER_WORKER_MESSAGE_TYPES.error
+  );
+}

--- a/assets/js/core/renderer-worker.ts
+++ b/assets/js/core/renderer-worker.ts
@@ -1,0 +1,328 @@
+/* global GPU */
+
+import {
+  ACESFilmicToneMapping,
+  Color,
+  PerspectiveCamera,
+  Scene,
+  SRGBColorSpace,
+} from 'three';
+import type { RendererInitConfig } from './renderer-setup.ts';
+import {
+  RENDERER_WORKER_MESSAGE_TYPES,
+  type RendererWorkerFramePayload,
+  type RendererWorkerPresetPayload,
+  type RendererWorkerQualityPayload,
+  type RendererWorkerRequestMessage,
+  type RendererWorkerResizePayload,
+  type RendererWorkerResponseMessage,
+} from './renderer-worker-protocol.ts';
+import { WebGPURenderer } from './webgpu-renderer.ts';
+
+const scope = globalThis as typeof globalThis & {
+  postMessage: (message: RendererWorkerResponseMessage) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (
+      event: MessageEvent<RendererWorkerRequestMessage>,
+    ) => void | Promise<void>,
+  ) => void;
+};
+
+type WorkerRendererState = {
+  renderer: WebGPURenderer | null;
+  scene: Scene | null;
+  camera: PerspectiveCamera | null;
+  canvas: OffscreenCanvas | null;
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+  options: Partial<RendererInitConfig>;
+  latestPreset: RendererWorkerPresetPayload | null;
+  latestFrame: RendererWorkerFramePayload | null;
+};
+
+const state: WorkerRendererState = {
+  renderer: null,
+  scene: null,
+  camera: null,
+  canvas: null,
+  width: 1,
+  height: 1,
+  devicePixelRatio: 1,
+  options: {},
+  latestPreset: null,
+  latestFrame: null,
+};
+
+function postMessage(message: RendererWorkerResponseMessage) {
+  scope.postMessage(message);
+}
+
+function resolveEffectivePixelRatio({
+  devicePixelRatio,
+  renderScale = 1,
+  maxPixelRatio = 1.5,
+}: {
+  devicePixelRatio: number;
+  renderScale?: number;
+  maxPixelRatio?: number;
+}) {
+  return Math.min(devicePixelRatio * renderScale, maxPixelRatio);
+}
+
+function applyRendererOptions(
+  renderer: WebGPURenderer,
+  {
+    width,
+    height,
+    devicePixelRatio,
+    options,
+  }: {
+    width: number;
+    height: number;
+    devicePixelRatio: number;
+    options: Partial<RendererInitConfig>;
+  },
+) {
+  renderer.setPixelRatio(
+    resolveEffectivePixelRatio({
+      devicePixelRatio,
+      renderScale: options.renderScale,
+      maxPixelRatio: options.maxPixelRatio,
+    }),
+  );
+  renderer.setSize(width, height, false);
+  renderer.outputColorSpace = SRGBColorSpace;
+  renderer.toneMapping = ACESFilmicToneMapping;
+  renderer.toneMappingExposure = options.exposure ?? 1;
+}
+
+async function initRenderer({
+  canvas,
+  width,
+  height,
+  devicePixelRatio,
+  options = {},
+}: {
+  canvas: OffscreenCanvas;
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+  options?: Partial<RendererInitConfig>;
+}) {
+  const gpu = (navigator as Navigator & { gpu?: GPU }).gpu;
+  if (!gpu?.requestAdapter) {
+    throw new Error('WebGPU is unavailable inside the renderer worker.');
+  }
+
+  const adapter = await gpu.requestAdapter();
+  if (!adapter) {
+    throw new Error(
+      'Unable to acquire a WebGPU adapter inside the renderer worker.',
+    );
+  }
+
+  const device = await adapter.requestDevice();
+  const renderer = new WebGPURenderer({
+    canvas,
+    antialias: options.antialias ?? true,
+    alpha: options.alpha ?? false,
+    device,
+  });
+  if ('init' in renderer && typeof renderer.init === 'function') {
+    await renderer.init();
+  }
+
+  const scene = new Scene();
+  scene.background = new Color(0x05070d);
+  const camera = new PerspectiveCamera(45, width / height, 0.1, 10);
+  camera.position.z = 1;
+
+  state.renderer = renderer;
+  state.scene = scene;
+  state.camera = camera;
+  state.canvas = canvas;
+  state.width = width;
+  state.height = height;
+  state.devicePixelRatio = devicePixelRatio;
+  state.options = options;
+
+  applyRendererOptions(renderer, {
+    width,
+    height,
+    devicePixelRatio,
+    options,
+  });
+
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.ready,
+    payload: {
+      backend: 'webgpu',
+      width,
+      height,
+    },
+  });
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'initialized' },
+  });
+}
+
+function ensureRendererReady() {
+  if (!state.renderer || !state.scene || !state.camera) {
+    throw new Error(
+      'Renderer worker received a message before initialization completed.',
+    );
+  }
+
+  return {
+    renderer: state.renderer,
+    scene: state.scene,
+    camera: state.camera,
+  };
+}
+
+function handleResize({
+  width,
+  height,
+  devicePixelRatio,
+}: RendererWorkerResizePayload) {
+  const { renderer, camera } = ensureRendererReady();
+  state.width = width;
+  state.height = height;
+  state.devicePixelRatio = devicePixelRatio;
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  applyRendererOptions(renderer, {
+    width,
+    height,
+    devicePixelRatio,
+    options: state.options,
+  });
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'resized' },
+  });
+}
+
+function handleQualityUpdate({
+  runtimeControls,
+  options = {},
+}: RendererWorkerQualityPayload) {
+  const { renderer } = ensureRendererReady();
+  state.options = {
+    ...state.options,
+    ...options,
+    renderScale:
+      (options.renderScale ?? state.options.renderScale ?? 1) *
+      runtimeControls.renderScale,
+  };
+  applyRendererOptions(renderer, {
+    width: state.width,
+    height: state.height,
+    devicePixelRatio: state.devicePixelRatio,
+    options: state.options,
+  });
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'quality-updated' },
+  });
+}
+
+function handlePreset(payload: RendererWorkerPresetPayload) {
+  const { scene } = ensureRendererReady();
+  state.latestPreset = payload;
+  const titleHash = `${payload.id ?? ''}:${payload.title ?? ''}:${payload.source ?? ''}`;
+  let accumulator = 0;
+  for (let index = 0; index < titleHash.length; index += 1) {
+    accumulator =
+      (accumulator + titleHash.charCodeAt(index) * (index + 1)) % 255;
+  }
+  scene.background = new Color(
+    accumulator / 255,
+    Math.max(0.05, accumulator / 510),
+    Math.max(0.1, 1 - accumulator / 320),
+  );
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'preset-applied' },
+  });
+}
+
+function handleFrame(payload: RendererWorkerFramePayload) {
+  const { renderer, scene, camera } = ensureRendererReady();
+  state.latestFrame = payload;
+
+  const bass = payload.energy?.bass ?? payload.audioLevel ?? 0;
+  const mids = payload.energy?.mids ?? 0;
+  const treble = payload.energy?.treble ?? 0;
+  const pointerX = payload.pointer?.x ?? 0.5;
+  const pointerY = payload.pointer?.y ?? 0.5;
+
+  scene.background = new Color(
+    Math.min(1, 0.04 + bass * 0.65 + pointerX * 0.12),
+    Math.min(1, 0.05 + mids * 0.55 + pointerY * 0.1),
+    Math.min(1, 0.1 + treble * 0.65 + (payload.pointer?.down ? 0.1 : 0)),
+  );
+
+  renderer.render(scene, camera);
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'frame-submitted' },
+  });
+}
+
+function disposeRenderer() {
+  state.renderer?.dispose?.();
+  state.renderer = null;
+  state.scene = null;
+  state.camera = null;
+  state.canvas = null;
+  state.latestPreset = null;
+  state.latestFrame = null;
+  postMessage({
+    type: RENDERER_WORKER_MESSAGE_TYPES.status,
+    payload: { phase: 'disposed' },
+  });
+}
+
+scope.addEventListener(
+  'message',
+  async (event: MessageEvent<RendererWorkerRequestMessage>) => {
+    try {
+      switch (event.data.type) {
+        case RENDERER_WORKER_MESSAGE_TYPES.init:
+          await initRenderer(event.data.payload);
+          break;
+        case RENDERER_WORKER_MESSAGE_TYPES.resize:
+          handleResize(event.data.payload);
+          break;
+        case RENDERER_WORKER_MESSAGE_TYPES.quality:
+          handleQualityUpdate(event.data.payload);
+          break;
+        case RENDERER_WORKER_MESSAGE_TYPES.preset:
+          handlePreset(event.data.payload);
+          break;
+        case RENDERER_WORKER_MESSAGE_TYPES.frame:
+          handleFrame(event.data.payload);
+          break;
+        case RENDERER_WORKER_MESSAGE_TYPES.dispose:
+          disposeRenderer();
+          break;
+        default:
+          throw new Error('Renderer worker received an unknown message type.');
+      }
+    } catch (error) {
+      postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.error,
+        payload: {
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Unknown renderer worker failure.',
+        },
+      });
+    }
+  },
+);

--- a/assets/js/core/worker-renderer-track.ts
+++ b/assets/js/core/worker-renderer-track.ts
@@ -1,0 +1,199 @@
+import {
+  getRendererOptimizationSupport,
+  type RendererCapabilities,
+  recordRendererOptimizationTelemetry,
+} from './renderer-capabilities.ts';
+import type { RendererRuntimeControls } from './renderer-settings.ts';
+import type { RendererInitConfig } from './renderer-setup.ts';
+import {
+  isRendererWorkerResponseMessage,
+  RENDERER_WORKER_MESSAGE_TYPES,
+  type RendererWorkerFramePayload,
+  type RendererWorkerPresetPayload,
+  type RendererWorkerResponseMessage,
+} from './renderer-worker-protocol.ts';
+
+export const RENDERER_WORKER_EXPERIMENT_SEARCH_PARAM = 'render-worker';
+export const RENDERER_WORKER_EXPERIMENT_STORAGE_KEY =
+  'stims:experiments:render-worker';
+
+export type ExperimentalWorkerRendererTrack = {
+  worker: Worker;
+  postResize: (payload: {
+    width: number;
+    height: number;
+    devicePixelRatio?: number;
+  }) => void;
+  postQualityUpdate: (payload: {
+    runtimeControls: RendererRuntimeControls;
+    options?: Partial<RendererInitConfig>;
+  }) => void;
+  postPreset: (payload: RendererWorkerPresetPayload) => void;
+  postFrame: (payload: RendererWorkerFramePayload) => void;
+  dispose: () => void;
+};
+
+export type ExperimentalWorkerRendererTrackOptions = {
+  canvas: HTMLCanvasElement;
+  capabilities: RendererCapabilities | null;
+  width: number;
+  height: number;
+  devicePixelRatio?: number;
+  options?: Partial<RendererInitConfig>;
+  enabled?: boolean;
+  workerFactory?: () => Worker;
+  onMessage?: (message: RendererWorkerResponseMessage) => void;
+};
+
+function isExperimentEnabledFlag(value: string | null | undefined) {
+  if (!value) {
+    return false;
+  }
+
+  return ['1', 'true', 'on', 'yes', 'enabled'].includes(
+    value.trim().toLowerCase(),
+  );
+}
+
+export function isRendererWorkerExperimentEnabled({
+  location = globalThis.location,
+  storage = globalThis.localStorage,
+}: {
+  location?: Pick<Location, 'search'> | null;
+  storage?: Pick<Storage, 'getItem'> | null;
+} = {}) {
+  const searchValue = location?.search
+    ? new URLSearchParams(location.search).get(
+        RENDERER_WORKER_EXPERIMENT_SEARCH_PARAM,
+      )
+    : null;
+  if (isExperimentEnabledFlag(searchValue)) {
+    return true;
+  }
+
+  const storageValue = storage?.getItem?.(
+    RENDERER_WORKER_EXPERIMENT_STORAGE_KEY,
+  );
+  return isExperimentEnabledFlag(storageValue);
+}
+
+export function canUseExperimentalWorkerRenderer({
+  canvas,
+  capabilities,
+  enabled = isRendererWorkerExperimentEnabled(),
+}: {
+  canvas: HTMLCanvasElement | null | undefined;
+  capabilities: RendererCapabilities | null | undefined;
+  enabled?: boolean;
+}) {
+  if (!enabled || !canvas) {
+    return false;
+  }
+
+  const optimization = getRendererOptimizationSupport(capabilities);
+  return (
+    capabilities?.preferredBackend === 'webgpu' &&
+    optimization.workerOffscreenPipeline &&
+    typeof canvas.transferControlToOffscreen === 'function'
+  );
+}
+
+function createDefaultWorker() {
+  return new Worker(new URL('./renderer-worker.ts', import.meta.url), {
+    type: 'module',
+  });
+}
+
+export function createExperimentalWorkerRendererTrack({
+  canvas,
+  capabilities,
+  width,
+  height,
+  devicePixelRatio = globalThis.devicePixelRatio || 1,
+  options = {},
+  enabled = isRendererWorkerExperimentEnabled(),
+  workerFactory = createDefaultWorker,
+  onMessage,
+}: ExperimentalWorkerRendererTrackOptions): ExperimentalWorkerRendererTrack | null {
+  if (
+    !canUseExperimentalWorkerRenderer({
+      canvas,
+      capabilities,
+      enabled,
+    })
+  ) {
+    return null;
+  }
+
+  const worker = workerFactory();
+  const offscreenCanvas = canvas.transferControlToOffscreen();
+  const handleMessage = (event: MessageEvent<unknown>) => {
+    if (!isRendererWorkerResponseMessage(event.data)) {
+      return;
+    }
+    onMessage?.(event.data);
+  };
+  worker.addEventListener('message', handleMessage as EventListener);
+  worker.postMessage(
+    {
+      type: RENDERER_WORKER_MESSAGE_TYPES.init,
+      payload: {
+        canvas: offscreenCanvas,
+        width,
+        height,
+        devicePixelRatio,
+        options,
+      },
+    },
+    [offscreenCanvas],
+  );
+  recordRendererOptimizationTelemetry({
+    counter: 'workerOffscreenUsage',
+  });
+
+  return {
+    worker,
+    postResize: ({
+      width: nextWidth,
+      height: nextHeight,
+      devicePixelRatio: nextDevicePixelRatio = globalThis.devicePixelRatio || 1,
+    }) => {
+      worker.postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.resize,
+        payload: {
+          width: nextWidth,
+          height: nextHeight,
+          devicePixelRatio: nextDevicePixelRatio,
+        },
+      });
+    },
+    postQualityUpdate: ({ runtimeControls, options: nextOptions }) => {
+      worker.postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.quality,
+        payload: {
+          runtimeControls,
+          options: nextOptions,
+        },
+      });
+    },
+    postPreset: (payload) => {
+      worker.postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.preset,
+        payload,
+      });
+    },
+    postFrame: (payload) => {
+      worker.postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.frame,
+        payload,
+      });
+    },
+    dispose: () => {
+      worker.postMessage({
+        type: RENDERER_WORKER_MESSAGE_TYPES.dispose,
+      });
+      worker.removeEventListener('message', handleMessage as EventListener);
+      worker.terminate();
+    },
+  };
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,7 @@ flowchart LR
 - **Initialization**: `renderer-setup.ts` builds a renderer using the preferred backend, applies tone mapping, sets pixel ratio/size, and returns metadata consumed by `web-toy.ts`.
 - **Quality presets**: `settings-panel.ts` broadcasts max pixel ratio, render scale, and exposure; `WebToy.updateRendererSettings` re-applies them without a reload.
 - **Renderer settings**: `renderer-settings.ts` merges quality presets, render preferences, and per-toy overrides so pooled renderers can be reconfigured on the fly.
+- **Experimental worker render track**: `worker-renderer-track.ts` and `renderer-worker.ts` define an opt-in OffscreenCanvas path for future WebGPU render submission off the main thread. The gate reuses `renderer-capabilities.ts` worker/offscreen checks plus an explicit opt-in flag (`?render-worker=1` or `localStorage['stims:experiments:render-worker']='enabled'`). The current track only owns renderer initialization, resize/quality propagation, preset messages, and per-frame signal/input submission; DOM-driven overlay, catalog, and editor flows remain on the main thread until parity is proven.
 
 ## WebToy Composition
 

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -116,9 +116,12 @@ describe('render-service pooling', () => {
     setRendererRuntimeControls({ renderScale: 0.5 });
 
     const first = await requestRenderer({ initRendererImpl });
+    const firstInitCall = initRendererImpl.mock.calls[0] as unknown as
+      | [HTMLCanvasElement, { renderScale?: number }]
+      | undefined;
 
-    expect(initRendererImpl.mock.calls[0]?.[0]).toBe(first.canvas);
-    expect(initRendererImpl.mock.calls[0]?.[1]).toMatchObject({
+    expect(firstInitCall?.[0]).toBe(first.canvas);
+    expect(firstInitCall?.[1]).toMatchObject({
       renderScale: 0.5,
     });
 

--- a/tests/worker-renderer-track.test.ts
+++ b/tests/worker-renderer-track.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import type { RendererCapabilities } from '../assets/js/core/renderer-capabilities.ts';
+import { RENDERER_WORKER_MESSAGE_TYPES } from '../assets/js/core/renderer-worker-protocol.ts';
+import {
+  canUseExperimentalWorkerRenderer,
+  createExperimentalWorkerRendererTrack,
+  isRendererWorkerExperimentEnabled,
+  RENDERER_WORKER_EXPERIMENT_SEARCH_PARAM,
+  RENDERER_WORKER_EXPERIMENT_STORAGE_KEY,
+} from '../assets/js/core/worker-renderer-track.ts';
+
+const webgpuCapabilities: RendererCapabilities = {
+  preferredBackend: 'webgpu',
+  adapter: null,
+  device: null,
+  fallbackReason: null,
+  fallbackReasonCode: null,
+  shouldRetryWebGPU: false,
+  forceWebGL: false,
+  webgpu: {
+    features: {
+      bgra8unormStorage: true,
+      float32Blendable: true,
+      float32Filterable: true,
+      shaderF16: true,
+      subgroups: true,
+      timestampQuery: true,
+    },
+    limits: {
+      maxColorAttachments: 8,
+      maxComputeInvocationsPerWorkgroup: 512,
+      maxStorageBufferBindingSize: 1_073_741_824,
+      maxTextureDimension2D: 8192,
+    },
+    workers: {
+      workers: true,
+      offscreenCanvas: true,
+      transferControlToOffscreen: true,
+    },
+    optimization: {
+      timestampQuery: true,
+      shaderF16: true,
+      subgroups: true,
+      workers: true,
+      offscreenCanvas: true,
+      transferControlToOffscreen: true,
+      workerOffscreenPipeline: true,
+    },
+    preferredCanvasFormat: 'bgra8unorm',
+    performanceTier: 'high-end',
+    recommendedQualityPreset: 'hi-fi',
+  },
+};
+
+describe('worker renderer track gating', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('stays disabled by default even when worker offscreen support is available', () => {
+    const canvas = document.createElement('canvas');
+    canvas.transferControlToOffscreen = mock(
+      () => ({ marker: 'offscreen' }) as unknown as OffscreenCanvas,
+    );
+
+    expect(
+      canUseExperimentalWorkerRenderer({
+        canvas,
+        capabilities: webgpuCapabilities,
+      }),
+    ).toBe(false);
+  });
+
+  test('accepts either the query param or local storage opt-in flags', () => {
+    expect(
+      isRendererWorkerExperimentEnabled({
+        location: {
+          search: `?${RENDERER_WORKER_EXPERIMENT_SEARCH_PARAM}=1`,
+        },
+        storage: null,
+      }),
+    ).toBe(true);
+
+    const storage = {
+      getItem: (key: string) =>
+        key === RENDERER_WORKER_EXPERIMENT_STORAGE_KEY ? 'enabled' : null,
+    };
+    expect(
+      isRendererWorkerExperimentEnabled({
+        location: { search: '' },
+        storage,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('worker renderer track messaging', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('boots the experimental worker track and forwards the minimal protocol', () => {
+    const postMessage = mock();
+    const addEventListener = mock();
+    const removeEventListener = mock();
+    const terminate = mock();
+    const fakeWorker = {
+      postMessage,
+      addEventListener,
+      removeEventListener,
+      terminate,
+    } as unknown as Worker;
+    const workerFactory = mock(() => fakeWorker);
+    const canvas = document.createElement('canvas');
+    const offscreenCanvas = {
+      marker: 'offscreen',
+    } as unknown as OffscreenCanvas;
+    canvas.transferControlToOffscreen = mock(() => offscreenCanvas);
+
+    const track = createExperimentalWorkerRendererTrack({
+      canvas,
+      capabilities: webgpuCapabilities,
+      width: 1280,
+      height: 720,
+      devicePixelRatio: 2,
+      options: { maxPixelRatio: 1.5, renderScale: 0.8 },
+      enabled: true,
+      workerFactory,
+    });
+
+    expect(track).not.toBeNull();
+    expect(workerFactory).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: RENDERER_WORKER_MESSAGE_TYPES.init,
+        payload: {
+          canvas: offscreenCanvas,
+          width: 1280,
+          height: 720,
+          devicePixelRatio: 2,
+          options: { maxPixelRatio: 1.5, renderScale: 0.8 },
+        },
+      },
+      [offscreenCanvas],
+    );
+
+    track?.postResize({ width: 1440, height: 900 });
+    track?.postQualityUpdate({
+      runtimeControls: {
+        renderScale: 0.75,
+        feedbackScale: 1,
+        meshDensityMultiplier: 1,
+        waveSampleMultiplier: 1,
+        motionVectorDensityMultiplier: 1,
+      },
+      options: { exposure: 1.2 },
+    });
+    track?.postPreset({ id: 'signal-field', title: 'Signal Field' });
+    track?.postFrame({
+      now: 200,
+      deltaMs: 16.67,
+      audioLevel: 0.4,
+      energy: { bass: 0.6, mids: 0.5, treble: 0.7 },
+      pointer: { x: 0.25, y: 0.75, down: true },
+    });
+    track?.dispose();
+
+    expect(postMessage).toHaveBeenNthCalledWith(2, {
+      type: RENDERER_WORKER_MESSAGE_TYPES.resize,
+      payload: {
+        width: 1440,
+        height: 900,
+        devicePixelRatio: 1,
+      },
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(3, {
+      type: RENDERER_WORKER_MESSAGE_TYPES.quality,
+      payload: {
+        runtimeControls: {
+          renderScale: 0.75,
+          feedbackScale: 1,
+          meshDensityMultiplier: 1,
+          waveSampleMultiplier: 1,
+          motionVectorDensityMultiplier: 1,
+        },
+        options: { exposure: 1.2 },
+      },
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(4, {
+      type: RENDERER_WORKER_MESSAGE_TYPES.preset,
+      payload: { id: 'signal-field', title: 'Signal Field' },
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(5, {
+      type: RENDERER_WORKER_MESSAGE_TYPES.frame,
+      payload: {
+        now: 200,
+        deltaMs: 16.67,
+        audioLevel: 0.4,
+        energy: { bass: 0.6, mids: 0.5, treble: 0.7 },
+        pointer: { x: 0.25, y: 0.75, down: true },
+      },
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(6, {
+      type: RENDERER_WORKER_MESSAGE_TYPES.dispose,
+    });
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Explore moving WebGPU renderer ownership and frame submission off the main thread without coupling UI/editor/catalog logic to the worker yet.
- Gate the experiment on runtime capabilities (OffscreenCanvas / transferControlToOffscreen / worker support) reported by `renderer-capabilities.ts` and require an explicit opt-in so the main-thread path remains the default.
- Start with a minimal, isolated protocol and worker entry so parity can be proven before migrating other responsibilities.

### Description
- Add a typed minimal message protocol for the renderer worker in `assets/js/core/renderer-worker-protocol.ts` (init, resize, quality, preset, frame, dispose plus ready/status/error responses).
- Add a worker entry module `assets/js/core/renderer-worker.ts` that can own a WebGPU `WebGPURenderer` on an `OffscreenCanvas` and handle lifecycle/messages for init/resize/quality/preset/frame/dispose.
- Add an opt-in track API `createExperimentalWorkerRendererTrack` in `assets/js/core/worker-renderer-track.ts` that uses `renderer-capabilities.ts` worker/offscreen checks plus explicit opt-in flags (`?render-worker=1` or localStorage key) and records telemetry while transferring the canvas.
- Keep main-thread renderer pooling and behavior unchanged, document the experiment and its current limited scope in `docs/ARCHITECTURE.md`, and apply a small test typing tweak in `tests/services-pool.test.ts`.

### Testing
- Ran `bun run test tests/worker-renderer-track.test.ts` which passed (3 tests, focused gating and protocol behavior).
- Ran `bun run test tests/services-pool.test.ts` which passed (render/audio pooling tests) after a small test typing adjustment.
- Ran `bun run check:quick` (Biome + typecheck quick) which passed locally.
- Ran the full quality gate `bun run check` which executes the full test suite and TypeScript check; it surfaced an existing, unrelated failing test in the repository: `tests/milkdrop-renderer-adapter.test.ts` -> "falls back to CPU motion-vector overlays on webgpu for legacy controls", causing the full gate to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf273092248332aa5a564b0809e7db)