### PR TITLE
Queue renderer worker messages until ready

### DIFF
--- a/assets/js/core/worker-renderer-track.ts
+++ b/assets/js/core/worker-renderer-track.ts
@@ -10,6 +10,7 @@ import {
   RENDERER_WORKER_MESSAGE_TYPES,
   type RendererWorkerFramePayload,
   type RendererWorkerPresetPayload,
+  type RendererWorkerRequestMessage,
   type RendererWorkerResponseMessage,
 } from './renderer-worker-protocol.ts';
 
@@ -127,10 +128,46 @@ export function createExperimentalWorkerRendererTrack({
 
   const worker = workerFactory();
   const offscreenCanvas = canvas.transferControlToOffscreen();
+  const queuedMessages: RendererWorkerRequestMessage[] = [];
+  let isReady = false;
+  let isDisposed = false;
+
+  const postWhenReady = (message: RendererWorkerRequestMessage) => {
+    if (isDisposed) {
+      return;
+    }
+
+    if (!isReady && message.type !== RENDERER_WORKER_MESSAGE_TYPES.dispose) {
+      queuedMessages.push(message);
+      return;
+    }
+
+    worker.postMessage(message);
+  };
+
+  const flushQueuedMessages = () => {
+    if (!isReady || isDisposed || queuedMessages.length === 0) {
+      return;
+    }
+
+    while (queuedMessages.length > 0) {
+      const message = queuedMessages.shift();
+      if (message) {
+        worker.postMessage(message);
+      }
+    }
+  };
+
   const handleMessage = (event: MessageEvent<unknown>) => {
     if (!isRendererWorkerResponseMessage(event.data)) {
       return;
     }
+
+    if (event.data.type === RENDERER_WORKER_MESSAGE_TYPES.ready) {
+      isReady = true;
+      flushQueuedMessages();
+    }
+
     onMessage?.(event.data);
   };
   worker.addEventListener('message', handleMessage as EventListener);
@@ -158,7 +195,7 @@ export function createExperimentalWorkerRendererTrack({
       height: nextHeight,
       devicePixelRatio: nextDevicePixelRatio = globalThis.devicePixelRatio || 1,
     }) => {
-      worker.postMessage({
+      postWhenReady({
         type: RENDERER_WORKER_MESSAGE_TYPES.resize,
         payload: {
           width: nextWidth,
@@ -168,7 +205,7 @@ export function createExperimentalWorkerRendererTrack({
       });
     },
     postQualityUpdate: ({ runtimeControls, options: nextOptions }) => {
-      worker.postMessage({
+      postWhenReady({
         type: RENDERER_WORKER_MESSAGE_TYPES.quality,
         payload: {
           runtimeControls,
@@ -177,18 +214,24 @@ export function createExperimentalWorkerRendererTrack({
       });
     },
     postPreset: (payload) => {
-      worker.postMessage({
+      postWhenReady({
         type: RENDERER_WORKER_MESSAGE_TYPES.preset,
         payload,
       });
     },
     postFrame: (payload) => {
-      worker.postMessage({
+      postWhenReady({
         type: RENDERER_WORKER_MESSAGE_TYPES.frame,
         payload,
       });
     },
     dispose: () => {
+      if (isDisposed) {
+        return;
+      }
+
+      isDisposed = true;
+      queuedMessages.length = 0;
       worker.postMessage({
         type: RENDERER_WORKER_MESSAGE_TYPES.dispose,
       });

--- a/tests/worker-renderer-track.test.ts
+++ b/tests/worker-renderer-track.test.ts
@@ -99,9 +99,21 @@ describe('worker renderer track messaging', () => {
     window.localStorage.clear();
   });
 
-  test('boots the experimental worker track and forwards the minimal protocol', () => {
+  test('queues outbound messages until the worker reports ready, then flushes them in order', () => {
     const postMessage = mock();
-    const addEventListener = mock();
+    let messageListener: ((event: MessageEvent<unknown>) => void) | null = null;
+    const emitMessage = (event: MessageEvent<unknown>) => {
+      if (!messageListener) {
+        throw new Error('Expected worker message listener to be registered.');
+      }
+
+      messageListener(event);
+    };
+    const addEventListener = mock((type: string, listener: EventListener) => {
+      if (type === 'message') {
+        messageListener = listener as (event: MessageEvent<unknown>) => void;
+      }
+    });
     const removeEventListener = mock();
     const terminate = mock();
     const fakeWorker = {
@@ -130,6 +142,7 @@ describe('worker renderer track messaging', () => {
 
     expect(track).not.toBeNull();
     expect(workerFactory).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
     expect(postMessage).toHaveBeenNthCalledWith(
       1,
       {
@@ -164,7 +177,20 @@ describe('worker renderer track messaging', () => {
       energy: { bass: 0.6, mids: 0.5, treble: 0.7 },
       pointer: { x: 0.25, y: 0.75, down: true },
     });
-    track?.dispose();
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    expect(messageListener).not.toBeNull();
+    emitMessage({
+      data: {
+        type: RENDERER_WORKER_MESSAGE_TYPES.ready,
+        payload: {
+          backend: 'webgpu',
+          width: 1280,
+          height: 720,
+        },
+      },
+    } as MessageEvent<unknown>);
 
     expect(postMessage).toHaveBeenNthCalledWith(2, {
       type: RENDERER_WORKER_MESSAGE_TYPES.resize,
@@ -201,10 +227,65 @@ describe('worker renderer track messaging', () => {
         pointer: { x: 0.25, y: 0.75, down: true },
       },
     });
+
+    track?.dispose();
+
     expect(postMessage).toHaveBeenNthCalledWith(6, {
       type: RENDERER_WORKER_MESSAGE_TYPES.dispose,
     });
     expect(removeEventListener).toHaveBeenCalledTimes(1);
     expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  test('forwards worker response messages to the optional callback', () => {
+    const postMessage = mock();
+    let messageListener: ((event: MessageEvent<unknown>) => void) | null = null;
+    const emitMessage = (event: MessageEvent<unknown>) => {
+      if (!messageListener) {
+        throw new Error('Expected worker message listener to be registered.');
+      }
+
+      messageListener(event);
+    };
+    const addEventListener = mock((type: string, listener: EventListener) => {
+      if (type === 'message') {
+        messageListener = listener as (event: MessageEvent<unknown>) => void;
+      }
+    });
+    const fakeWorker = {
+      postMessage,
+      addEventListener,
+      removeEventListener: mock(),
+      terminate: mock(),
+    } as unknown as Worker;
+    const canvas = document.createElement('canvas');
+    const offscreenCanvas = {
+      marker: 'offscreen',
+    } as unknown as OffscreenCanvas;
+    canvas.transferControlToOffscreen = mock(() => offscreenCanvas);
+    const onMessage = mock();
+
+    createExperimentalWorkerRendererTrack({
+      canvas,
+      capabilities: webgpuCapabilities,
+      width: 640,
+      height: 360,
+      enabled: true,
+      workerFactory: () => fakeWorker,
+      onMessage,
+    });
+
+    expect(messageListener).not.toBeNull();
+    emitMessage({
+      data: {
+        type: RENDERER_WORKER_MESSAGE_TYPES.status,
+        payload: { phase: 'initialized' },
+      },
+    } as MessageEvent<unknown>);
+
+    expect(onMessage).toHaveBeenCalledWith({
+      type: RENDERER_WORKER_MESSAGE_TYPES.status,
+      payload: { phase: 'initialized' },
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent a startup race where resize/quality/preset/frame messages are posted to the experimental renderer worker before it has finished initializing and can handle them.

### Description
- Add a ready-queue for outbound `RendererWorkerRequestMessage` items and track `isReady` / `isDisposed` state to gate posting until the worker reports `ready`.
- Implement `postWhenReady` to enqueue messages until ready and `flushQueuedMessages` to drain the queue when the worker sends a `ready` response.
- Ensure `dispose` clears queued messages and prevents further posts after teardown.
- Update tests to assert the queuing behavior and to verify that worker response messages are still forwarded to the optional `onMessage` callback, including a small `emitMessage` helper to drive the fake worker listener.
- Files changed: `assets/js/core/worker-renderer-track.ts`, `tests/worker-renderer-track.test.ts`.

### Testing
- Ran the focused tests: `bun run test tests/worker-renderer-track.test.ts` and the suite reported all tests passed.
- Ran the project quality gate: `bun run check` and it completed successfully (includes Biome, TypeScript typecheck, and full test run).

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2a44444c83329d7e1c6f2fc8ab0d)