### PR TITLE
Follow up: fix WebGPU timeout fallback cleanup

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -1,7 +1,6 @@
 /* global GPUAdapter, GPUDevice, GPU */
 
 import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
-
 import { isCompatibilityModeEnabled } from './render-preferences.ts';
 import {
   getRendererFallbackReasonMessage,
@@ -9,6 +8,10 @@ import {
   RENDERER_FALLBACK_REASON_CODES,
   type RendererFallbackReasonCode,
 } from './renderer-fallback-reasons.ts';
+import {
+  DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
+  resolveWithTimeout,
+} from './renderer-init-timeout.ts';
 
 export type RendererBackend = 'webgl' | 'webgpu';
 
@@ -387,7 +390,11 @@ export function getRenderingSupport(): RenderingSupport {
   };
 }
 
-async function probeRendererCapabilities(): Promise<RendererCapabilities> {
+async function probeRendererCapabilities({
+  webgpuInitTimeoutMs = DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
+}: {
+  webgpuInitTimeoutMs?: number;
+} = {}): Promise<RendererCapabilities> {
   if (typeof navigator === 'undefined') {
     return cacheResult(
       buildFallback(
@@ -437,7 +444,11 @@ async function probeRendererCapabilities(): Promise<RendererCapabilities> {
 
     let device: GPUDevice | null = null;
     try {
-      device = await adapter.requestDevice();
+      device = await resolveWithTimeout(
+        adapter.requestDevice(),
+        webgpuInitTimeoutMs,
+        'WebGPU device initialization timed out.',
+      );
     } catch (error) {
       console.warn(
         'WebGPU device request failed. Falling back to WebGL.',
@@ -533,7 +544,13 @@ export function rememberRendererFallback(
   return result;
 }
 
-export async function getRendererCapabilities({ forceRetry = false } = {}) {
+export async function getRendererCapabilities({
+  forceRetry = false,
+  webgpuInitTimeoutMs = DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
+}: {
+  forceRetry?: boolean;
+  webgpuInitTimeoutMs?: number;
+} = {}) {
   const environmentKey = getEnvironmentKey();
   const environmentChanged = environmentKey !== cachedEnvironmentKey;
 
@@ -544,7 +561,7 @@ export async function getRendererCapabilities({ forceRetry = false } = {}) {
   cachedEnvironmentKey = environmentKey;
 
   if (!capabilitiesPromise) {
-    capabilitiesPromise = probeRendererCapabilities();
+    capabilitiesPromise = probeRendererCapabilities({ webgpuInitTimeoutMs });
   }
 
   return capabilitiesPromise;

--- a/assets/js/core/renderer-init-timeout.ts
+++ b/assets/js/core/renderer-init-timeout.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_WEBGPU_INIT_TIMEOUT_MS = 4000;
+
+export async function resolveWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}

--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -1,5 +1,6 @@
 import type * as THREE from 'three';
 import { isMobileDevice } from '../utils/device-detect';
+import { DEFAULT_WEBGPU_INIT_TIMEOUT_MS } from './renderer-init-timeout.ts';
 import type {
   RendererInitConfig,
   RendererInitResult,
@@ -47,7 +48,7 @@ const BASE_RENDERER_SETTINGS: Required<RendererInitConfig> = {
   exposure: 1,
   antialias: true,
   alpha: false,
-  webgpuInitTimeoutMs: 4000,
+  webgpuInitTimeoutMs: DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
 };
 
 export const DEFAULT_RENDERER_RUNTIME_CONTROLS: RendererRuntimeControls = {

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -17,6 +17,10 @@ import {
   getRendererFallbackReasonMessage,
   RENDERER_FALLBACK_REASON_CODES,
 } from './renderer-fallback-reasons.ts';
+import {
+  DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
+  resolveWithTimeout,
+} from './renderer-init-timeout.ts';
 import { deriveRendererPlan } from './renderer-plan.ts';
 import { getRendererBackendMaxPixelRatioCap } from './renderer-settings.ts';
 import type { WebGPURenderer } from './webgpu-renderer.ts';
@@ -46,39 +50,25 @@ export type RendererInitConfig = {
   webgpuInitTimeoutMs?: number;
 };
 
-export const DEFAULT_WEBGPU_INIT_TIMEOUT_MS = 4000;
-
-export async function resolveWithTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  message: string,
-): Promise<T> {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return promise;
-  }
-
-  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
-  const timeoutPromise = new Promise<T>((_, reject) => {
-    timeoutId = globalThis.setTimeout(() => {
-      reject(new Error(message));
-    }, timeoutMs);
-  });
-
-  try {
-    return await Promise.race([promise, timeoutPromise]);
-  } finally {
-    if (timeoutId !== null) {
-      globalThis.clearTimeout(timeoutId);
-    }
-  }
-}
-
 async function loadWebGPURenderer() {
   const module = await import('./webgpu-renderer.ts');
   return module.WebGPURenderer;
 }
 
 const isMobileUserAgent = isMobileDevice();
+
+function disposeRenderer(renderer: Partial<WebGLRenderer | WebGPURenderer>) {
+  if (
+    'setAnimationLoop' in renderer &&
+    typeof renderer.setAnimationLoop === 'function'
+  ) {
+    renderer.setAnimationLoop(null);
+  }
+
+  if ('dispose' in renderer && typeof renderer.dispose === 'function') {
+    renderer.dispose();
+  }
+}
 
 export async function initRenderer(
   canvas: HTMLCanvasElement,
@@ -167,7 +157,9 @@ export async function initRenderer(
     return finalize(renderer, 'webgl', null, null);
   };
 
-  const capabilities = await getRendererCapabilities();
+  const capabilities = await getRendererCapabilities({
+    webgpuInitTimeoutMs,
+  });
   const plan = deriveRendererPlan({
     capabilities,
     hasWebGL: true,
@@ -207,13 +199,26 @@ export async function initRenderer(
         device,
       });
       if ('init' in renderer && typeof renderer.init === 'function') {
+        const initPromise = renderer.init();
+        let rendererDisposed = false;
+        const disposeTimedOutRenderer = () => {
+          if (rendererDisposed) {
+            return;
+          }
+
+          rendererDisposed = true;
+          disposeRenderer(renderer);
+        };
+
         try {
           await resolveWithTimeout(
-            renderer.init(),
+            initPromise,
             webgpuInitTimeoutMs,
             'WebGPU renderer initialization timed out.',
           );
         } catch (error) {
+          disposeTimedOutRenderer();
+          void initPromise.then(disposeTimedOutRenderer).catch(() => {});
           return fallbackToWebGL(
             getRendererFallbackReasonMessage(
               RENDERER_FALLBACK_REASON_CODES.webgpuInitFailed,

--- a/tests/renderer-capabilities.test.js
+++ b/tests/renderer-capabilities.test.js
@@ -96,6 +96,41 @@ describe('renderer capabilities', () => {
     expect(result.forceWebGL).toBe(false);
   });
 
+  test('falls back when WebGPU device acquisition times out during capability probing', async () => {
+    const requestDevice = mock(() => new Promise(() => {}));
+    const requestAdapter = mock(async () => ({
+      features: new Set(),
+      limits: {},
+      requestDevice,
+    }));
+
+    Object.defineProperty(global, 'navigator', {
+      writable: true,
+      configurable: true,
+      value: {
+        gpu: {
+          requestAdapter,
+          getPreferredCanvasFormat: () => 'bgra8unorm',
+        },
+      },
+    });
+
+    const result = await getRendererCapabilities({
+      forceRetry: true,
+      webgpuInitTimeoutMs: 5,
+    });
+
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+    expect(requestDevice).toHaveBeenCalledTimes(1);
+    expect(
+      result.preferredBackend === 'webgl' || result.preferredBackend === null,
+    ).toBe(true);
+    expect(result.fallbackReason).toBe('Unable to acquire a WebGPU device.');
+    expect(result.shouldRetryWebGPU).toBe(true);
+    expect(result.device).toBeNull();
+    expect(result.adapter).toBeNull();
+  });
+
   test('falls back to WebGL when WebGPU is missing', async () => {
     Object.defineProperty(global, 'navigator', {
       writable: true,

--- a/tests/renderer-setup.test.ts
+++ b/tests/renderer-setup.test.ts
@@ -8,15 +8,28 @@ const freshImport = async () =>
 describe('renderer setup WebGPU fallback safety', () => {
   const originalConsoleInfo = console.info;
   const originalConsoleDebug = console.debug;
+  const originalUserAgent = navigator.userAgent;
 
   afterEach(() => {
     mock.restore();
     console.info = originalConsoleInfo;
     console.debug = originalConsoleDebug;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: originalUserAgent,
+    });
     document.body.innerHTML = '';
   });
 
   test('falls back to WebGL when WebGPU renderer init stalls', async () => {
+    const stalledRenderer = {
+      setPixelRatio: mock(),
+      setSize: mock(),
+      setAnimationLoop: mock(),
+      dispose: mock(),
+      toneMappingExposure: 1,
+    };
+
     const createWebGLRenderer = mock(() => ({
       setPixelRatio: mock(),
       setSize: mock(),
@@ -34,20 +47,29 @@ describe('renderer setup WebGPU fallback safety', () => {
     const consoleInfo = mock(() => {});
     const consoleDebug = mock(() => {});
 
-    mock.module('../assets/js/utils/device-detect', () => ({
-      isMobileDevice: () => false,
-    }));
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122 Safari/537.36',
+    });
     mock.module('../assets/js/utils/webgl-check', () => ({
       ensureWebGL: () => true,
     }));
     mock.module('../assets/js/utils/webgl-renderer', () => ({
       createWebGLRenderer,
     }));
+    const getRendererCapabilities = mock(
+      async (options?: { webgpuInitTimeoutMs?: number }) => {
+        void options;
+        return {
+          adapter: { requestDevice },
+          device: null,
+        };
+      },
+    );
+
     mock.module('../assets/js/core/renderer-capabilities.ts', () => ({
-      getRendererCapabilities: async () => ({
-        adapter: { requestDevice },
-        device: null,
-      }),
+      getRendererCapabilities,
       rememberRendererFallback,
     }));
     mock.module('../assets/js/core/renderer-plan.ts', () => ({
@@ -63,9 +85,10 @@ describe('renderer setup WebGPU fallback safety', () => {
           return new Promise(() => {});
         }
 
-        setPixelRatio() {}
-        setSize() {}
-        setAnimationLoop() {}
+        setPixelRatio = stalledRenderer.setPixelRatio;
+        setSize = stalledRenderer.setSize;
+        setAnimationLoop = stalledRenderer.setAnimationLoop;
+        dispose = stalledRenderer.dispose;
       },
     }));
 
@@ -78,8 +101,13 @@ describe('renderer setup WebGPU fallback safety', () => {
     });
 
     expect(result?.backend).toBe('webgl');
+    expect(getRendererCapabilities).toHaveBeenCalledWith({
+      webgpuInitTimeoutMs: 5,
+    });
     expect(createWebGLRenderer).toHaveBeenCalledTimes(1);
     expect(requestDevice).toHaveBeenCalledTimes(1);
+    expect(stalledRenderer.setAnimationLoop).toHaveBeenCalledWith(null);
+    expect(stalledRenderer.dispose).toHaveBeenCalledTimes(1);
     expect(rememberRendererFallback).toHaveBeenCalledWith(
       'WebGPU initialization failed.',
       expect.objectContaining({


### PR DESCRIPTION
### Motivation
- Prevent a slow but eventually-resolving WebGPU path from leaving a hidden WebGPU renderer running after we already fell back to WebGL. 
- Ensure the device acquisition timeout is effective during capability probing so a stalled `requestDevice()` will trigger a fallback earlier. 

### Description
- Centralize the timeout helper and default into `assets/js/core/renderer-init-timeout.ts` (`DEFAULT_WEBGPU_INIT_TIMEOUT_MS` and `resolveWithTimeout`) and use it from capability probing and renderer setup. 
- Move the WebGPU device timeout into `getRendererCapabilities()`/probe so `adapter.requestDevice()` is wrapped and will fall back when it stalls (`assets/js/core/renderer-capabilities.ts`). 
- Dispose a timed-out WebGPU renderer by clearing its animation loop and calling `dispose()` before returning a WebGL fallback, and ensure the eventual resolution of the original `init()` also triggers a disposal (`assets/js/core/renderer-setup.ts`). 
- Thread `webgpuInitTimeoutMs` through `RendererInitConfig`/`resolveRendererSettings`/`BASE_RENDERER_SETTINGS` so pooled renderers and callers can control the timeout (`assets/js/core/renderer-settings.ts`). 
- Add regression tests for both failure modes: stalled device acquisition and stalled `WebGPURenderer.init()` cleanup (`tests/renderer-capabilities.test.js` and `tests/renderer-setup.test.ts`). 

### Testing
- Ran targeted unit tests with `bun run test tests/renderer-setup.test.ts tests/renderer-capabilities.test.js` and the tests passed. 
- Ran additional focused checks `bun run test tests/renderer-setup.test.ts tests/device-detect.test.ts tests/control-panel.test.js` to validate related behavior and they passed. 
- Ran the full quality gate with `bun run check` (Biome lint/format, TypeScript typecheck, and the full test suite) and it completed with all tests passing. 

Files changed: `assets/js/core/renderer-init-timeout.ts`, `assets/js/core/renderer-capabilities.ts`, `assets/js/core/renderer-setup.ts`, `assets/js/core/renderer-settings.ts`, and updates to `tests/renderer-capabilities.test.js` and `tests/renderer-setup.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf418bc90c8332ba5b3cb8a66eab70)