### PR TITLE
Update README alignment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It is built to feel like a first-class browser experience rather than a nostalgi
 - [Shipped experience](#shipped-experience)
 - [Quickstart](#quickstart)
 - [Common commands](#common-commands)
+- [README maintenance checklist](#readme-maintenance-checklist)
 - [Development notes](#development-notes)
 - [Contributing at a glance](#contributing-at-a-glance)
 - [Project shape](#project-shape)
@@ -109,6 +110,18 @@ If you want to validate the production bundle locally, run `bun run build` and t
 
 For JavaScript or TypeScript changes, `bun run check` is the repository quality gate.
 
+## README maintenance checklist
+
+When changing project workflows or documentation structure, keep README-level entry points aligned in the same change:
+
+- `README.md` (this file)
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `docs/README.md`
+- `docs/agents/README.md`
+
+Use [docs/DOCS_MAINTENANCE.md](./docs/DOCS_MAINTENANCE.md) as the synchronization checklist for add/move/rename/delete docs updates.
+
 ## Development notes
 
 - Prefer `bun run dev:host` when testing on phones, tablets, or TV browsers on your local network.
@@ -151,6 +164,7 @@ Start with:
 - [docs/MILKDROP_PRESET_RUNTIME.md](./docs/MILKDROP_PRESET_RUNTIME.md)
 - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 - [docs/FEATURE_SPECIFICATIONS.md](./docs/FEATURE_SPECIFICATIONS.md)
+- [docs/DOCS_MAINTENANCE.md](./docs/DOCS_MAINTENANCE.md)
 - [docs/LINEAGE_AND_CREDITS.md](./docs/LINEAGE_AND_CREDITS.md)
 - [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,18 @@ The following docs still describe the retired multi-toy model. Keep them only as
 - [`TOY_SCRIPT_INDEX.md`](./TOY_SCRIPT_INDEX.md)
 - [`toys.md`](./toys.md)
 
+## README synchronization
+
+When docs are added, moved, renamed, archived, or removed, keep the repository entry-point READMEs aligned in the same PR:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `docs/README.md`
+- `docs/agents/README.md`
+
+Reference [`DOCS_MAINTENANCE.md`](./DOCS_MAINTENANCE.md) for the full synchronization contract and per-change requirements.
+
 ## Conventions
 
 - Package manager: `bun`

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -26,6 +26,18 @@ Use this folder as a focused, progressive-disclosure overlay for agent tasks.
 - [`../README.md`](../README.md) (canonical docs index)
 - [`../DOCS_MAINTENANCE.md`](../DOCS_MAINTENANCE.md) (docs synchronization contract for add/move/rename/delete changes)
 
+### README alignment changes
+
+When a task updates any README, verify cross-link alignment across:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `docs/README.md`
+- `docs/agents/README.md`
+
+Use [`../DOCS_MAINTENANCE.md`](../DOCS_MAINTENANCE.md) as the checklist before finalizing commit/PR metadata.
+
 ## Fast repo map
 
 - `milkdrop/index.html` — primary app entrypoint for the flagship visualizer.


### PR DESCRIPTION
### Motivation

- Make README-level entry points and documentation-entry synchronization explicit so docs restructures and metadata changes keep cross-links aligned.

### Description

- Add a `## README maintenance checklist` section to `README.md` and link it from the table of contents.  
- Add `docs/DOCS_MAINTENANCE.md` to the root README docs starter list for easier discovery of the synchronization rules.  
- Add a `## README synchronization` section to `docs/README.md` to codify which entry-point READMEs must stay aligned.  
- Add a `### README alignment changes` subsection to `docs/agents/README.md` so agent workflows verify cross-link consistency before finalizing PR metadata.

### Testing

- Run `bun run check:quick`, which ran the no-`@ts-nocheck` guard, Biome checks, the bundled catalog fidelity check, and `tsc --noEmit`, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3f71bc5c8332ad490124ba132732)