### PR TITLE
Add red-blue stereo feedback effect (red_blue_stereo) and propagate legacy aliases through pipeline

### DIFF
--- a/assets/js/milkdrop/compiler/default-state.ts
+++ b/assets/js/milkdrop/compiler/default-state.ts
@@ -206,6 +206,7 @@ const DEFAULT_MILKDROP_STATE: Record<string, number> = {
   darken_center: 0,
   solarize: 0,
   invert: 0,
+  red_blue_stereo: 0,
   gammaadj: 1,
   video_echo_enabled: 0,
   video_echo_alpha: 0.18,

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -252,6 +252,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         darkenCenter: { value: 0 },
         solarize: { value: 0 },
         invert: { value: 0 },
+        redBlueStereo: { value: 0 },
         gammaAdj: { value: 1 },
         textureWrap: { value: 0 },
         feedbackTexture: { value: 0 },
@@ -322,6 +323,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
         uniform float darkenCenter;
         uniform float solarize;
         uniform float invert;
+        uniform float redBlueStereo;
         uniform float gammaAdj;
         uniform float textureWrap;
         uniform float feedbackTexture;
@@ -539,6 +541,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
           if (invert > 0.01 || invertBoost > 0.01) {
             color = mix(color, 1.0 - color, clamp(max(invert, invertBoost), 0.0, 1.0));
           }
+          if (redBlueStereo > 0.5) {
+            float stereoOffset = 0.003 + signalEnergy * 0.003;
+            vec2 stereoShift = vec2(stereoOffset, 0.0);
+            vec3 leftColor = texture2D(previousTex, sampleUv(prevUv - stereoShift, textureWrap)).rgb;
+            vec3 rightColor = texture2D(previousTex, sampleUv(prevUv + stereoShift, textureWrap)).rgb;
+            color = mix(color, vec3(leftColor.r, rightColor.g, rightColor.b), 0.85);
+          }
           color = hueRotate(color, hueShift);
           color = applySaturation(color, saturation);
           color = applyContrast(color, contrast);
@@ -610,6 +619,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     uniforms.darkenCenter.value = state.darkenCenter;
     uniforms.solarize.value = state.solarize;
     uniforms.invert.value = state.invert;
+    uniforms.redBlueStereo.value = state.redBlueStereo ?? 0;
     uniforms.gammaAdj.value = state.gammaAdj;
     uniforms.textureWrap.value = state.textureWrap;
     uniforms.feedbackTexture.value = state.feedbackTexture;

--- a/assets/js/milkdrop/feedback-manager-webgpu.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu.ts
@@ -284,6 +284,7 @@ function createCompositeUniforms(
     darkenCenter: uniform(0),
     solarize: uniform(0),
     invert: uniform(0),
+    redBlueStereo: uniform(0),
     gammaAdj: uniform(1),
     textureWrap: uniform(0),
     feedbackTexture: uniform(0),
@@ -1181,6 +1182,16 @@ function createCompositeOutputNode(
         clamp(max(uniforms.invert, uniforms.invertBoost), 0, 1),
       ),
     );
+    const stereoEnabled = step(0.5, uniforms.redBlueStereo);
+    const stereoOffset = float(0.003).add(uniforms.signalEnergy.mul(0.003));
+    const leftStereo = uniforms.previousTex.sample(
+      sampleUvNode(previousUv.sub(vec2(stereoOffset, 0)), uniforms.textureWrap),
+    ).rgb;
+    const rightStereo = uniforms.previousTex.sample(
+      sampleUvNode(previousUv.add(vec2(stereoOffset, 0)), uniforms.textureWrap),
+    ).rgb;
+    const stereoColor = vec3(leftStereo.r, rightStereo.g, rightStereo.b);
+    color.assign(mix(color, stereoColor, stereoEnabled.mul(0.85)));
     color.assign(hueRotateNode(color, uniforms.hueShift));
     color.assign(applySaturationNode(color, uniforms.saturation));
     color.assign(applyContrastNode(color, uniforms.contrast));
@@ -1405,6 +1416,7 @@ class WebGPUMilkdropFeedbackManager {
       state.darkenCenter > 0.5 ||
       state.solarize > 0.5 ||
       state.invert > 0.5 ||
+      (state.redBlueStereo ?? 0) > 0.5 ||
       Math.abs(state.gammaAdj - 1) > 0.0001;
     const nextResolutionScale = needsSceneResolution
       ? this.sceneResolutionScale
@@ -1427,6 +1439,8 @@ class WebGPUMilkdropFeedbackManager {
     this.compositeMaterial.uniforms.darkenCenter.value = state.darkenCenter;
     this.compositeMaterial.uniforms.solarize.value = state.solarize;
     this.compositeMaterial.uniforms.invert.value = state.invert;
+    this.compositeMaterial.uniforms.redBlueStereo.value =
+      state.redBlueStereo ?? 0;
     this.compositeMaterial.uniforms.gammaAdj.value = state.gammaAdj;
     this.compositeMaterial.uniforms.textureWrap.value = state.textureWrap;
     this.compositeMaterial.uniforms.feedbackTexture.value =

--- a/assets/js/milkdrop/field-normalization.ts
+++ b/assets/js/milkdrop/field-normalization.ts
@@ -6,6 +6,8 @@ const aliasMap: Record<string, string | null> = {
   fvideoechozoom: 'video_echo_zoom',
   fvideoechoalpha: 'video_echo_alpha',
   nvideoechoorientation: 'video_echo_orientation',
+  bredbluestereo: 'red_blue_stereo',
+  redbluestereo: 'red_blue_stereo',
   fwavealpha: 'wave_a',
   fwavethick: 'wave_thick',
   fwavescale: 'wave_scale',

--- a/assets/js/milkdrop/renderer-helpers/feedback-composite.ts
+++ b/assets/js/milkdrop/renderer-helpers/feedback-composite.ts
@@ -68,6 +68,12 @@ export function buildFeedbackCompositeState({
     darkenCenter: frameState.post.darkenCenter ? 1 : 0,
     solarize: frameState.post.solarize ? 1 : 0,
     invert: frameState.post.invert ? 1 : 0,
+    redBlueStereo:
+      (frameState.variables.red_blue_stereo ??
+        frameState.variables.redbluestereo ??
+        0) > 0.5
+        ? 1
+        : 0,
     gammaAdj: frameState.post.gammaAdj,
     textureWrap: frameState.post.textureWrap ? 1 : 0,
     feedbackTexture: frameState.post.feedbackTexture ? 1 : 0,

--- a/assets/js/milkdrop/renderer-types.ts
+++ b/assets/js/milkdrop/renderer-types.ts
@@ -257,6 +257,7 @@ export type MilkdropFeedbackCompositeState = {
   darkenCenter: number;
   solarize: number;
   invert: number;
+  redBlueStereo?: number;
   gammaAdj: number;
   textureWrap: number;
   feedbackTexture: number;

--- a/tests/milkdrop-compiler-seams.test.ts
+++ b/tests/milkdrop-compiler-seams.test.ts
@@ -251,6 +251,14 @@ describe('milkdrop compiler seams', () => {
         section: null,
       }),
     ).toBe('wave_thick');
+    expect(
+      normalizeFieldKey({
+        key: 'bRedBlueStereo',
+        rawValue: '1',
+        line: 5,
+        section: null,
+      }),
+    ).toBe('red_blue_stereo');
 
     const lowered = lowerGpuFieldProgram({
       statements: [

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -131,6 +131,19 @@ wavethick=2
     expect(compiled.ir.numericFields.wave_thick).toBeCloseTo(2, 6);
   });
 
+  test('supports legacy bRedBlueStereo flag as a canonical post field', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+[preset00]
+bRedBlueStereo=1
+      `.trim(),
+      { id: 'legacy-red-blue-stereo' },
+    );
+
+    expect(compiled.ir.compatibility.unsupportedKeys).toEqual([]);
+    expect(compiled.ir.numericFields.red_blue_stereo).toBe(1);
+  });
+
   test('normalizes legacy projectm shapecode booleans onto canonical shape fields', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-corpus-compat.test.ts
+++ b/tests/milkdrop-corpus-compat.test.ts
@@ -108,8 +108,8 @@ const BUNDLED_PRESET_EXPECTATIONS: Record<string, BundledPresetExpectation> = {
   'low-motion-halo-drift.milk': { webgl: 'supported', webgpu: 'supported' },
   'prism-drum-tunnel.milk': { webgl: 'supported', webgpu: 'supported' },
   'rovastar-parallel-universe.milk': {
-    webgl: 'partial',
-    webgpu: 'partial',
+    webgl: 'supported',
+    webgpu: 'supported',
     forbiddenUnsupportedKeys: [
       'mv_dx',
       'mv_dy',

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -887,6 +887,52 @@ video_echo_orientation=3
     });
   });
 
+  test('routes red-blue stereo flag through the feedback composite state', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Feedback Stereo Routing
+bRedBlueStereo=1
+      `.trim(),
+      { id: 'feedback-red-blue-stereo-routing' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals());
+    const compositeStates: MilkdropFeedbackCompositeState[] = [];
+    const feedback = {
+      applyCompositeState(state: MilkdropFeedbackCompositeState) {
+        compositeStates.push(state);
+      },
+      render() {
+        return true;
+      },
+      swap() {},
+      resize() {},
+      dispose() {},
+    } as MilkdropFeedbackManager;
+
+    const adapter = createMilkdropRendererAdapterCore({
+      scene: new Scene(),
+      camera: new OrthographicCamera(-1, 1, 1, -1, 0, 10),
+      renderer: {
+        getSize: (target: Vector2) => target.set(320, 180),
+        render() {},
+        setRenderTarget() {},
+      },
+      backend: 'webgl',
+      createFeedbackManager: () => feedback,
+    });
+
+    adapter.attach();
+    expect(
+      adapter.render({
+        frameState,
+        blendState: null,
+      }),
+    ).toBe(true);
+
+    expect(compositeStates[0]?.redBlueStereo).toBe(1);
+  });
+
   test('forwards overlay and warp volume sampling metadata into feedback state', () => {
     const preset = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Introduce support for a red-blue stereo feedback effect (canonical field `red_blue_stereo`) so legacy presets and runtime controls can enable a stereo color-splitting feedback visual.
- Ensure legacy keys like `bRedBlueStereo` and `redbluestereo` are normalized to the canonical `red_blue_stereo` field so older presets work without modification.

### Description
- Added `red_blue_stereo` to the default Milkdrop state and included aliases `bredbluestereo` and `redbluestereo` in the field normalization map.
- Plumbed a `redBlueStereo` uniform through the WebGL composite shader and applied a stereo effect that samples the previous frame with a small horizontal offset and mixes red from the left and green/blue from the right channels; the effect strength depends on a flag and `signalEnergy`.
- Implemented the same uniform and stereo mixing logic in the WebGPU composite node graph and added the `redBlueStereo` uniform into the GPU composite uniforms and material update logic, including using the flag to trigger scene-resolution decisions.
- Exposed `redBlueStereo` in the feedback composite state type and `buildFeedbackCompositeState` so renderer adapters and feedback managers receive the flag; updated feedback manager apply/update paths to read `state.redBlueStereo`.
- Updated tests and expectations: added unit tests for normalization of `bRedBlueStereo` and for routing the flag through the feedback composite state, and adjusted a bundled preset compatibility expectation to mark `rovastar-parallel-universe.milk` as supported.

### Testing
- Ran the full unit test suite with `npm test`, which executed the updated and new tests including `supports legacy bRedBlueStereo flag as a canonical post field` and `routes red-blue stereo flag through the feedback composite state`, and all tests passed.
- Verified that existing compiler and renderer seam tests continued to succeed after introducing the normalization aliases and new feedback state field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49ab7e2e4833295676df3a4e03e54)