### PR TITLE
Expand legacy wave alias regression coverage

### DIFF
--- a/tests/milkdrop-compiler-seams.test.ts
+++ b/tests/milkdrop-compiler-seams.test.ts
@@ -181,6 +181,22 @@ describe('milkdrop compiler seams', () => {
     ).toBe('wave_additive');
     expect(
       normalizeFieldKey({
+        key: 'additivewaves',
+        rawValue: '1',
+        line: 2,
+        section: null,
+      }),
+    ).toBe('wave_additive');
+    expect(
+      normalizeFieldKey({
+        key: 'waveadditive',
+        rawValue: '1',
+        line: 2,
+        section: null,
+      }),
+    ).toBe('wave_additive');
+    expect(
+      normalizeFieldKey({
         key: 'bWaveDots',
         rawValue: '1',
         line: 3,
@@ -197,6 +213,22 @@ describe('milkdrop compiler seams', () => {
     ).toBe('wave_usedots');
     expect(
       normalizeFieldKey({
+        key: 'wavedots',
+        rawValue: '1',
+        line: 3,
+        section: null,
+      }),
+    ).toBe('wave_usedots');
+    expect(
+      normalizeFieldKey({
+        key: 'waveusedots',
+        rawValue: '1',
+        line: 3,
+        section: null,
+      }),
+    ).toBe('wave_usedots');
+    expect(
+      normalizeFieldKey({
         key: 'fWaveThick',
         rawValue: '2',
         line: 4,
@@ -206,6 +238,14 @@ describe('milkdrop compiler seams', () => {
     expect(
       normalizeFieldKey({
         key: 'waveThick',
+        rawValue: '2',
+        line: 4,
+        section: null,
+      }),
+    ).toBe('wave_thick');
+    expect(
+      normalizeFieldKey({
+        key: 'wavethick',
         rawValue: '2',
         line: 4,
         section: null,

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -104,11 +104,16 @@ wavecode_0_a=1
 [preset00]
 bAdditiveWaves=1
 AdditiveWaves=1
+additivewaves=1
+waveadditive=1
 bWaveDots=1
 waveDots=1
+wavedots=1
+waveusedots=1
 bWaveThick=1
 fWaveThick=1.6
 waveThick=1.8
+wavethick=2
       `.trim(),
       { id: 'legacy-root-wave-aliases' },
     );
@@ -123,7 +128,7 @@ waveThick=1.8
     );
     expect(compiled.ir.numericFields.wave_additive).toBe(1);
     expect(compiled.ir.numericFields.wave_usedots).toBe(1);
-    expect(compiled.ir.numericFields.wave_thick).toBeCloseTo(1.8, 6);
+    expect(compiled.ir.numericFields.wave_thick).toBeCloseTo(2, 6);
   });
 
   test('normalizes legacy projectm shapecode booleans onto canonical shape fields', () => {


### PR DESCRIPTION
### Motivation
- Ensure additional real-world legacy wave key variants normalize to canonical fields so they no longer surface as unknown/unsupported preset fields.
- Broaden compiler regression coverage to verify that alternate forms populate the canonical numeric targets used by the runtime and tooling.

### Description
- Add seam-level normalization assertions in `tests/milkdrop-compiler-seams.test.ts` for `additivewaves`/`waveadditive`, `wavedots`/`waveusedots`, and `wavethick` to confirm `normalizeFieldKey` maps them to `wave_additive`, `wave_usedots`, and `wave_thick` respectively.
- Extend the compiler regression fixture in `tests/milkdrop-compiler.test.ts` to include the lowercase/alternate legacy variants and assert the compiled IR contains the canonical numeric fields.
- Update the expected `wave_thick` numeric assertion to reflect the included `wavethick=2` value in the expanded fixture.
- No production code was changed; this PR increases test coverage to guard existing normalization behavior and prevent regressions.

### Testing
- Ran `bun run check`, which runs the full quality gate including typecheck and tests, and observed a pre-existing unrelated test failure in `tests/library-filter-state.test.ts` (`replays the initial card preview sync after effects load`).
- Ran `bun run test tests/milkdrop-compiler-seams.test.ts tests/milkdrop-compiler.test.ts` and both test files passed.
- Ran `bun run test tests/library-filter-state.test.ts` to reproduce the failing quality-gate case and confirmed the existing flaky/unrelated failure persists.

Docs
- None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34104385083328436163b1e6897b8)