### PR TITLE
Use canonical /milkdrop/ launch route and update library links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is built to feel like a first-class browser experience rather than a nostalgi
 Quick links:
 
 - Live site: [no.toil.fyi](https://no.toil.fyi)
-- Launch app: [no.toil.fyi/toy.html](https://no.toil.fyi/toy.html)
+- Launch app: [no.toil.fyi/milkdrop/](https://no.toil.fyi/milkdrop/)
 - Product page: [no.toil.fyi/toys/milkdrop/](https://no.toil.fyi/toys/milkdrop/)
 - Docs hub: [docs/README.md](./docs/README.md)
 - Contributing: [CONTRIBUTING.md](./CONTRIBUTING.md)
@@ -32,7 +32,7 @@ Stims aims to make MilkDrop-style visual play feel native to the browser instead
 - A launch flow with readiness checks before microphone prompts and renderer-heavy startup.
 - Multiple audio paths including microphone, demo audio, tab capture, and YouTube-backed tab capture.
 - Renderer preference handling with WebGPU-first startup and direct WebGL fallback when needed.
-- A focused marketing/launch page at `index.html` and the main app at `toy.html`.
+- A focused marketing/launch page at `index.html`, plus the canonical visualizer route at `milkdrop/index.html` (`/milkdrop/`).
 
 ## Shipped experience
 
@@ -61,7 +61,7 @@ At the product level, Stims currently ships one flagship MilkDrop-led visualizer
 3. Open the visualizer:
 
    ```text
-   http://localhost:5173/toy.html
+   http://localhost:5173/milkdrop/
    ```
 
 4. Use `index.html` at the same host if you want to review the launch/marketing surface.
@@ -96,7 +96,8 @@ If you change workflows, scripts, or documentation structure, keep the doc entry
 
 ## Project shape
 
-- `toy.html` is the primary visualizer entrypoint.
+- `milkdrop/index.html` (`/milkdrop/`) is the primary visualizer entrypoint.
+- `toy.html` remains available as a legacy alias for backwards compatibility.
 - `index.html` is the focused launch page for the same product.
 - `assets/js/` contains the runtime, renderer, UI shell, and preset infrastructure.
 - `assets/data/toys.json` is the checked-in app manifest source for the shipped MilkDrop entry.

--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -11,6 +11,7 @@ import {
 } from './library-view/filter-state.js';
 import { ensureIconSymbol, SVG_NS } from './library-view/icon-sprite.js';
 import { setupDarkModeToggle } from './library-view/theme-toggle.js';
+import { getToyRouteHref } from './router.ts';
 import { getRecentToySlugs } from './utils/growth-metrics.ts';
 
 const LIBRARY_RENDER_BATCH_SIZE = 24;
@@ -965,10 +966,7 @@ export function createLibraryView({
     if (toy.module) {
       card.dataset.toyModule = toy.module;
     }
-    const href =
-      toy.type === 'module'
-        ? `toy.html?toy=${encodeURIComponent(toy.slug)}`
-        : toy.module;
+    const href = toy.type === 'module' ? getToyRouteHref(toy.slug) : toy.module;
     if (cardElement === 'button') {
       card.type = 'button';
     } else if (cardElement === 'a') {

--- a/assets/js/router.ts
+++ b/assets/js/router.ts
@@ -10,6 +10,26 @@ const DEFAULT_SLUG_PATHS: SlugPathMap = {
   milkdrop: '/milkdrop/',
 };
 
+export function getToyRouteHref(
+  slug: string,
+  {
+    queryParam = 'toy',
+    toyPath = 'toy.html',
+    slugPaths = DEFAULT_SLUG_PATHS,
+  }: {
+    queryParam?: string;
+    toyPath?: string;
+    slugPaths?: SlugPathMap;
+  } = {},
+) {
+  const mappedPath = slugPaths[slug];
+  if (mappedPath) {
+    return mappedPath;
+  }
+
+  return `${toyPath}?${queryParam}=${encodeURIComponent(slug)}`;
+}
+
 const normalizePath = (pathname: string) => {
   const normalized = pathname.replace(/\/index\.html$/u, '/');
   if (normalized === '') return '/';
@@ -112,12 +132,14 @@ export function createRouter({
     if (!win?.history) return;
 
     const url = getUrl(win);
-    const targetPath = slugPaths[slug];
-    if (targetPath) {
+    const href = getToyRouteHref(slug, { queryParam, toyPath, slugPaths });
+    if (href.startsWith('/')) {
       url.searchParams.delete(queryParam);
-      url.pathname = resolvePath(url.pathname, targetPath);
+      url.pathname = resolvePath(url.pathname, href);
     } else {
-      url.searchParams.set(queryParam, slug);
+      const nextUrl = new URL(href, url);
+      url.pathname = nextUrl.pathname;
+      url.search = nextUrl.search;
     }
     win.history.pushState({ [queryParam]: slug }, '', url);
   };

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,7 +8,7 @@ Stims is now a single browser-native MilkDrop-inspired visualizer. Prefer change
 
 1. Install dependencies with `bun install`.
 2. Start local development with `bun run dev`.
-3. Open `http://localhost:5173/toy.html`.
+3. Open `http://localhost:5173/milkdrop/`.
 4. Run `bun run check:quick` while iterating.
 5. Run `bun run check` before finalizing changes.
 
@@ -27,7 +27,8 @@ Stims is now a single browser-native MilkDrop-inspired visualizer. Prefer change
 
 ## Product assumptions
 
-- The primary app entrypoint is `toy.html`, which defaults to the MilkDrop visualizer.
+- The primary app entrypoint is `milkdrop/index.html` (`/milkdrop/`).
+- `toy.html` remains available as a legacy alias when you need to verify backwards compatibility.
 - `index.html` boots the MilkDrop visualizer in place on load, using the same shared loader/runtime as the dedicated launch route.
 - Presets are part of one visualizer product, not separate first-class toys.
 

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -208,6 +208,55 @@ test('search query filters library cards and persists in the URL', async () => {
   );
 });
 
+test('renders canonical launch hrefs for mapped toys', async () => {
+  window.location.href = 'https://example.com/';
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+
+  document.body.innerHTML = `
+    <p data-search-results></p>
+    <div data-active-filters>
+      <span data-active-filters-status></span>
+      <button data-active-filters-clear type="button">Reset view</button>
+    </div>
+    <form data-search-form>
+      <input id="toy-search" type="search" />
+      <button data-search-clear type="button">Clear</button>
+      <datalist id="toy-search-suggestions"></datalist>
+    </form>
+    <button data-filter-reset type="button">Reset view</button>
+    <select data-sort-control>
+      <option value="featured">Featured</option>
+    </select>
+    <div id="toy-list"></div>
+  `;
+
+  const view = createLibraryView({
+    toys: [
+      {
+        slug: 'milkdrop',
+        title: 'MilkDrop Visualizer',
+        description: 'Canonical launch route.',
+        module: 'assets/js/toys/milkdrop-toy.ts',
+        type: 'module',
+        requiresWebGPU: true,
+        capabilities: {
+          demoAudio: true,
+          microphone: true,
+          motion: false,
+        },
+      },
+    ],
+  });
+
+  await view.init();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  const listMarkup = document.getElementById('toy-list')?.innerHTML ?? '';
+  expect(listMarkup).toContain('/milkdrop/');
+  expect(listMarkup).not.toContain('toy.html?toy=milkdrop');
+});
+
 test('reset view clears active search, filters, and sort chips from the sticky rail', async () => {
   document.body.innerHTML = `
     <p data-search-results></p>

--- a/tests/router.test.js
+++ b/tests/router.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { createRouter } from '../assets/js/router.ts';
+import { createRouter, getToyRouteHref } from '../assets/js/router.ts';
 
 function createWindowStub(href = 'http://example.com/library') {
   const location = new URL(href);
@@ -24,6 +24,11 @@ function createWindowStub(href = 'http://example.com/library') {
 }
 
 describe('router utilities', () => {
+  test('returns canonical hrefs for mapped toy routes', () => {
+    expect(getToyRouteHref('milkdrop')).toBe('/milkdrop/');
+    expect(getToyRouteHref('custom-slug')).toBe('toy.html?toy=custom-slug');
+  });
+
   test('pushes toy state and resets to library', () => {
     const { windowStub, location } = createWindowStub(
       'http://example.com/library',


### PR DESCRIPTION
### Motivation
- Production site uses clean-URL redirects for HTML entrypoints which caused library links that referenced `toy.html` to detour through a redirect and weaken the canonical launch experience for the MilkDrop visualizer. 
- Align the repo's generated hrefs and contributor docs with the canonical `/milkdrop/` route so links and previews resolve directly without the redirect detour.

### Description
- Add `getToyRouteHref()` to `assets/js/router.ts` and update `pushToyState` to resolve mapped slugs (for example `milkdrop`) to canonical paths (for example `/milkdrop/`) while preserving the fallback `toy.html?toy=...` format for unmapped slugs. 
- Update library card rendering in `assets/js/library-view.js` to call `getToyRouteHref()` for module toys so generated anchor `href` and `data-toy-href` use the canonical route when applicable. 
- Add/adjust tests in `tests/router.test.js` and `tests/library-filter-state.test.ts` to cover canonical href generation and the rendered library output. 
- Update contributor docs and quickstart references in `README.md` and `docs/DEVELOPMENT.md` to point to `/milkdrop/` as the canonical launch route while documenting `toy.html` as a legacy alias.

### Testing
- Ran the repository quality gate with `bun run check` which runs Biome formatting/lint, TypeScript typecheck, and the full test suite, and it completed successfully. 
- Ran targeted tests `bun test tests/router.test.js tests/library-filter-state.test.ts` and confirmed they passed. 
- Verified production surface manually with `curl` to confirm redirects and canonical route behavior during investigation (smoke HTTP checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf37b594b483329e144d71b656b67a)