### PR TITLE
Suppress floating audio prompt during shell-managed audio startup

### DIFF
--- a/assets/js/loader/toy-audio-prompt-controller.ts
+++ b/assets/js/loader/toy-audio-prompt-controller.ts
@@ -16,6 +16,38 @@ type LoaderView = {
 
 export function createToyAudioPromptController({ view }: { view: LoaderView }) {
   const hasActiveAudio = () => document.body.dataset.audioActive === 'true';
+  const hasShellManagedAudioStartupInFlight = () =>
+    document.querySelector(
+      '[data-audio-controls] [data-loading], [data-audio-controls] [aria-busy="true"]',
+    ) !== null;
+
+  let promptVisibilityTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const stopWatchingPromptVisibility = () => {
+    if (promptVisibilityTimer !== null) {
+      clearTimeout(promptVisibilityTimer);
+      promptVisibilityTimer = null;
+    }
+  };
+
+  const hidePrompt = () => {
+    view.showAudioPrompt(false);
+    stopWatchingPromptVisibility();
+  };
+
+  const watchForExternalAudioStart = () => {
+    stopWatchingPromptVisibility();
+
+    const checkPromptVisibility = () => {
+      if (hasActiveAudio()) {
+        hidePrompt();
+        return;
+      }
+      promptVisibilityTimer = setTimeout(checkPromptVisibility, 16);
+    };
+
+    promptVisibilityTimer = setTimeout(checkPromptVisibility, 16);
+  };
 
   const maybeShowPrompt = ({
     launchResult,
@@ -31,12 +63,14 @@ export function createToyAudioPromptController({ view }: { view: LoaderView }) {
     if (
       !launchResult.audioStarterAvailable ||
       !launchResult.startAudio ||
-      hasActiveAudio()
+      hasActiveAudio() ||
+      hasShellManagedAudioStartupInFlight()
     ) {
       return;
     }
 
     let lastAudioSource: 'microphone' | 'demo' = 'microphone';
+    watchForExternalAudioStart();
     view.showAudioPrompt(true, {
       preferDemoAudio,
       starterTips,
@@ -49,7 +83,7 @@ export function createToyAudioPromptController({ view }: { view: LoaderView }) {
         await launchResult.startAudio?.({ source: 'demo' });
       },
       onSuccess: () => {
-        view.showAudioPrompt(false);
+        hidePrompt();
         setAudioActive(true, lastAudioSource);
       },
     });

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -299,6 +299,34 @@ describe('loadToy', () => {
     ).not.toBeNull();
   });
 
+  test('suppresses the floating audio prompt when shell audio startup is already in flight', async () => {
+    document.body.innerHTML = `
+      <div id="toy-list"></div>
+      <div data-audio-controls>
+        <button type="button" data-loading aria-busy="true">Starting…</button>
+      </div>
+    `;
+
+    const { loader } = await buildLoader({
+      toys: [
+        {
+          slug: 'audio-toy',
+          title: 'Audio Toy',
+          module: './__mocks__/fake-global-audio-module.js',
+          type: 'module',
+          requiresWebGPU: false,
+        },
+      ],
+      manifestPath: (modulePath) => modulePath,
+    });
+
+    await loader.loadToy('audio-toy');
+
+    expect(
+      document.querySelector('#active-toy-container .control-panel'),
+    ).toBeNull();
+  });
+
   test('keeps the current toy mounted while the next toy is loading', async () => {
     const { loader } = await buildLoader({
       toys: [

--- a/tests/toy-audio-prompt-controller.test.ts
+++ b/tests/toy-audio-prompt-controller.test.ts
@@ -59,4 +59,59 @@ describe('toy audio prompt controller', () => {
     expect(options.preferDemoAudio).toBe(true);
     expect(options.starterTips).toEqual(['Try demo first']);
   });
+
+  test('suppresses the floating prompt while shell-managed audio startup is already pending', () => {
+    document.body.innerHTML = `
+      <div id="active-toy-container"></div>
+      <div data-audio-controls>
+        <button type="button" data-loading aria-busy="true">Starting…</button>
+      </div>
+    `;
+
+    const showAudioPrompt = mock();
+    const controller = createToyAudioPromptController({
+      view: { showAudioPrompt },
+    });
+
+    controller.maybeShowPrompt({
+      launchResult: {
+        instance: {},
+        audioStarterAvailable: true,
+        supportedSources: ['microphone', 'demo'],
+        startAudio: async () => {},
+      },
+      preferDemoAudio: false,
+      container: document.getElementById('active-toy-container'),
+      starterTips: ['Try mic first'],
+    });
+
+    expect(showAudioPrompt).not.toHaveBeenCalled();
+  });
+
+  test('hides the floating prompt when audio becomes active through shell-managed startup', async () => {
+    const showAudioPrompt = mock();
+    const controller = createToyAudioPromptController({
+      view: { showAudioPrompt },
+    });
+
+    controller.maybeShowPrompt({
+      launchResult: {
+        instance: {},
+        audioStarterAvailable: true,
+        supportedSources: ['microphone', 'demo'],
+        startAudio: async () => {},
+      },
+      preferDemoAudio: false,
+      container: document.getElementById('active-toy-container'),
+      starterTips: ['Try mic first'],
+    });
+
+    expect(showAudioPrompt).toHaveBeenCalledTimes(1);
+
+    document.body.dataset.audioActive = 'true';
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(showAudioPrompt).toHaveBeenCalledTimes(2);
+    expect(showAudioPrompt.mock.calls[1]).toEqual([false]);
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent the active-toy floating audio prompt from rendering when the shell is already starting audio so the prompt does not become a stale overlay over a running toy. 
- Ensure the floating prompt auto-hides if audio becomes active via the shell path after the prompt was shown.

### Description
- Add a guard to the toy audio prompt controller that detects shell-managed startup in flight by checking `'[data-audio-controls] [data-loading], [data-audio-controls] [aria-busy="true"]'` and skip showing the floating prompt when present in `assets/js/loader/toy-audio-prompt-controller.ts`.
- Start a lightweight watcher that hides the floating prompt when `document.body.dataset.audioActive` flips to `true`, and centralize prompt hide/stop-watching logic in the controller implementation.
- Replace flaky MutationObserver approach with a small polling loop (timed via `setTimeout`) to reliably observe external audio activation in test and runtime contexts.
- Add regression tests covering the new suppression and auto-hide behaviors in `tests/toy-audio-prompt-controller.test.ts` and a loader-level focused-session test in `tests/loader.test.js`.

### Testing
- Ran the focused tests with `bun run test tests/toy-audio-prompt-controller.test.ts tests/loader.test.js` and they passed (all tests in those files succeeded).
- Ran the full quality gate with `bun run check` (Biome + TypeScript + tests) and the test suite completed successfully with zero failures.
- Files changed: `assets/js/loader/toy-audio-prompt-controller.ts`, `tests/toy-audio-prompt-controller.test.ts`, and `tests/loader.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf4ad6726c8332abbff557c191d3b8)