### PR TITLE
Deduplicate demo audio start request handling

### DIFF
--- a/assets/js/ui/audio-controls.ts
+++ b/assets/js/ui/audio-controls.ts
@@ -484,6 +484,20 @@ export function initAudioControls(
     }
   };
 
+  const startDemoAudio = () =>
+    handleRequest(
+      demoBtn,
+      async () => {
+        await options.onRequestDemoAudio();
+        writeStoredSource('demo');
+        setPreferredSource('demo');
+      },
+      'Demo audio failed to load.',
+      undefined,
+      'Demo audio started.',
+      'Starting demo audio…',
+    );
+
   micBtn?.addEventListener('click', () => {
     void handleRequest(
       micBtn,
@@ -507,33 +521,11 @@ export function initAudioControls(
   });
 
   demoBtn?.addEventListener('click', () => {
-    void handleRequest(
-      demoBtn,
-      async () => {
-        await options.onRequestDemoAudio();
-        writeStoredSource('demo');
-        setPreferredSource('demo');
-      },
-      'Demo audio failed to load.',
-      undefined,
-      'Demo audio started.',
-      'Starting demo audio…',
-    );
+    void startDemoAudio();
   });
 
   if (options.autoStartSource === 'demo') {
-    void handleRequest(
-      demoBtn,
-      async () => {
-        await options.onRequestDemoAudio();
-        writeStoredSource('demo');
-        setPreferredSource('demo');
-      },
-      'Demo audio failed to load.',
-      undefined,
-      'Demo audio started.',
-      'Starting demo audio…',
-    );
+    void startDemoAudio();
   }
 
   tabBtn?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Reduce duplicated UI/request logic in the audio start flow by consolidating the demo-audio startup path into a single helper so manual and auto-start use the same behavior.

### Description
- Extracted a `startDemoAudio` helper inside `initAudioControls` and replaced the duplicated `handleRequest(...)` calls for demo button click and `options.autoStartSource === 'demo'` with calls to that helper (changed file: `assets/js/ui/audio-controls.ts`).

### Testing
- Ran the focused unit tests with `bun run test tests/audio-controls.test.ts`, which passed (33 tests, 0 failures). 
- Ran the full quality gate with `bun run check`, which failed due to unrelated pre-existing repository issues (exports/tests errors surfaced during the full test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d29b65cc8332939c5411f7ddfa11)