### PR TITLE
Keep MilkDrop startup and next navigation on loadable presets

### DIFF
--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -999,10 +999,15 @@ export function createMilkdropExperience({
         overlay.setActiveCollectionTag(requestedCollectionTag);
       }
       const requestedPresetId = consumeRequestedMilkdropPresetSelection();
-      const startupPresetId =
+      const preferredStartupPresetId =
         requestedPresetId ??
         preferences.getStartupPresetId(initialPresetId) ??
         collectionEntry?.id;
+      const startupPresetId =
+        preferredStartupPresetId &&
+        navigation.isBackendSelectable(preferredStartupPresetId, activeBackend)
+          ? preferredStartupPresetId
+          : navigation.getFirstSelectablePresetId(activeBackend);
       if (startupPresetId) {
         await navigation.selectPreset(startupPresetId, {
           recordHistory: false,
@@ -1011,9 +1016,12 @@ export function createMilkdropExperience({
           return;
         }
       }
-      const first = catalogCoordinator.getCatalogEntries()[0];
-      if (first) {
-        await navigation.selectPreset(first.id, { recordHistory: false });
+      const firstSelectablePresetId =
+        navigation.getFirstSelectablePresetId(activeBackend);
+      if (firstSelectablePresetId) {
+        await navigation.selectPreset(firstSelectablePresetId, {
+          recordHistory: false,
+        });
       }
     });
 

--- a/assets/js/milkdrop/runtime/preset-navigation-controller.ts
+++ b/assets/js/milkdrop/runtime/preset-navigation-controller.ts
@@ -51,6 +51,21 @@ export function createMilkdropPresetNavigationController({
       activeBackend: getActiveBackend(),
     });
 
+  const isBackendSelectable = (id: string, backend = getActiveBackend()) => {
+    const entry = catalogCoordinator
+      .getCatalogEntries()
+      .find((candidate) => candidate.id === id);
+    if (!entry) {
+      return true;
+    }
+    return entry.supports[backend].status !== 'unsupported';
+  };
+
+  const getFirstSelectablePresetId = (backend = getActiveBackend()) =>
+    catalogCoordinator.getCatalogEntries().find((entry) => {
+      return entry.supports[backend].status !== 'unsupported';
+    })?.id ?? null;
+
   const selectPreset = async (
     id: string,
     options: { recordHistory?: boolean } = {},
@@ -106,15 +121,26 @@ export function createMilkdropPresetNavigationController({
     if (!catalogEntries.length) {
       return;
     }
+    const selectableEntries = catalogEntries.filter(
+      (entry) => entry.supports[getActiveBackend()].status !== 'unsupported',
+    );
+    const navigationPool = selectableEntries.length
+      ? selectableEntries
+      : catalogEntries;
     const currentIndex = catalogEntries.findIndex(
       (entry) => entry.id === getActivePresetId(),
     );
+    const navigationIndex = navigationPool.findIndex(
+      (entry) => entry.id === getActivePresetId(),
+    );
     const nextIndex =
-      currentIndex >= 0
-        ? (currentIndex + direction + catalogEntries.length) %
-          catalogEntries.length
-        : 0;
-    const next = catalogEntries[nextIndex];
+      navigationIndex >= 0
+        ? (navigationIndex + direction + navigationPool.length) %
+          navigationPool.length
+        : currentIndex >= 0
+          ? Math.min(currentIndex, navigationPool.length - 1)
+          : 0;
+    const next = navigationPool[nextIndex];
     if (next) {
       await selectPreset(next.id);
     }
@@ -166,6 +192,8 @@ export function createMilkdropPresetNavigationController({
   };
 
   return {
+    getFirstSelectablePresetId,
+    isBackendSelectable,
     selectPreset,
     selectAdjacentPreset,
     selectRandomPreset,

--- a/tests/milkdrop-preset-navigation-controller.test.ts
+++ b/tests/milkdrop-preset-navigation-controller.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from 'bun:test';
+import type { MilkdropCatalogCoordinator } from '../assets/js/milkdrop/runtime/catalog-coordinator.ts';
+import { createMilkdropPresetNavigationController } from '../assets/js/milkdrop/runtime/preset-navigation-controller.ts';
+import type {
+  MilkdropBlendState,
+  MilkdropCatalogEntry,
+  MilkdropCatalogStore,
+  MilkdropCompiledPreset,
+  MilkdropEditorSession,
+  MilkdropFrameState,
+  MilkdropPresetSource,
+  MilkdropRenderBackend,
+  MilkdropSupportStatus,
+} from '../assets/js/milkdrop/types.ts';
+
+function createCatalogEntry(
+  id: string,
+  statuses: { webgl: MilkdropSupportStatus; webgpu: MilkdropSupportStatus },
+): MilkdropCatalogEntry {
+  const createBackendSupport = (status: MilkdropSupportStatus) => ({
+    status,
+    reasons: [],
+    evidence: [],
+    requiredFeatures: [],
+    unsupportedFeatures: [],
+  });
+
+  return {
+    id,
+    title: id,
+    origin: 'bundled',
+    tags: [],
+    isFavorite: false,
+    rating: 0,
+    featuresUsed: [],
+    warnings: [],
+    supports: {
+      webgl: createBackendSupport(statuses.webgl),
+      webgpu: createBackendSupport(statuses.webgpu),
+    },
+    fidelityClass: 'fallback',
+    visualEvidenceTier: 'compile',
+    evidence: {
+      visual: 'not-captured',
+      runtime: 'not-run',
+      compile: 'verified',
+    },
+    certification: 'bundled',
+    corpusTier: 'bundled',
+    parity: {
+      ignoredFields: [],
+      fidelityClass: 'fallback',
+      evidence: {
+        visual: 'not-captured',
+        runtime: 'not-run',
+        compile: 'verified',
+      },
+      visualEvidenceTier: 'compile',
+      degradationReasons: [],
+      missingAliasesOrFunctions: [],
+      backendDivergence: [],
+      visualFallbacks: [],
+      approximatedShaderLines: [],
+      blockedConstructs: [],
+      blockingConstructDetails: [],
+    },
+  };
+}
+
+function createCompiledPreset(id: string): MilkdropCompiledPreset {
+  const source: MilkdropPresetSource = {
+    id,
+    title: id,
+    raw: `title=${id}\n`,
+    origin: 'bundled',
+  };
+
+  return {
+    source,
+    title: id,
+    formattedSource: source.raw,
+    ir: {
+      compatibility: {
+        gpuDescriptorPlans: {
+          webgpu: {
+            routing: 'descriptor-plan',
+            proceduralWaves: [],
+            proceduralMesh: null,
+            proceduralMotionVectors: null,
+            feedback: null,
+            unsupported: [],
+          },
+        },
+      },
+    },
+  } as unknown as MilkdropCompiledPreset;
+}
+
+function createSession(compiledById: Record<string, MilkdropCompiledPreset>) {
+  return {
+    async loadPreset(source: MilkdropPresetSource) {
+      return {
+        activeCompiled: compiledById[source.id] ?? null,
+      };
+    },
+  } as MilkdropEditorSession;
+}
+
+describe('milkdrop preset navigation controller', () => {
+  test('prefers a startup preset that is selectable on the current backend', () => {
+    const entries = [
+      createCatalogEntry('unsupported-webgl', {
+        webgl: 'unsupported',
+        webgpu: 'supported',
+      }),
+      createCatalogEntry('supported-webgl', {
+        webgl: 'supported',
+        webgpu: 'supported',
+      }),
+    ];
+
+    const controller = createMilkdropPresetNavigationController({
+      catalogStore: {} as MilkdropCatalogStore,
+      catalogCoordinator: {
+        async syncCatalog() {},
+        scheduleCatalogSync: async () => undefined,
+        async rememberSelection() {},
+        async consumePreviousSelection() {
+          return null;
+        },
+        getCatalogEntries: () => entries,
+        getActiveCatalogEntry: () => null,
+        dispose() {},
+      } as unknown as MilkdropCatalogCoordinator,
+      session: createSession({}),
+      getActivePresetId: () => 'unsupported-webgl',
+      getActiveBackend: () => 'webgl',
+      getCurrentFrameState: () => null as MilkdropFrameState | null,
+      getBlendDuration: () => 1,
+      getTransitionMode: () => 'blend',
+      applyCompiledPreset: () => undefined,
+      setOverlayStatus: () => undefined,
+      shouldFallbackToWebgl: () => false,
+      triggerWebglFallback: () => undefined,
+      rememberLastPreset: () => undefined,
+      preparePresetTransition: (_blendState: MilkdropBlendState | null) =>
+        undefined,
+      markPresetSwitched: () => undefined,
+    });
+
+    expect(controller.isBackendSelectable('unsupported-webgl', 'webgl')).toBe(
+      false,
+    );
+    expect(controller.getFirstSelectablePresetId('webgl')).toBe(
+      'supported-webgl',
+    );
+  });
+
+  test('skips unsupported adjacent presets on the active backend', async () => {
+    const entries = [
+      createCatalogEntry('supported-a', {
+        webgl: 'supported',
+        webgpu: 'supported',
+      }),
+      createCatalogEntry('unsupported-b', {
+        webgl: 'unsupported',
+        webgpu: 'supported',
+      }),
+      createCatalogEntry('supported-c', {
+        webgl: 'partial',
+        webgpu: 'supported',
+      }),
+    ];
+    const compiledById = Object.fromEntries(
+      entries.map((entry) => [entry.id, createCompiledPreset(entry.id)]),
+    );
+    const selected: string[] = [];
+    let activePresetId = 'supported-a';
+
+    const controller = createMilkdropPresetNavigationController({
+      catalogStore: {
+        async getPresetSource(id: string) {
+          return {
+            id,
+            title: id,
+            raw: `title=${id}\n`,
+            origin: 'bundled',
+          };
+        },
+        async getDraft() {
+          return null;
+        },
+      } as unknown as MilkdropCatalogStore,
+      catalogCoordinator: {
+        async syncCatalog() {},
+        async scheduleCatalogSync() {},
+        async rememberSelection() {},
+        async consumePreviousSelection() {
+          return null;
+        },
+        getCatalogEntries: () => entries,
+        getActiveCatalogEntry: () => null,
+        dispose() {},
+      } as unknown as MilkdropCatalogCoordinator,
+      session: createSession(compiledById),
+      getActivePresetId: () => activePresetId,
+      getActiveBackend: () => 'webgl' as MilkdropRenderBackend,
+      getCurrentFrameState: () => null,
+      getBlendDuration: () => 1,
+      getTransitionMode: () => 'blend',
+      applyCompiledPreset: (compiled) => {
+        activePresetId = compiled.source.id;
+        selected.push(compiled.source.id);
+      },
+      setOverlayStatus: () => undefined,
+      shouldFallbackToWebgl: () => false,
+      triggerWebglFallback: () => undefined,
+      rememberLastPreset: () => undefined,
+      preparePresetTransition: () => undefined,
+      markPresetSwitched: () => undefined,
+    });
+
+    await controller.selectAdjacentPreset(1);
+
+    expect(selected).toEqual(['supported-c']);
+    expect(activePresetId).toBe('supported-c');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the visualizer from landing on a remembered/requested preset that cannot run on the active renderer backend, which produced a blank/never-started session for users.
- Ensure adjacent/next navigation lands on presets that actually load for the current backend instead of cycling to unsupported entries.

### Description
- Change startup preset resolution in `createMilkdropExperience` so the requested or remembered preset is only reopened when `navigation.isBackendSelectable(...)` confirms it is loadable, otherwise fall back to the first selectable preset via `navigation.getFirstSelectablePresetId(...)` (`assets/js/milkdrop/runtime.ts`).
- Add `isBackendSelectable` and `getFirstSelectablePresetId` helpers to the preset navigation controller and update `selectAdjacentPreset` to skip presets whose support status is `unsupported` for the active backend (`assets/js/milkdrop/runtime/preset-navigation-controller.ts`).
- Add focused regression tests that assert startup selection honors backend support and that adjacent navigation skips unsupported presets (`tests/milkdrop-preset-navigation-controller.test.ts`).
- No docs modified.

### Testing
- Ran the focused unit tests with `bun run test tests/milkdrop-preset-navigation-controller.test.ts` and they passed (2 tests, 0 failures).
- Ran the full repo gate with `bun run check` (Biome formatting/lint, TypeScript typecheck, and test suite) and it completed successfully (all automated checks passed; 493 pass, 4 skip, 0 fail in this environment).
- Attempted a browser-backed smoke run with `bun run play:toy milkdrop`, but Playwright could not launch in this environment because the Chromium executable was not installed (error: "Please run npx playwright install"), so visual Playwright verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02d6ef024833297350888dd8daf91)