### PR TITLE
Ignore generated Husky shim wrappers and document regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ yarn-error.log*
 
 # Build directories
 /dist/
+
+# Husky generated shims (recreated by `husky install` via `bun install`/`bun run prepare`)
+.husky/_/*

--- a/docs/agents/tooling-and-quality.md
+++ b/docs/agents/tooling-and-quality.md
@@ -70,6 +70,19 @@ bun run check:quick
   bun run test:integration
   ```
 
+## Husky hook bootstrap and generated wrappers
+
+- Husky hooks are bootstrapped through the `prepare` script in `package.json`:
+
+  ```bash
+  bun run prepare
+  ```
+
+  In normal development this runs automatically during `bun install`.
+- `.husky/*` files (for example, `.husky/pre-commit`) are the user-maintained hook sources and should be committed.
+- `.husky/_/*` shim wrappers are generated artifacts from `husky install`; do not hand-edit or commit them.
+- If wrappers are missing or stale, reinstall dependencies (or run `bun run prepare`) to regenerate them locally.
+
 ## Docs-only updates
 
 For Markdown-only edits, you can skip typecheck/tests unless the change modifies commands, paths, or workflow-critical instructions that should be validated.


### PR DESCRIPTION
### Motivation
- Prevent generated Husky shim wrappers under `.husky/_/` from creating commit noise and clarify which Husky files are source-managed versus generated.
- Provide contributors clear instructions for regenerating hooks during normal dev installs so local setups remain consistent.

### Description
- Added `.husky/_/*` to the root `.gitignore` so Husky-generated shim wrappers are not tracked (`.husky/_/*`).
- Updated `docs/agents/tooling-and-quality.md` with a short section explaining that hooks are bootstrapped via the `prepare` script (`bun run prepare` / `husky install`), that `.husky/*` are the user-maintained hook sources, and that `.husky/_/*` are generated and should not be hand-edited.
- Verified the repo uses the `prepare` script (`husky install`) in `package.json` and that no `.husky/_/*` wrapper files were tracked prior to this change.

### Testing
- Ran `bun install` and observed `husky install` run and generated files under `.husky/_/`, which completed successfully.
- Ran `find .husky -maxdepth 3 -type f | sort` to confirm generated wrapper files exist locally, which succeeded.
- Ran `git check-ignore -v .husky/_/pre-commit .husky/_/h .husky/_/.gitignore` to validate the ignore rule matches the generated wrappers, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44aefab5083329200deda9d9e99d5)