### PR TITLE
Tighten compact landscape search layout

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -4112,6 +4112,37 @@ footer {
     padding: 0.4rem 0.55rem;
   }
 
+  .library-search {
+    top: calc(env(safe-area-inset-top) + 3.8rem);
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+  }
+
+  .search-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.55rem;
+  }
+
+  .search-meta {
+    min-width: 0;
+    position: relative;
+    top: 0;
+  }
+
+  .filter-row {
+    gap: 0.55rem;
+  }
+
+  .chip-row {
+    gap: 0.5rem;
+  }
+
+  .filter-actions {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-start;
+  }
+
   .hero {
     padding-block: 0.8rem 0.6rem;
   }


### PR DESCRIPTION
### Motivation
- The library search and filter controls were horizontally cramped on short-height landscape viewports, so compact breakpoint rules were tightened to stack controls and reduce sticky offsets.

### Description
- Updated `assets/css/index.css` inside the `@media (max-width: 920px) and (max-height: 520px) and (orientation: landscape)` block to adjust `.library-search` `top`, `gap`, and `padding` for a more compact sticky position.
- Added compact layout rules to make `.search-row` a single-column grid, relax `.search-meta` sticky sizing, reduce `.filter-row` and `.chip-row` gaps, and make `.filter-actions` full-width and left-aligned to avoid horizontal crowding.

### Testing
- Ran `bun run check`, which runs Biome, TypeScript typecheck, and the test suite, and the command completed successfully with `509` tests passing, `4` skipped, and `0` failures.
- Docs touched: None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c72eebf6048332a98d3d41ab295f9f)