### PR TITLE
Replay initial library card previews after effects load

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -58,6 +58,7 @@ export function createLibraryView({
   let threeEffects = createNoopThreeEffects();
   let threeEffectsLoader = null;
   let threeEffectsInitialized = false;
+  let pendingCardPreviewSync = null;
   const filterLabelCache = new Map();
 
   const {
@@ -79,6 +80,17 @@ export function createLibraryView({
   const getState = () => stateController.getState();
   const getToyKey = (toy, index = 0) => toy?.slug ?? `toy-${index}`;
 
+  const syncThreeEffectCardPreviews = (cards, renderedToys) => {
+    pendingCardPreviewSync = { cards, renderedToys };
+    threeEffects.syncCardPreviews(cards, renderedToys);
+  };
+
+  const replayPendingCardPreviewSync = () => {
+    if (!pendingCardPreviewSync) return;
+    const { cards, renderedToys } = pendingCardPreviewSync;
+    threeEffects.syncCardPreviews(cards, renderedToys);
+  };
+
   const ensureThreeEffects = async () => {
     if (threeEffectsLoader) return threeEffectsLoader;
     threeEffectsLoader = import('./library-view/three-library-effects.ts')
@@ -86,6 +98,7 @@ export function createLibraryView({
         threeEffects = createLibraryThreeEffects();
         if (threeEffectsInitialized) {
           threeEffects.init();
+          replayPendingCardPreviewSync();
         }
         return threeEffects;
       })
@@ -589,7 +602,7 @@ export function createLibraryView({
     renderGrowthPanels,
     createEmptyState,
     onCardsRendered: (cards, renderedToys) => {
-      threeEffects.syncCardPreviews(cards, renderedToys);
+      syncThreeEffectCardPreviews(cards, renderedToys);
       updateResultsMeta(lastFilteredToys.length);
       updateActiveFiltersSummary();
     },

--- a/tests/library-filter-state.test.ts
+++ b/tests/library-filter-state.test.ts
@@ -1,6 +1,16 @@
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import { createLibraryView } from '../assets/js/library-view.js';
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+afterEach(() => {
+  mock.restore();
+});
 
 const toys = [
   {
@@ -137,6 +147,55 @@ describe('library filter state normalization', () => {
     expect(refineChip?.classList.contains('is-active')).toBe(false);
     expect(document.querySelectorAll('.webtoy-card')).toHaveLength(2);
   });
+});
+
+test('replays the initial card preview sync after effects load', async () => {
+  const initThreeEffects = mock<() => void>(() => {});
+  const syncCardPreviews = mock<
+    (cards: Element[], renderedToys: typeof toys) => void
+  >(() => {});
+  const idleCallbacks: Array<IdleRequestCallback> = [];
+  const originalRequestIdleCallback = window.requestIdleCallback;
+
+  mock.module('../assets/js/library-view/three-library-effects.ts', () => ({
+    createLibraryThreeEffects: () => ({
+      init: initThreeEffects,
+      syncCardPreviews,
+      triggerLaunchTransition() {},
+      startLaunchTransition() {},
+      dispose() {},
+    }),
+  }));
+
+  window.requestIdleCallback = ((callback: IdleRequestCallback) => {
+    idleCallbacks.push(callback);
+    return idleCallbacks.length;
+  }) as typeof window.requestIdleCallback;
+
+  try {
+    const view = createLibraryView({
+      toys,
+    });
+
+    await view.init();
+
+    expect(syncCardPreviews).not.toHaveBeenCalled();
+    expect(idleCallbacks).toHaveLength(1);
+
+    idleCallbacks[0]({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    } as IdleDeadline);
+    await flushMicrotasks();
+
+    const cards = Array.from(document.querySelectorAll('.webtoy-card'));
+
+    expect(initThreeEffects).toHaveBeenCalledTimes(1);
+    expect(syncCardPreviews).toHaveBeenCalledTimes(1);
+    expect(syncCardPreviews).toHaveBeenCalledWith(cards, toys);
+  } finally {
+    window.requestIdleCallback = originalRequestIdleCallback;
+  }
 });
 
 test('renders continue panel when returner signals are present', async () => {


### PR DESCRIPTION
### Motivation
- The lazy-loaded Three.js effects module could load after the first library render, causing the initial `onCardsRendered` payload to hit a noop and leaving first-load cards without preview canvases. 
- Ensure the initial card-preview sync is applied as soon as the effects module initializes so the library UX shows previews on first render.

### Description
- Buffer the most recent `onCardsRendered` payload in `createLibraryView` and route list renders through a `syncThreeEffectCardPreviews` wrapper that records the last cards/toys snapshot. 
- Replay the buffered snapshot after the lazy `three-library-effects` module finishes loading and `init()` runs by calling the buffered `syncCardPreviews`. 
- Updated the library list render callback to call the wrapper and added a focused regression test that mocks the deferred effects import and verifies the replay behavior (`assets/js/library-view.js`, `tests/library-filter-state.test.ts`).

### Testing
- Ran the focused regression test with `bun run test tests/library-filter-state.test.ts`, which passed. 
- Ran the repository quality gate with `bun run check` (Biome formatting/lint, TypeScript typecheck, full test suite), which completed successfully with all checks and tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00f96c28c8332a25703983cca20f2)