### PR TITLE
Refactor MilkDrop catalog store modules

### DIFF
--- a/assets/js/milkdrop/catalog-store-analysis.ts
+++ b/assets/js/milkdrop/catalog-store-analysis.ts
@@ -1,0 +1,104 @@
+import { compileMilkdropPresetSource } from './compiler';
+import type {
+  MilkdropBackendSupport,
+  MilkdropBundledCatalogEntry,
+  MilkdropCatalogEntry,
+  MilkdropCompiledPreset,
+  MilkdropPresetSource,
+} from './types';
+
+export function supportsFromCompiled(compiled: MilkdropCompiledPreset): {
+  webgl: MilkdropBackendSupport;
+  webgpu: MilkdropBackendSupport;
+} {
+  return {
+    webgl: compiled.ir.compatibility.backends.webgl,
+    webgpu: compiled.ir.compatibility.backends.webgpu,
+  };
+}
+
+function supportFlagMatchesCompiled(
+  status: MilkdropBackendSupport['status'],
+  flag: boolean | undefined,
+) {
+  if (typeof flag !== 'boolean') {
+    return true;
+  }
+
+  return flag ? status === 'supported' : status !== 'supported';
+}
+
+function catalogSupportsMatchCompiled(
+  entry: MilkdropBundledCatalogEntry,
+  compiled: MilkdropCompiledPreset,
+) {
+  const catalogSupports = entry.supports;
+  if (!catalogSupports) {
+    return true;
+  }
+
+  const compiledSupports = supportsFromCompiled(compiled);
+  return (
+    supportFlagMatchesCompiled(
+      compiledSupports.webgl.status,
+      catalogSupports.webgl,
+    ) &&
+    supportFlagMatchesCompiled(
+      compiledSupports.webgpu.status,
+      catalogSupports.webgpu,
+    )
+  );
+}
+
+export function getValidatedCatalogOverrides(
+  entry: MilkdropBundledCatalogEntry,
+  compiled: MilkdropCompiledPreset,
+): {
+  expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
+  visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
+} {
+  if (!catalogSupportsMatchCompiled(entry, compiled)) {
+    return {};
+  }
+
+  const overrides: {
+    expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
+    visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
+  } = {};
+
+  if (
+    entry.expectedFidelityClass ===
+    compiled.ir.compatibility.parity.fidelityClass
+  ) {
+    overrides.expectedFidelityClass = entry.expectedFidelityClass;
+  }
+
+  if (
+    entry.visualEvidenceTier ===
+    compiled.ir.compatibility.parity.visualEvidenceTier
+  ) {
+    overrides.visualEvidenceTier = entry.visualEvidenceTier;
+  }
+
+  return overrides;
+}
+
+export function createCatalogAnalysis() {
+  const analysisCache = new Map<string, MilkdropCompiledPreset>();
+  const analysisOptionsKey = 'compat';
+
+  const getCompiled = (source: MilkdropPresetSource) => {
+    const cacheKey = `${analysisOptionsKey}:${source.id}:${source.updatedAt ?? 0}:${source.raw}`;
+    const cached = analysisCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const compiled = compileMilkdropPresetSource(source.raw, source);
+    analysisCache.set(cacheKey, compiled);
+    return compiled;
+  };
+
+  return {
+    getCompiled,
+  };
+}

--- a/assets/js/milkdrop/catalog-store-bundled-loader.ts
+++ b/assets/js/milkdrop/catalog-store-bundled-loader.ts
@@ -1,0 +1,93 @@
+import type {
+  MilkdropBundledCatalogEntry,
+  MilkdropPresetSource,
+} from './types';
+
+type BundledCatalogDocument =
+  | MilkdropBundledCatalogEntry[]
+  | {
+      certification?: 'bundled' | 'certified' | 'exploratory';
+      corpusTier?: 'bundled' | 'certified' | 'exploratory';
+      presets?: Array<
+        MilkdropBundledCatalogEntry & {
+          order?: number;
+          compatibility?: {
+            webgl?: boolean;
+            webgpu?: boolean;
+          };
+        }
+      >;
+    };
+
+export async function loadText(url: string) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch preset source: ${url}`);
+  }
+  return response.text();
+}
+
+export function createBundledCatalogLoader({
+  catalogUrl,
+}: {
+  catalogUrl: string;
+}) {
+  const bundledSourceCache = new Map<string, MilkdropPresetSource>();
+  let bundledCatalogPromise: Promise<MilkdropBundledCatalogEntry[]> | null =
+    null;
+
+  const getBundledCatalog = async () => {
+    if (!bundledCatalogPromise) {
+      bundledCatalogPromise = fetch(catalogUrl, { cache: 'no-store' })
+        .then(async (response) => {
+          if (!response.ok) {
+            return [] as MilkdropBundledCatalogEntry[];
+          }
+          const document = (await response.json()) as BundledCatalogDocument;
+          if (Array.isArray(document)) {
+            return document;
+          }
+          const defaultCertification = document.certification ?? 'bundled';
+          const defaultCorpusTier = document.corpusTier ?? 'bundled';
+          return (document.presets ?? []).map((entry) => ({
+            id: entry.id,
+            title: entry.title,
+            author: entry.author,
+            file: entry.file,
+            tags: entry.tags,
+            curatedRank: entry.curatedRank ?? entry.order,
+            certification: entry.certification ?? defaultCertification,
+            corpusTier: entry.corpusTier ?? defaultCorpusTier,
+            expectedFidelityClass: entry.expectedFidelityClass,
+            visualEvidenceTier: entry.visualEvidenceTier,
+            supports: entry.supports ?? entry.compatibility,
+          }));
+        })
+        .catch(() => [] as MilkdropBundledCatalogEntry[]);
+    }
+    return bundledCatalogPromise;
+  };
+
+  const loadBundledSource = async (entry: MilkdropBundledCatalogEntry) => {
+    const cached = bundledSourceCache.get(entry.id);
+    if (cached) {
+      return cached;
+    }
+    const raw = await loadText(entry.file);
+    const source: MilkdropPresetSource = {
+      id: entry.id,
+      title: entry.title,
+      author: entry.author,
+      raw,
+      origin: 'bundled',
+      path: entry.file,
+    };
+    bundledSourceCache.set(entry.id, source);
+    return source;
+  };
+
+  return {
+    getBundledCatalog,
+    loadBundledSource,
+  };
+}

--- a/assets/js/milkdrop/catalog-store-persistence.ts
+++ b/assets/js/milkdrop/catalog-store-persistence.ts
@@ -1,0 +1,215 @@
+import type { MilkdropPresetSource } from './types';
+
+export type StoredPresetRecord = MilkdropPresetSource;
+
+export type StoredMetaRecord = {
+  id: string;
+  favorite?: boolean;
+  rating?: number;
+  lastOpenedAt?: number;
+  draft?: string;
+  stack?: string[];
+};
+
+const DB_OPEN_TIMEOUT_MS = 750;
+
+function requestToPromise<T>(request: IDBRequest<T>) {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function transactionDone(transaction: IDBTransaction) {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}
+
+function openDb(name: string) {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.resolve<IDBDatabase | null>(null);
+  }
+
+  return new Promise<IDBDatabase | null>((resolve, reject) => {
+    const request = indexedDB.open(name, 2);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('presets')) {
+        db.createObjectStore('presets', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('meta')) {
+        db.createObjectStore('meta', { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export function openDbWithTimeout(
+  name: string,
+  timeoutMs = DB_OPEN_TIMEOUT_MS,
+) {
+  return new Promise<IDBDatabase | null>((resolve, reject) => {
+    let settled = false;
+    const timeout = globalThis.setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(null);
+    }, timeoutMs);
+
+    openDb(name).then(
+      (db) => {
+        if (settled) {
+          db?.close();
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolve(db);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function getAllRecords<T>(
+  db: IDBDatabase | null,
+  storeName: string,
+) {
+  if (!db) {
+    return [] as T[];
+  }
+  const transaction = db.transaction(storeName, 'readonly');
+  const store = transaction.objectStore(storeName);
+  const records = await requestToPromise(store.getAll() as IDBRequest<T[]>);
+  await transactionDone(transaction);
+  return records;
+}
+
+export async function getRecord<T>(
+  db: IDBDatabase | null,
+  storeName: string,
+  key: string,
+) {
+  if (!db) {
+    return null as T | null;
+  }
+  const transaction = db.transaction(storeName, 'readonly');
+  const store = transaction.objectStore(storeName);
+  const record = await requestToPromise(
+    store.get(key) as IDBRequest<T | undefined>,
+  );
+  await transactionDone(transaction);
+  return record ?? null;
+}
+
+export async function putRecord<T extends { id: string }>(
+  db: IDBDatabase | null,
+  storeName: string,
+  record: T,
+) {
+  if (!db) {
+    return;
+  }
+  const transaction = db.transaction(storeName, 'readwrite');
+  transaction.objectStore(storeName).put(record);
+  await transactionDone(transaction);
+}
+
+export async function deleteRecord(
+  db: IDBDatabase | null,
+  storeName: string,
+  key: string,
+) {
+  if (!db) {
+    return;
+  }
+  const transaction = db.transaction(storeName, 'readwrite');
+  transaction.objectStore(storeName).delete(key);
+  await transactionDone(transaction);
+}
+
+export function createCatalogPersistence({ dbName }: { dbName: string }) {
+  const memoryPresets = new Map<string, StoredPresetRecord>();
+  const memoryMeta = new Map<string, StoredMetaRecord>();
+  let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+  const getDb = () => {
+    if (!dbPromise) {
+      dbPromise = openDbWithTimeout(dbName).catch(() => null);
+    }
+    return dbPromise;
+  };
+
+  return {
+    async listPresets() {
+      const db = await getDb();
+      return db
+        ? getAllRecords<StoredPresetRecord>(db, 'presets')
+        : [...memoryPresets.values()];
+    },
+
+    async getPreset(id: string) {
+      const db = await getDb();
+      return db
+        ? getRecord<StoredPresetRecord>(db, 'presets', id)
+        : (memoryPresets.get(id) ?? null);
+    },
+
+    async savePreset(record: StoredPresetRecord) {
+      const db = await getDb();
+      if (!db) {
+        memoryPresets.set(record.id, record);
+        return;
+      }
+      await putRecord(db, 'presets', record);
+    },
+
+    async deletePreset(id: string) {
+      const db = await getDb();
+      if (!db) {
+        memoryPresets.delete(id);
+        memoryMeta.delete(id);
+        return;
+      }
+      await deleteRecord(db, 'presets', id);
+      await deleteRecord(db, 'meta', id);
+    },
+
+    async listMeta() {
+      const db = await getDb();
+      return db
+        ? getAllRecords<StoredMetaRecord>(db, 'meta')
+        : [...memoryMeta.values()];
+    },
+
+    async readMeta(id: string) {
+      const db = await getDb();
+      return db
+        ? getRecord<StoredMetaRecord>(db, 'meta', id)
+        : (memoryMeta.get(id) ?? null);
+    },
+
+    async writeMeta(record: StoredMetaRecord) {
+      const db = await getDb();
+      if (!db) {
+        memoryMeta.set(record.id, record);
+        return;
+      }
+      await putRecord(db, 'meta', record);
+    },
+  };
+}

--- a/assets/js/milkdrop/catalog-store-projection.ts
+++ b/assets/js/milkdrop/catalog-store-projection.ts
@@ -1,0 +1,126 @@
+import { supportsFromCompiled } from './catalog-store-analysis';
+import type { StoredMetaRecord } from './catalog-store-persistence';
+import type {
+  MilkdropBundledCatalogEntry,
+  MilkdropCatalogEntry,
+  MilkdropCompiledPreset,
+  MilkdropPresetSource,
+} from './types';
+
+export function toCatalogEntry(
+  source: MilkdropPresetSource,
+  compiled: MilkdropCompiledPreset,
+  meta: StoredMetaRecord | null,
+  options: {
+    tags?: string[];
+    curatedRank?: number;
+    bundledFile?: string;
+    historyIndex?: number;
+    corpusTier?: MilkdropCatalogEntry['corpusTier'];
+    certification?: MilkdropCatalogEntry['certification'];
+    expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
+    visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
+  } = {},
+): MilkdropCatalogEntry {
+  return {
+    id: source.id,
+    title: compiled.title,
+    author: compiled.author ?? source.author,
+    origin: source.origin,
+    tags: options.tags ?? [],
+    curatedRank: options.curatedRank,
+    isFavorite: Boolean(meta?.favorite),
+    rating: meta?.rating ?? 0,
+    lastOpenedAt: meta?.lastOpenedAt,
+    updatedAt: source.updatedAt,
+    historyIndex: options.historyIndex,
+    featuresUsed: compiled.ir.compatibility.featureAnalysis.featuresUsed,
+    warnings: compiled.ir.compatibility.warnings,
+    supports: supportsFromCompiled(compiled),
+    fidelityClass:
+      options.expectedFidelityClass ??
+      compiled.ir.compatibility.parity.fidelityClass,
+    visualEvidenceTier:
+      options.visualEvidenceTier ??
+      compiled.ir.compatibility.parity.visualEvidenceTier,
+    evidence: compiled.ir.compatibility.parity.evidence,
+    certification: options.certification ?? 'exploratory',
+    corpusTier: options.corpusTier ?? 'exploratory',
+    parity: compiled.ir.compatibility.parity,
+    bundledFile: options.bundledFile,
+  };
+}
+
+export function toUnavailableBundledCatalogEntry(
+  entry: MilkdropBundledCatalogEntry,
+  meta: StoredMetaRecord | null,
+  historyIndex: number,
+): MilkdropCatalogEntry {
+  return {
+    id: entry.id,
+    title: entry.title,
+    author: entry.author,
+    origin: 'bundled',
+    tags: entry.tags ?? [],
+    curatedRank: entry.curatedRank,
+    isFavorite: Boolean(meta?.favorite),
+    rating: meta?.rating ?? 0,
+    lastOpenedAt: meta?.lastOpenedAt,
+    updatedAt: undefined,
+    historyIndex,
+    featuresUsed: [],
+    warnings: ['Bundled preset could not be analyzed.'],
+    supports: {
+      webgl: {
+        status: 'partial',
+        reasons: ['Bundled preset could not be analyzed.'],
+        evidence: [],
+        requiredFeatures: [],
+        unsupportedFeatures: [],
+      },
+      webgpu: {
+        status: 'partial',
+        reasons: ['Bundled preset could not be analyzed.'],
+        evidence: [],
+        requiredFeatures: [],
+        unsupportedFeatures: [],
+        recommendedFallback: 'webgl',
+      },
+    },
+    fidelityClass: 'fallback',
+    visualEvidenceTier: 'none',
+    evidence: {
+      compile: 'issues',
+      runtime: 'not-run',
+      visual: 'not-captured',
+    },
+    certification: entry.certification ?? 'bundled',
+    corpusTier: entry.corpusTier ?? 'bundled',
+    parity: {
+      ignoredFields: [],
+      approximatedShaderLines: [],
+      missingAliasesOrFunctions: [],
+      backendDivergence: [],
+      visualFallbacks: [],
+      blockedConstructs: [],
+      blockingConstructDetails: [],
+      degradationReasons: [
+        {
+          code: 'backend-unsupported',
+          category: 'backend-degradation',
+          message: 'Bundled preset could not be analyzed.',
+          system: 'compiler',
+          blocking: true,
+        },
+      ],
+      fidelityClass: 'fallback',
+      evidence: {
+        compile: 'issues',
+        runtime: 'not-run',
+        visual: 'not-captured',
+      },
+      visualEvidenceTier: 'none',
+    },
+    bundledFile: entry.file,
+  };
+}

--- a/assets/js/milkdrop/catalog-store.ts
+++ b/assets/js/milkdrop/catalog-store.ts
@@ -1,42 +1,19 @@
-import { compileMilkdropPresetSource } from './compiler';
-import type {
-  MilkdropBackendSupport,
-  MilkdropBundledCatalogEntry,
-  MilkdropCatalogEntry,
-  MilkdropCatalogStore,
-  MilkdropCompiledPreset,
-  MilkdropPresetSource,
-} from './types';
-
-type StoredPresetRecord = MilkdropPresetSource;
-
-type StoredMetaRecord = {
-  id: string;
-  favorite?: boolean;
-  rating?: number;
-  lastOpenedAt?: number;
-  draft?: string;
-  stack?: string[];
-};
-
-type BundledCatalogDocument =
-  | MilkdropBundledCatalogEntry[]
-  | {
-      certification?: 'bundled' | 'certified' | 'exploratory';
-      corpusTier?: 'bundled' | 'certified' | 'exploratory';
-      presets?: Array<
-        MilkdropBundledCatalogEntry & {
-          order?: number;
-          compatibility?: {
-            webgl?: boolean;
-            webgpu?: boolean;
-          };
-        }
-      >;
-    };
+import {
+  createCatalogAnalysis,
+  getValidatedCatalogOverrides,
+} from './catalog-store-analysis';
+import { createBundledCatalogLoader } from './catalog-store-bundled-loader';
+import {
+  createCatalogPersistence,
+  type StoredMetaRecord,
+} from './catalog-store-persistence';
+import {
+  toCatalogEntry,
+  toUnavailableBundledCatalogEntry,
+} from './catalog-store-projection';
+import type { MilkdropCatalogStore, MilkdropPresetSource } from './types';
 
 const HISTORY_RECORD_ID = '__history__';
-const DB_OPEN_TIMEOUT_MS = 750;
 
 function slugify(value: string) {
   return (
@@ -47,248 +24,6 @@ function slugify(value: string) {
   );
 }
 
-function requestToPromise<T>(request: IDBRequest<T>) {
-  return new Promise<T>((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function transactionDone(transaction: IDBTransaction) {
-  return new Promise<void>((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
-    transaction.onerror = () => reject(transaction.error);
-    transaction.onabort = () => reject(transaction.error);
-  });
-}
-
-function openDb(name: string) {
-  if (typeof indexedDB === 'undefined') {
-    return Promise.resolve<IDBDatabase | null>(null);
-  }
-
-  return new Promise<IDBDatabase | null>((resolve, reject) => {
-    const request = indexedDB.open(name, 2);
-    request.onupgradeneeded = () => {
-      const db = request.result;
-      if (!db.objectStoreNames.contains('presets')) {
-        db.createObjectStore('presets', { keyPath: 'id' });
-      }
-      if (!db.objectStoreNames.contains('meta')) {
-        db.createObjectStore('meta', { keyPath: 'id' });
-      }
-    };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function openDbWithTimeout(name: string, timeoutMs = DB_OPEN_TIMEOUT_MS) {
-  return new Promise<IDBDatabase | null>((resolve, reject) => {
-    let settled = false;
-    const timeout = globalThis.setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(null);
-    }, timeoutMs);
-
-    openDb(name).then(
-      (db) => {
-        if (settled) {
-          db?.close();
-          return;
-        }
-        settled = true;
-        clearTimeout(timeout);
-        resolve(db);
-      },
-      (error) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(timeout);
-        reject(error);
-      },
-    );
-  });
-}
-
-async function getAllRecords<T>(db: IDBDatabase | null, storeName: string) {
-  if (!db) {
-    return [] as T[];
-  }
-  const transaction = db.transaction(storeName, 'readonly');
-  const store = transaction.objectStore(storeName);
-  const records = await requestToPromise(store.getAll() as IDBRequest<T[]>);
-  await transactionDone(transaction);
-  return records;
-}
-
-async function getRecord<T>(
-  db: IDBDatabase | null,
-  storeName: string,
-  key: string,
-) {
-  if (!db) {
-    return null as T | null;
-  }
-  const transaction = db.transaction(storeName, 'readonly');
-  const store = transaction.objectStore(storeName);
-  const record = await requestToPromise(
-    store.get(key) as IDBRequest<T | undefined>,
-  );
-  await transactionDone(transaction);
-  return record ?? null;
-}
-
-async function putRecord<T extends { id: string }>(
-  db: IDBDatabase | null,
-  storeName: string,
-  record: T,
-) {
-  if (!db) {
-    return;
-  }
-  const transaction = db.transaction(storeName, 'readwrite');
-  transaction.objectStore(storeName).put(record);
-  await transactionDone(transaction);
-}
-
-async function deleteRecord(
-  db: IDBDatabase | null,
-  storeName: string,
-  key: string,
-) {
-  if (!db) {
-    return;
-  }
-  const transaction = db.transaction(storeName, 'readwrite');
-  transaction.objectStore(storeName).delete(key);
-  await transactionDone(transaction);
-}
-
-async function loadText(url: string) {
-  const response = await fetch(url, { cache: 'no-store' });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch preset source: ${url}`);
-  }
-  return response.text();
-}
-
-function supportsFromCompiled(compiled: MilkdropCompiledPreset): {
-  webgl: MilkdropBackendSupport;
-  webgpu: MilkdropBackendSupport;
-} {
-  return {
-    webgl: compiled.ir.compatibility.backends.webgl,
-    webgpu: compiled.ir.compatibility.backends.webgpu,
-  };
-}
-
-function supportFlagMatchesCompiled(
-  status: MilkdropBackendSupport['status'],
-  flag: boolean | undefined,
-) {
-  if (typeof flag !== 'boolean') {
-    return true;
-  }
-
-  return flag ? status === 'supported' : status !== 'supported';
-}
-
-function getValidatedCatalogOverrides(
-  entry: MilkdropBundledCatalogEntry,
-  compiled: MilkdropCompiledPreset,
-): {
-  expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
-  visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
-} {
-  const overrides: {
-    expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
-    visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
-  } = {};
-
-  if (
-    entry.expectedFidelityClass ===
-    compiled.ir.compatibility.parity.fidelityClass
-  ) {
-    overrides.expectedFidelityClass = entry.expectedFidelityClass;
-  }
-
-  if (
-    entry.visualEvidenceTier ===
-    compiled.ir.compatibility.parity.visualEvidenceTier
-  ) {
-    overrides.visualEvidenceTier = entry.visualEvidenceTier;
-  }
-
-  const catalogSupports = entry.supports;
-  if (catalogSupports) {
-    const compiledSupports = supportsFromCompiled(compiled);
-    const webglMatches = supportFlagMatchesCompiled(
-      compiledSupports.webgl.status,
-      catalogSupports.webgl,
-    );
-    const webgpuMatches = supportFlagMatchesCompiled(
-      compiledSupports.webgpu.status,
-      catalogSupports.webgpu,
-    );
-
-    if (!webglMatches || !webgpuMatches) {
-      return overrides;
-    }
-  }
-
-  return overrides;
-}
-
-function toCatalogEntry(
-  source: MilkdropPresetSource,
-  compiled: MilkdropCompiledPreset,
-  meta: StoredMetaRecord | null,
-  options: {
-    tags?: string[];
-    curatedRank?: number;
-    bundledFile?: string;
-    historyIndex?: number;
-    corpusTier?: MilkdropCatalogEntry['corpusTier'];
-    certification?: MilkdropCatalogEntry['certification'];
-    expectedFidelityClass?: MilkdropCatalogEntry['fidelityClass'];
-    visualEvidenceTier?: MilkdropCatalogEntry['visualEvidenceTier'];
-  } = {},
-): MilkdropCatalogEntry {
-  return {
-    id: source.id,
-    title: compiled.title,
-    author: compiled.author ?? source.author,
-    origin: source.origin,
-    tags: options.tags ?? [],
-    curatedRank: options.curatedRank,
-    isFavorite: Boolean(meta?.favorite),
-    rating: meta?.rating ?? 0,
-    lastOpenedAt: meta?.lastOpenedAt,
-    updatedAt: source.updatedAt,
-    historyIndex: options.historyIndex,
-    featuresUsed: compiled.ir.compatibility.featureAnalysis.featuresUsed,
-    warnings: compiled.ir.compatibility.warnings,
-    supports: supportsFromCompiled(compiled),
-    fidelityClass:
-      options.expectedFidelityClass ??
-      compiled.ir.compatibility.parity.fidelityClass,
-    visualEvidenceTier:
-      options.visualEvidenceTier ??
-      compiled.ir.compatibility.parity.visualEvidenceTier,
-    evidence: compiled.ir.compatibility.parity.evidence,
-    certification: options.certification ?? 'exploratory',
-    corpusTier: options.corpusTier ?? 'exploratory',
-    parity: compiled.ir.compatibility.parity,
-    bundledFile: options.bundledFile,
-  };
-}
-
 export function createMilkdropCatalogStore({
   dbName = 'stims-milkdrop',
   catalogUrl = '/milkdrop-presets/catalog.json',
@@ -296,216 +31,59 @@ export function createMilkdropCatalogStore({
   dbName?: string;
   catalogUrl?: string;
 } = {}): MilkdropCatalogStore {
-  const memoryPresets = new Map<string, StoredPresetRecord>();
-  const memoryMeta = new Map<string, StoredMetaRecord>();
-  const bundledSourceCache = new Map<string, MilkdropPresetSource>();
-  const analysisCache = new Map<string, MilkdropCompiledPreset>();
-  const analysisOptionsKey = 'compat';
-  let dbPromise: Promise<IDBDatabase | null> | null = null;
-  let bundledCatalogPromise: Promise<MilkdropBundledCatalogEntry[]> | null =
-    null;
-
-  const getDb = () => {
-    if (!dbPromise) {
-      dbPromise = openDbWithTimeout(dbName).catch(() => null);
-    }
-    return dbPromise;
-  };
-
-  const getBundledCatalog = async () => {
-    if (!bundledCatalogPromise) {
-      bundledCatalogPromise = fetch(catalogUrl, { cache: 'no-store' })
-        .then(async (response) => {
-          if (!response.ok) {
-            return [] as MilkdropBundledCatalogEntry[];
-          }
-          const document = (await response.json()) as BundledCatalogDocument;
-          if (Array.isArray(document)) {
-            return document;
-          }
-          const defaultCertification = document.certification ?? 'bundled';
-          const defaultCorpusTier = document.corpusTier ?? 'bundled';
-          return (document.presets ?? []).map((entry) => ({
-            id: entry.id,
-            title: entry.title,
-            author: entry.author,
-            file: entry.file,
-            tags: entry.tags,
-            curatedRank: entry.curatedRank ?? entry.order,
-            certification: entry.certification ?? defaultCertification,
-            corpusTier: entry.corpusTier ?? defaultCorpusTier,
-            expectedFidelityClass: entry.expectedFidelityClass,
-            visualEvidenceTier: entry.visualEvidenceTier,
-            supports: entry.supports ?? entry.compatibility,
-          }));
-        })
-        .catch(() => [] as MilkdropBundledCatalogEntry[]);
-    }
-    return bundledCatalogPromise;
-  };
-
-  const readMeta = async (id: string) => {
-    const db = await getDb();
-    if (!db) {
-      return memoryMeta.get(id) ?? null;
-    }
-    return getRecord<StoredMetaRecord>(db, 'meta', id);
-  };
-
-  const writeMeta = async (record: StoredMetaRecord) => {
-    const db = await getDb();
-    if (!db) {
-      memoryMeta.set(record.id, record);
-      return;
-    }
-    await putRecord(db, 'meta', record);
-  };
+  const persistence = createCatalogPersistence({ dbName });
+  const bundledCatalog = createBundledCatalogLoader({ catalogUrl });
+  const analysis = createCatalogAnalysis();
 
   const getHistoryRecord = async () =>
-    (await readMeta(HISTORY_RECORD_ID)) ?? { id: HISTORY_RECORD_ID, stack: [] };
-
-  const getCompiled = (source: MilkdropPresetSource) => {
-    const cacheKey = `${analysisOptionsKey}:${source.id}:${source.updatedAt ?? 0}:${source.raw}`;
-    const cached = analysisCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const compiled = compileMilkdropPresetSource(source.raw, source);
-    analysisCache.set(cacheKey, compiled);
-    return compiled;
-  };
-
-  const loadBundledSource = async (entry: MilkdropBundledCatalogEntry) => {
-    const cached = bundledSourceCache.get(entry.id);
-    if (cached) {
-      return cached;
-    }
-    const raw = await loadText(entry.file);
-    const source: MilkdropPresetSource = {
-      id: entry.id,
-      title: entry.title,
-      author: entry.author,
-      raw,
-      origin: 'bundled',
-      path: entry.file,
+    (await persistence.readMeta(HISTORY_RECORD_ID)) ?? {
+      id: HISTORY_RECORD_ID,
+      stack: [],
     };
-    bundledSourceCache.set(entry.id, source);
-    return source;
-  };
+
+  const writeMeta = (record: StoredMetaRecord) => persistence.writeMeta(record);
 
   return {
     async listPresets() {
-      const [bundled, db, historyRecord] = await Promise.all([
-        getBundledCatalog(),
-        getDb(),
-        getHistoryRecord(),
-      ]);
-      const storedPresets = db
-        ? await getAllRecords<StoredPresetRecord>(db, 'presets')
-        : [...memoryPresets.values()];
-      const storedMeta = db
-        ? await getAllRecords<StoredMetaRecord>(db, 'meta')
-        : [...memoryMeta.values()];
+      const [bundled, storedPresets, storedMeta, historyRecord] =
+        await Promise.all([
+          bundledCatalog.getBundledCatalog(),
+          persistence.listPresets(),
+          persistence.listMeta(),
+          getHistoryRecord(),
+        ]);
       const metaById = new Map(storedMeta.map((record) => [record.id, record]));
       const history = historyRecord.stack ?? [];
 
       const bundledEntries = await Promise.all(
         bundled.map(async (entry) => {
+          const meta = metaById.get(entry.id) ?? null;
+          const historyIndex = history.indexOf(entry.id);
+
           try {
-            const source = await loadBundledSource(entry);
-            const compiled = getCompiled(source);
+            const source = await bundledCatalog.loadBundledSource(entry);
+            const compiled = analysis.getCompiled(source);
             const validatedOverrides = getValidatedCatalogOverrides(
               entry,
               compiled,
             );
-            return toCatalogEntry(
-              source,
-              compiled,
-              metaById.get(entry.id) ?? null,
-              {
-                tags: entry.tags ?? [],
-                curatedRank: entry.curatedRank,
-                bundledFile: entry.file,
-                historyIndex: history.indexOf(entry.id),
-                certification: entry.certification ?? 'bundled',
-                corpusTier: entry.corpusTier ?? 'bundled',
-                ...validatedOverrides,
-              },
-            );
-          } catch {
-            return {
-              id: entry.id,
-              title: entry.title,
-              author: entry.author,
-              origin: 'bundled' as const,
+            return toCatalogEntry(source, compiled, meta, {
               tags: entry.tags ?? [],
               curatedRank: entry.curatedRank,
-              isFavorite: Boolean(metaById.get(entry.id)?.favorite),
-              rating: metaById.get(entry.id)?.rating ?? 0,
-              lastOpenedAt: metaById.get(entry.id)?.lastOpenedAt,
-              updatedAt: undefined,
-              historyIndex: history.indexOf(entry.id),
-              featuresUsed: [],
-              warnings: ['Bundled preset could not be analyzed.'],
-              supports: {
-                webgl: {
-                  status: 'partial',
-                  reasons: ['Bundled preset could not be analyzed.'],
-                  evidence: [],
-                  requiredFeatures: [],
-                  unsupportedFeatures: [],
-                },
-                webgpu: {
-                  status: 'partial',
-                  reasons: ['Bundled preset could not be analyzed.'],
-                  evidence: [],
-                  requiredFeatures: [],
-                  unsupportedFeatures: [],
-                  recommendedFallback: 'webgl',
-                },
-              },
-              fidelityClass: 'fallback',
-              visualEvidenceTier: 'none',
-              evidence: {
-                compile: 'issues',
-                runtime: 'not-run',
-                visual: 'not-captured',
-              },
+              bundledFile: entry.file,
+              historyIndex,
               certification: entry.certification ?? 'bundled',
               corpusTier: entry.corpusTier ?? 'bundled',
-              parity: {
-                ignoredFields: [],
-                approximatedShaderLines: [],
-                missingAliasesOrFunctions: [],
-                backendDivergence: [],
-                visualFallbacks: [],
-                blockedConstructs: [],
-                blockingConstructDetails: [],
-                degradationReasons: [
-                  {
-                    code: 'backend-unsupported',
-                    category: 'backend-degradation',
-                    message: 'Bundled preset could not be analyzed.',
-                    system: 'compiler',
-                    blocking: true,
-                  },
-                ],
-                fidelityClass: 'fallback',
-                evidence: {
-                  compile: 'issues',
-                  runtime: 'not-run',
-                  visual: 'not-captured',
-                },
-                visualEvidenceTier: 'none',
-              },
-              bundledFile: entry.file,
-            } satisfies MilkdropCatalogEntry;
+              ...validatedOverrides,
+            });
+          } catch {
+            return toUnavailableBundledCatalogEntry(entry, meta, historyIndex);
           }
         }),
       );
 
       const customEntries = storedPresets.map((entry) => {
-        const compiled = getCompiled(entry);
+        const compiled = analysis.getCompiled(entry);
         return toCatalogEntry(entry, compiled, metaById.get(entry.id) ?? null, {
           tags: ['custom'],
           historyIndex: history.indexOf(entry.id),
@@ -547,46 +125,31 @@ export function createMilkdropCatalogStore({
     },
 
     async getPresetSource(id) {
-      const db = await getDb();
-      const stored = db
-        ? await getRecord<StoredPresetRecord>(db, 'presets', id)
-        : (memoryPresets.get(id) ?? null);
+      const stored = await persistence.getPreset(id);
       if (stored) {
         return stored;
       }
 
-      const bundled = await getBundledCatalog();
+      const bundled = await bundledCatalog.getBundledCatalog();
       const entry = bundled.find((candidate) => candidate.id === id);
       if (!entry) {
         return null;
       }
-      return loadBundledSource(entry);
+      return bundledCatalog.loadBundledSource(entry);
     },
 
     async savePreset(source) {
-      const resolved = {
+      const resolved: MilkdropPresetSource = {
         ...source,
         id: source.id || `${slugify(source.title)}-${Date.now()}`,
         updatedAt: source.updatedAt ?? Date.now(),
       };
-      const db = await getDb();
-      if (!db) {
-        memoryPresets.set(resolved.id, resolved);
-        return resolved;
-      }
-      await putRecord(db, 'presets', resolved);
+      await persistence.savePreset(resolved);
       return resolved;
     },
 
     async deletePreset(id) {
-      const db = await getDb();
-      if (!db) {
-        memoryPresets.delete(id);
-        memoryMeta.delete(id);
-      } else {
-        await deleteRecord(db, 'presets', id);
-        await deleteRecord(db, 'meta', id);
-      }
+      await persistence.deletePreset(id);
       const history = await getHistoryRecord();
       const nextStack = (history.stack ?? []).filter((entry) => entry !== id);
       await writeMeta({
@@ -596,26 +159,26 @@ export function createMilkdropCatalogStore({
     },
 
     async saveDraft(id, raw) {
-      const current = (await readMeta(id)) ?? { id };
+      const current = (await persistence.readMeta(id)) ?? { id };
       await writeMeta({ ...current, draft: raw });
     },
 
     async getDraft(id) {
-      return (await readMeta(id))?.draft ?? null;
+      return (await persistence.readMeta(id))?.draft ?? null;
     },
 
     async setFavorite(id, favorite) {
-      const current = (await readMeta(id)) ?? { id };
+      const current = (await persistence.readMeta(id)) ?? { id };
       await writeMeta({ ...current, favorite });
     },
 
     async setRating(id, rating) {
-      const current = (await readMeta(id)) ?? { id };
+      const current = (await persistence.readMeta(id)) ?? { id };
       await writeMeta({ ...current, rating: clampRating(rating) });
     },
 
     async recordRecent(id) {
-      const current = (await readMeta(id)) ?? { id };
+      const current = (await persistence.readMeta(id)) ?? { id };
       await writeMeta({ ...current, lastOpenedAt: Date.now() });
     },
 

--- a/tests/milkdrop-catalog-store.test.ts
+++ b/tests/milkdrop-catalog-store.test.ts
@@ -15,7 +15,7 @@ describe('milkdrop catalog store', () => {
     mock.restore();
   });
 
-  test('ignores optimistic catalog metadata when compiled analysis is weaker', async () => {
+  test('ignores catalog fidelity metadata when support flags do not match compiled analysis', async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/milkdrop-presets/catalog.json')) {
@@ -24,26 +24,26 @@ describe('milkdrop catalog store', () => {
           json: async () => ({
             presets: [
               {
-                id: 'optimistic-pack',
-                title: 'Optimistic Pack',
+                id: 'mismatch-pack',
+                title: 'Mismatch Pack',
                 author: 'Curated',
-                file: '/milkdrop-presets/optimistic-pack.milk',
+                file: '/milkdrop-presets/mismatch-pack.milk',
                 tags: ['curated'],
                 order: 1,
-                expectedFidelityClass: 'exact',
-                visualEvidenceTier: 'visual',
-                supports: { webgl: true, webgpu: true },
+                expectedFidelityClass: 'fallback',
+                visualEvidenceTier: 'compile',
+                supports: { webgl: true, webgpu: false },
               },
             ],
           }),
         };
       }
 
-      if (url.endsWith('/milkdrop-presets/optimistic-pack.milk')) {
+      if (url.endsWith('/milkdrop-presets/mismatch-pack.milk')) {
         return {
           ok: true,
           text: async () =>
-            'title=Optimistic Pack\nvideo_echo=1\nwavecode_0_enabled=1\n',
+            'title=Mismatch Pack\nvideo_echo=1\nwavecode_0_enabled=1\n',
         };
       }
 
@@ -51,12 +51,12 @@ describe('milkdrop catalog store', () => {
     }) as unknown as typeof fetch;
 
     const store = createMilkdropCatalogStore({
-      dbName: 'milkdrop-catalog-store-optimistic-test',
+      dbName: 'milkdrop-catalog-store-support-mismatch-test',
       catalogUrl: '/milkdrop-presets/catalog.json',
     });
 
     const entries = await store.listPresets();
-    const bundled = entries.find((entry) => entry.id === 'optimistic-pack');
+    const bundled = entries.find((entry) => entry.id === 'mismatch-pack');
 
     expect(bundled).toBeDefined();
     expect(bundled?.supports.webgl.status).toBe('supported');
@@ -154,6 +154,38 @@ describe('milkdrop catalog store', () => {
     expect(history[0]).toBe('local-shader');
   });
 
+  test('falls back to memory storage when indexedDB is unavailable', async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/milkdrop-presets/catalog.json')) {
+        return {
+          ok: true,
+          json: async () => ({ presets: [] }),
+        };
+      }
+
+      return { ok: false };
+    }) as unknown as typeof fetch;
+
+    const store = createMilkdropCatalogStore({
+      dbName: 'milkdrop-catalog-store-memory-test',
+      catalogUrl: '/milkdrop-presets/catalog.json',
+    });
+
+    await store.savePreset({
+      id: 'memory-only',
+      title: 'Memory Only',
+      raw: 'title=Memory Only\n',
+      origin: 'user',
+    });
+
+    const saved = await store.getPresetSource('memory-only');
+    expect(saved?.id).toBe('memory-only');
+
+    const entries = await store.listPresets();
+    expect(entries.map((entry) => entry.id)).toContain('memory-only');
+  });
+
   test('falls back to memory storage when indexedDB open stalls', async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -183,13 +215,27 @@ describe('milkdrop catalog store', () => {
     expect(Date.now() - startedAt).toBeLessThan(2000);
 
     await store.savePreset({
-      id: 'memory-only',
-      title: 'Memory Only',
-      raw: 'title=Memory Only\n',
+      id: 'memory-only-stalled',
+      title: 'Memory Only Stalled',
+      raw: 'title=Memory Only Stalled\n',
       origin: 'user',
     });
 
-    const saved = await store.getPresetSource('memory-only');
-    expect(saved?.id).toBe('memory-only');
+    const saved = await store.getPresetSource('memory-only-stalled');
+    expect(saved?.id).toBe('memory-only-stalled');
+  });
+
+  test('returns an empty bundled catalog when the catalog fetch fails', async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    const store = createMilkdropCatalogStore({
+      dbName: 'milkdrop-catalog-store-fetch-failure-test',
+      catalogUrl: '/milkdrop-presets/catalog.json',
+    });
+
+    await expect(store.listPresets()).resolves.toEqual([]);
+    await expect(store.getPresetSource('missing-bundled')).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation
- Split the monolithic catalog store to improve separation of concerns and make storage, bundling, analysis, and projection logic easier to maintain and test.
- Centralize IndexedDB and memory-fallback logic so persistence behavior is consistent and small in-memory fallbacks are explicit.
- Surface and guard catalog fidelity/support metadata validation so bundled metadata cannot incorrectly override compiled analysis.

### Description
- Extracted persistence helpers and the memory fallback into `assets/js/milkdrop/catalog-store-persistence.ts` and exposed `createCatalogPersistence` and `openDbWithTimeout` helpers.
- Extracted bundled catalog fetching and source loading into `assets/js/milkdrop/catalog-store-bundled-loader.ts` and exposed `createBundledCatalogLoader` and `loadText`.
- Extracted compile/caching and support-metadata validation into `assets/js/milkdrop/catalog-store-analysis.ts` with `createCatalogAnalysis`, `supportsFromCompiled`, and `getValidatedCatalogOverrides`.
- Moved catalog entry shaping and the unavailable-bundled fallback into `assets/js/milkdrop/catalog-store-projection.ts` with `toCatalogEntry` and `toUnavailableBundledCatalogEntry` and rebuilt `createMilkdropCatalogStore()` as a thin composition root that composes the new modules.
- Updated and expanded `tests/milkdrop-catalog-store.test.ts` to cover IndexedDB-unavailable, stalled IndexedDB open, bundled catalog fetch failure, and mismatched support-metadata scenarios.

### Testing
- Ran `bun run test tests/milkdrop-catalog-store.test.ts` and all catalog-store tests passed (5 passed, 0 failed).
- Ran the project quality gate with `bun run check`; formatting and typechecking succeeded, but the full test sweep surfaced an existing unrelated assertion failure in `tests/library-filter-state.test.ts` (`initThreeEffects` was called 3 times vs expected 1) that is not related to these catalog-store changes.
- Biome formatting and import-order fixes were applied to the new files as part of the quality checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02507e58c8332be20053aa9991dfb)