### PR TITLE
tests: refine motion vector detection and type-safe renderer init mock

### DIFF
--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -767,7 +767,7 @@ warpanimspeed=1.25
 
     const matchingMotionVectorMesh = flattenRenderTree(root).find(
       (child) =>
-        child.geometry?.getAttribute?.('instanceStart') !== undefined &&
+        isWebGPUSegmentBatchNode(child) &&
         getGeometryInstanceCount(child) === frameState.motionVectors.length,
     );
 

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -5,6 +5,7 @@ import type {
   PositionalAudio,
   WebGLRenderer,
 } from 'three';
+import type { RendererInitConfig } from '../assets/js/core/renderer-setup.ts';
 import {
   acquireAudioHandle,
   resetAudioPool,
@@ -100,18 +101,20 @@ describe('render-service pooling', () => {
   });
 
   test('applies runtime renderScale overrides to new and pooled renderers', async () => {
-    const initRendererImpl = mock(async () => ({
-      renderer: fakeRenderer,
-      backend: 'webgl' as const,
-      adapter: null,
-      device: null,
-      maxPixelRatio: 2,
-      renderScale: 1,
-      adaptiveMaxPixelRatioMultiplier: 1,
-      adaptiveRenderScaleMultiplier: 1,
-      adaptiveDensityMultiplier: 1,
-      exposure: 1,
-    }));
+    const initRendererImpl = mock(
+      async (_canvas: HTMLCanvasElement, _config: RendererInitConfig = {}) => ({
+        renderer: fakeRenderer,
+        backend: 'webgl' as const,
+        adapter: null,
+        device: null,
+        maxPixelRatio: 2,
+        renderScale: 1,
+        adaptiveMaxPixelRatioMultiplier: 1,
+        adaptiveRenderScaleMultiplier: 1,
+        adaptiveDensityMultiplier: 1,
+        exposure: 1,
+      }),
+    );
 
     setRendererRuntimeControls({ renderScale: 0.5 });
 


### PR DESCRIPTION
### Motivation

- Improve the motion-vector mesh detection in the renderer adapter test to use the specific WebGPU segment-batch node predicate instead of a raw geometry attribute check.
- Make the renderer initialization mock in the render-service pooling tests accept the `canvas` and a typed `RendererInitConfig` so the tests can assert that runtime overrides are passed through.

### Description

- Replaced the attribute-based predicate with `isWebGPUSegmentBatchNode(child)` in `tests/milkdrop-renderer-adapter.test.ts` when locating the motion vector instance mesh.
- Added an import for `RendererInitConfig` and updated the `initRendererImpl` mock in `tests/services-pool.test.ts` to the signature `async (_canvas: HTMLCanvasElement, _config: RendererInitConfig = {}) => ({ ... })` so call arguments and config propagation can be asserted.
- Minor formatting adjustments around the updated mock implementation.

### Testing

- Ran the unit tests via `bun:test` for the affected specs and confirmed `tests/milkdrop-renderer-adapter.test.ts` and `tests/services-pool.test.ts` passed.
- The full test run completed without failures for the touched tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf25b534f48332823be5c039542959)