### PR TITLE
Add WebGL fallback for stalled WebGPU init

### DIFF
--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -47,6 +47,7 @@ const BASE_RENDERER_SETTINGS: Required<RendererInitConfig> = {
   exposure: 1,
   antialias: true,
   alpha: false,
+  webgpuInitTimeoutMs: 4000,
 };
 
 export const DEFAULT_RENDERER_RUNTIME_CONTROLS: RendererRuntimeControls = {
@@ -135,6 +136,10 @@ export function resolveRendererSettings(
       defaults.antialias ??
       BASE_RENDERER_SETTINGS.antialias,
     alpha: options.alpha ?? defaults.alpha ?? BASE_RENDERER_SETTINGS.alpha,
+    webgpuInitTimeoutMs:
+      options.webgpuInitTimeoutMs ??
+      defaults.webgpuInitTimeoutMs ??
+      BASE_RENDERER_SETTINGS.webgpuInitTimeoutMs,
   };
 }
 

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -43,7 +43,35 @@ export type RendererInitConfig = {
   adaptiveMaxPixelRatioMultiplier?: number;
   adaptiveRenderScaleMultiplier?: number;
   adaptiveDensityMultiplier?: number;
+  webgpuInitTimeoutMs?: number;
 };
+
+export const DEFAULT_WEBGPU_INIT_TIMEOUT_MS = 4000;
+
+export async function resolveWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}
 
 async function loadWebGPURenderer() {
   const module = await import('./webgpu-renderer.ts');
@@ -75,6 +103,7 @@ export async function initRenderer(
     adaptiveMaxPixelRatioMultiplier = 1,
     adaptiveRenderScaleMultiplier = 1,
     adaptiveDensityMultiplier = 1,
+    webgpuInitTimeoutMs = DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
   } = config;
 
   const finalize = (
@@ -150,7 +179,11 @@ export async function initRenderer(
 
     if (!device) {
       try {
-        device = await adapter.requestDevice();
+        device = await resolveWithTimeout(
+          adapter.requestDevice(),
+          webgpuInitTimeoutMs,
+          'WebGPU device initialization timed out.',
+        );
       } catch (error) {
         return fallbackToWebGL(
           getRendererFallbackReasonMessage(
@@ -174,7 +207,20 @@ export async function initRenderer(
         device,
       });
       if ('init' in renderer && typeof renderer.init === 'function') {
-        await renderer.init();
+        try {
+          await resolveWithTimeout(
+            renderer.init(),
+            webgpuInitTimeoutMs,
+            'WebGPU renderer initialization timed out.',
+          );
+        } catch (error) {
+          return fallbackToWebGL(
+            getRendererFallbackReasonMessage(
+              RENDERER_FALLBACK_REASON_CODES.webgpuInitFailed,
+            ),
+            error,
+          );
+        }
       }
       return finalize(renderer, 'webgpu', adapter, device);
     } catch (error) {

--- a/tests/renderer-setup.test.ts
+++ b/tests/renderer-setup.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+const freshImport = async () =>
+  import(
+    `../assets/js/core/renderer-setup.ts?ts=${Date.now()}-${Math.random()}`
+  );
+
+describe('renderer setup WebGPU fallback safety', () => {
+  const originalConsoleInfo = console.info;
+  const originalConsoleDebug = console.debug;
+
+  afterEach(() => {
+    mock.restore();
+    console.info = originalConsoleInfo;
+    console.debug = originalConsoleDebug;
+    document.body.innerHTML = '';
+  });
+
+  test('falls back to WebGL when WebGPU renderer init stalls', async () => {
+    const createWebGLRenderer = mock(() => ({
+      setPixelRatio: mock(),
+      setSize: mock(),
+      setAnimationLoop: mock(),
+      dispose: mock(),
+      toneMappingExposure: 1,
+    }));
+
+    const requestDevice = mock(
+      async () => ({ label: 'mock-device' }) as unknown as GPUDevice,
+    );
+
+    const rememberRendererFallback = mock();
+
+    const consoleInfo = mock(() => {});
+    const consoleDebug = mock(() => {});
+
+    mock.module('../assets/js/utils/device-detect', () => ({
+      isMobileDevice: () => false,
+    }));
+    mock.module('../assets/js/utils/webgl-check', () => ({
+      ensureWebGL: () => true,
+    }));
+    mock.module('../assets/js/utils/webgl-renderer', () => ({
+      createWebGLRenderer,
+    }));
+    mock.module('../assets/js/core/renderer-capabilities.ts', () => ({
+      getRendererCapabilities: async () => ({
+        adapter: { requestDevice },
+        device: null,
+      }),
+      rememberRendererFallback,
+    }));
+    mock.module('../assets/js/core/renderer-plan.ts', () => ({
+      deriveRendererPlan: () => ({
+        backend: 'webgpu',
+        reasonMessage: null,
+        canRetryWebGPU: true,
+      }),
+    }));
+    mock.module('../assets/js/core/webgpu-renderer.ts', () => ({
+      WebGPURenderer: class MockWebGPURenderer {
+        init() {
+          return new Promise(() => {});
+        }
+
+        setPixelRatio() {}
+        setSize() {}
+        setAnimationLoop() {}
+      },
+    }));
+
+    console.info = consoleInfo;
+    console.debug = consoleDebug;
+
+    const { initRenderer } = await freshImport();
+    const result = await initRenderer(document.createElement('canvas'), {
+      webgpuInitTimeoutMs: 5,
+    });
+
+    expect(result?.backend).toBe('webgl');
+    expect(createWebGLRenderer).toHaveBeenCalledTimes(1);
+    expect(requestDevice).toHaveBeenCalledTimes(1);
+    expect(rememberRendererFallback).toHaveBeenCalledWith(
+      'WebGPU initialization failed.',
+      expect.objectContaining({
+        backend: 'webgl',
+        shouldRetryWebGPU: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Some mobile browsers can stall while acquiring a WebGPU device or initializing the Three.js WebGPU renderer, which left the visualizer blank instead of recovering to WebGL. 

### Description
- Add a bounded startup helper `resolveWithTimeout` and `DEFAULT_WEBGPU_INIT_TIMEOUT_MS` and use it to wrap `adapter.requestDevice()` and `renderer.init()` in `assets/js/core/renderer-setup.ts`. 
- Expose a new optional `webgpuInitTimeoutMs` field on `RendererInitConfig` and thread it through `resolveRendererSettings` and `BASE_RENDERER_SETTINGS` in `assets/js/core/renderer-settings.ts` so pooled renderers receive the full config. 
- On timed-out or failed WebGPU init, fall back to creating a WebGL renderer and record the fallback via the existing `rememberRendererFallback` path. 
- Add a regression test `tests/renderer-setup.test.ts` that simulates a stalled `WebGPURenderer.init()` and verifies a WebGL fallback is created. 

### Testing
- Ran `bun run test tests/renderer-setup.test.ts` and the new test passed. 
- Ran the full repository gate with `bun run check` which executed the test suite and typecheck; the quality gate completed successfully. 
- Docs: None changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf3d64bffc8332872df421cf0f388a)