### PR TITLE
Simplify homepage and launch UI by removing redundant status/checklist and quick-check actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,27 +112,11 @@
                 Start with demo audio now. Use <code>/milkdrop/</code> for mic or tab audio,
                 presets, and editing.
               </p>
-              <div class="home-hero__status-row" aria-label="Session indicators">
-                <span class="pill pill--accent">Demo ready</span>
-                <span class="pill">Mic + tab audio</span>
-                <span class="pill">Preset browser</span>
-              </div>
               <div class="hero-cta-row" role="group" aria-label="Primary actions">
                 <a href="/milkdrop/?audio=demo&panel=browse&collection=cream-of-the-crop" class="cta-button primary">
                   Start with demo audio
                 </a>
                 <a href="/milkdrop/" class="cta-button ghost">Set up live audio</a>
-              </div>
-              <div class="home-hero__focus" aria-label="Launch flow summary">
-                <p class="home-hero__support">
-                  The homepage nods to the desktop-visualizer lineage, then hands you the deeper
-                  controls inside <code>/milkdrop/</code> when you want them.
-                </p>
-                <ul class="home-hero__checklist">
-                  <li>Boot the visualizer fast with bundled demo audio.</li>
-                  <li>Switch to microphone or tab capture when you are ready.</li>
-                  <li>Open presets and the editor without leaving the session.</li>
-                </ul>
               </div>
             </div>
 

--- a/milkdrop/index.html
+++ b/milkdrop/index.html
@@ -81,9 +81,6 @@
                 <a class="cta-button primary" href="/milkdrop/?audio=demo&panel=browse&collection=cream-of-the-crop">
                   Start with demo audio
                 </a>
-                <a class="cta-button ghost" href="/milkdrop/?audio=demo&panel=browse&collection=cream-of-the-crop">
-                  Open preset browser
-                </a>
                 <a class="cta-button ghost" href="/milkdrop/?audio=demo&panel=editor&collection=cream-of-the-crop">
                   Open editor
                 </a>
@@ -94,28 +91,7 @@
               </p>
               <div class="launch-utility-row" role="group" aria-label="Launch helpers">
                 <a class="text-link" href="/">Back to Stims</a>
-                <button type="button" class="text-link launch-utility-row__button" data-open-preflight>
-                  Run quick check
-                </button>
               </div>
-            </div>
-
-            <div class="launch-checklist" aria-label="Quick start checklist">
-              <article class="launch-check">
-                <p class="launch-check__step">1. Get motion on screen</p>
-                <h2>Demo audio is the cleanest first run.</h2>
-                <p>No permissions and no blank state. It is the quickest way to confirm the visualizer is working.</p>
-              </article>
-              <article class="launch-check">
-                <p class="launch-check__step">2. Switch to your own sound</p>
-                <h2>Use mic or tab audio when you want live response.</h2>
-                <p>The Start panel handles those options without forcing you to leave the page.</p>
-              </article>
-              <article class="launch-check">
-                <p class="launch-check__step">3. Shape the session</p>
-                <h2>Browse presets, tune quality, or edit once audio is live.</h2>
-                <p>The launch surface stays useful after startup instead of disappearing into a separate tool.</p>
-              </article>
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation

- Streamline the homepage and MilkDrop launch surface by removing redundant status indicators, launch checklist, and quick-check controls to reduce clutter and focus users on primary actions.

### Description

- Removed the homepage status row (`.home-hero__status-row`) and the launch summary/focus block (`.home-hero__focus`) from `index.html` to simplify the hero section.
- Removed the duplicate "Open preset browser" CTA and the "Run quick check" button from `milkdrop/index.html` to avoid redundant launch actions.
- Removed the entire launch quick-start checklist block (`.launch-checklist`) from `milkdrop/index.html` to keep the launch surface concise.

### Testing

- No automated tests were run for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c432e688088332bac713e4e3280b77)