### PR TITLE
Restore floating audio prompt in focused toy sessions

### DIFF
--- a/assets/js/loader/toy-audio-prompt-controller.ts
+++ b/assets/js/loader/toy-audio-prompt-controller.ts
@@ -15,13 +15,6 @@ type LoaderView = {
 };
 
 export function createToyAudioPromptController({ view }: { view: LoaderView }) {
-  const shellOwnsAudioControls = () => {
-    const container = document.querySelector<HTMLElement>(
-      '[data-audio-controls]',
-    );
-    return Boolean(container && container.childElementCount > 0);
-  };
-
   const hasActiveAudio = () => document.body.dataset.audioActive === 'true';
 
   const maybeShowPrompt = ({
@@ -38,7 +31,6 @@ export function createToyAudioPromptController({ view }: { view: LoaderView }) {
     if (
       !launchResult.audioStarterAvailable ||
       !launchResult.startAudio ||
-      shellOwnsAudioControls() ||
       hasActiveAudio()
     ) {
       return;

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -275,7 +275,7 @@ describe('loadToy', () => {
     expect(vibrate).toHaveBeenCalled();
   });
 
-  test('does not show a duplicate floating audio prompt when shell controls already exist', async () => {
+  test('shows the floating audio prompt even when shell controls exist behind the active toy overlay', async () => {
     document.body.innerHTML =
       '<div id="toy-list"></div><div data-audio-controls><div data-existing="true"></div></div>';
 
@@ -296,7 +296,7 @@ describe('loadToy', () => {
 
     expect(
       document.querySelector('#active-toy-container .control-panel'),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   test('keeps the current toy mounted while the next toy is loading', async () => {

--- a/tests/toy-audio-prompt-controller.test.ts
+++ b/tests/toy-audio-prompt-controller.test.ts
@@ -32,7 +32,7 @@ describe('toy audio prompt controller', () => {
     expect(options.starterTips).toEqual(['Try mic first']);
   });
 
-  test('skips the floating prompt when shell controls already exist', () => {
+  test('still shows the floating prompt when shell controls exist behind the active toy overlay', () => {
     document.body.innerHTML =
       '<div id="active-toy-container"></div><div data-audio-controls><div data-existing="true"></div></div>';
 
@@ -53,6 +53,10 @@ describe('toy audio prompt controller', () => {
       starterTips: ['Try demo first'],
     });
 
-    expect(showAudioPrompt).not.toHaveBeenCalled();
+    expect(showAudioPrompt).toHaveBeenCalledTimes(1);
+    const [active, options] = showAudioPrompt.mock.calls[0];
+    expect(active).toBe(true);
+    expect(options.preferDemoAudio).toBe(true);
+    expect(options.starterTips).toEqual(['Try demo first']);
   });
 });


### PR DESCRIPTION
### Motivation
- Mobile and focused-toy sessions could hide the floating start-audio prompt when shell audio controls existed elsewhere in the DOM, leaving users without an accessible way to start audio from the active toy overlay. 
- The change restores the intended UX where the active toy overlay can surface its own floating audio prompt even if shell controls are present behind it.

### Description
- Remove the DOM presence check that suppressed the floating prompt in `assets/js/loader/toy-audio-prompt-controller.ts` so the controller no longer skips prompt display when `[data-audio-controls]` exists. 
- Update unit tests in `tests/toy-audio-prompt-controller.test.ts` to assert the floating prompt is shown when shell controls exist behind the active toy overlay. 
- Update the regression test in `tests/loader.test.js` to verify the floating control panel mounts inside `#active-toy-container` when shell audio controls are present.

### Testing
- Ran the focused tests with `bun run test tests/toy-audio-prompt-controller.test.ts tests/loader.test.js` and both test files passed. 
- Ran the repo quality gate with `bun run check` (Biome + TypeScript + tests) and it completed successfully with the test suite passing. 
- Docs: None (no documentation files were modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf447894108332933c70908e77a829)