### PR TITLE
Forward root `/` to demo-backed `/milkdrop/` with `?landing=1` opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Quick links:
 - Live site: [no.toil.fyi](https://no.toil.fyi)
 - Launch app: [no.toil.fyi/milkdrop/](https://no.toil.fyi/milkdrop/)
 - Product page: [no.toil.fyi/milkdrop/](https://no.toil.fyi/milkdrop/)
+- Marketing page opt-out: [no.toil.fyi/?landing=1](https://no.toil.fyi/?landing=1)
 - Docs hub: [docs/README.md](./docs/README.md)
 - Contributing: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
@@ -32,7 +33,7 @@ Stims aims to make MilkDrop-style visual play feel native to the browser instead
 - A launch flow with readiness checks before microphone prompts and renderer-heavy startup.
 - Multiple audio paths including microphone, demo audio, tab capture, and YouTube-backed tab capture.
 - Renderer preference handling with WebGPU-first startup and direct WebGL fallback when needed.
-- A focused marketing/launch page at `index.html`, plus the canonical visualizer route at `milkdrop/index.html` (`/milkdrop/`).
+- A root URL that auto-forwards to the demo-backed visualizer, plus an opt-out marketing page at `/?landing=1` and the canonical visualizer route at `milkdrop/index.html` (`/milkdrop/`).
 
 ## Shipped experience
 

--- a/assets/js/bootstrap/home-page.ts
+++ b/assets/js/bootstrap/home-page.ts
@@ -1,8 +1,36 @@
 import type { createLoader } from '../loader.ts';
 
 const HOME_TOY_SLUG = 'milkdrop';
+const HOME_LANDING_PARAM = 'landing';
+const HOME_LANDING_OPT_OUT = '1';
 
 type LoaderApi = ReturnType<typeof createLoader>;
+
+function redirectHomeTrafficToLaunch(win: Window = window) {
+  const currentUrl = new URL(win.location.href);
+
+  if (currentUrl.pathname !== '/') {
+    return false;
+  }
+
+  if (
+    currentUrl.searchParams.get(HOME_LANDING_PARAM) === HOME_LANDING_OPT_OUT
+  ) {
+    return false;
+  }
+
+  const launchUrl = new URL('/milkdrop/', currentUrl);
+  for (const [key, value] of currentUrl.searchParams.entries()) {
+    launchUrl.searchParams.append(key, value);
+  }
+  if (!launchUrl.searchParams.has('audio')) {
+    launchUrl.searchParams.set('audio', 'demo');
+  }
+  launchUrl.hash = currentUrl.hash;
+
+  win.location.replace(launchUrl.toString());
+  return true;
+}
 
 export function bootHomePage({
   loadToy,
@@ -11,6 +39,10 @@ export function bootHomePage({
   loadToy: LoaderApi['loadToy'];
   initNavigation: LoaderApi['initNavigation'];
 }) {
+  if (redirectHomeTrafficToLaunch()) {
+    return;
+  }
+
   initNavigation();
   void loadToy(HOME_TOY_SLUG, { preferDemoAudio: true });
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document summarizes how the Stims app is assembled, from the entry HTML she
 
 ## Architecture at a Glance
 
-- **Entry shells** (`index.html` and `milkdrop/index.html`) are the user-facing HTML shells that bootstrap `assets/js/app.ts`; `/` now boots the demo-backed MilkDrop session in place, while `/milkdrop/` remains the canonical launch route.
+- **Entry shells** (`index.html` and `milkdrop/index.html`) are the user-facing HTML shells that bootstrap `assets/js/app.ts`; `/` now forwards to the demo-backed MilkDrop launch by default, `/?landing=1` preserves the editorial homepage shell, and `/milkdrop/` remains the canonical launch route.
 - **App + loader orchestration** (`assets/js/app.ts`, `assets/js/loader.ts`, `assets/js/router.ts`) owns page boot, capability preflight, navigation, lifecycle boundaries, and loader state.
 - **View state** (`assets/js/toy-view.ts`, `assets/js/library-view.js`) renders the library, toy container, and status banners.
 - **Runtime core** (`assets/js/core/*`) encapsulates rendering, audio, settings, and per-frame loop wiring.
@@ -21,7 +21,7 @@ Use this split when making trade-offs: keep Tier 0 reliable first, and treat Tie
 
 ## Runtime Layers
 
-- **HTML entry points** (`index.html` and `milkdrop/index.html`) load `assets/js/app.ts`; `index.html` now boots the visualizer directly with demo-audio preference, and query params still refine launch state on the dedicated visualizer route.
+- **HTML entry points** (`index.html` and `milkdrop/index.html`) load `assets/js/app.ts`; `index.html` now redirects default root traffic to the demo launch route unless `landing=1` is present, and query params still refine launch state on the dedicated visualizer route.
 - **App bootstrap** (`assets/js/app.ts`) detects library vs toy pages, wires controls, runs capability preflight, and starts loader flows.
 - **Loader + routing** (`assets/js/loader.ts`, `assets/js/router.ts`) coordinate navigation, history, active toy lifecycle, and dynamic module loading.
 - **UI views** (`assets/js/toy-view.ts`, `assets/js/library-view.js`) render the library grid, active toy container, loading/error states, and renderer status badges.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -179,9 +179,9 @@ Cloudflare Pages issues a unique preview deployment for each pull request. Every
 
 ## Validate shell routes before merge
 
-The project ships a marketing homepage at `/` and a canonical launch route at `/milkdrop/`. Validate representative routes locally and on the PR preview:
+The project now auto-forwards the root URL `/` to the demo-backed launch route, while `/?landing=1` preserves the marketing homepage and `/milkdrop/` remains the canonical launch route. Validate representative routes locally and on the PR preview:
 
-1. Run `bun run build` followed by `bun run preview` and open representative routes manually (for example, `http://localhost:4173/` and `http://localhost:4173/milkdrop/`).
+1. Run `bun run build` followed by `bun run preview` and open representative routes manually (for example, `http://localhost:4173/`, `http://localhost:4173/?landing=1`, and `http://localhost:4173/milkdrop/`).
 2. Repeat the checks against the PR’s Cloudflare Pages preview URL to ensure CDN caching and hashed asset references behave the same as local preview.
 3. If any route relies on audio or interaction-specific features, perform at least one interaction test (mic input, pointer/touch) to confirm runtime permissions and event handling.
 

--- a/docs/PAGE_SPECIFICATIONS.md
+++ b/docs/PAGE_SPECIFICATIONS.md
@@ -1,12 +1,13 @@
 # Page-level specifications
 
-Detailed, testable requirements for the two canonical site routes: the marketing homepage at `/` and the dedicated launch route at `/milkdrop/`.
+Detailed, testable requirements for the root launch flow, the opt-out marketing homepage, and the dedicated launch route at `/milkdrop/`.
 
 ## Homepage (`/` via `index.html`)
 
 | Section | Expected data and state | Layout and interaction expectations | Accessibility and status behaviors |
 | --- | --- | --- | --- |
-| **Global frame** | Loads shared styles from `assets/css/base.css` and `assets/css/index.css`. Uses `lang="en"` and preserves the saved theme before paint. On load, the shared app runtime starts the MilkDrop session in place with demo-audio preference. | The home document now acts as an immediate launch shell rather than a separate first-step page. | Theme toggle must keep `aria-pressed` and `aria-label` in sync for any visible shell controls. |
+| **Root launch behavior** | Loads shared styles from `assets/css/base.css` and `assets/css/index.css`. Uses `lang="en"` and preserves the saved theme before paint. By default, the shared app runtime immediately forwards `/` traffic to `/milkdrop/?audio=demo`, preserving existing query params. | The bare root URL should behave like a working launch shortcut instead of a separate first-step page. | Redirects must stay same-origin and avoid trapping users who explicitly request the landing page. |
+| **Marketing opt-out** | Visiting `/?landing=1` keeps the `index.html` document active and starts the MilkDrop session in place with demo-audio preference. | The opt-out page remains available for sharing, SEO review, and editorial content. | Theme toggle must keep `aria-pressed` and `aria-label` in sync for any visible shell controls. |
 | **Top nav** | Brand lockup plus links to `#experience`, `#presets`, `#lineage`, `/milkdrop/`, and GitHub. | Nav stays compact and sticky without competing with the hero CTAs. | Links remain keyboard reachable and visible in mobile menu mode. |
 | **Hero** | Copy remains inline in `index.html`, but the active session takes priority once the runtime boots. Primary CTA still links to `/milkdrop/?audio=demo`, with a secondary link to `/milkdrop/` for explicit route navigation. | The hero remains as underlying page content, while the fullscreen visualizer session becomes the immediate first-run experience. | CTA focus treatment stays visible whenever the hero is exposed, and modified clicks should fall back to native navigation. |
 | **Experience section** | Static explanatory cards only. No runtime setup widgets live here anymore. | Section clarifies the new information architecture and why setup moved off the homepage. | Cards keep headings in reading order and do not rely on color alone for meaning. |

--- a/tests/app-shell.test.js
+++ b/tests/app-shell.test.js
@@ -43,7 +43,19 @@ describe('home shell user journeys', () => {
     delete globalThis.__stimsLoaderOverrides;
   });
 
-  test('home landing starts the milkdrop visualizer in place with demo audio preference', async () => {
+  test('home landing redirects straight to the canonical demo launch route', async () => {
+    await loadAppShell();
+
+    const currentUrl = new URL(window.location.href);
+    expect(currentUrl.pathname).toBe('/milkdrop/');
+    expect(currentUrl.searchParams.get('audio')).toBe('demo');
+    expect(mockInitNavigation).not.toHaveBeenCalled();
+    expect(mockLoadToy).not.toHaveBeenCalled();
+  });
+
+  test('landing opt-out keeps the homepage session boot in place', async () => {
+    window.location.href = 'https://example.com/?landing=1';
+
     await loadAppShell();
 
     expect(mockInitNavigation).toHaveBeenCalledTimes(1);
@@ -52,10 +64,13 @@ describe('home shell user journeys', () => {
       preferDemoAudio: true,
     });
     expect(new URL(window.location.href).pathname).toBe('/');
+    expect(new URL(window.location.href).searchParams.get('landing')).toBe('1');
     expect(mockLoadFromQuery).not.toHaveBeenCalled();
   });
 
   test('homepage quickstart stays a native navigation instead of SPA-loading in place', async () => {
+    window.location.href = 'https://example.com/?landing=1';
+
     await loadAppShell();
 
     const cta = document.querySelector('[data-quickstart-slug="milkdrop"]');


### PR DESCRIPTION
### Motivation

- Make the site root act as a convenient launch shortcut that opens the demo-backed MilkDrop visualizer by default while preserving the existing editorial marketing homepage for sharing and SEO via an explicit opt-out.
- Keep query params and hash across the redirect so preseeded launch state (for example `audio=demo`) is preserved when forwarding root traffic.

### Description

- Add `redirectHomeTrafficToLaunch` to `assets/js/bootstrap/home-page.ts` that forwards `/` to `/milkdrop/`, preserves query params and hash, and defaults `audio=demo` when not present, and short-circuits `bootHomePage` when a redirect occurs.  
- Add constants `HOME_LANDING_PARAM` and `HOME_LANDING_OPT_OUT` and treat `/?landing=1` as an explicit opt-out that keeps the marketing homepage active.  
- Update `README.md` to surface the marketing opt-out link and clarify the root launch behavior.  
- Update `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md`, and `docs/PAGE_SPECIFICATIONS.md` to document the new default forward and the `/?landing=1` opt-out semantics.  
- Update `tests/app-shell.test.js` to reflect the new redirect behavior and to add a test ensuring `/?landing=1` preserves in-place homepage boot and CTA behavior.

### Testing

- Ran the updated unit test suite (run via `bun test` in the project) which includes `tests/app-shell.test.js`, and the test suite succeeded.  
- Confirmed that `tests/app-shell.test.js` covers the redirect case and the landing opt-out case and both assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf61474fc08332878be7434d1faf27)