### PR TITLE
Simplify workspace UI: tighten spacing, remove starter cards, and update copy

### DIFF
--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -200,7 +200,7 @@ body[data-page="workspace"] {
 .stims-shell__session-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .stims-shell__nav-actions {
@@ -218,14 +218,14 @@ body[data-page="workspace"] {
 .stims-shell__sheet-tab {
   border: 1px solid var(--stims-line);
   border-radius: var(--stims-radius-control);
-  padding: 10px 14px;
+  padding: 9px 12px;
   background: var(--stims-control-fill);
   color: inherit;
   font: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 42px;
+  min-height: 44px;
   box-shadow: var(--stims-shadow-control);
   transition:
     transform 160ms ease,
@@ -329,13 +329,13 @@ body[data-page="workspace"] {
 
 .stims-shell__launch {
   display: grid;
-  gap: 20px;
-  padding: 24px;
+  gap: 14px;
+  padding: 18px;
 }
 
 .stims-shell__launch-header {
   display: grid;
-  gap: 20px;
+  gap: 14px;
   align-items: start;
 }
 
@@ -364,7 +364,7 @@ body[data-page="workspace"] {
 
 .stims-shell__launch-copy {
   display: grid;
-  gap: 14px;
+  gap: 10px;
   max-width: 56rem;
 }
 
@@ -372,8 +372,8 @@ body[data-page="workspace"] {
   margin: 0;
   max-width: 34rem;
   color: color-mix(in srgb, var(--stims-ink) 88%, transparent);
-  font-size: 1.02rem;
-  line-height: 1.6;
+  font-size: 0.98rem;
+  line-height: 1.48;
 }
 
 .stims-shell__launch-note {
@@ -434,63 +434,12 @@ body[data-page="workspace"] {
   padding-right: 4px;
 }
 
-.stims-shell__starter-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.stims-shell__starter-card {
-  display: grid;
-  gap: 6px;
-  padding: 14px;
-  text-align: left;
-  border: 1px solid var(--stims-line);
-  border-radius: var(--stims-radius-card);
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.08),
-    rgba(255, 255, 255, 0.03)
-  );
-  color: inherit;
-  font: inherit;
-  box-shadow:
-    0 16px 28px rgba(0, 0, 0, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  transition:
-    transform 160ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.stims-shell__starter-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(244, 122, 84, 0.42);
-  background: linear-gradient(
-    180deg,
-    rgba(244, 122, 84, 0.16),
-    rgba(119, 201, 255, 0.08)
-  );
-}
-
-.stims-shell__starter-label,
 .stims-shell__preset-vibe {
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: color-mix(in srgb, var(--stims-cool) 62%, var(--stims-ink));
-}
-
-.stims-shell__starter-summary,
-.stims-shell__starter-preset {
-  line-height: 1.45;
-}
-
-.stims-shell__starter-preset {
-  color: var(--stims-ink-strong);
-  font-weight: 700;
 }
 
 .stims-shell__browse-toolbar {
@@ -1059,7 +1008,7 @@ body[data-page="workspace"] {
 
   .stims-shell__launch {
     order: 1;
-    gap: 12px;
+    gap: 10px;
   }
 
   .stims-shell__workspace {
@@ -1137,7 +1086,7 @@ body[data-page="workspace"] {
   }
 
   .stims-shell__launch-header {
-    gap: 10px;
+    gap: 8px;
   }
 
   .stims-shell__launch-copy h1,
@@ -1239,10 +1188,6 @@ body[data-page="workspace"] {
   .stims-shell__stage-frame {
     min-height: clamp(240px, 36svh, 340px);
     border-radius: 14px;
-  }
-
-  .stims-shell__starter-grid {
-    grid-template-columns: 1fr;
   }
 
   .stims-shell__preset-list {

--- a/assets/js/frontend/App.tsx
+++ b/assets/js/frontend/App.tsx
@@ -950,10 +950,10 @@ export function StimsWorkspaceApp() {
       ? 'Pick an audio path.'
       : 'Loading the visualizer.';
   const launchSummary = missingRequestedPreset
-    ? 'The requested preset is not bundled in this build. Start with demo audio for the quickest recovery, or browse the library before you play.'
+    ? 'This preset is no longer bundled. Start demo to recover quickly, or open Looks before you play.'
     : runtimeReady || routeState.invalidExperienceSlug
-      ? 'Start demo for the quickest payoff. Mic reacts to your room. Tab capture is best when music is already playing in the browser.'
-      : 'One moment while the visuals warm up.';
+      ? 'Start demo fastest. Use mic for room-reactive visuals or capture tab audio when music is already playing.'
+      : 'One moment while visuals warm up.';
   const stageEyebrow = missingRequestedPreset
     ? 'Link needs a rescue'
     : loadingRequestedPreset
@@ -975,7 +975,7 @@ export function StimsWorkspaceApp() {
       : selectedPreset
         ? `${selectedPreset.author || 'Unknown author'} · ${formatPresetSupportLabel(selectedPreset)}`
         : featuredPreset
-          ? `Featured first pick: ${featuredPreset.title} · ${describePresetMood(featuredPreset)}. Open Looks for curated starters or shuffle into something new.`
+          ? `Featured first pick: ${featuredPreset.title} · ${describePresetMood(featuredPreset)}. Open Looks or shuffle for another vibe.`
           : 'Open Looks to pick a preset without losing the stage.';
 
   return (
@@ -1271,34 +1271,9 @@ export function StimsWorkspaceApp() {
             <div className="stims-shell__sheet-body">
               {routeState.panel === 'browse' ? (
                 <div className="stims-shell__sheet-panel">
-                  {starterLooks.length > 0 ? (
-                    <section className="stims-shell__starter-grid">
-                      {starterLooks.map((starterLook) => (
-                        <button
-                          key={starterLook.key}
-                          type="button"
-                          className="stims-shell__starter-card"
-                          onClick={() =>
-                            handlePresetSelection(starterLook.preset.id)
-                          }
-                        >
-                          <span className="stims-shell__starter-label">
-                            {starterLook.label}
-                          </span>
-                          <span className="stims-shell__starter-summary">
-                            {starterLook.summary}
-                          </span>
-                          <span className="stims-shell__starter-preset">
-                            {starterLook.preset.title}
-                          </span>
-                        </button>
-                      ))}
-                    </section>
-                  ) : null}
-
                   <div className="stims-shell__browse-toolbar">
                     <p className="stims-shell__meta-copy">
-                      Start with a featured vibe or search the full library.
+                      Search the full library or shuffle a surprise.
                     </p>
                     <button
                       type="button"

--- a/tests/app-shell-mobile-layout.test.ts
+++ b/tests/app-shell-mobile-layout.test.ts
@@ -47,7 +47,7 @@ describe('Workspace shell mobile layout regression', () => {
       /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__readiness-chips\s*\{\s*flex-wrap:\s*nowrap;[\s\S]*?overflow-x:\s*auto;/u,
     );
     expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__starter-grid\s*\{\s*grid-template-columns:\s*1fr;/u,
+      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__launch-header\s*\{\s*gap:\s*8px;/u,
     );
   });
 });

--- a/tests/app-shell-ui-simplification.test.ts
+++ b/tests/app-shell-ui-simplification.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 describe('Workspace shell UI simplification regression', () => {
-  test('keeps the shell copy centered on the launch path, featured looks, and quick tuning', () => {
+  test('keeps the shell copy centered on the launch path and quick tuning', () => {
     const source = readFileSync(
       join(import.meta.dir, '..', 'assets', 'js', 'frontend', 'App.tsx'),
       'utf8',
@@ -13,11 +13,9 @@ describe('Workspace shell UI simplification regression', () => {
       'Start with a featured vibe or dive into the full preset library.',
     );
     expect(source).toContain(
-      'Start demo for the quickest payoff. Mic reacts to your room. Tab capture is best when music is already playing in the browser.',
+      'Start demo fastest. Use mic for room-reactive visuals or capture tab audio when music is already playing.',
     );
-    expect(source).toContain(
-      'Start with a featured vibe or search the full library.',
-    );
+    expect(source).toContain('Search the full library or shuffle a surprise.');
     expect(source).toContain('Shuffle a look');
     expect(source).toContain(
       'Stay on Balanced unless the picture feels rough.',


### PR DESCRIPTION
### Motivation
- Reduce visual clutter and align mobile spacing for a more compact, scannable workspace UI.
- Remove legacy starter card UI that duplicated browse functionality and streamline the launch/browse copy for clarity.

### Description
- Tightened spacing and sizing in `assets/css/app-shell.css` (reduced `gap`, `padding`, adjusted `min-height`, and tweaked font sizing/line-height across the launch and nav UI). 
- Removed the `.stims-shell__starter-grid` and `.stims-shell__starter-card` styles and the associated starter-card markup in `assets/js/frontend/App.tsx`, collapsing the launcher to the primary browse controls.
- Updated launch and browse copy in `App.tsx` to shorter, clearer strings (e.g. `launchSummary`, browse toolbar text, shuffle wording, and a featured-stage summary tweak).
- Updated tests to match the new layout and copy expectations in `tests/app-shell-mobile-layout.test.ts` and `tests/app-shell-ui-simplification.test.ts`.

### Testing
- Ran the workspace shell mobile layout regression test `tests/app-shell-mobile-layout.test.ts`, which was updated to expect the new media-query spacing selector and passed.
- Ran the workspace shell UI simplification regression test `tests/app-shell-ui-simplification.test.ts`, which was updated for the revised strings and passed.
- Ran the project unit tests under `bun:test` and verified the modified tests succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ccbb017c8332a65868960d667241)