### PR TITLE
Simplify browse filters and unify applied filter summary

### DIFF
--- a/assets/js/frontend/workspace-helpers.ts
+++ b/assets/js/frontend/workspace-helpers.ts
@@ -136,6 +136,40 @@ export function getCollectionTags(entries: PresetCatalogEntry[]) {
   return [...collectionTags].sort((left, right) => left.localeCompare(right));
 }
 
+export function getFeaturedCollectionTags(collectionTags: string[]) {
+  const featuredHints = [
+    'collection:classic-milkdrop',
+    'collection:bright',
+    'collection:space',
+  ];
+  const featured = featuredHints.filter((tag) => collectionTags.includes(tag));
+  if (featured.length > 0) {
+    return featured;
+  }
+  return collectionTags.slice(0, 3);
+}
+
+export function buildAppliedFilterSummary({
+  searchQuery,
+  collectionTag,
+}: {
+  searchQuery: string;
+  collectionTag: string | null;
+}) {
+  const appliedFilters = [
+    searchQuery.trim().length > 0 ? `Search: "${searchQuery.trim()}"` : null,
+    collectionTag
+      ? `Collection: ${prettifyCollectionTag(collectionTag)}`
+      : null,
+  ].filter(Boolean);
+
+  if (appliedFilters.length === 0) {
+    return 'Applied filters: none';
+  }
+
+  return `Applied filters: ${appliedFilters.join(' · ')}`;
+}
+
 export function buildPresetSearchIndex(entry: PresetCatalogEntry) {
   return [entry.id, entry.title, entry.author, ...(entry.tags ?? [])]
     .filter(Boolean)

--- a/assets/js/frontend/workspace-ui.tsx
+++ b/assets/js/frontend/workspace-ui.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, ReactNode, RefObject } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MotionPreference } from '../core/motion-preferences.ts';
 import type { QualityPreset } from '../core/settings-panel.ts';
 import type { RenderPreferences } from '../core/state/render-preference-store.ts';
@@ -15,8 +15,10 @@ import type {
   SessionRouteState,
 } from './contracts.ts';
 import {
+  buildAppliedFilterSummary,
   describePresetMood,
   formatPresetSupportNote,
+  getFeaturedCollectionTags,
   getPresetCardSupportLabel,
   getQualityImpactSummary,
   getSettingsPresetOptions,
@@ -984,9 +986,17 @@ function BrowseSheetPanel({
   searchQuery: string;
   starterPresets: StarterPreset[];
 }) {
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const showStarterPresets =
     searchQuery.trim().length === 0 && routeState.collectionTag === null;
   const showActivitySections = showStarterPresets;
+  const featuredCollectionTags = getFeaturedCollectionTags(collectionTags);
+  const hiddenCollectionTags = collectionTags.filter(
+    (tag) => !featuredCollectionTags.includes(tag),
+  );
+  const usingHiddenCollectionFilter =
+    routeState.collectionTag !== null &&
+    !featuredCollectionTags.includes(routeState.collectionTag);
   const previewTargetIds = [
     ...starterPresets.map((starter) => starter.preset.id),
     ...recentPresets.map((entry) => entry.id),
@@ -1027,6 +1037,12 @@ function BrowseSheetPanel({
   useEffect(() => {
     onVisiblePresetIdsChange(visiblePreviewIds);
   }, [onVisiblePresetIdsChange, visiblePreviewIds]);
+
+  useEffect(() => {
+    if (usingHiddenCollectionFilter) {
+      setShowAdvancedFilters(true);
+    }
+  }, [usingHiddenCollectionFilter]);
 
   return (
     <div className="stims-shell__sheet-panel stims-shell__sheet-panel--browse">
@@ -1086,25 +1102,21 @@ function BrowseSheetPanel({
           onChange={(event) => onSearchQueryChange(event.target.value)}
         />
 
-        {searchQuery.trim().length > 0 || routeState.collectionTag ? (
-          <p
-            className="stims-shell__active-filters"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            Showing{' '}
-            {[
-              searchQuery.trim().length > 0 ? `"${searchQuery.trim()}"` : '',
-              routeState.collectionTag
-                ? prettifyCollectionTag(routeState.collectionTag)
-                : '',
-            ]
-              .filter(Boolean)
-              .join(' in ')}
-          </p>
-        ) : null}
+        <p
+          className="stims-shell__active-filters"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {buildAppliedFilterSummary({
+            searchQuery,
+            collectionTag: routeState.collectionTag,
+          })}
+        </p>
 
-        <nav className="stims-shell__collections" aria-label="Collections">
+        <nav
+          className="stims-shell__collections"
+          aria-label="Popular collections"
+        >
           <button
             type="button"
             className="stims-shell__collection-pill"
@@ -1113,7 +1125,7 @@ function BrowseSheetPanel({
           >
             All
           </button>
-          {collectionTags.map((collectionTag) => (
+          {featuredCollectionTags.map((collectionTag) => (
             <button
               key={collectionTag}
               type="button"
@@ -1131,6 +1143,48 @@ function BrowseSheetPanel({
             </button>
           ))}
         </nav>
+        <div
+          className="stims-shell__browse-toolbar-extras"
+          data-open={String(showAdvancedFilters)}
+        >
+          <button
+            type="button"
+            className="stims-shell__text-button"
+            onClick={() => {
+              setShowAdvancedFilters((current) => !current);
+            }}
+          >
+            Advanced filters
+          </button>
+          {showAdvancedFilters && hiddenCollectionTags.length > 0 ? (
+            <nav
+              className="stims-shell__collections"
+              aria-label="All collections"
+            >
+              {hiddenCollectionTags.map((collectionTag) => (
+                <button
+                  key={collectionTag}
+                  type="button"
+                  className="stims-shell__collection-pill"
+                  data-active={String(
+                    routeState.collectionTag === collectionTag,
+                  )}
+                  onClick={() =>
+                    onCollectionTagChange(
+                      routeState.collectionTag === collectionTag
+                        ? null
+                        : collectionTag,
+                    )
+                  }
+                >
+                  {prettifyCollectionTag(collectionTag)}
+                </button>
+              ))}
+            </nav>
+          ) : showAdvancedFilters ? (
+            <p className="stims-shell__meta-copy">No additional filters.</p>
+          ) : null}
+        </div>
       </section>
 
       {showStarterPresets && starterPresets.length > 0 ? (
@@ -1217,9 +1271,7 @@ function BrowseSheetPanel({
           <p className="stims-shell__meta-copy">
             {filteredCatalog.length} result
             {filteredCatalog.length === 1 ? '' : 's'}
-            {searchQuery.trim().length > 0 || routeState.collectionTag
-              ? ' match the current filters.'
-              : ' ready to explore.'}
+            ready to explore.
           </p>
         </div>
         <ul className="stims-shell__preset-list">


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the preset browser by exposing only high-impact controls by default (search + key collection pills) while keeping full filtering available. 
- Provide a single, canonical place for filter-state messaging so the UI and URL state remain easy to scan and unambiguous. 
- Ensure deep-linked advanced filters reveal their controls so routes with advanced params remain discoverable. 

### Description
- Default browse controls now show the search input plus an "All" pill and a curated set of featured collection pills, with remaining collections moved under an "Advanced filters" section implemented as a toggleable area in the sheet UI (`assets/js/frontend/workspace-ui.tsx`).
- Added `getFeaturedCollectionTags` and `buildAppliedFilterSummary` helpers to `assets/js/frontend/workspace-helpers.ts` and wired them into the browse sheet so the applied-filter row always reflects `searchQuery` and `collectionTag` state.
- Introduced auto-expand behavior that opens advanced controls when the current route/query targets a non-featured collection tag so deep links surface the active control automatically (`useEffect` that toggles advanced filters based on route state in `workspace-ui.tsx`).
- Removed duplicate filter wording from the results summary and consolidated all filter-state messaging into the single applied-filters row to avoid repeated/contradictory text.

### Testing
- Ran the quick quality gate via `bun run check:quick`, which failed in this workspace due to unrelated pre-existing tooling/artifact issues (missing platform-specific Biome binary and stale generated SEO/toys assets), so the full gate did not complete successfully.
- Ran the staged format/lint check used by pre-commit (`biome` checks for the modified files) and resolved formatting/lint feedback so the changes pass the local staged lint/format rules for the updated files.
- No runtime/browser visual tests were executed as part of this run; recommend `bun run dev` and browser verification at `http://localhost:5173/?agent=true` for visual confirmation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccb6b50bc8332b9f95f25b5aebffb)