### PR TITLE
Verify video echo orientation parity support

### DIFF
--- a/assets/data/milkdrop-parity/corpus-manifest.json
+++ b/assets/data/milkdrop-parity/corpus-manifest.json
@@ -4,7 +4,7 @@
   "backendTarget": "webgpu",
   "fallbackBackend": "webgl",
   "minimumPresetCount": 100,
-  "presetCount": 101,
+  "presetCount": 102,
   "defaults": {
     "provenance": "Stims parity corpus",
     "license": "Repo fixtures for compatibility testing",
@@ -719,6 +719,13 @@
       "title": "Parity Allowlisted Shader Gap",
       "file": "parity-allowlisted-shader-gap.milk",
       "strata": ["shader-supported", "video-echo"],
+      "allowlisted": false
+    },
+    {
+      "id": "parity-feedback-orientation-01",
+      "title": "Parity Feedback Orientation 01",
+      "file": "parity-feedback-orientation-01.milk",
+      "strata": ["feedback", "video-echo", "orientation"],
       "allowlisted": false
     }
   ],

--- a/tests/fixtures/milkdrop/parity-corpus/parity-feedback-orientation-01.milk
+++ b/tests/fixtures/milkdrop/parity-corpus/parity-feedback-orientation-01.milk
@@ -1,0 +1,7 @@
+title=Parity Feedback Orientation 01
+author=Stim Legacy Corpus
+video_echo_enabled=1
+video_echo_alpha=0.145
+video_echo_zoom=1.018
+echo_orient=2
+per_frame_1=rot = rot + 0.0025; zoom = zoom + 0.001

--- a/tests/milkdrop-overlay.test.ts
+++ b/tests/milkdrop-overlay.test.ts
@@ -249,7 +249,7 @@ describe('milkdrop overlay compatibility messaging', () => {
     globalThis.MutationObserver = OriginalMutationObserver;
   });
 
-  test('shows unsupported feature messaging for imported blocker presets', () => {
+  test('does not show unsupported feature messaging for imported video echo orientation presets', () => {
     globalThis.MutationObserver = class {
       disconnect() {}
       observe() {}
@@ -259,42 +259,19 @@ describe('milkdrop overlay compatibility messaging', () => {
     } as unknown as typeof MutationObserver;
 
     const overlay = createOverlay();
-    const preset = createCatalogEntry('blocked-import', 'Blocked import');
-    preset.origin = 'imported';
-    preset.supports.webgl.status = 'unsupported';
-    preset.supports.webgl.reasons = [
-      'Unsupported feature "video-echo-orientation" from preset field "video_echo_orientation": Video echo orientation is not implemented, so rotated or mirrored feedback trails cannot be reproduced.',
-    ];
-    preset.supports.webgl.evidence = [
-      {
-        backend: 'webgl',
-        scope: 'shared',
-        status: 'unsupported',
-        code: 'unsupported-hard-feature',
-        feature: 'video-echo-orientation',
-        message:
-          'Unsupported feature "video-echo-orientation" from preset field "video_echo_orientation": Video echo orientation is not implemented, so rotated or mirrored feedback trails cannot be reproduced.',
-      },
-    ];
-    preset.supports.webgl.unsupportedFeatures = ['video-echo-orientation'];
-    preset.fidelityClass = 'fallback';
-    preset.parity.degradationReasons = [
-      {
-        code: 'unsupported-hard-feature',
-        category: 'unsupported-syntax',
-        message:
-          'Unsupported feature "video-echo-orientation" is triggered by preset field "video_echo_orientation".',
-        system: 'compiler',
-        blocking: true,
-      },
-    ];
-
-    overlay.setCatalog([preset], 'blocked-import', 'webgl');
-
-    expect(document.body.textContent).toContain(
-      'Unsupported feature: Unsupported feature "video-echo-orientation" is triggered by preset field "video_echo_orientation".',
+    const preset = createCatalogEntry(
+      'supported-import',
+      'Supported orientation import',
     );
-    expect(document.body.textContent).toContain('Blocked import');
+    preset.origin = 'imported';
+    preset.supports.webgl.status = 'supported';
+    preset.supports.webgpu.status = 'supported';
+    preset.fidelityClass = 'near-exact';
+
+    overlay.setCatalog([preset], 'supported-import', 'webgl');
+
+    expect(document.body.textContent).toContain('Supported orientation import');
+    expect(document.body.textContent).not.toContain('Unsupported feature:');
 
     overlay.dispose();
   });

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -98,6 +98,11 @@ const REPRESENTATIVE_BACKEND_EXPECTATIONS = {
       'webgpu:supported-shader-text-gap',
     ],
   },
+  'parity-feedback-orientation-01': {
+    webgl: 'supported',
+    webgpu: 'supported',
+    divergence: [],
+  },
 } as const;
 
 function loadJson<T>(filePath: string): T {
@@ -318,6 +323,43 @@ describe('milkdrop parity corpus harness', () => {
         );
       }
     });
+  });
+
+  test('keeps dedicated video echo orientation parity fixtures fully supported and out of the allowlist path', () => {
+    const manifest = loadJson<ParityManifest>(PARITY_MANIFEST_PATH);
+    const entry = manifest.presets.find(
+      (candidate) => candidate.id === 'parity-feedback-orientation-01',
+    );
+
+    expect(entry).toBeDefined();
+    if (!entry) {
+      throw new Error(
+        'Missing video echo orientation parity fixture in manifest.',
+      );
+    }
+
+    expect(entry.allowlisted).toBe(false);
+    const compiled = compileParityPreset(entry);
+    const frameState = createMilkdropVM(compiled).step(
+      makeSignals({ frame: 4 }),
+    );
+
+    expect(compiled.ir.numericFields.video_echo_orientation).toBe(2);
+    expect(compiled.ir.post.videoEchoOrientation).toBe(2);
+    expect(compiled.ir.compatibility.hardUnsupportedKeys).toEqual([]);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.compatibility.backends.webgpu.status).toBe('supported');
+    expect(compiled.ir.compatibility.parity.blockedConstructs).toEqual([]);
+    expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual(
+      [],
+    );
+    expect(
+      compiled.ir.compatibility.parity.degradationReasons.map(
+        (reason) => reason.code,
+      ),
+    ).not.toContain('allowlisted-gap');
+    expect(frameState.post.videoEchoOrientation).toBe(2);
+    expect(frameState.variables.video_echo_orientation).toBeCloseTo(2, 6);
   });
 
   test('treats former shader-gap parity entries as supported richer shader programs', () => {

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -825,10 +825,66 @@ video_echo=1
     ).toBe(true);
     expect(renderCalls).toBe(1);
     expect(compositeStates[0]?.mixAlpha).toBeGreaterThan(0);
+    expect(compositeStates[0]?.videoEchoOrientation).toBe(0);
     expect(compositeStates[0]?.signalTime).toBeCloseTo(
       frameState.signals.time,
       6,
     );
+  });
+
+  test.each([
+    'webgl',
+    'webgpu',
+  ] as const)('routes video echo orientation through the feedback composite state on %s', (backend) => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Feedback Orientation Routing
+video_echo=1
+video_echo_orientation=3
+        `.trim(),
+      { id: `feedback-orientation-routing-${backend}` },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    const compositeStates: MilkdropFeedbackCompositeState[] = [];
+    const feedback = {
+      applyCompositeState(state: MilkdropFeedbackCompositeState) {
+        compositeStates.push(state);
+      },
+      render() {
+        return true;
+      },
+      swap() {},
+      resize() {},
+      dispose() {},
+    } as MilkdropFeedbackManager;
+
+    const adapter = createMilkdropRendererAdapterCore({
+      scene: new Scene(),
+      camera: new OrthographicCamera(-1, 1, 1, -1, 0, 10),
+      renderer: {
+        getSize: (target: Vector2) => target.set(320, 180),
+        render() {},
+        setRenderTarget() {},
+      },
+      backend,
+      createFeedbackManager: () => feedback,
+    });
+
+    adapter.attach();
+    expect(
+      adapter.render({
+        frameState,
+        blendState: null,
+      }),
+    ).toBe(true);
+
+    expect(compositeStates[0]).toMatchObject({
+      videoEchoOrientation: 3,
+      zoom:
+        frameState.post.videoEchoZoom +
+        frameState.post.shaderControls.warpScale * 0.04,
+    });
   });
 
   test('forwards overlay and warp volume sampling metadata into feedback state', () => {


### PR DESCRIPTION
### Motivation
- Audit showed there are no active hard-unsupported field specs and the parity allowlist is empty, so `video_echo_orientation` was prioritized as the remaining divergence to resolve or explicitly document.
- The change ensures `video_echo_orientation` is treated as a supported, first-class post-effect input and that the system routes it consistently through compile → IR → VM → feedback composite state for both WebGL and WebGPU.

### Description
- Added a certified parity corpus fixture `tests/fixtures/milkdrop/parity-corpus/parity-feedback-orientation-01.milk` and registered it in `assets/data/milkdrop-parity/corpus-manifest.json` (incremented `presetCount`).
- Added a parity regression test in `tests/milkdrop-parity.test.ts` that verifies the fixture is not allowlisted, compiles without hard-unsupported keys, preserves normalized `video_echo_orientation` in IR/post, and produces the expected VM post state.
- Added renderer-adapter tests in `tests/milkdrop-renderer-adapter.test.ts` that assert `videoEchoOrientation` is forwarded into the feedback composite state for both `webgl` and `webgpu` runs, and added an assertion for the existing feedback composite case.
- Replaced a stale overlay test that simulated orientation as an unsupported import with one that asserts supported orientation imports do not show unsupported-feature messaging in `tests/milkdrop-overlay.test.ts`.

### Testing
- Ran targeted test subset with `bun run test tests/milkdrop-overlay.test.ts tests/milkdrop-parity.test.ts tests/milkdrop-renderer-adapter.test.ts`, and all tests passed.
- Ran the project quality gate with `bun run check` (Biome format/lint, TypeScript typecheck, and tests) and the check completed successfully.
- No changes were made to `assets/data/milkdrop-parity/allowlist.json` (it remains empty) and no new hard-unsupported specs were added; the test fixtures prove consistent support or rejection behavior for `video_echo_orientation`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d8ed45083328495a49e1f135144)