### PR TITLE
Refactor audio source help disclosures

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1534,13 +1534,19 @@ body {
 }
 
 .control-panel__info-wrap {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  width: fit-content;
+}
+
+.control-panel__info-disclosure {
+  display: grid;
+  gap: 6px;
 }
 
 .control-panel__info {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
   border: none;
   background: none;
   padding: 0;
@@ -1551,6 +1557,22 @@ body {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
+  list-style: none;
+}
+
+.control-panel__info::-webkit-details-marker {
+  display: none;
+}
+
+.control-panel__info::after {
+  content: "▾";
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.control-panel__info-disclosure[open] .control-panel__info::after {
+  transform: rotate(180deg);
 }
 
 .control-panel__info:focus-visible {
@@ -1560,20 +1582,14 @@ body {
 }
 
 .control-panel__info-text {
+  max-width: min(32rem, 100%);
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(155, 243, 255, 0.22);
+  background: rgba(10, 18, 28, 0.72);
   font-size: 0.85rem;
-  color: rgba(233, 251, 255, 0.85);
-  opacity: 0;
-  max-height: 0;
-  overflow: hidden;
-  transition:
-    opacity 0.2s ease,
-    max-height 0.2s ease;
-}
-
-.control-panel__info-wrap:hover .control-panel__info-text,
-.control-panel__info-wrap:focus-within .control-panel__info-text {
-  opacity: 1;
-  max-height: 80px;
+  line-height: 1.45;
+  color: rgba(233, 251, 255, 0.9);
 }
 
 .control-panel__note {

--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -751,6 +751,40 @@ function renderPostStartGuidance({
   `;
 }
 
+function renderSourceHelpDisclosure({
+  sourceLabelId,
+  summaryId,
+  panelId,
+  summary,
+  content,
+}: {
+  sourceLabelId: string;
+  summaryId: string;
+  panelId: string;
+  summary: string;
+  content: string;
+}) {
+  return `
+    <details class="control-panel__info-wrap control-panel__info-disclosure">
+      <summary
+        id="${summaryId}"
+        class="control-panel__info"
+        aria-controls="${panelId}"
+      >
+        ${summary}
+      </summary>
+      <div
+        id="${panelId}"
+        class="control-panel__info-text"
+        role="note"
+        aria-labelledby="${sourceLabelId} ${summaryId}"
+      >
+        ${content}
+      </div>
+    </details>
+  `;
+}
+
 function renderAdvancedSources(options: AudioControlsOptions) {
   if (!options.onRequestTabAudio && !options.onRequestYouTubeAudio) {
     return '';
@@ -766,20 +800,15 @@ function renderAdvancedSources(options: AudioControlsOptions) {
             ? `
         <div class="control-panel__row">
           <div class="control-panel__text">
-            <span class="control-panel__label">Tab capture</span>
-            <span class="control-panel__info-wrap">
-              <button
-                class="control-panel__info"
-                type="button"
-                aria-describedby="tab-audio-info"
-              >
-                Tab tips
-              </button>
-              <span id="tab-audio-info" class="control-panel__info-text">
-                Capture sound from the current tab. In the picker, choose “This tab” and enable
-                Share audio.
-              </span>
-            </span>
+            <span id="tab-audio-label" class="control-panel__label">Tab capture</span>
+            ${renderSourceHelpDisclosure({
+              sourceLabelId: 'tab-audio-label',
+              summaryId: 'tab-audio-summary',
+              panelId: 'tab-audio-info',
+              summary: 'Tab tips',
+              content:
+                'Capture sound from the current tab. In the picker, choose “This tab” and enable Share audio.',
+            })}
           </div>
           <button id="use-tab-audio" class="cta-button" type="button">Capture tab</button>
         </div>
@@ -791,20 +820,15 @@ function renderAdvancedSources(options: AudioControlsOptions) {
             ? `
         <div class="control-panel__row control-panel__row--stacked">
           <div class="control-panel__text">
-            <span class="control-panel__label">YouTube capture</span>
-            <span class="control-panel__info-wrap">
-              <button
-                class="control-panel__info"
-                type="button"
-                aria-describedby="youtube-audio-info"
-              >
-                YouTube tips
-              </button>
-              <span id="youtube-audio-info" class="control-panel__info-text">
-                Paste a link, load it, then capture. In the picker, choose “This tab” and enable
-                Share audio. The embedded video keeps playing with sound here while it drives the visualizer.
-              </span>
-            </span>
+            <span id="youtube-audio-label" class="control-panel__label">YouTube capture</span>
+            ${renderSourceHelpDisclosure({
+              sourceLabelId: 'youtube-audio-label',
+              summaryId: 'youtube-audio-summary',
+              panelId: 'youtube-audio-info',
+              summary: 'YouTube tips',
+              content:
+                'Paste a link, load it, then capture. In the picker, choose “This tab” and enable Share audio. The embedded video keeps playing with sound here while it drives the visualizer.',
+            })}
           </div>
           <div class="control-panel__field">
             <label class="sr-only" for="youtube-url">YouTube URL</label>


### PR DESCRIPTION
### Motivation
- Replace hover/focus-only tooltip reveal with a declarative disclosure so the "Tab tips" and "YouTube tips" help text is readable on coarse-pointer/touch devices and no longer relies on hover.
- Preserve the visible labels and accessible relationships so screen readers can announce the help content clearly.

### Description
- Introduced a reusable helper `renderSourceHelpDisclosure` and replaced the previous `.control-panel__info-wrap`/button + reveal span pairs in `renderAdvancedSources` with `<details>/<summary>` disclosures for Tab and YouTube help panels in `assets/js/ui/audio-controls.ts`.
- Updated `assets/css/base.css` to add `.control-panel__info-disclosure`, style the disclosure `summary` trigger (chevron, focus state), style the persistent help panel, and removed the old `opacity`/`max-height` hover/focus reveal rules tied to `.control-panel__info-text`.
- Kept visible labels (`Tab tips`, `YouTube tips`) and wired `aria` attributes (`aria-controls`, `aria-labelledby`) to preserve accessible context.

### Testing
- Ran `bun run check` (runs Biome checks, TypeScript `tsc --noEmit`, and the test suite) and it completed successfully with the test suite results: 503 passed, 4 skipped, 0 failed.
- `biome format`/lint were run during commit and reported no outstanding issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09fe92dc883328cd4df768e451427)