### PR TITLE
Defer offscreen card rendering in index styles

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1249,6 +1249,13 @@ header.hero {
     rgba(255, 255, 255, 0.03);
 }
 
+@supports (content-visibility: auto) {
+  .milkdrop-showcase__card {
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 220px;
+  }
+}
+
 .milkdrop-showcase__card-eyebrow {
   margin: 0;
   font-size: 0.72rem;
@@ -3264,6 +3271,13 @@ html.light .search-meta__note {
   touch-action: manipulation;
   min-height: clamp(188px, 18vw, 224px);
   isolation: isolate;
+}
+
+@supports (content-visibility: auto) {
+  .webtoy-card {
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 320px;
+  }
 }
 
 html:not(.light) .webtoy-card {
@@ -5800,6 +5814,28 @@ body[data-page="home"] .content {
 .launch-check p:last-child {
   color: var(--text-muted);
   line-height: 1.55;
+}
+
+@supports (content-visibility: auto) {
+  .home-lineage__card,
+  .home-source__card,
+  .home-showcase__frame,
+  .launch-check {
+    content-visibility: auto;
+  }
+
+  .home-lineage__card,
+  .home-source__card {
+    contain-intrinsic-size: 1px 220px;
+  }
+
+  .home-showcase__frame {
+    contain-intrinsic-size: 1px 680px;
+  }
+
+  .launch-check {
+    contain-intrinsic-size: 1px 180px;
+  }
 }
 
 .launch-workspace__header {


### PR DESCRIPTION
### Motivation
- Reduce layout and paint cost for repeated, below-the-fold card/list surfaces by deferring rendering of offscreen items where safe. 
- Target visually self-contained, repeatable blocks (card/list containers and showcase frames) so the JS rendering model and interactions are unchanged. 
- Avoid measurement-sensitive elements (sticky/fixed or overlay panels) and verify preview/measurement code paths to ensure no regressions.

### Description
- Added `content-visibility: auto` and `contain-intrinsic-size` hints in `assets/css/index.css` for repeated/below-the-fold surfaces: `.webtoy-card`, `.milkdrop-showcase__card`, `.home-lineage__card`, `.home-source__card`, `.home-showcase__frame`, and `.launch-check`.
- Chose conservative intrinsic sizes: `1px 320px` for `.webtoy-card`, `1px 220px` for `.milkdrop-showcase__card`, `1px 220px` for lineage/source cards, `1px 680px` for the showcase frame, and `1px 180px` for the launch-check panel.
- Kept the change CSS-only after reviewing `assets/js/library-view/render-list.js` and `assets/js/library-view/three-library-effects.ts` (including `LIBRARY_RENDER_BATCH_SIZE` and `syncCardPreviews`) to ensure preview initialization and batch rendering do not rely on immediate element measurement.

### Testing
- Ran the quick quality gate with `bun run check:quick`, which includes Biome checks and TypeScript typecheck, and it completed successfully.
- Biome formatting/linting ran as part of the commit and produced no remaining issues.
- No automated visual tests were run because this is a performance-oriented CSS-only change; no docs were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a1c288948332b8e8a79bdcc7ccc6)