### PR TITLE
Improve touch layout for MilkDrop overlay panel

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -3736,6 +3736,27 @@ body.tv-mode .control-panel input {
   }
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .milkdrop-overlay {
+    inset: auto 10px max(10px, env(safe-area-inset-bottom, 0px)) 10px;
+    display: grid;
+    justify-items: stretch;
+    align-items: end;
+  }
+
+  :root[data-focused-session="launch"] .milkdrop-overlay,
+  :root[data-focused-session="live"] .milkdrop-overlay {
+    inset: auto 10px max(10px, env(safe-area-inset-bottom, 0px)) 10px;
+  }
+
+  .milkdrop-overlay__panel,
+  :root[data-focused-session="launch"] .milkdrop-overlay__panel,
+  :root[data-focused-session="live"] .milkdrop-overlay__panel {
+    width: 100%;
+    max-width: none;
+  }
+}
+
 :root {
   --toy-shell-metal: linear-gradient(
     180deg,


### PR DESCRIPTION
### Motivation
- Fix the MilkDrop overlay on touch-coarse devices so the overlay panel stretches across the available width and is anchored with touch-safe insets instead of remaining a narrow desktop-style card in the corner.

### Description
- Add a `@media (hover: none) and (pointer: coarse)` rule in `assets/css/base.css` that adjusts `.milkdrop-overlay` insets, makes it `display: grid` with `justify-items: stretch` and `align-items: end`, and forces the overlay panel (`.milkdrop-overlay__panel` and focused-session variants) to use `width: 100%` and `max-width: none`.

### Testing
- Ran the project quality gate with `bun run check`, which runs the Biome checks, TypeScript `tsc --noEmit`, and the full test suite, and all automated checks and tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c487ef8df08332adf12368130949df)