### PR TITLE
Fail closed on renderer worker init errors

### DIFF
--- a/assets/js/core/worker-renderer-track.ts
+++ b/assets/js/core/worker-renderer-track.ts
@@ -131,9 +131,22 @@ export function createExperimentalWorkerRendererTrack({
   const queuedMessages: RendererWorkerRequestMessage[] = [];
   let isReady = false;
   let isDisposed = false;
+  let hasInitFailed = false;
+
+  const failClosed = () => {
+    if (isDisposed) {
+      return;
+    }
+
+    hasInitFailed = true;
+    isDisposed = true;
+    queuedMessages.length = 0;
+    worker.removeEventListener('message', handleMessage as EventListener);
+    worker.terminate();
+  };
 
   const postWhenReady = (message: RendererWorkerRequestMessage) => {
-    if (isDisposed) {
+    if (isDisposed || hasInitFailed) {
       return;
     }
 
@@ -166,6 +179,10 @@ export function createExperimentalWorkerRendererTrack({
     if (event.data.type === RENDERER_WORKER_MESSAGE_TYPES.ready) {
       isReady = true;
       flushQueuedMessages();
+    }
+
+    if (event.data.type === RENDERER_WORKER_MESSAGE_TYPES.error && !isReady) {
+      failClosed();
     }
 
     onMessage?.(event.data);

--- a/tests/worker-renderer-track.test.ts
+++ b/tests/worker-renderer-track.test.ts
@@ -288,4 +288,79 @@ describe('worker renderer track messaging', () => {
       payload: { phase: 'initialized' },
     });
   });
+
+  test('fails closed when the worker reports an init error before ready', () => {
+    const postMessage = mock();
+    let messageListener: ((event: MessageEvent<unknown>) => void) | null = null;
+    const emitMessage = (event: MessageEvent<unknown>) => {
+      if (!messageListener) {
+        throw new Error('Expected worker message listener to be registered.');
+      }
+
+      messageListener(event);
+    };
+    const addEventListener = mock((type: string, listener: EventListener) => {
+      if (type === 'message') {
+        messageListener = listener as (event: MessageEvent<unknown>) => void;
+      }
+    });
+    const removeEventListener = mock();
+    const terminate = mock();
+    const fakeWorker = {
+      postMessage,
+      addEventListener,
+      removeEventListener,
+      terminate,
+    } as unknown as Worker;
+    const canvas = document.createElement('canvas');
+    const offscreenCanvas = {
+      marker: 'offscreen',
+    } as unknown as OffscreenCanvas;
+    canvas.transferControlToOffscreen = mock(() => offscreenCanvas);
+    const onMessage = mock();
+
+    const track = createExperimentalWorkerRendererTrack({
+      canvas,
+      capabilities: webgpuCapabilities,
+      width: 640,
+      height: 360,
+      enabled: true,
+      workerFactory: () => fakeWorker,
+      onMessage,
+    });
+
+    track?.postFrame({
+      now: 16.67,
+      deltaMs: 16.67,
+      audioLevel: 0.5,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    emitMessage({
+      data: {
+        type: RENDERER_WORKER_MESSAGE_TYPES.error,
+        payload: {
+          message:
+            'Unable to acquire a WebGPU adapter inside the renderer worker.',
+        },
+      },
+    } as MessageEvent<unknown>);
+
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(terminate).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith({
+      type: RENDERER_WORKER_MESSAGE_TYPES.error,
+      payload: {
+        message:
+          'Unable to acquire a WebGPU adapter inside the renderer worker.',
+      },
+    });
+
+    track?.postResize({ width: 800, height: 600 });
+    track?.postPreset({ id: 'after-error' });
+    track?.dispose();
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent a hot path where an experimental renderer worker that fails during initialization causes outbound messages to be buffered forever and leak memory.

### Description
- Add a `hasInitFailed` flag and a `failClosed` helper that clears queued messages, removes the worker listener, and terminates the worker when init fails before `renderer:ready`.
- Gate `postWhenReady` to no-op if disposal or an init failure has occurred so subsequent `post*` calls stop buffering.
- Detect `renderer:error` responses in `handleMessage` and call `failClosed` when the error arrives before `ready` while still forwarding the error to the optional `onMessage` callback.
- Add a regression test that simulates an init-time worker error and verifies the worker is terminated, queued messages are cleared, and no further outbound messages are posted.

### Testing
- Ran the focused test: `bun run test tests/worker-renderer-track.test.ts` and all tests in that file passed (5 pass, 0 fail).
- Ran the project quality gate: `bun run check`; the modified tests passed but the full quality gate surfaced an unrelated existing test expectation failure in `tests/services-pool.test.ts`, not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2fe17c2083329d66cc91d36c60ff)