### PR TITLE
Include GPU presence, userAgent and compatibility mode in environment key; reset render preferences in tests

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -169,7 +169,12 @@ const cacheResult = (result: RendererCapabilities) => {
 function getEnvironmentKey() {
   if (typeof navigator === 'undefined') return 'no-navigator';
   const nav = navigator as Navigator & { gpu?: GPU; userAgent?: string };
-  return nav.gpu ?? nav.userAgent ?? nav;
+  const hasGpu = Boolean(nav.gpu);
+  const userAgent = nav.userAgent ?? '';
+  const compatibilityMode = isCompatibilityModeEnabled()
+    ? 'compat-on'
+    : 'compat-off';
+  return `${hasGpu}:${userAgent}:${compatibilityMode}`;
 }
 
 function isGuardedMobileWebGPUEnvironment() {

--- a/tests/renderer-capabilities.test.js
+++ b/tests/renderer-capabilities.test.js
@@ -13,6 +13,14 @@ let resetRendererCapabilities;
 let summarizeRendererOptimizationSupport;
 
 const originalNavigator = global.navigator;
+const COMPATIBILITY_MODE_KEY = 'stims:compatibility-mode';
+
+async function resetRenderPreferencesState() {
+  const { resetRenderPreferencesState: resetPreferences } = await import(
+    '../assets/js/core/render-preferences.ts'
+  );
+  resetPreferences();
+}
 
 function mockNavigatorWithGPU({ device = {}, adapter = {} } = {}) {
   const requestDevice = mock(async () => device);
@@ -37,6 +45,8 @@ function mockNavigatorWithGPU({ device = {}, adapter = {} } = {}) {
 
 beforeEach(async () => {
   mock.restore();
+  await resetRenderPreferencesState();
+  window.localStorage.removeItem(COMPATIBILITY_MODE_KEY);
   ({
     getRendererCapabilities,
     getRendererOptimizationSupport,
@@ -48,10 +58,11 @@ beforeEach(async () => {
   } = await freshImport());
 });
 
-afterEach(() => {
+afterEach(async () => {
   resetRendererCapabilities();
   mock.restore();
-  window.localStorage.removeItem('stims:compatibility-mode');
+  window.localStorage.removeItem(COMPATIBILITY_MODE_KEY);
+  await resetRenderPreferencesState();
   Object.defineProperty(global, 'navigator', {
     writable: true,
     configurable: true,
@@ -188,11 +199,8 @@ describe('renderer capabilities', () => {
   });
 
   test('marks forced WebGL when compatibility mode is enabled', async () => {
-    window.localStorage.setItem('stims:compatibility-mode', 'true');
-    const { resetRenderPreferencesState } = await import(
-      '../assets/js/core/render-preferences.ts'
-    );
-    resetRenderPreferencesState();
+    window.localStorage.setItem(COMPATIBILITY_MODE_KEY, 'true');
+    await resetRenderPreferencesState();
 
     const result = await getRendererCapabilities({ forceRetry: true });
 
@@ -217,10 +225,7 @@ describe('renderer capabilities', () => {
   });
 
   test('captures high-end WebGPU feature support for richer defaults', async () => {
-    const { resetRenderPreferencesState } = await import(
-      '../assets/js/core/render-preferences.ts'
-    );
-    resetRenderPreferencesState();
+    await resetRenderPreferencesState();
     mockNavigatorWithGPU({
       device: { label: 'device' },
       adapter: {


### PR DESCRIPTION
### Motivation
- Ensure the cached renderer capabilities key changes when compatibility mode or the environment (GPU presence or userAgent) changes so telemetry and caching don't incorrectly reuse stale probes.

### Description
- Change `getEnvironmentKey()` to return a string composed of GPU presence, `userAgent`, and a compatibility-mode flag via `isCompatibilityModeEnabled()` instead of returning raw navigator properties.
- Add and use a `resetRenderPreferencesState()` helper in tests to ensure render preference state is cleared between tests.
- Replace hardcoded localStorage key usage with a `COMPATIBILITY_MODE_KEY` constant in `tests/renderer-capabilities.test.js` and update tests to await preference resets where needed.

### Testing
- Ran the renderer capabilities tests (`tests/renderer-capabilities.test.js`) with the test harness (`bun:test`) and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b09eb5f0833294b68c95b8ba31f7)