### PR TITLE
Refactor Milkdrop VM frame builders

### DIFF
--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -1,144 +1,45 @@
-import {
-  DEFAULT_MILKDROP_STATE,
-  evaluateMilkdropShaderControlProgram,
-} from './compiler';
+import { DEFAULT_MILKDROP_STATE } from './compiler';
 import { evaluateMilkdropExpression } from './expression';
 import type {
-  MilkdropBorderVisual,
-  MilkdropColor,
   MilkdropCompiledPreset,
   MilkdropFrameState,
-  MilkdropGpuFieldSignalInputs,
-  MilkdropGpuGeometryHints,
-  MilkdropMeshVisual,
-  MilkdropMotionVectorVisual,
-  MilkdropPolyline,
-  MilkdropPostVisual,
-  MilkdropProceduralCustomWaveVisual,
-  MilkdropProceduralMeshDescriptorPlan,
-  MilkdropProceduralMeshFieldVisual,
-  MilkdropProceduralMotionVectorFieldVisual,
-  MilkdropProceduralWaveVisual,
   MilkdropRuntimeSignals,
   MilkdropShapeDefinition,
-  MilkdropShapeVisual,
-  MilkdropVideoEchoOrientation,
   MilkdropVM,
   MilkdropWaveDefinition,
-  MilkdropWaveVisual,
 } from './types';
 import {
-  buildMainWaveFrame,
   buildMilkdropFrameState,
   defaultSignalEnv,
 } from './vm/frame-generation';
+import {
+  buildGpuGeometryHints,
+  buildMesh,
+  buildMeshField,
+  buildMotionVectors,
+} from './vm/geometry-builder';
+import { buildPost } from './vm/post-effects-builder';
+import { buildBorders, buildShapes } from './vm/shape-border-builder';
+import {
+  clamp,
+  color,
+  type GeometryBuilderState,
+  hashSeed,
+  MAX_CUSTOM_WAVE_SLOTS,
+  type MutableState,
+  type ShapeBuilderState,
+  type WaveBuilderState,
+} from './vm/shared';
+import {
+  buildCustomWaves,
+  buildMainWave,
+  commitMainWaveFrame,
+} from './vm/wave-builder';
 import {
   applyMilkdropWebGpuOptimizationFlags,
   DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
   type MilkdropWebGpuOptimizationFlags,
 } from './webgpu-optimization-flags';
-
-const MAX_TRAILS = 5;
-const MAX_CUSTOM_WAVE_SLOTS = 32;
-const MAX_CUSTOM_SHAPE_SLOTS = 32;
-const MAX_MOTION_VECTOR_COLUMNS = 96;
-const MAX_MOTION_VECTOR_ROWS = 72;
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function normalizeVideoEchoOrientation(
-  value: number,
-): MilkdropVideoEchoOrientation {
-  const truncated = Math.trunc(value);
-  return (((truncated % 4) + 4) % 4) as MilkdropVideoEchoOrientation;
-}
-
-function color(r: number, g: number, b: number, a = 1): MilkdropColor {
-  return {
-    r: clamp(r, 0, 1),
-    g: clamp(g, 0, 1),
-    b: clamp(b, 0, 1),
-    a: clamp(a, 0, 1),
-  };
-}
-
-function hashSeed(input: string) {
-  let hash = 2166136261;
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-function sampleFrequencyData(signals: MilkdropRuntimeSignals, t: number) {
-  const sampleIndex = Math.min(
-    signals.frequencyData.length - 1,
-    Math.max(0, Math.round(t * Math.max(0, signals.frequencyData.length - 1))),
-  );
-  return (signals.frequencyData[sampleIndex] ?? 0) / 255;
-}
-
-function sampleCustomWaveChannels(
-  signals: MilkdropRuntimeSignals,
-  sample: number,
-) {
-  const normalizedSample = sampleFrequencyData(signals, sample);
-  return {
-    sample,
-    value: normalizedSample,
-    value1: normalizedSample,
-    value2: normalizedSample,
-  };
-}
-
-function normalizeTransformCenter(value: number) {
-  if (value >= 0 && value <= 1) {
-    return value * 2 - 1;
-  }
-  return value;
-}
-
-type MutableState = Record<string, number>;
-type MeshFieldPoint = {
-  sourceX: number;
-  sourceY: number;
-  x: number;
-  y: number;
-};
-type MeshField = {
-  density: number;
-  points: MeshFieldPoint[];
-  program: MilkdropProceduralMeshDescriptorPlan['fieldProgram'];
-  signals: MilkdropGpuFieldSignalInputs | null;
-};
-
-type MotionVectorHistoryPoint = {
-  sourceX: number;
-  sourceY: number;
-  x: number;
-  y: number;
-};
-
-type MotionVectorFieldHistory = {
-  countX: number;
-  countY: number;
-  points: MotionVectorHistoryPoint[];
-};
-
-type MotionVectorDescriptorContext = {
-  legacyControls: boolean;
-  countX: number;
-  countY: number;
-};
-
-type WaveFrameBuffers = {
-  liveSamples: number[];
-  previousSamples: number[];
-  smoothedSamples: number[];
-  momentumSamples: number[];
-};
 
 class MilkdropPresetVM implements MilkdropVM {
   private preset: MilkdropCompiledPreset;
@@ -150,25 +51,28 @@ class MilkdropPresetVM implements MilkdropVM {
   private webgpuOptimizationFlags: MilkdropWebGpuOptimizationFlags = {
     ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
   };
-  private trails: MilkdropPolyline[] = [];
-  private lastWaveform: MilkdropWaveVisual | null = null;
-  private lastProceduralWave: MilkdropProceduralWaveVisual | null = null;
-  private lastWaveSamples: number[] = [];
-  private lastWaveMomentum: number[] = [];
-  private customWaveState: MutableState[] = [];
-  private proceduralTrailWaves: MilkdropProceduralWaveVisual[] = [];
-  private customShapeState: MutableState[] = [];
-  private lastMotionVectorField: MotionVectorFieldHistory | null = null;
-  private readonly waveBuffers: WaveFrameBuffers = {
-    liveSamples: [],
-    previousSamples: [],
-    smoothedSamples: [],
-    momentumSamples: [],
+  private readonly waveState: WaveBuilderState = {
+    trails: [],
+    lastWaveform: null,
+    lastProceduralWave: null,
+    lastWaveSamples: [],
+    lastWaveMomentum: [],
+    customWaveLocals: [],
+    proceduralTrailWaves: [],
+    buffers: {
+      liveSamples: [],
+      previousSamples: [],
+      smoothedSamples: [],
+      momentumSamples: [],
+    },
   };
-  private readonly frameTransformCache = new Map<
-    number,
-    { x: number; y: number }
-  >();
+  private readonly geometryState: GeometryBuilderState = {
+    lastMotionVectorField: null,
+    frameTransformCache: new Map<number, { x: number; y: number }>(),
+  };
+  private readonly shapeState: ShapeBuilderState = {
+    customShapeLocals: [],
+  };
 
   constructor(
     preset: MilkdropCompiledPreset,
@@ -212,39 +116,45 @@ class MilkdropPresetVM implements MilkdropVM {
     }
     this.randomState =
       hashSeed(this.preset.source.id || this.preset.title || 'milkdrop') || 1;
-    this.trails = [];
-    this.lastWaveform = null;
-    this.lastProceduralWave = null;
-    this.lastWaveSamples = [];
-    this.lastWaveMomentum = [];
-    this.customWaveState = this.preset.ir.customWaves.map((wave) =>
+    this.waveState.trails = [];
+    this.waveState.lastWaveform = null;
+    this.waveState.lastProceduralWave = null;
+    this.waveState.lastWaveSamples = [];
+    this.waveState.lastWaveMomentum = [];
+    this.waveState.customWaveLocals = this.preset.ir.customWaves.map((wave) =>
       this.seedCustomWaveState(wave),
     );
-    this.customShapeState = this.preset.ir.customShapes.map((shape) =>
-      this.seedCustomShapeState(shape),
+    this.shapeState.customShapeLocals = this.preset.ir.customShapes.map(
+      (shape) => this.seedCustomShapeState(shape),
     );
-    this.proceduralTrailWaves = [];
-    this.lastMotionVectorField = null;
-    this.waveBuffers.liveSamples.length = 0;
-    this.waveBuffers.previousSamples.length = 0;
-    this.waveBuffers.smoothedSamples.length = 0;
-    this.waveBuffers.momentumSamples.length = 0;
-    this.frameTransformCache.clear();
+    this.waveState.proceduralTrailWaves = [];
+    this.geometryState.lastMotionVectorField = null;
+    this.waveState.buffers.liveSamples.length = 0;
+    this.waveState.buffers.previousSamples.length = 0;
+    this.waveState.buffers.smoothedSamples.length = 0;
+    this.waveState.buffers.momentumSamples.length = 0;
+    this.geometryState.frameTransformCache.clear();
 
     const zeroSignals = defaultSignalEnv();
     this.runProgram(this.preset.ir.programs.init, this.createEnv(zeroSignals));
     this.preset.ir.customWaves.forEach((wave, index) => {
       this.runProgram(
         wave.programs.init,
-        this.createEnv(zeroSignals, this.customWaveState[index] ?? {}),
-        this.customWaveState[index],
+        this.createEnv(
+          zeroSignals,
+          this.waveState.customWaveLocals[index] ?? {},
+        ),
+        this.waveState.customWaveLocals[index],
       );
     });
     this.preset.ir.customShapes.forEach((shape, index) => {
       this.runProgram(
         shape.programs.init,
-        this.createEnv(zeroSignals, this.customShapeState[index] ?? {}),
-        this.customShapeState[index],
+        this.createEnv(
+          zeroSignals,
+          this.shapeState.customShapeLocals[index] ?? {},
+        ),
+        this.shapeState.customShapeLocals[index],
       );
     });
   }
@@ -254,7 +164,7 @@ class MilkdropPresetVM implements MilkdropVM {
       ...this.state,
       ...this.registers,
       ...Object.fromEntries(
-        this.customWaveState.flatMap((waveState, index) =>
+        this.waveState.customWaveLocals.flatMap((waveState, index) =>
           Object.entries(waveState).map(([key, value]) => [
             `wave${index + 1}_${key}`,
             value,
@@ -262,7 +172,7 @@ class MilkdropPresetVM implements MilkdropVM {
         ),
       ),
       ...Object.fromEntries(
-        this.customShapeState.flatMap((shapeState, index) =>
+        this.shapeState.customShapeLocals.flatMap((shapeState, index) =>
           Object.entries(shapeState).map(([key, value]) => [
             `shape${index + 1}_${key}`,
             value,
@@ -270,20 +180,6 @@ class MilkdropPresetVM implements MilkdropVM {
         ),
       ),
     };
-  }
-
-  private syncLastWaveSamples(samples: number[], count: number) {
-    this.lastWaveSamples.length = count;
-    for (let index = 0; index < count; index += 1) {
-      this.lastWaveSamples[index] = samples[index] ?? 0;
-    }
-  }
-
-  private syncLastWaveMomentum(samples: number[], count: number) {
-    this.lastWaveMomentum.length = count;
-    for (let index = 0; index < count; index += 1) {
-      this.lastWaveMomentum[index] = samples[index] ?? 0;
-    }
   }
 
   private nextRandom = () => {
@@ -443,12 +339,6 @@ class MilkdropPresetVM implements MilkdropVM {
     });
   }
 
-  private getTransformCacheKey(x: number, y: number) {
-    const quantizedX = Math.round((x + 1) * 2048);
-    const quantizedY = Math.round((y + 1) * 2048);
-    return quantizedX * 4096 + quantizedY;
-  }
-
   private supportsProceduralWave(drawMode: 'line' | 'dots') {
     const plan = this.getEffectiveWebGpuDescriptorPlan();
     return (
@@ -488,792 +378,86 @@ class MilkdropPresetVM implements MilkdropVM {
     );
   }
 
-  private buildProceduralFieldTransform() {
-    return {
-      zoom: Math.max(this.state.zoom ?? 1, 0.0001),
-      zoomExponent: Math.max(this.state.zoomexp ?? 1, 0.0001),
-      rotation: this.state.rot ?? 0,
-      warp: this.state.warp ?? 0,
-      warpAnimSpeed: clamp(this.state.warpanimspeed ?? 1, 0, 4),
-      centerX: normalizeTransformCenter(this.state.cx ?? 0.5),
-      centerY: normalizeTransformCenter(this.state.cy ?? 0.5),
-      scaleX: this.state.sx ?? 1,
-      scaleY: this.state.sy ?? 1,
-      translateX: (this.state.dx ?? 0) * 2,
-      translateY: (this.state.dy ?? 0) * 2,
-    };
-  }
+  step(signals: MilkdropRuntimeSignals): MilkdropFrameState {
+    this.geometryState.frameTransformCache.clear();
+    this.runProgram(this.preset.ir.programs.perFrame, this.createEnv(signals));
 
-  private buildProceduralFieldSignals(
-    signals: MilkdropRuntimeSignals,
-  ): MilkdropGpuFieldSignalInputs {
-    return {
-      time: signals.time,
-      frame: signals.frame,
-      fps: signals.fps,
-      bass: signals.bass,
-      mid: signals.mid,
-      mids: signals.mids,
-      treble: signals.treble,
-      bassAtt: signals.bassAtt,
-      midAtt: signals.mid_att,
-      midsAtt: signals.midsAtt,
-      trebleAtt: signals.trebleAtt,
-      beat: signals.beat,
-      beatPulse: signals.beatPulse,
-      rms: signals.rms,
-      vol: signals.vol,
-      music: signals.music,
-      weightedEnergy: signals.weightedEnergy,
-    };
-  }
-
-  private getMeshDensity() {
-    return clamp(
-      Math.round((this.state.mesh_density ?? 16) * this.detailScale),
-      8,
-      28,
-    );
-  }
-
-  private getMotionVectorDescriptorContext(): MotionVectorDescriptorContext | null {
-    const legacyControls =
-      Math.abs(this.state.mv_dx ?? 0) > 0.0001 ||
-      Math.abs(this.state.mv_dy ?? 0) > 0.0001 ||
-      Math.abs(this.state.mv_l ?? 0) > 0.0001 ||
-      this.preset.ir.programs.init.statements.some(
-        (statement) =>
-          statement.target === 'motion_vectors_x' ||
-          statement.target === 'motion_vectors_y',
-      ) ||
-      this.preset.ir.programs.perFrame.statements.some(
-        (statement) =>
-          statement.target === 'motion_vectors_x' ||
-          statement.target === 'motion_vectors_y',
-      );
-
-    if ((this.state.motion_vectors ?? 0) < 0.5 && !legacyControls) {
-      return null;
-    }
-
-    return {
-      legacyControls,
-      countX: clamp(
-        Math.round(this.state.motion_vectors_x ?? 16),
-        1,
-        MAX_MOTION_VECTOR_COLUMNS,
-      ),
-      countY: clamp(
-        Math.round(this.state.motion_vectors_y ?? 12),
-        1,
-        MAX_MOTION_VECTOR_ROWS,
-      ),
-    };
-  }
-
-  private buildMainWave(signals: MilkdropRuntimeSignals) {
-    const drawMode = (this.state.wave_usedots ?? 0) >= 0.5 ? 'dots' : 'line';
-    const useProcedural = this.supportsProceduralWave(drawMode);
-    const built = buildMainWaveFrame({
+    const { visual: mainWave, procedural: proceduralMainWave } = buildMainWave({
       state: this.state,
       signals,
       detailScale: this.detailScale,
-      previousSamples: this.lastWaveSamples,
-      previousMomentum: this.lastWaveMomentum,
-      useProcedural,
+      waveState: this.waveState,
+      supportsProceduralWave: this.supportsProceduralWave.bind(this),
     });
-    this.syncLastWaveSamples(built.nextSamples, built.nextSamples.length);
-    this.syncLastWaveMomentum(built.nextMomentum, built.nextMomentum.length);
-    return {
-      visual: built.visual,
-      procedural: built.procedural,
-    };
-  }
-
-  private buildCustomWaves(signals: MilkdropRuntimeSignals): {
-    visual: MilkdropWaveVisual[];
-    procedural: MilkdropProceduralCustomWaveVisual[];
-  } {
-    const waves: MilkdropWaveVisual[] = [];
-    const proceduralWaves: MilkdropProceduralCustomWaveVisual[] = [];
-
-    this.preset.ir.customWaves.forEach((wave, index) => {
-      const persistent =
-        this.customWaveState[index] ?? this.seedCustomWaveState(wave);
-      const frameLocals = { ...persistent };
-      this.runProgram(
-        wave.programs.perFrame,
-        this.createEnv(signals, frameLocals),
-        frameLocals,
-      );
-      this.customWaveState[index] = { ...frameLocals };
-
-      if ((frameLocals.enabled ?? 0) < 0.5) {
-        return;
-      }
-
-      const sampleCount = clamp(
-        Math.round((frameLocals.samples ?? 64) * this.detailScale),
-        8,
-        256,
-      );
-      const centerX = ((frameLocals.x ?? 0.5) - 0.5) * 2;
-      const centerY = (0.5 - (frameLocals.y ?? 0.5)) * 2;
-      const scaling = frameLocals.scaling ?? 1;
-      const drawMode = (frameLocals.usedots ?? 0) >= 0.5 ? 'dots' : 'line';
-      const additive = (frameLocals.additive ?? 0) >= 0.5;
-      const waveColor = color(
-        frameLocals.r ?? 1,
-        frameLocals.g ?? 1,
-        frameLocals.b ?? 1,
-        frameLocals.a ?? 0.4,
-      );
-      const waveAlpha = clamp(frameLocals.a ?? 0.4, 0.02, 1);
-      const useProcedural = this.supportsProceduralCustomWave(wave, drawMode);
-      const positions = useProcedural ? [] : new Array<number>(sampleCount * 3);
-      const proceduralSamples = useProcedural
-        ? new Array<number>(sampleCount)
-        : null;
-      const pointLocals: MutableState = { ...frameLocals };
-
-      for (let point = 0; point < sampleCount; point += 1) {
-        const sample = point / Math.max(1, sampleCount - 1);
-        const waveChannels = sampleCustomWaveChannels(signals, sample);
-        const spectrumValue = waveChannels.value1;
-        const baseY =
-          centerY +
-          (spectrumValue - 0.5) *
-            0.55 *
-            scaling *
-            (1 + (frameLocals.mystery ?? 0) * 0.25);
-
-        if (useProcedural && proceduralSamples) {
-          proceduralSamples[point] = spectrumValue;
-          continue;
-        }
-
-        Object.assign(pointLocals, frameLocals, {
-          ...waveChannels,
-          x: centerX + (-1 + sample * 2) * 0.85,
-          y:
-            (frameLocals.spectrum ?? 0) >= 0.5
-              ? baseY
-              : centerY +
-                Math.sin(
-                  sample * Math.PI * 2 * (1 + (frameLocals.mystery ?? 0)) +
-                    signals.time,
-                ) *
-                  0.18 *
-                  scaling,
-        });
-        pointLocals.rad = Math.sqrt(
-          pointLocals.x * pointLocals.x + pointLocals.y * pointLocals.y,
-        );
-        pointLocals.ang = Math.atan2(pointLocals.y, pointLocals.x);
-        this.runProgram(
-          wave.programs.perPoint,
-          this.createEnv(signals, pointLocals),
-          pointLocals,
-        );
-        const writeIndex = point * 3;
-        positions[writeIndex] = pointLocals.x;
-        positions[writeIndex + 1] = pointLocals.y;
-        positions[writeIndex + 2] = 0.28;
-      }
-
-      waves.push({
-        positions,
-        color: waveColor,
-        alpha: waveAlpha,
-        thickness: clamp(frameLocals.thick ?? 1, 1, 6),
-        drawMode,
-        additive,
-        pointSize: clamp((frameLocals.thick ?? 1) * 3.2, 1, 14),
-        spectrum: (frameLocals.spectrum ?? 0) >= 0.5,
-      });
-
-      if (useProcedural) {
-        proceduralWaves.push({
-          samples: proceduralSamples ?? [],
-          spectrum: (frameLocals.spectrum ?? 0) >= 0.5,
-          centerX,
-          centerY,
-          scaling,
-          mystery: frameLocals.mystery ?? 0,
-          time: signals.time,
-          color: waveColor,
-          alpha: waveAlpha,
-          additive,
-        });
-      }
+    commitMainWaveFrame({
+      waveState: this.waveState,
+      mainWave,
+      proceduralMainWave,
     });
 
-    return {
-      visual: waves,
-      procedural: proceduralWaves,
-    };
-  }
-
-  private transformMeshPoint(
-    signals: MilkdropRuntimeSignals,
-    gridX: number,
-    gridY: number,
-  ) {
-    const cacheKey = this.getTransformCacheKey(gridX, gridY);
-    const cached = this.frameTransformCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const local: MutableState = {
-      x: gridX,
-      y: gridY,
-      rad: Math.sqrt(gridX * gridX + gridY * gridY),
-      ang: Math.atan2(gridY, gridX),
-      zoom: this.state.zoom ?? 1,
-      zoomexp: this.state.zoomexp ?? 1,
-      rot: this.state.rot ?? 0,
-      warp: this.state.warp ?? 0,
-      cx: this.state.cx ?? 0.5,
-      cy: this.state.cy ?? 0.5,
-      sx: this.state.sx ?? 1,
-      sy: this.state.sy ?? 1,
-      dx: this.state.dx ?? 0,
-      dy: this.state.dy ?? 0,
-    };
-    this.runProgram(
-      this.preset.ir.programs.perPixel,
-      this.createEnv(signals, local),
-      local,
-    );
-
-    const warpAnimSpeed = clamp(this.state.warpanimspeed ?? 1, 0, 4);
-    const angle = local.ang + local.rot;
-    const centerX = normalizeTransformCenter(local.cx ?? 0.5);
-    const centerY = normalizeTransformCenter(local.cy ?? 0.5);
-    const scaleX = local.sx ?? 1;
-    const scaleY = local.sy ?? 1;
-    const translateX = (local.dx ?? 0) * 2;
-    const translateY = (local.dy ?? 0) * 2;
-    const transformedX = (local.x - centerX) * scaleX + centerX + translateX;
-    const transformedY = (local.y - centerY) * scaleY + centerY + translateY;
-    const ripple =
-      Math.sin(
-        local.rad * 12 +
-          signals.time * (0.6 + signals.trebleAtt) * (0.35 + warpAnimSpeed),
-      ) *
-      local.warp *
-      0.08;
-    const radiusNormalized = clamp(local.rad / Math.SQRT2, 0, 1);
-    const zoomExponent = Math.max(local.zoomexp ?? 1, 0.0001);
-    const zoomScale =
-      Math.max(local.zoom ?? 1, 0.0001) **
-      (zoomExponent ** (radiusNormalized * 2 - 1));
-    const px = (transformedX + Math.cos(angle * 3) * ripple) * zoomScale;
-    const py = (transformedY + Math.sin(angle * 4) * ripple) * zoomScale;
-    const cos = Math.cos(local.rot);
-    const sin = Math.sin(local.rot);
-    const transformed = {
-      x: px * cos - py * sin,
-      y: px * sin + py * cos,
-    };
-    this.frameTransformCache.set(cacheKey, transformed);
-    return transformed;
-  }
-
-  private buildMeshField(signals: MilkdropRuntimeSignals): MeshField {
-    const density = this.getMeshDensity();
     const proceduralMeshPlan = this.getProceduralMeshDescriptorPlan();
-    if (proceduralMeshPlan) {
-      return {
-        density,
-        points: [],
-        program: proceduralMeshPlan.fieldProgram,
-        signals: this.buildProceduralFieldSignals(signals),
-      };
-    }
-
-    const points = new Array<MeshFieldPoint>(density * density);
-
-    for (let row = 0; row < density; row += 1) {
-      for (let col = 0; col < density; col += 1) {
-        const x = (col / Math.max(1, density - 1)) * 2 - 1;
-        const y = (row / Math.max(1, density - 1)) * 2 - 1;
-        const point = this.transformMeshPoint(signals, x, y);
-        points[row * density + col] = {
-          sourceX: x,
-          sourceY: y,
-          x: point.x,
-          y: point.y,
-        };
-      }
-    }
-
-    return { density, points, program: null, signals: null };
-  }
-
-  private buildMesh(meshField: MeshField): MilkdropMeshVisual {
-    const colorValue = color(
-      this.state.mesh_r ?? 0.4,
-      this.state.mesh_g ?? 0.6,
-      this.state.mesh_b ?? 1,
-      this.state.mesh_alpha ?? 0.2,
-    );
-    const alpha = clamp(this.state.mesh_alpha ?? 0.2, 0.02, 0.9);
-
-    if (meshField.points.length === 0) {
-      return {
-        positions: [],
-        color: colorValue,
-        alpha,
-      };
-    }
-
-    const positions = new Array<number>(
-      meshField.density * Math.max(0, meshField.density - 1) * 12,
-    );
-    let writeIndex = 0;
-
-    for (let row = 0; row < meshField.density; row += 1) {
-      for (let col = 0; col < meshField.density; col += 1) {
-        const index = row * meshField.density + col;
-        const point = meshField.points[index];
-        if (!point) {
-          continue;
-        }
-
-        if (col + 1 < meshField.density) {
-          const next = meshField.points[index + 1];
-          if (next) {
-            positions[writeIndex] = point.x;
-            positions[writeIndex + 1] = point.y;
-            positions[writeIndex + 2] = -0.25;
-            positions[writeIndex + 3] = next.x;
-            positions[writeIndex + 4] = next.y;
-            positions[writeIndex + 5] = -0.25;
-            writeIndex += 6;
-          }
-        }
-
-        if (row + 1 < meshField.density) {
-          const next = meshField.points[index + meshField.density];
-          if (next) {
-            positions[writeIndex] = point.x;
-            positions[writeIndex + 1] = point.y;
-            positions[writeIndex + 2] = -0.25;
-            positions[writeIndex + 3] = next.x;
-            positions[writeIndex + 4] = next.y;
-            positions[writeIndex + 5] = -0.25;
-            writeIndex += 6;
-          }
-        }
-      }
-    }
-
-    return {
-      positions: positions.slice(0, writeIndex),
-      color: colorValue,
-      alpha,
-    };
-  }
-
-  private getProceduralMeshFieldVisual(
-    meshField: MeshField,
-  ): MilkdropProceduralMeshFieldVisual | null {
-    if (!meshField.signals) {
-      return null;
-    }
-
-    return {
-      density: meshField.density,
-      program: meshField.program,
-      signals: meshField.signals,
-      ...this.buildProceduralFieldTransform(),
-    };
-  }
-
-  private getProceduralMotionVectorFieldVisual(
-    meshField: MeshField,
-  ): MilkdropProceduralMotionVectorFieldVisual | null {
     const proceduralMotionVectorPlan =
       this.getProceduralMotionVectorDescriptorPlan();
-    if (!meshField.signals || !proceduralMotionVectorPlan) {
-      return null;
-    }
-
-    const motionVectorContext = this.getMotionVectorDescriptorContext();
-    if (!motionVectorContext) {
-      return null;
-    }
-
-    const legacyLength = Math.max(0, this.state.mv_l ?? 0);
-    const legacyCellScale =
-      Math.min(
-        2 / Math.max(motionVectorContext.countX, 1),
-        2 / Math.max(motionVectorContext.countY, 1),
-      ) * 0.625;
-
-    return {
-      countX: motionVectorContext.countX,
-      countY: motionVectorContext.countY,
-      sourceOffsetX: motionVectorContext.legacyControls
-        ? clamp(this.state.mv_dx ?? 0, -1, 1)
-        : 0,
-      sourceOffsetY: motionVectorContext.legacyControls
-        ? clamp(this.state.mv_dy ?? 0, -1, 1)
-        : 0,
-      explicitLength:
-        legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale,
-      legacyControls: motionVectorContext.legacyControls,
-      program: proceduralMotionVectorPlan.fieldProgram,
-      signals: meshField.signals,
-      ...this.buildProceduralFieldTransform(),
-    };
-  }
-
-  private buildGpuGeometryHints(
-    meshField: MeshField,
-  ): MilkdropGpuGeometryHints {
-    return {
-      mainWave: null,
-      trailWaves: this.proceduralTrailWaves.slice(),
-      customWaves: [],
-      meshField: this.getProceduralMeshFieldVisual(meshField),
-      motionVectorField: this.getProceduralMotionVectorFieldVisual(meshField),
-    };
-  }
-
-  private buildMotionVectors(
-    signals: MilkdropRuntimeSignals,
-    meshField: MeshField,
-  ): MilkdropMotionVectorVisual[] {
-    const motionVectorContext = this.getMotionVectorDescriptorContext();
-    if (!motionVectorContext) {
-      this.lastMotionVectorField = null;
-      return [];
-    }
-
-    if (this.getProceduralMotionVectorDescriptorPlan() && meshField.signals) {
-      this.lastMotionVectorField = null;
-      return [];
-    }
-
-    const {
-      legacyControls: hasLegacyMotionVectorControls,
-      countX,
-      countY,
-    } = motionVectorContext;
-    const colorValue = color(
-      this.state.mv_r ?? 1,
-      this.state.mv_g ?? 1,
-      this.state.mv_b ?? 1,
-      this.state.mv_a ?? 0.35,
-    );
-    const alpha = clamp(
-      this.state.mv_a ?? 0.35,
-      hasLegacyMotionVectorControls ? 0 : 0.02,
-      1,
-    );
-    const vectors: MilkdropMotionVectorVisual[] = [];
-    const nextHistoryPoints = new Array<MotionVectorHistoryPoint>(
-      countX * countY,
-    );
-    const previousField = this.lastMotionVectorField;
-    const hasPerPixelPrograms =
-      this.preset.ir.programs.perPixel.statements.length > 0;
-    const legacyOffsetX = clamp(this.state.mv_dx ?? 0, -1, 1);
-    const legacyOffsetY = clamp(this.state.mv_dy ?? 0, -1, 1);
-    const legacyLength = Math.max(0, this.state.mv_l ?? 0);
-    const legacyCellScale =
-      Math.min(2 / Math.max(countX, 1), 2 / Math.max(countY, 1)) * 0.625;
-    const explicitLegacyMagnitude =
-      legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale;
-
-    for (let row = 0; row < countY; row += 1) {
-      for (let col = 0; col < countX; col += 1) {
-        const sourceBaseX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
-        const sourceBaseY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
-        const sourceX = hasLegacyMotionVectorControls
-          ? clamp(sourceBaseX + legacyOffsetX, -1, 1)
-          : sourceBaseX;
-        const sourceY = hasLegacyMotionVectorControls
-          ? clamp(sourceBaseY + legacyOffsetY, -1, 1)
-          : sourceBaseY;
-        const index = row * countX + col;
-        const currentPoint = this.transformMeshPoint(signals, sourceX, sourceY);
-        nextHistoryPoints[index] = {
-          sourceX,
-          sourceY,
-          x: currentPoint.x,
-          y: currentPoint.y,
-        };
-        const previous = previousField?.points[index] ?? {
-          sourceX,
-          sourceY,
-          x: sourceX,
-          y: sourceY,
-        };
-        const sourceDx = (currentPoint.x - sourceX) * 1.35;
-        const sourceDy = (currentPoint.y - sourceY) * 1.35;
-        const historyDx = hasPerPixelPrograms
-          ? (currentPoint.x - previous.x) * 1.1
-          : 0;
-        const historyDy = hasPerPixelPrograms
-          ? (currentPoint.y - previous.y) * 1.1
-          : 0;
-        const baseDx = sourceDx + historyDx;
-        const baseDy = sourceDy + historyDy;
-        const baseMagnitude = Math.hypot(baseDx, baseDy);
-        let dx = clamp(baseDx, -0.24, 0.24);
-        let dy = clamp(baseDy, -0.24, 0.24);
-
-        if (hasLegacyMotionVectorControls && explicitLegacyMagnitude > 0.0001) {
-          if (baseMagnitude < 0.0001) {
-            continue;
-          }
-          const normalizedX = baseDx / baseMagnitude;
-          const normalizedY = baseDy / baseMagnitude;
-          dx = normalizedX * explicitLegacyMagnitude;
-          dy = normalizedY * explicitLegacyMagnitude;
-        }
-
-        const magnitude = Math.hypot(dx, dy);
-        if (magnitude < 0.002) {
-          continue;
-        }
-        vectors.push({
-          positions: [
-            currentPoint.x - dx * 0.45,
-            currentPoint.y - dy * 0.45,
-            0.18,
-            currentPoint.x + dx,
-            currentPoint.y + dy,
-            0.18,
-          ],
-          color: colorValue,
-          alpha: hasLegacyMotionVectorControls
-            ? alpha
-            : clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
-          thickness: hasLegacyMotionVectorControls
-            ? clamp(1 + magnitude * 10, 1, 4)
-            : clamp(1 + magnitude * 18, 1, 4),
-          additive: false,
-        });
-      }
-    }
-
-    this.lastMotionVectorField = {
-      countX,
-      countY,
-      points: nextHistoryPoints,
-    };
-    return vectors;
-  }
-
-  private buildShapes(signals: MilkdropRuntimeSignals): MilkdropShapeVisual[] {
-    const builtFromCustom = this.preset.ir.customShapes.map((shape, index) => {
-      const locals = {
-        ...(this.customShapeState[index] ?? this.seedCustomShapeState(shape)),
-      };
-      this.runProgram(
-        shape.programs.perFrame,
-        this.createEnv(signals, locals),
-        locals,
-      );
-      this.customShapeState[index] = { ...locals };
-      if ((locals.enabled ?? 0) < 0.5) {
-        return null;
-      }
-      return this.shapeVisualFromLocals(
-        `shape_${shape.index}`,
-        locals,
-        signals,
-      );
+    const meshField = buildMeshField({
+      state: this.state,
+      preset: this.preset,
+      signals,
+      detailScale: this.detailScale,
+      geometryState: this.geometryState,
+      runProgram: this.runProgram.bind(this),
+      createEnv: this.createEnv.bind(this),
+      proceduralMeshPlan,
     });
-
-    const customShapeIndices = new Set(
-      this.preset.ir.customShapes.map((shape) => shape.index),
-    );
-    const built = builtFromCustom.filter(
-      (shape): shape is MilkdropShapeVisual => shape !== null,
-    );
-
-    for (let index = 1; index <= MAX_CUSTOM_SHAPE_SLOTS; index += 1) {
-      if (customShapeIndices.has(index)) {
-        continue;
-      }
-      const prefix = `shape_${index}`;
-      if ((this.state[`${prefix}_enabled`] ?? 0) < 0.5) {
-        continue;
-      }
-      built.push(
-        this.shapeVisualFromLocals(
-          prefix,
-          {
-            enabled: this.state[`${prefix}_enabled`] ?? 0,
-            sides: this.state[`${prefix}_sides`] ?? 6,
-            x: this.state[`${prefix}_x`] ?? 0.5,
-            y: this.state[`${prefix}_y`] ?? 0.5,
-            rad: this.state[`${prefix}_rad`] ?? 0.15,
-            ang: this.state[`${prefix}_ang`] ?? 0,
-            r: this.state[`${prefix}_r`] ?? 1,
-            g: this.state[`${prefix}_g`] ?? 1,
-            b: this.state[`${prefix}_b`] ?? 1,
-            a: this.state[`${prefix}_a`] ?? 0.2,
-            r2: this.state[`${prefix}_r2`] ?? 0,
-            g2: this.state[`${prefix}_g2`] ?? 0,
-            b2: this.state[`${prefix}_b2`] ?? 0,
-            a2: this.state[`${prefix}_a2`] ?? 0,
-            border_r: this.state[`${prefix}_border_r`] ?? 1,
-            border_g: this.state[`${prefix}_border_g`] ?? 1,
-            border_b: this.state[`${prefix}_border_b`] ?? 1,
-            border_a: this.state[`${prefix}_border_a`] ?? 0.8,
-            additive: this.state[`${prefix}_additive`] ?? 0,
-            thickoutline: this.state[`${prefix}_thickoutline`] ?? 0,
-          },
-          signals,
-        ),
-      );
-    }
-
-    return built;
-  }
-
-  private shapeVisualFromLocals(
-    key: string,
-    locals: MutableState,
-    signals: MilkdropRuntimeSignals,
-  ): MilkdropShapeVisual {
-    const secondaryAlpha = locals.a2 ?? 0;
-    return {
-      key,
-      x: ((locals.x ?? 0.5) - 0.5) * 2,
-      y: (0.5 - (locals.y ?? 0.5)) * 2,
-      radius: clamp(
-        (locals.rad ?? 0.15) * (1 + signals.beatPulse * 0.1),
-        0.04,
-        0.9,
-      ),
-      sides: Math.max(3, Math.round(locals.sides ?? 6)),
-      rotation: (locals.ang ?? 0) + signals.time * 0.08,
-      color: color(
-        locals.r ?? 1,
-        locals.g ?? 0.5,
-        locals.b ?? 0.85,
-        locals.a ?? 0.24,
-      ),
-      secondaryColor:
-        secondaryAlpha > 0
-          ? color(
-              locals.r2 ?? 0,
-              locals.g2 ?? 0,
-              locals.b2 ?? 0,
-              secondaryAlpha,
-            )
-          : null,
-      borderColor: color(
-        locals.border_r ?? 1,
-        locals.border_g ?? 0.84,
-        locals.border_b ?? 1,
-        locals.border_a ?? 0.82,
-      ),
-      additive: (locals.additive ?? 0) >= 0.5,
-      thickOutline: (locals.thickoutline ?? 0) >= 0.5,
-    };
-  }
-
-  private buildBorders(): MilkdropBorderVisual[] {
-    const borders: MilkdropBorderVisual[] = [];
-    if ((this.state.ob_size ?? 0) > 0.001) {
-      borders.push({
-        key: 'outer',
-        size: clamp(this.state.ob_size ?? 0, 0, 0.3),
-        color: color(
-          this.state.ob_r ?? 1,
-          this.state.ob_g ?? 1,
-          this.state.ob_b ?? 1,
-          this.state.ob_a ?? 0.8,
-        ),
-        alpha: clamp(this.state.ob_a ?? 0.8, 0.02, 1),
-        styled: (this.state.ob_border ?? 0) > 0.5,
-      });
-    }
-    if ((this.state.ib_size ?? 0) > 0.001) {
-      borders.push({
-        key: 'inner',
-        size: clamp(this.state.ib_size ?? 0, 0, 0.3),
-        color: color(
-          this.state.ib_r ?? 1,
-          this.state.ib_g ?? 1,
-          this.state.ib_b ?? 1,
-          this.state.ib_a ?? 0.76,
-        ),
-        alpha: clamp(this.state.ib_a ?? 0.76, 0.02, 1),
-        styled: (this.state.ib_border ?? 0) > 0.5,
-      });
-    }
-    return borders;
-  }
-
-  private buildShaderControls(signals: MilkdropRuntimeSignals) {
-    const env = this.createEnv(signals);
-    return evaluateMilkdropShaderControlProgram({
-      warp: this.preset.ir.shaderText.warp,
-      comp: this.preset.ir.shaderText.comp,
-      env,
+    const gpuGeometry = buildGpuGeometryHints({
+      state: this.state,
+      preset: this.preset,
+      meshField,
+      trailWaves: this.waveState.proceduralTrailWaves,
+      proceduralMotionVectorPlan,
     });
-  }
-
-  private buildPost(signals: MilkdropRuntimeSignals): MilkdropPostVisual {
-    return {
-      shaderEnabled: (this.state.shader ?? 1) > 0.5,
-      textureWrap: (this.state.texture_wrap ?? 0) > 0.5,
-      feedbackTexture: (this.state.feedback_texture ?? 0) > 0.5,
-      outerBorderStyle: (this.state.ob_border ?? 0) > 0.5,
-      innerBorderStyle: (this.state.ib_border ?? 0) > 0.5,
-      shaderControls: this.buildShaderControls(signals),
-      shaderPrograms: this.preset.ir.post.shaderPrograms,
-      brighten: (this.state.brighten ?? 0) > 0.5,
-      darken: (this.state.darken ?? 0) > 0.5,
-      darkenCenter: (this.state.darken_center ?? 0) > 0.5,
-      solarize: (this.state.solarize ?? 0) > 0.5,
-      invert: (this.state.invert ?? 0) > 0.5,
-      gammaAdj: clamp(this.state.gammaadj ?? 1, 0.25, 4),
-      videoEchoEnabled: (this.state.video_echo_enabled ?? 0) > 0.5,
-      videoEchoAlpha: clamp(this.state.video_echo_alpha ?? 0.18, 0, 1),
-      videoEchoZoom: clamp(this.state.video_echo_zoom ?? 1, 0.85, 1.3),
-      videoEchoOrientation: normalizeVideoEchoOrientation(
-        this.state.video_echo_orientation ?? 0,
-      ),
-      warp: clamp(this.state.warp ?? 0.08, 0, 1),
-    };
-  }
-
-  step(signals: MilkdropRuntimeSignals): MilkdropFrameState {
-    this.frameTransformCache.clear();
-    this.runProgram(this.preset.ir.programs.perFrame, this.createEnv(signals));
-
-    const { visual: mainWave, procedural: proceduralMainWave } =
-      this.buildMainWave(signals);
-    if (this.lastWaveform) {
-      this.trails.unshift(this.lastWaveform);
-      this.trails = this.trails.slice(0, MAX_TRAILS);
-    }
-    if (this.lastProceduralWave) {
-      this.proceduralTrailWaves.unshift(this.lastProceduralWave);
-      this.proceduralTrailWaves = this.proceduralTrailWaves.slice(
-        0,
-        MAX_TRAILS,
-      );
-    }
-    this.lastWaveform = mainWave;
-    this.lastProceduralWave = proceduralMainWave;
-
-    const meshField = this.buildMeshField(signals);
-    const gpuGeometry = this.buildGpuGeometryHints(meshField);
     gpuGeometry.mainWave = proceduralMainWave;
-    const customWaves = this.buildCustomWaves(signals);
-    const mesh = this.buildMesh(meshField);
-    const motionVectors = this.buildMotionVectors(signals, meshField);
+
+    const customWaves = buildCustomWaves({
+      preset: this.preset,
+      signals,
+      detailScale: this.detailScale,
+      waveState: this.waveState,
+      runProgram: this.runProgram.bind(this),
+      createEnv: this.createEnv.bind(this),
+      seedCustomWaveState: this.seedCustomWaveState.bind(this),
+      supportsProceduralCustomWave:
+        this.supportsProceduralCustomWave.bind(this),
+    });
+    const mesh = buildMesh({
+      state: this.state,
+      meshField,
+    });
+    const motionVectors = buildMotionVectors({
+      state: this.state,
+      preset: this.preset,
+      signals,
+      meshField,
+      geometryState: this.geometryState,
+      runProgram: this.runProgram.bind(this),
+      createEnv: this.createEnv.bind(this),
+      proceduralMotionVectorPlan,
+    });
+    const shapes = buildShapes({
+      preset: this.preset,
+      state: this.state,
+      signals,
+      shapeState: this.shapeState,
+      runProgram: this.runProgram.bind(this),
+      createEnv: this.createEnv.bind(this),
+      seedCustomShapeState: this.seedCustomShapeState.bind(this),
+    });
+    const borders = buildBorders(this.state);
+    const post = buildPost({
+      preset: this.preset,
+      state: this.state,
+      signals,
+      createEnv: this.createEnv.bind(this),
+    });
 
     const frameState: MilkdropFrameState = buildMilkdropFrameState({
       presetId: this.preset.source.id,
@@ -1286,19 +470,19 @@ class MilkdropPresetVM implements MilkdropVM {
       waveform: mainWave,
       mainWave,
       customWaves: customWaves.visual,
-      trails: this.trails,
+      trails: this.waveState.trails,
       mesh,
-      shapes: this.buildShapes(signals),
-      borders: this.buildBorders(),
+      shapes,
+      borders,
       motionVectors,
-      post: this.buildPost(signals),
+      post,
       signals,
       variables: this.getStateSnapshot(),
       compatibility: this.preset.ir.compatibility,
       gpuGeometry,
     });
     gpuGeometry.customWaves = customWaves.procedural;
-    this.frameTransformCache.clear();
+    this.geometryState.frameTransformCache.clear();
 
     return frameState;
   }

--- a/assets/js/milkdrop/vm/geometry-builder.ts
+++ b/assets/js/milkdrop/vm/geometry-builder.ts
@@ -1,0 +1,588 @@
+import type {
+  MilkdropCompiledPreset,
+  MilkdropGpuFieldSignalInputs,
+  MilkdropGpuGeometryHints,
+  MilkdropMeshVisual,
+  MilkdropMotionVectorVisual,
+  MilkdropProceduralMeshDescriptorPlan,
+  MilkdropProceduralMeshFieldVisual,
+  MilkdropProceduralMotionVectorDescriptorPlan,
+  MilkdropProceduralMotionVectorFieldVisual,
+  MilkdropRuntimeSignals,
+} from '../types';
+import {
+  clamp,
+  color,
+  type GeometryBuilderState,
+  MAX_MOTION_VECTOR_COLUMNS,
+  MAX_MOTION_VECTOR_ROWS,
+  type MeshField,
+  type MotionVectorDescriptorContext,
+  type MotionVectorHistoryPoint,
+  type MutableState,
+  normalizeTransformCenter,
+} from './shared';
+
+function getTransformCacheKey(x: number, y: number) {
+  const quantizedX = Math.round((x + 1) * 2048);
+  const quantizedY = Math.round((y + 1) * 2048);
+  return quantizedX * 4096 + quantizedY;
+}
+
+function transformMeshPoint({
+  signals,
+  gridX,
+  gridY,
+  state,
+  preset,
+  geometryState,
+  runProgram,
+  createEnv,
+}: {
+  signals: MilkdropRuntimeSignals;
+  gridX: number;
+  gridY: number;
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+  geometryState: GeometryBuilderState;
+  runProgram: (
+    block: MilkdropCompiledPreset['ir']['programs']['init'],
+    env: MutableState,
+    locals?: MutableState | null,
+  ) => void;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+}) {
+  const cacheKey = getTransformCacheKey(gridX, gridY);
+  const cached = geometryState.frameTransformCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const local: MutableState = {
+    x: gridX,
+    y: gridY,
+    rad: Math.sqrt(gridX * gridX + gridY * gridY),
+    ang: Math.atan2(gridY, gridX),
+    zoom: state.zoom ?? 1,
+    zoomexp: state.zoomexp ?? 1,
+    rot: state.rot ?? 0,
+    warp: state.warp ?? 0,
+    cx: state.cx ?? 0.5,
+    cy: state.cy ?? 0.5,
+    sx: state.sx ?? 1,
+    sy: state.sy ?? 1,
+    dx: state.dx ?? 0,
+    dy: state.dy ?? 0,
+  };
+  runProgram(preset.ir.programs.perPixel, createEnv(signals, local), local);
+
+  const warpAnimSpeed = clamp(state.warpanimspeed ?? 1, 0, 4);
+  const angle = local.ang + local.rot;
+  const centerX = normalizeTransformCenter(local.cx ?? 0.5);
+  const centerY = normalizeTransformCenter(local.cy ?? 0.5);
+  const scaleX = local.sx ?? 1;
+  const scaleY = local.sy ?? 1;
+  const translateX = (local.dx ?? 0) * 2;
+  const translateY = (local.dy ?? 0) * 2;
+  const transformedX = (local.x - centerX) * scaleX + centerX + translateX;
+  const transformedY = (local.y - centerY) * scaleY + centerY + translateY;
+  const ripple =
+    Math.sin(
+      local.rad * 12 +
+        signals.time * (0.6 + signals.trebleAtt) * (0.35 + warpAnimSpeed),
+    ) *
+    local.warp *
+    0.08;
+  const radiusNormalized = clamp(local.rad / Math.SQRT2, 0, 1);
+  const zoomExponent = Math.max(local.zoomexp ?? 1, 0.0001);
+  const zoomScale =
+    Math.max(local.zoom ?? 1, 0.0001) **
+    (zoomExponent ** (radiusNormalized * 2 - 1));
+  const px = (transformedX + Math.cos(angle * 3) * ripple) * zoomScale;
+  const py = (transformedY + Math.sin(angle * 4) * ripple) * zoomScale;
+  const cos = Math.cos(local.rot);
+  const sin = Math.sin(local.rot);
+  const transformed = {
+    x: px * cos - py * sin,
+    y: px * sin + py * cos,
+  };
+  geometryState.frameTransformCache.set(cacheKey, transformed);
+  return transformed;
+}
+
+function getMeshDensity(state: MutableState, detailScale: number) {
+  return clamp(Math.round((state.mesh_density ?? 16) * detailScale), 8, 28);
+}
+
+export function getMotionVectorDescriptorContext({
+  state,
+  preset,
+}: {
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+}): MotionVectorDescriptorContext | null {
+  const legacyControls =
+    Math.abs(state.mv_dx ?? 0) > 0.0001 ||
+    Math.abs(state.mv_dy ?? 0) > 0.0001 ||
+    Math.abs(state.mv_l ?? 0) > 0.0001 ||
+    preset.ir.programs.init.statements.some(
+      (statement) =>
+        statement.target === 'motion_vectors_x' ||
+        statement.target === 'motion_vectors_y',
+    ) ||
+    preset.ir.programs.perFrame.statements.some(
+      (statement) =>
+        statement.target === 'motion_vectors_x' ||
+        statement.target === 'motion_vectors_y',
+    );
+
+  if ((state.motion_vectors ?? 0) < 0.5 && !legacyControls) {
+    return null;
+  }
+
+  return {
+    legacyControls,
+    countX: clamp(
+      Math.round(state.motion_vectors_x ?? 16),
+      1,
+      MAX_MOTION_VECTOR_COLUMNS,
+    ),
+    countY: clamp(
+      Math.round(state.motion_vectors_y ?? 12),
+      1,
+      MAX_MOTION_VECTOR_ROWS,
+    ),
+  };
+}
+
+export function buildProceduralFieldTransform(state: MutableState) {
+  return {
+    zoom: Math.max(state.zoom ?? 1, 0.0001),
+    zoomExponent: Math.max(state.zoomexp ?? 1, 0.0001),
+    rotation: state.rot ?? 0,
+    warp: state.warp ?? 0,
+    warpAnimSpeed: clamp(state.warpanimspeed ?? 1, 0, 4),
+    centerX: normalizeTransformCenter(state.cx ?? 0.5),
+    centerY: normalizeTransformCenter(state.cy ?? 0.5),
+    scaleX: state.sx ?? 1,
+    scaleY: state.sy ?? 1,
+    translateX: (state.dx ?? 0) * 2,
+    translateY: (state.dy ?? 0) * 2,
+  };
+}
+
+export function buildProceduralFieldSignals(
+  signals: MilkdropRuntimeSignals,
+): MilkdropGpuFieldSignalInputs {
+  return {
+    time: signals.time,
+    frame: signals.frame,
+    fps: signals.fps,
+    bass: signals.bass,
+    mid: signals.mid,
+    mids: signals.mids,
+    treble: signals.treble,
+    bassAtt: signals.bassAtt,
+    midAtt: signals.mid_att,
+    midsAtt: signals.midsAtt,
+    trebleAtt: signals.trebleAtt,
+    beat: signals.beat,
+    beatPulse: signals.beatPulse,
+    rms: signals.rms,
+    vol: signals.vol,
+    music: signals.music,
+    weightedEnergy: signals.weightedEnergy,
+  };
+}
+
+export function buildMeshField({
+  state,
+  preset,
+  signals,
+  detailScale,
+  geometryState,
+  runProgram,
+  createEnv,
+  proceduralMeshPlan,
+}: {
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+  signals: MilkdropRuntimeSignals;
+  detailScale: number;
+  geometryState: GeometryBuilderState;
+  runProgram: (
+    block: MilkdropCompiledPreset['ir']['programs']['init'],
+    env: MutableState,
+    locals?: MutableState | null,
+  ) => void;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+  proceduralMeshPlan: MilkdropProceduralMeshDescriptorPlan | null;
+}): MeshField {
+  const density = getMeshDensity(state, detailScale);
+  if (proceduralMeshPlan) {
+    return {
+      density,
+      points: [],
+      program: proceduralMeshPlan.fieldProgram,
+      signals: buildProceduralFieldSignals(signals),
+    };
+  }
+
+  const points = new Array<MeshField['points'][number]>(density * density);
+
+  for (let row = 0; row < density; row += 1) {
+    for (let col = 0; col < density; col += 1) {
+      const x = (col / Math.max(1, density - 1)) * 2 - 1;
+      const y = (row / Math.max(1, density - 1)) * 2 - 1;
+      const point = transformMeshPoint({
+        signals,
+        gridX: x,
+        gridY: y,
+        state,
+        preset,
+        geometryState,
+        runProgram,
+        createEnv,
+      });
+      points[row * density + col] = {
+        sourceX: x,
+        sourceY: y,
+        x: point.x,
+        y: point.y,
+      };
+    }
+  }
+
+  return { density, points, program: null, signals: null };
+}
+
+export function buildMesh({
+  state,
+  meshField,
+}: {
+  state: MutableState;
+  meshField: MeshField;
+}): MilkdropMeshVisual {
+  const colorValue = color(
+    state.mesh_r ?? 0.4,
+    state.mesh_g ?? 0.6,
+    state.mesh_b ?? 1,
+    state.mesh_alpha ?? 0.2,
+  );
+  const alpha = clamp(state.mesh_alpha ?? 0.2, 0.02, 0.9);
+
+  if (meshField.points.length === 0) {
+    return {
+      positions: [],
+      color: colorValue,
+      alpha,
+    };
+  }
+
+  const positions = new Array<number>(
+    meshField.density * Math.max(0, meshField.density - 1) * 12,
+  );
+  let writeIndex = 0;
+
+  for (let row = 0; row < meshField.density; row += 1) {
+    for (let col = 0; col < meshField.density; col += 1) {
+      const index = row * meshField.density + col;
+      const point = meshField.points[index];
+      if (!point) {
+        continue;
+      }
+
+      if (col + 1 < meshField.density) {
+        const next = meshField.points[index + 1];
+        if (next) {
+          positions[writeIndex] = point.x;
+          positions[writeIndex + 1] = point.y;
+          positions[writeIndex + 2] = -0.25;
+          positions[writeIndex + 3] = next.x;
+          positions[writeIndex + 4] = next.y;
+          positions[writeIndex + 5] = -0.25;
+          writeIndex += 6;
+        }
+      }
+
+      if (row + 1 < meshField.density) {
+        const next = meshField.points[index + meshField.density];
+        if (next) {
+          positions[writeIndex] = point.x;
+          positions[writeIndex + 1] = point.y;
+          positions[writeIndex + 2] = -0.25;
+          positions[writeIndex + 3] = next.x;
+          positions[writeIndex + 4] = next.y;
+          positions[writeIndex + 5] = -0.25;
+          writeIndex += 6;
+        }
+      }
+    }
+  }
+
+  return {
+    positions: positions.slice(0, writeIndex),
+    color: colorValue,
+    alpha,
+  };
+}
+
+function getProceduralMeshFieldVisual({
+  state,
+  meshField,
+}: {
+  state: MutableState;
+  meshField: MeshField;
+}): MilkdropProceduralMeshFieldVisual | null {
+  if (!meshField.signals) {
+    return null;
+  }
+
+  return {
+    density: meshField.density,
+    program: meshField.program,
+    signals: meshField.signals,
+    ...buildProceduralFieldTransform(state),
+  };
+}
+
+function getProceduralMotionVectorFieldVisual({
+  state,
+  preset,
+  meshField,
+  proceduralMotionVectorPlan,
+}: {
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+  meshField: MeshField;
+  proceduralMotionVectorPlan: MilkdropProceduralMotionVectorDescriptorPlan | null;
+}): MilkdropProceduralMotionVectorFieldVisual | null {
+  if (!meshField.signals || !proceduralMotionVectorPlan) {
+    return null;
+  }
+
+  const motionVectorContext = getMotionVectorDescriptorContext({
+    state,
+    preset,
+  });
+  if (!motionVectorContext) {
+    return null;
+  }
+
+  const legacyLength = Math.max(0, state.mv_l ?? 0);
+  const legacyCellScale =
+    Math.min(
+      2 / Math.max(motionVectorContext.countX, 1),
+      2 / Math.max(motionVectorContext.countY, 1),
+    ) * 0.625;
+
+  return {
+    countX: motionVectorContext.countX,
+    countY: motionVectorContext.countY,
+    sourceOffsetX: motionVectorContext.legacyControls
+      ? clamp(state.mv_dx ?? 0, -1, 1)
+      : 0,
+    sourceOffsetY: motionVectorContext.legacyControls
+      ? clamp(state.mv_dy ?? 0, -1, 1)
+      : 0,
+    explicitLength:
+      legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale,
+    legacyControls: motionVectorContext.legacyControls,
+    program: proceduralMotionVectorPlan.fieldProgram,
+    signals: meshField.signals,
+    ...buildProceduralFieldTransform(state),
+  };
+}
+
+export function buildGpuGeometryHints({
+  state,
+  preset,
+  meshField,
+  trailWaves,
+  proceduralMotionVectorPlan,
+}: {
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+  meshField: MeshField;
+  trailWaves: import('../types').MilkdropProceduralWaveVisual[];
+  proceduralMotionVectorPlan: MilkdropProceduralMotionVectorDescriptorPlan | null;
+}): MilkdropGpuGeometryHints {
+  return {
+    mainWave: null,
+    trailWaves: trailWaves.slice(),
+    customWaves: [],
+    meshField: getProceduralMeshFieldVisual({ state, meshField }),
+    motionVectorField: getProceduralMotionVectorFieldVisual({
+      state,
+      preset,
+      meshField,
+      proceduralMotionVectorPlan,
+    }),
+  };
+}
+
+export function buildMotionVectors({
+  state,
+  preset,
+  signals,
+  meshField,
+  geometryState,
+  runProgram,
+  createEnv,
+  proceduralMotionVectorPlan,
+}: {
+  state: MutableState;
+  preset: MilkdropCompiledPreset;
+  signals: MilkdropRuntimeSignals;
+  meshField: MeshField;
+  geometryState: GeometryBuilderState;
+  runProgram: (
+    block: MilkdropCompiledPreset['ir']['programs']['init'],
+    env: MutableState,
+    locals?: MutableState | null,
+  ) => void;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+  proceduralMotionVectorPlan: MilkdropProceduralMotionVectorDescriptorPlan | null;
+}): MilkdropMotionVectorVisual[] {
+  const motionVectorContext = getMotionVectorDescriptorContext({
+    state,
+    preset,
+  });
+  if (!motionVectorContext) {
+    geometryState.lastMotionVectorField = null;
+    return [];
+  }
+
+  if (proceduralMotionVectorPlan && meshField.signals) {
+    geometryState.lastMotionVectorField = null;
+    return [];
+  }
+
+  const {
+    legacyControls: hasLegacyMotionVectorControls,
+    countX,
+    countY,
+  } = motionVectorContext;
+  const colorValue = color(
+    state.mv_r ?? 1,
+    state.mv_g ?? 1,
+    state.mv_b ?? 1,
+    state.mv_a ?? 0.35,
+  );
+  const alpha = clamp(
+    state.mv_a ?? 0.35,
+    hasLegacyMotionVectorControls ? 0 : 0.02,
+    1,
+  );
+  const vectors: MilkdropMotionVectorVisual[] = [];
+  const nextHistoryPoints = new Array<MotionVectorHistoryPoint>(
+    countX * countY,
+  );
+  const previousField = geometryState.lastMotionVectorField;
+  const hasPerPixelPrograms = preset.ir.programs.perPixel.statements.length > 0;
+  const legacyOffsetX = clamp(state.mv_dx ?? 0, -1, 1);
+  const legacyOffsetY = clamp(state.mv_dy ?? 0, -1, 1);
+  const legacyLength = Math.max(0, state.mv_l ?? 0);
+  const legacyCellScale =
+    Math.min(2 / Math.max(countX, 1), 2 / Math.max(countY, 1)) * 0.625;
+  const explicitLegacyMagnitude =
+    legacyLength <= 1 ? legacyLength : legacyLength * legacyCellScale;
+
+  for (let row = 0; row < countY; row += 1) {
+    for (let col = 0; col < countX; col += 1) {
+      const sourceBaseX = countX === 1 ? 0 : (col / (countX - 1)) * 2 - 1;
+      const sourceBaseY = countY === 1 ? 0 : (row / (countY - 1)) * 2 - 1;
+      const sourceX = hasLegacyMotionVectorControls
+        ? clamp(sourceBaseX + legacyOffsetX, -1, 1)
+        : sourceBaseX;
+      const sourceY = hasLegacyMotionVectorControls
+        ? clamp(sourceBaseY + legacyOffsetY, -1, 1)
+        : sourceBaseY;
+      const index = row * countX + col;
+      const currentPoint = transformMeshPoint({
+        signals,
+        gridX: sourceX,
+        gridY: sourceY,
+        state,
+        preset,
+        geometryState,
+        runProgram,
+        createEnv,
+      });
+      nextHistoryPoints[index] = {
+        sourceX,
+        sourceY,
+        x: currentPoint.x,
+        y: currentPoint.y,
+      };
+      const previous = previousField?.points[index] ?? {
+        sourceX,
+        sourceY,
+        x: sourceX,
+        y: sourceY,
+      };
+      const sourceDx = (currentPoint.x - sourceX) * 1.35;
+      const sourceDy = (currentPoint.y - sourceY) * 1.35;
+      const historyDx = hasPerPixelPrograms
+        ? (currentPoint.x - previous.x) * 1.1
+        : 0;
+      const historyDy = hasPerPixelPrograms
+        ? (currentPoint.y - previous.y) * 1.1
+        : 0;
+      const baseDx = sourceDx + historyDx;
+      const baseDy = sourceDy + historyDy;
+      const baseMagnitude = Math.hypot(baseDx, baseDy);
+      let dx = clamp(baseDx, -0.24, 0.24);
+      let dy = clamp(baseDy, -0.24, 0.24);
+
+      if (hasLegacyMotionVectorControls && explicitLegacyMagnitude > 0.0001) {
+        if (baseMagnitude < 0.0001) {
+          continue;
+        }
+        const normalizedX = baseDx / baseMagnitude;
+        const normalizedY = baseDy / baseMagnitude;
+        dx = normalizedX * explicitLegacyMagnitude;
+        dy = normalizedY * explicitLegacyMagnitude;
+      }
+
+      const magnitude = Math.hypot(dx, dy);
+      if (magnitude < 0.002) {
+        continue;
+      }
+      vectors.push({
+        positions: [
+          currentPoint.x - dx * 0.45,
+          currentPoint.y - dy * 0.45,
+          0.18,
+          currentPoint.x + dx,
+          currentPoint.y + dy,
+          0.18,
+        ],
+        color: colorValue,
+        alpha: hasLegacyMotionVectorControls
+          ? alpha
+          : clamp(alpha * (0.75 + magnitude * 2.2), 0.02, 1),
+        thickness: hasLegacyMotionVectorControls
+          ? clamp(1 + magnitude * 10, 1, 4)
+          : clamp(1 + magnitude * 18, 1, 4),
+        additive: false,
+      });
+    }
+  }
+
+  geometryState.lastMotionVectorField = {
+    countX,
+    countY,
+    points: nextHistoryPoints,
+  };
+  return vectors;
+}

--- a/assets/js/milkdrop/vm/post-effects-builder.ts
+++ b/assets/js/milkdrop/vm/post-effects-builder.ts
@@ -1,0 +1,68 @@
+import { evaluateMilkdropShaderControlProgram } from '../compiler';
+import type {
+  MilkdropCompiledPreset,
+  MilkdropPostVisual,
+  MilkdropRuntimeSignals,
+} from '../types';
+import {
+  clamp,
+  type MutableState,
+  normalizeVideoEchoOrientation,
+} from './shared';
+
+export function buildShaderControls({
+  preset,
+  signals,
+  createEnv,
+}: {
+  preset: MilkdropCompiledPreset;
+  signals: MilkdropRuntimeSignals;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+}) {
+  return evaluateMilkdropShaderControlProgram({
+    warp: preset.ir.shaderText.warp,
+    comp: preset.ir.shaderText.comp,
+    env: createEnv(signals),
+  });
+}
+
+export function buildPost({
+  preset,
+  state,
+  signals,
+  createEnv,
+}: {
+  preset: MilkdropCompiledPreset;
+  state: MutableState;
+  signals: MilkdropRuntimeSignals;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+}): MilkdropPostVisual {
+  return {
+    shaderEnabled: (state.shader ?? 1) > 0.5,
+    textureWrap: (state.texture_wrap ?? 0) > 0.5,
+    feedbackTexture: (state.feedback_texture ?? 0) > 0.5,
+    outerBorderStyle: (state.ob_border ?? 0) > 0.5,
+    innerBorderStyle: (state.ib_border ?? 0) > 0.5,
+    shaderControls: buildShaderControls({ preset, signals, createEnv }),
+    shaderPrograms: preset.ir.post.shaderPrograms,
+    brighten: (state.brighten ?? 0) > 0.5,
+    darken: (state.darken ?? 0) > 0.5,
+    darkenCenter: (state.darken_center ?? 0) > 0.5,
+    solarize: (state.solarize ?? 0) > 0.5,
+    invert: (state.invert ?? 0) > 0.5,
+    gammaAdj: clamp(state.gammaadj ?? 1, 0.25, 4),
+    videoEchoEnabled: (state.video_echo_enabled ?? 0) > 0.5,
+    videoEchoAlpha: clamp(state.video_echo_alpha ?? 0.18, 0, 1),
+    videoEchoZoom: clamp(state.video_echo_zoom ?? 1, 0.85, 1.3),
+    videoEchoOrientation: normalizeVideoEchoOrientation(
+      state.video_echo_orientation ?? 0,
+    ),
+    warp: clamp(state.warp ?? 0.08, 0, 1),
+  };
+}

--- a/assets/js/milkdrop/vm/shape-border-builder.ts
+++ b/assets/js/milkdrop/vm/shape-border-builder.ts
@@ -1,0 +1,176 @@
+import type {
+  MilkdropBorderVisual,
+  MilkdropCompiledPreset,
+  MilkdropRuntimeSignals,
+  MilkdropShapeDefinition,
+  MilkdropShapeVisual,
+} from '../types';
+import {
+  clamp,
+  color,
+  MAX_CUSTOM_SHAPE_SLOTS,
+  type MutableState,
+  type ShapeBuilderState,
+} from './shared';
+
+export function shapeVisualFromLocals(
+  key: string,
+  locals: MutableState,
+  signals: MilkdropRuntimeSignals,
+): MilkdropShapeVisual {
+  const secondaryAlpha = locals.a2 ?? 0;
+  return {
+    key,
+    x: ((locals.x ?? 0.5) - 0.5) * 2,
+    y: (0.5 - (locals.y ?? 0.5)) * 2,
+    radius: clamp(
+      (locals.rad ?? 0.15) * (1 + signals.beatPulse * 0.1),
+      0.04,
+      0.9,
+    ),
+    sides: Math.max(3, Math.round(locals.sides ?? 6)),
+    rotation: (locals.ang ?? 0) + signals.time * 0.08,
+    color: color(
+      locals.r ?? 1,
+      locals.g ?? 0.5,
+      locals.b ?? 0.85,
+      locals.a ?? 0.24,
+    ),
+    secondaryColor:
+      secondaryAlpha > 0
+        ? color(locals.r2 ?? 0, locals.g2 ?? 0, locals.b2 ?? 0, secondaryAlpha)
+        : null,
+    borderColor: color(
+      locals.border_r ?? 1,
+      locals.border_g ?? 0.84,
+      locals.border_b ?? 1,
+      locals.border_a ?? 0.82,
+    ),
+    additive: (locals.additive ?? 0) >= 0.5,
+    thickOutline: (locals.thickoutline ?? 0) >= 0.5,
+  };
+}
+
+function fallbackShapeLocals(
+  state: MutableState,
+  prefix: string,
+): MutableState {
+  return {
+    enabled: state[`${prefix}_enabled`] ?? 0,
+    sides: state[`${prefix}_sides`] ?? 6,
+    x: state[`${prefix}_x`] ?? 0.5,
+    y: state[`${prefix}_y`] ?? 0.5,
+    rad: state[`${prefix}_rad`] ?? 0.15,
+    ang: state[`${prefix}_ang`] ?? 0,
+    r: state[`${prefix}_r`] ?? 1,
+    g: state[`${prefix}_g`] ?? 1,
+    b: state[`${prefix}_b`] ?? 1,
+    a: state[`${prefix}_a`] ?? 0.2,
+    r2: state[`${prefix}_r2`] ?? 0,
+    g2: state[`${prefix}_g2`] ?? 0,
+    b2: state[`${prefix}_b2`] ?? 0,
+    a2: state[`${prefix}_a2`] ?? 0,
+    border_r: state[`${prefix}_border_r`] ?? 1,
+    border_g: state[`${prefix}_border_g`] ?? 1,
+    border_b: state[`${prefix}_border_b`] ?? 1,
+    border_a: state[`${prefix}_border_a`] ?? 0.8,
+    additive: state[`${prefix}_additive`] ?? 0,
+    thickoutline: state[`${prefix}_thickoutline`] ?? 0,
+  };
+}
+
+export function buildShapes({
+  preset,
+  state,
+  signals,
+  shapeState,
+  runProgram,
+  createEnv,
+  seedCustomShapeState,
+}: {
+  preset: MilkdropCompiledPreset;
+  state: MutableState;
+  signals: MilkdropRuntimeSignals;
+  shapeState: ShapeBuilderState;
+  runProgram: (
+    block: MilkdropCompiledPreset['ir']['programs']['init'],
+    env: MutableState,
+    locals?: MutableState | null,
+  ) => void;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+  seedCustomShapeState: (shape: MilkdropShapeDefinition) => MutableState;
+}): MilkdropShapeVisual[] {
+  const builtFromCustom = preset.ir.customShapes.map((shape, index) => {
+    const locals = {
+      ...(shapeState.customShapeLocals[index] ?? seedCustomShapeState(shape)),
+    };
+    runProgram(shape.programs.perFrame, createEnv(signals, locals), locals);
+    shapeState.customShapeLocals[index] = { ...locals };
+    if ((locals.enabled ?? 0) < 0.5) {
+      return null;
+    }
+    return shapeVisualFromLocals(`shape_${shape.index}`, locals, signals);
+  });
+
+  const customShapeIndices = new Set(
+    preset.ir.customShapes.map((shape) => shape.index),
+  );
+  const built = builtFromCustom.filter(
+    (shape): shape is MilkdropShapeVisual => shape !== null,
+  );
+
+  for (let index = 1; index <= MAX_CUSTOM_SHAPE_SLOTS; index += 1) {
+    if (customShapeIndices.has(index)) {
+      continue;
+    }
+    const prefix = `shape_${index}`;
+    if ((state[`${prefix}_enabled`] ?? 0) < 0.5) {
+      continue;
+    }
+    built.push(
+      shapeVisualFromLocals(
+        prefix,
+        fallbackShapeLocals(state, prefix),
+        signals,
+      ),
+    );
+  }
+
+  return built;
+}
+
+export function buildBorders(state: MutableState): MilkdropBorderVisual[] {
+  const borders: MilkdropBorderVisual[] = [];
+  if ((state.ob_size ?? 0) > 0.001) {
+    borders.push({
+      key: 'outer',
+      size: clamp(state.ob_size ?? 0, 0, 0.3),
+      color: color(
+        state.ob_r ?? 1,
+        state.ob_g ?? 1,
+        state.ob_b ?? 1,
+        state.ob_a ?? 0.8,
+      ),
+      alpha: clamp(state.ob_a ?? 0.8, 0.02, 1),
+      styled: (state.ob_border ?? 0) > 0.5,
+    });
+  }
+  if ((state.ib_size ?? 0) > 0.001) {
+    borders.push({
+      key: 'inner',
+      size: clamp(state.ib_size ?? 0, 0, 0.3),
+      color: color(
+        state.ib_r ?? 1,
+        state.ib_g ?? 1,
+        state.ib_b ?? 1,
+        state.ib_a ?? 0.76,
+      ),
+      alpha: clamp(state.ib_a ?? 0.76, 0.02, 1),
+      styled: (state.ib_border ?? 0) > 0.5,
+    });
+  }
+  return borders;
+}

--- a/assets/js/milkdrop/vm/shared.ts
+++ b/assets/js/milkdrop/vm/shared.ts
@@ -1,0 +1,134 @@
+import type {
+  MilkdropColor,
+  MilkdropGpuFieldSignalInputs,
+  MilkdropProceduralMeshDescriptorPlan,
+  MilkdropProceduralWaveVisual,
+  MilkdropRuntimeSignals,
+  MilkdropWaveVisual,
+} from '../types';
+
+export const MAX_TRAILS = 5;
+export const MAX_CUSTOM_WAVE_SLOTS = 32;
+export const MAX_CUSTOM_SHAPE_SLOTS = 32;
+export const MAX_MOTION_VECTOR_COLUMNS = 96;
+export const MAX_MOTION_VECTOR_ROWS = 72;
+
+export type MutableState = Record<string, number>;
+
+export type MeshFieldPoint = {
+  sourceX: number;
+  sourceY: number;
+  x: number;
+  y: number;
+};
+
+export type MeshField = {
+  density: number;
+  points: MeshFieldPoint[];
+  program: MilkdropProceduralMeshDescriptorPlan['fieldProgram'];
+  signals: MilkdropGpuFieldSignalInputs | null;
+};
+
+export type MotionVectorHistoryPoint = {
+  sourceX: number;
+  sourceY: number;
+  x: number;
+  y: number;
+};
+
+export type MotionVectorFieldHistory = {
+  countX: number;
+  countY: number;
+  points: MotionVectorHistoryPoint[];
+};
+
+export type MotionVectorDescriptorContext = {
+  legacyControls: boolean;
+  countX: number;
+  countY: number;
+};
+
+export type WaveFrameBuffers = {
+  liveSamples: number[];
+  previousSamples: number[];
+  smoothedSamples: number[];
+  momentumSamples: number[];
+};
+
+export type WaveBuilderState = {
+  trails: MilkdropWaveVisual[];
+  lastWaveform: MilkdropWaveVisual | null;
+  lastProceduralWave: MilkdropProceduralWaveVisual | null;
+  lastWaveSamples: number[];
+  lastWaveMomentum: number[];
+  customWaveLocals: MutableState[];
+  proceduralTrailWaves: MilkdropProceduralWaveVisual[];
+  buffers: WaveFrameBuffers;
+};
+
+export type GeometryBuilderState = {
+  lastMotionVectorField: MotionVectorFieldHistory | null;
+  frameTransformCache: Map<number, { x: number; y: number }>;
+};
+
+export type ShapeBuilderState = {
+  customShapeLocals: MutableState[];
+};
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function normalizeVideoEchoOrientation(value: number) {
+  const truncated = Math.trunc(value);
+  return (((truncated % 4) + 4) % 4) as 0 | 1 | 2 | 3;
+}
+
+export function color(r: number, g: number, b: number, a = 1): MilkdropColor {
+  return {
+    r: clamp(r, 0, 1),
+    g: clamp(g, 0, 1),
+    b: clamp(b, 0, 1),
+    a: clamp(a, 0, 1),
+  };
+}
+
+export function hashSeed(input: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function sampleFrequencyData(
+  signals: MilkdropRuntimeSignals,
+  t: number,
+) {
+  const sampleIndex = Math.min(
+    signals.frequencyData.length - 1,
+    Math.max(0, Math.round(t * Math.max(0, signals.frequencyData.length - 1))),
+  );
+  return (signals.frequencyData[sampleIndex] ?? 0) / 255;
+}
+
+export function sampleCustomWaveChannels(
+  signals: MilkdropRuntimeSignals,
+  sample: number,
+) {
+  const normalizedSample = sampleFrequencyData(signals, sample);
+  return {
+    sample,
+    value: normalizedSample,
+    value1: normalizedSample,
+    value2: normalizedSample,
+  };
+}
+
+export function normalizeTransformCenter(value: number) {
+  if (value >= 0 && value <= 1) {
+    return value * 2 - 1;
+  }
+  return value;
+}

--- a/assets/js/milkdrop/vm/wave-builder.ts
+++ b/assets/js/milkdrop/vm/wave-builder.ts
@@ -1,0 +1,237 @@
+import type {
+  MilkdropCompiledPreset,
+  MilkdropProceduralCustomWaveVisual,
+  MilkdropRuntimeSignals,
+  MilkdropWaveDefinition,
+  MilkdropWaveVisual,
+} from '../types';
+import { buildMainWaveFrame } from './frame-generation';
+import {
+  clamp,
+  color,
+  MAX_TRAILS,
+  type MutableState,
+  sampleCustomWaveChannels,
+  type WaveBuilderState,
+} from './shared';
+
+function syncSamples(target: number[], samples: number[], count: number) {
+  target.length = count;
+  for (let index = 0; index < count; index += 1) {
+    target[index] = samples[index] ?? 0;
+  }
+}
+
+export function buildMainWave({
+  state,
+  signals,
+  detailScale,
+  waveState,
+  supportsProceduralWave,
+}: {
+  state: MutableState;
+  signals: MilkdropRuntimeSignals;
+  detailScale: number;
+  waveState: WaveBuilderState;
+  supportsProceduralWave: (drawMode: 'line' | 'dots') => boolean;
+}) {
+  const drawMode = (state.wave_usedots ?? 0) >= 0.5 ? 'dots' : 'line';
+  const built = buildMainWaveFrame({
+    state,
+    signals,
+    detailScale,
+    previousSamples: waveState.lastWaveSamples,
+    previousMomentum: waveState.lastWaveMomentum,
+    useProcedural: supportsProceduralWave(drawMode),
+  });
+  syncSamples(
+    waveState.lastWaveSamples,
+    built.nextSamples,
+    built.nextSamples.length,
+  );
+  syncSamples(
+    waveState.lastWaveMomentum,
+    built.nextMomentum,
+    built.nextMomentum.length,
+  );
+  return {
+    visual: built.visual,
+    procedural: built.procedural,
+  };
+}
+
+export function commitMainWaveFrame({
+  waveState,
+  mainWave,
+  proceduralMainWave,
+}: {
+  waveState: WaveBuilderState;
+  mainWave: MilkdropWaveVisual;
+  proceduralMainWave: import('../types').MilkdropProceduralWaveVisual | null;
+}) {
+  if (waveState.lastWaveform) {
+    waveState.trails.unshift(waveState.lastWaveform);
+    waveState.trails = waveState.trails.slice(0, MAX_TRAILS);
+  }
+  if (waveState.lastProceduralWave) {
+    waveState.proceduralTrailWaves.unshift(waveState.lastProceduralWave);
+    waveState.proceduralTrailWaves = waveState.proceduralTrailWaves.slice(
+      0,
+      MAX_TRAILS,
+    );
+  }
+  waveState.lastWaveform = mainWave;
+  waveState.lastProceduralWave = proceduralMainWave;
+}
+
+export function buildCustomWaves({
+  preset,
+  signals,
+  detailScale,
+  waveState,
+  runProgram,
+  createEnv,
+  seedCustomWaveState,
+  supportsProceduralCustomWave,
+}: {
+  preset: MilkdropCompiledPreset;
+  signals: MilkdropRuntimeSignals;
+  detailScale: number;
+  waveState: WaveBuilderState;
+  runProgram: (
+    block: MilkdropCompiledPreset['ir']['programs']['init'],
+    env: MutableState,
+    locals?: MutableState | null,
+  ) => void;
+  createEnv: (
+    signals: MilkdropRuntimeSignals,
+    extra?: Record<string, number>,
+  ) => MutableState;
+  seedCustomWaveState: (wave: MilkdropWaveDefinition) => MutableState;
+  supportsProceduralCustomWave: (
+    wave: MilkdropWaveDefinition,
+    drawMode: 'line' | 'dots',
+  ) => boolean;
+}): {
+  visual: MilkdropWaveVisual[];
+  procedural: MilkdropProceduralCustomWaveVisual[];
+} {
+  const waves: MilkdropWaveVisual[] = [];
+  const proceduralWaves: MilkdropProceduralCustomWaveVisual[] = [];
+
+  preset.ir.customWaves.forEach((wave, index) => {
+    const persistent =
+      waveState.customWaveLocals[index] ?? seedCustomWaveState(wave);
+    const frameLocals = { ...persistent };
+    runProgram(
+      wave.programs.perFrame,
+      createEnv(signals, frameLocals),
+      frameLocals,
+    );
+    waveState.customWaveLocals[index] = { ...frameLocals };
+
+    if ((frameLocals.enabled ?? 0) < 0.5) {
+      return;
+    }
+
+    const sampleCount = clamp(
+      Math.round((frameLocals.samples ?? 64) * detailScale),
+      8,
+      256,
+    );
+    const centerX = ((frameLocals.x ?? 0.5) - 0.5) * 2;
+    const centerY = (0.5 - (frameLocals.y ?? 0.5)) * 2;
+    const scaling = frameLocals.scaling ?? 1;
+    const drawMode = (frameLocals.usedots ?? 0) >= 0.5 ? 'dots' : 'line';
+    const additive = (frameLocals.additive ?? 0) >= 0.5;
+    const waveColor = color(
+      frameLocals.r ?? 1,
+      frameLocals.g ?? 1,
+      frameLocals.b ?? 1,
+      frameLocals.a ?? 0.4,
+    );
+    const waveAlpha = clamp(frameLocals.a ?? 0.4, 0.02, 1);
+    const useProcedural = supportsProceduralCustomWave(wave, drawMode);
+    const positions = useProcedural ? [] : new Array<number>(sampleCount * 3);
+    const proceduralSamples = useProcedural
+      ? new Array<number>(sampleCount)
+      : null;
+    const pointLocals: MutableState = { ...frameLocals };
+
+    for (let point = 0; point < sampleCount; point += 1) {
+      const sample = point / Math.max(1, sampleCount - 1);
+      const waveChannels = sampleCustomWaveChannels(signals, sample);
+      const spectrumValue = waveChannels.value1;
+      const baseY =
+        centerY +
+        (spectrumValue - 0.5) *
+          0.55 *
+          scaling *
+          (1 + (frameLocals.mystery ?? 0) * 0.25);
+
+      if (useProcedural && proceduralSamples) {
+        proceduralSamples[point] = spectrumValue;
+        continue;
+      }
+
+      Object.assign(pointLocals, frameLocals, {
+        ...waveChannels,
+        x: centerX + (-1 + sample * 2) * 0.85,
+        y:
+          (frameLocals.spectrum ?? 0) >= 0.5
+            ? baseY
+            : centerY +
+              Math.sin(
+                sample * Math.PI * 2 * (1 + (frameLocals.mystery ?? 0)) +
+                  signals.time,
+              ) *
+                0.18 *
+                scaling,
+      });
+      pointLocals.rad = Math.sqrt(
+        pointLocals.x * pointLocals.x + pointLocals.y * pointLocals.y,
+      );
+      pointLocals.ang = Math.atan2(pointLocals.y, pointLocals.x);
+      runProgram(
+        wave.programs.perPoint,
+        createEnv(signals, pointLocals),
+        pointLocals,
+      );
+      const writeIndex = point * 3;
+      positions[writeIndex] = pointLocals.x;
+      positions[writeIndex + 1] = pointLocals.y;
+      positions[writeIndex + 2] = 0.28;
+    }
+
+    waves.push({
+      positions,
+      color: waveColor,
+      alpha: waveAlpha,
+      thickness: clamp(frameLocals.thick ?? 1, 1, 6),
+      drawMode,
+      additive,
+      pointSize: clamp((frameLocals.thick ?? 1) * 3.2, 1, 14),
+      spectrum: (frameLocals.spectrum ?? 0) >= 0.5,
+    });
+
+    if (useProcedural) {
+      proceduralWaves.push({
+        samples: proceduralSamples ?? [],
+        spectrum: (frameLocals.spectrum ?? 0) >= 0.5,
+        centerX,
+        centerY,
+        scaling,
+        mystery: frameLocals.mystery ?? 0,
+        time: signals.time,
+        color: waveColor,
+        alpha: waveAlpha,
+        additive,
+      });
+    }
+  });
+
+  return {
+    visual: waves,
+    procedural: proceduralWaves,
+  };
+}


### PR DESCRIPTION
### Motivation
- Make `MilkdropPresetVM` a high-level coordinator so frame construction is delegated to focused, testable builder modules.
- Isolate wave, geometry, shape/border, and post-effect responsibilities to clarify per-subsystem state ownership and enable unit testing of each pipeline step.
- Replace scattered mutable caches with explicit per-subsystem state objects to make runtime state flows easier to reason about and maintain.

### Description
- Extracted wave-production logic into `assets/js/milkdrop/vm/wave-builder.ts`, mesh/motion-vector logic into `assets/js/milkdrop/vm/geometry-builder.ts`, shape/border logic into `assets/js/milkdrop/vm/shape-border-builder.ts`, post-effect assembly into `assets/js/milkdrop/vm/post-effects-builder.ts`, and shared types/helpers into `assets/js/milkdrop/vm/shared.ts`.
- Updated `assets/js/milkdrop/vm.ts` so `MilkdropPresetVM` now owns `waveState`, `geometryState`, and `shapeState` objects and calls the builders from `step()` to assemble a `MilkdropFrameState`.
- Preserved existing program-evaluation paths (`runProgram`, `createEnv`, `seed*State`) and GPU descriptor gating while moving concrete geometry/wave construction into the new modules.
- Applied Biome/formatting fixes and import reorganizations to integrate the new modules and keep lint/type checks clean.

### Testing
- Ran `bun run check:quick` and the quick quality gate completed successfully.
- Ran `bun run check` (full quality gate including typecheck and tests), which surfaced a failing assertion in `tests/library-filter-state.test.ts` (`replays the initial card preview sync after effects load`), causing the full check to fail.
- Ran targeted Milkdrop test suites `bun run test tests/milkdrop-vm.test.ts tests/milkdrop-renderer-adapter.test.ts tests/milkdrop-projectm-compat.test.ts tests/milkdrop-parity.test.ts` and those tests passed.
- Docs: None.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01bf499708332af151fdf0a861abd)