### PR TITLE
Disable WebGPU on specific unstable mobile browsers and add guarded-device test

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -1,6 +1,7 @@
 /* global GPUAdapter, GPUDevice, GPU */
 
 import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+import { isMobileDevice } from '../utils/device-detect.ts';
 import { isCompatibilityModeEnabled } from './render-preferences.ts';
 import {
   getRendererFallbackReasonMessage,
@@ -169,6 +170,19 @@ function getEnvironmentKey() {
   if (typeof navigator === 'undefined') return 'no-navigator';
   const nav = navigator as Navigator & { gpu?: GPU; userAgent?: string };
   return nav.gpu ?? nav.userAgent ?? nav;
+}
+
+function isGuardedMobileWebGPUEnvironment() {
+  if (typeof navigator === 'undefined' || !isMobileDevice()) {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent?.toLowerCase() ?? '';
+  return (
+    userAgent.includes('samsungbrowser/') ||
+    userAgent.includes('; wv') ||
+    userAgent.includes('miuibrowser/')
+  );
 }
 
 function resetCache() {
@@ -411,6 +425,15 @@ async function probeRendererCapabilities({
         getRendererFallbackReasonMessage(
           RENDERER_FALLBACK_REASON_CODES.compatibilityMode,
         ),
+        { forceWebGL: true },
+      ),
+    );
+  }
+
+  if (isGuardedMobileWebGPUEnvironment()) {
+    return cacheResult(
+      buildFallback(
+        'WebGPU is temporarily disabled on this mobile browser while we stabilize renderer compatibility. Using WebGL mode.',
         { forceWebGL: true },
       ),
     );

--- a/tests/renderer-capabilities.test.js
+++ b/tests/renderer-capabilities.test.js
@@ -76,7 +76,7 @@ describe('renderer capabilities', () => {
     expect(second.webgpu?.preferredCanvasFormat).toBe('bgra8unorm');
   });
 
-  test('probes WebGPU on mobile user agents when GPU APIs are present', async () => {
+  test('still probes WebGPU on capable mobile browsers', async () => {
     const { requestAdapter, requestDevice } = mockNavigatorWithGPU({
       device: { label: 'mobile-device' },
     });
@@ -94,6 +94,30 @@ describe('renderer capabilities', () => {
     expect(result.preferredBackend).toBe('webgpu');
     expect(result.fallbackReason).toBeNull();
     expect(result.forceWebGL).toBe(false);
+  });
+
+  test('forces WebGL on guarded mobile browsers with known WebGPU instability', async () => {
+    const { requestAdapter, requestDevice } = mockNavigatorWithGPU({
+      device: { label: 'mobile-device' },
+    });
+
+    Object.defineProperty(global.navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (Linux; Android 15; SAMSUNG SM-S928U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/28.0 Chrome/124.0.0.0 Mobile Safari/537.36',
+    });
+
+    const result = await getRendererCapabilities({ forceRetry: true });
+
+    expect(requestAdapter).toHaveBeenCalledTimes(0);
+    expect(requestDevice).toHaveBeenCalledTimes(0);
+    expect(
+      result.preferredBackend === 'webgl' || result.preferredBackend === null,
+    ).toBe(true);
+    expect(result.fallbackReason).toContain(
+      'temporarily disabled on this mobile browser',
+    );
+    expect(result.forceWebGL).toBe(true);
   });
 
   test('falls back when WebGPU device acquisition times out during capability probing', async () => {


### PR DESCRIPTION
### Motivation

- Avoid WebGPU usage on mobile browsers with known instability to prevent renderer crashes and improve compatibility.

### Description

- Import `isMobileDevice` and add `isGuardedMobileWebGPUEnvironment()` to detect SamsungBrowser, `; wv` (webview), and MIUIBrowser user agents on mobile devices. 
- Short-circuit `probeRendererCapabilities()` to return a WebGL-forced fallback with an explanatory message when the guarded mobile environment is detected. 
- Update `tests/renderer-capabilities.test.js` by renaming an existing mobile test and adding a new test that asserts WebGPU is disabled and WebGL is forced for the guarded mobile UA.

### Testing

- Ran the renderer capability unit tests in `tests/renderer-capabilities.test.js` which include the new `forces WebGL on guarded mobile browsers with known WebGPU instability` test. 
- All modified and existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3642202fc8332aeacfe0a28b1f6fd)