### PR TITLE
Introduce registerEventListener helper using AbortController and centralize listener cleanup

### DIFF
--- a/assets/js/library-view.js
+++ b/assets/js/library-view.js
@@ -62,6 +62,27 @@ export function createLibraryView({
     return cleanup;
   };
 
+  const registerEventListener = (target, type, listener, options) => {
+    if (!target || typeof target.addEventListener !== 'function') {
+      return;
+    }
+
+    if (typeof AbortController === 'function') {
+      const controller = new AbortController();
+      target.addEventListener(type, listener, {
+        ...options,
+        signal: controller.signal,
+      });
+      registerCleanup(() => controller.abort());
+      return;
+    }
+
+    target.addEventListener(type, listener, options);
+    registerCleanup(() => {
+      target.removeEventListener(type, listener, options);
+    });
+  };
+
   const runCleanupStack = () => {
     while (cleanupStack.length > 0) {
       const cleanup = cleanupStack.pop();
@@ -502,10 +523,7 @@ export function createLibraryView({
       handleOpenToy(toy, event);
     };
 
-    list.addEventListener('click', handleCardClick);
-    registerCleanup(() => {
-      list.removeEventListener('click', handleCardClick);
-    });
+    registerEventListener(list, 'click', handleCardClick);
 
     if (enableKeyboardHandlers) {
       const handleCardKeydown = (event) => {
@@ -534,10 +552,7 @@ export function createLibraryView({
         handleOpenToy(toy, event);
       };
 
-      list.addEventListener('keydown', handleCardKeydown);
-      registerCleanup(() => {
-        list.removeEventListener('keydown', handleCardKeydown);
-      });
+      registerEventListener(list, 'keydown', handleCardKeydown);
     }
 
     return null;
@@ -659,10 +674,7 @@ export function createLibraryView({
         applyState(nextState, { render: true });
         filterPresenter.syncRefineDisclosure();
       };
-      window.addEventListener('popstate', handlePopState);
-      registerCleanup(() => {
-        window.removeEventListener('popstate', handlePopState);
-      });
+      registerEventListener(window, 'popstate', handlePopState);
 
       if (
         typeof window !== 'undefined' &&
@@ -672,13 +684,11 @@ export function createLibraryView({
         const handleViewportChange = () =>
           filterPresenter.syncRefineDisclosure();
         if (typeof narrowViewportQuery.addEventListener === 'function') {
-          narrowViewportQuery.addEventListener('change', handleViewportChange);
-          registerCleanup(() => {
-            narrowViewportQuery.removeEventListener(
-              'change',
-              handleViewportChange,
-            );
-          });
+          registerEventListener(
+            narrowViewportQuery,
+            'change',
+            handleViewportChange,
+          );
         } else if (typeof narrowViewportQuery.addListener === 'function') {
           narrowViewportQuery.addListener(handleViewportChange);
           registerCleanup(() => {


### PR DESCRIPTION
### Motivation
- Reduce repetitive `addEventListener`/`removeEventListener` code and reliably manage event listener cleanup, using `AbortController` where available to simplify teardown and avoid leaks.

### Description
- Add `registerEventListener(target, type, listener, options)` which guards missing `addEventListener`, uses an `AbortController` to register a cancellable listener when supported, and registers a cleanup callback via `registerCleanup`.
- Replace direct `addEventListener`/`removeEventListener` calls in `initCardClickHandlers`, the `popstate` handler registration, and the `matchMedia` change handler with `registerEventListener` calls.
- Preserve fallback behavior for environments without `AbortController` and for `MediaQueryList` implementations that only support `addListener`/`removeListener`.
- Keep existing `registerCleanup`/`runCleanupStack` semantics unchanged so teardown behavior remains consistent.

### Testing
- No automated tests were added or modified for this change.
- No automated test runner was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b7fec2c83328e8be0d8100e3f67)