### PR TITLE
fix: Make visualizer UI copy clearer

### DIFF
--- a/assets/js/frontend/App.tsx
+++ b/assets/js/frontend/App.tsx
@@ -248,7 +248,7 @@ function StimsWorkspaceAppShell() {
       ) {
         quietDemoSuggestedRef.current = true;
         ui.setStatusMessage(
-          'Not hearing much? Switch to demo audio for guaranteed motion.',
+          'Not seeing much movement? Try demo audio for a stronger signal.',
         );
       }
     } else {
@@ -267,23 +267,23 @@ function StimsWorkspaceAppShell() {
     ? 'Loading preset'
     : liveMode
       ? 'Now playing'
-      : 'Stage ready';
+      : 'Ready to play';
   const stageTitle = engine.loadingRequestedPreset
     ? 'Loading preset'
     : engine.selectedPreset
       ? engine.selectedPreset.title
       : engine.missingRequestedPreset
-        ? 'Change preset'
-        : (engine.featuredPreset?.title ?? 'Featured pick');
+        ? 'Choose another preset'
+        : (engine.featuredPreset?.title ?? 'Recommended preset');
   const stageSummary = engine.loadingRequestedPreset
     ? `Loading ${ui.routeState.presetId}.`
     : engine.selectedPreset
       ? engine.selectedPreset.author || 'Unknown author'
       : engine.missingRequestedPreset
-        ? 'Start with the featured pick or open the full list.'
+        ? 'Start with the recommended preset, or browse the full list.'
         : engine.featuredPreset
           ? describePresetMood(engine.featuredPreset)
-          : 'Press play with demo audio, or open the full list first.';
+          : 'Start demo audio, or browse presets first.';
 
   useEffect(() => {
     const handleFullscreenChange = () => {

--- a/assets/js/frontend/BrowseSheetPanel.tsx
+++ b/assets/js/frontend/BrowseSheetPanel.tsx
@@ -126,7 +126,7 @@ export function BrowseSheetPanel({
       const results = await searchByFrame(canvas);
       setVisualSearchResults(results);
     } catch {
-      ui.setStatusMessage('Visual search failed.');
+      ui.setStatusMessage('Finding similar presets failed.');
     } finally {
       setVisualSearchLoading(false);
     }
@@ -220,9 +220,10 @@ export function BrowseSheetPanel({
       <section className="stims-shell__sheet-surface stims-shell__sheet-surface--sticky">
         <div className="stims-shell__browse-toolbar">
           <div className="stims-shell__browse-toolbar-copy">
-            <strong>Select a preset and press play.</strong>
+            <strong>Choose a preset to start playing.</strong>
             <p className="stims-shell__meta-copy">
-              Tap any card to play it. Previews update as they finish loading.
+              Tap any card to load it on the stage. Thumbnail previews fill in
+              as they are ready.
             </p>
           </div>
           <div className="stims-shell__browse-toolbar-actions">
@@ -232,21 +233,21 @@ export function BrowseSheetPanel({
               onClick={engine.handleShufflePreset}
               disabled={catalog.length === 0}
             >
-              Shuffle
+              Surprise me
             </button>
             <details className="stims-shell__browse-toolbar-extras">
               <summary
                 className="stims-shell__text-button"
-                aria-label="More browse tools"
+                aria-label="Preview tools"
               >
-                More
+                Preview tools
               </summary>
               <div className="stims-shell__browse-toolbar-extras-body">
                 <p
                   className="stims-shell__meta-copy"
                   data-testid="browse-preview-summary"
                 >
-                  Previews: {previewSummary || 'waiting on captures'}
+                  Preview status: {previewSummary || 'loading thumbnails'}
                 </p>
                 <button
                   type="button"
@@ -270,7 +271,7 @@ export function BrowseSheetPanel({
           id="preset-search"
           className="stims-shell__input"
           type="search"
-          placeholder="Search by title, mood, creator, or collection"
+          placeholder="Search presets by title, creator, mood, or collection"
           spellCheck={false}
           value={searchQuery}
           onChange={(event) => ui.setSearchQuery(event.target.value)}
@@ -294,14 +295,14 @@ export function BrowseSheetPanel({
                 onCollectionTagChange(null);
               }}
             >
-              Reset all
+              Clear search
             </button>
           ) : null}
         </p>
 
         <nav
           className="stims-shell__collections"
-          aria-label="Popular collections"
+          aria-label="Preset collections"
         >
           <button
             type="button"
@@ -355,7 +356,9 @@ export function BrowseSheetPanel({
                 : void handleVisualSearch()
             }
           >
-            {visualSearchLoading ? 'Searching\u2026' : 'Visual search'}
+            {visualSearchLoading
+              ? 'Searching\u2026'
+              : 'Find similar to current look'}
           </button>
         </nav>
         <div
@@ -369,7 +372,7 @@ export function BrowseSheetPanel({
               setShowAdvancedFilters((current) => !current);
             }}
           >
-            Advanced filters
+            More collections
           </button>
           {showAdvancedFilters && hiddenCollectionTags.length > 0 ? (
             <nav
@@ -397,7 +400,9 @@ export function BrowseSheetPanel({
               ))}
             </nav>
           ) : showAdvancedFilters ? (
-            <p className="stims-shell__meta-copy">No additional filters.</p>
+            <p className="stims-shell__meta-copy">
+              No more collections available.
+            </p>
           ) : null}
         </div>
       </section>
@@ -450,7 +455,9 @@ export function BrowseSheetPanel({
         ) : null}
         {visualSearchActive ? (
           <div className="stims-shell__section-heading">
-            <p className="stims-shell__section-label">Visual search</p>
+            <p className="stims-shell__section-label">
+              Find similar to current look
+            </p>
             <p className="stims-shell__meta-copy">
               {visualSearchResults.length} result
               {visualSearchResults.length === 1 ? '' : 's'}
@@ -474,11 +481,11 @@ export function BrowseSheetPanel({
           </div>
         ) : (
           <div className="stims-shell__section-heading">
-            <p className="stims-shell__section-label">Everything</p>
+            <p className="stims-shell__section-label">All presets</p>
             <p className="stims-shell__meta-copy">
               {filteredCatalog.length} result
               {filteredCatalog.length === 1 ? '' : 's'}
-              ready to explore.
+              available.
             </p>
           </div>
         )}
@@ -489,10 +496,10 @@ export function BrowseSheetPanel({
           routeState.collectionTag !== 'collection:community' &&
           filteredCatalog.length === 0) ? (
           <div className="stims-shell__empty-state">
-            <strong>No matching presets found</strong>
+            <strong>No presets match those filters</strong>
             <p>
-              We couldn't find any presets matching your query in this
-              collection.
+              Try a different search, choose another collection, or clear the
+              filters.
             </p>
             <button
               type="button"
@@ -502,7 +509,7 @@ export function BrowseSheetPanel({
                 onCollectionTagChange(null);
               }}
             >
-              Reset filters
+              Clear filters
             </button>
           </div>
         ) : (
@@ -614,10 +621,10 @@ export function BrowseSheetPanel({
             className="cta-button"
             onClick={engine.exportPreset}
           >
-            Export preset
+            Download current preset
           </button>
           <label className="cta-button stims-shell__file-button">
-            Import preset
+            Add preset file
             <input
               type="file"
               accept=".milk,.txt,text/plain"
@@ -626,7 +633,9 @@ export function BrowseSheetPanel({
             />
           </label>
           <label className="cta-button stims-shell__file-button">
-            {imageImportLoading ? 'Importing\u2026' : 'Import from image'}
+            {imageImportLoading
+              ? 'Importing\u2026'
+              : 'Create preset from image'}
             <input
               type="file"
               accept="image/png,image/jpeg,image/webp,image/gif"
@@ -638,12 +647,12 @@ export function BrowseSheetPanel({
             className="cta-button"
             onClick={() => void ui.handleShowCurrentLink()}
           >
-            Copy link
+            Copy share link
           </button>
         </div>
         {imageImportResult ? (
           <div className="stims-shell__image-import-result">
-            <p className="stims-shell__section-label">Import result</p>
+            <p className="stims-shell__section-label">Created preset</p>
             <p className="stims-shell__meta-copy">
               {imageImportResult.description}
             </p>

--- a/assets/js/frontend/NewHomePage.tsx
+++ b/assets/js/frontend/NewHomePage.tsx
@@ -83,10 +83,11 @@ export function NewHomePage() {
       <div className="stims-shell__launch-hero">
         <div className="stims-shell__launch-header">
           <div className="stims-shell__launch-copy">
-            <p className="stims-shell__eyebrow">Browser visualizer</p>
-            <h1 id="stims-launch-title">Sound into motion.</h1>
+            <p className="stims-shell__eyebrow">Audio visualizer</p>
+            <h1 id="stims-launch-title">Play music. Watch it move.</h1>
             <p className="stims-shell__launch-summary">
-              Demo audio starts automatically. Switch to your own music anytime.
+              Start instantly with demo audio, or connect your own sound when
+              you’re ready.
               {catalogReady
                 ? ` ${catalog.length} presets run in WebGL or WebGPU.`
                 : ' Presets run in WebGL or WebGPU.'}
@@ -103,7 +104,7 @@ export function NewHomePage() {
                 Play with demo audio
               </button>
               <details className="stims-shell__audio-setup-details">
-                <summary>Advanced audio setup</summary>
+                <summary>Use your own audio</summary>
                 <div
                   className="stims-shell__launch-actions"
                   style={{ marginTop: 10 }}
@@ -114,7 +115,7 @@ export function NewHomePage() {
                     disabled={loadingAudio}
                     onClick={() => handleStartAudio('microphone')}
                   >
-                    Use microphone
+                    Use microphone input
                   </button>
                   <button
                     type="button"
@@ -122,7 +123,7 @@ export function NewHomePage() {
                     disabled={loadingAudio}
                     onClick={() => handleStartAudio('tab')}
                   >
-                    Capture tab audio
+                    Use audio from a tab
                   </button>
                 </div>
               </details>
@@ -139,7 +140,7 @@ export function NewHomePage() {
         >
           <PresetArtwork entry={featuredPreset} compact />
           <div className="stims-shell__launch-recommendation-copy">
-            <p className="stims-shell__section-label">Featured pick</p>
+            <p className="stims-shell__section-label">Recommended preset</p>
             <strong>{featuredPreset.title}</strong>
             <span className="stims-shell__meta-copy">
               {describePresetMood(featuredPreset)}
@@ -159,7 +160,7 @@ export function NewHomePage() {
             </strong>
             <p className="stims-shell__meta-copy">
               {featuredPreset
-                ? `Try ${featuredPreset.title} instead, or browse everything.`
+                ? `Try ${featuredPreset.title} instead, or browse all presets.`
                 : 'Open the full list to pick another one.'}
             </p>
           </div>
@@ -170,7 +171,7 @@ export function NewHomePage() {
                 className="cta-button primary"
                 onClick={ui.handleFeaturedPresetSelection}
               >
-                Try featured pick
+                Play recommended preset
               </button>
             ) : null}
             <button
@@ -178,7 +179,7 @@ export function NewHomePage() {
               className="cta-button"
               onClick={ui.handleBrowseRecovery}
             >
-              Browse everything
+              Explore presets
             </button>
           </div>
         </section>
@@ -188,7 +189,7 @@ export function NewHomePage() {
         <PresetShelfSection
           entries={buildJumpBackEntries(favoritePresets, recentPresets)}
           summary=""
-          title="Jump back in"
+          title="Saved presets"
           onSelect={engine.handlePlayPreset}
           presetPreviews={presetPreviews}
         />
@@ -201,7 +202,7 @@ export function NewHomePage() {
             summary: describePresetMood(entry),
           }))}
           summary=""
-          title="Browse all presets"
+          title="Explore presets"
           titleAction={{
             label: `See all ${catalog.length} \u2192`,
             onClick: () => ui.updatePanel('browse'),

--- a/assets/js/frontend/SettingsSheetPanel.tsx
+++ b/assets/js/frontend/SettingsSheetPanel.tsx
@@ -123,7 +123,7 @@ export function SettingsSheetPanel({
   return (
     <div className="stims-shell__sheet-panel stims-shell__sheet-panel--settings">
       <section className="stims-shell__sheet-surface">
-        <p className="stims-shell__section-label">Quality presets</p>
+        <p className="stims-shell__section-label">Visual quality</p>
         <ul className="stims-shell__preset-guides">
           {guidedPresets.map((preset) => (
             <li key={preset.id}>
@@ -142,7 +142,7 @@ export function SettingsSheetPanel({
           ))}
         </ul>
         <label className="stims-shell__field-label" htmlFor="quality-select">
-          Or pick an exact render profile
+          Choose a specific quality profile
         </label>
         <select
           id="quality-select"
@@ -165,9 +165,9 @@ export function SettingsSheetPanel({
 
       <details className="stims-shell__settings-advanced">
         <summary className="stims-shell__settings-summary">
-          <span>Advanced Preferences</span>
+          <span>Manual preferences</span>
           <span className="stims-shell__meta-copy">
-            Open this only if you want manual controls
+            Optional controls for compatibility and device motion
           </span>
         </summary>
         <div className="stims-shell__settings-advanced-body">
@@ -180,9 +180,9 @@ export function SettingsSheetPanel({
               }
             />
             <span className="stims-shell__toggle-copy">
-              <strong>Keep things steadier on tricky hardware</strong>
+              <strong>Stability mode for older or unstable devices</strong>
               <small>
-                Back off riskier graphics paths when the browser gets unstable.
+                Uses safer rendering choices if your browser or GPU has trouble.
               </small>
             </span>
           </label>
@@ -196,9 +196,9 @@ export function SettingsSheetPanel({
               }
             />
             <span className="stims-shell__toggle-copy">
-              <strong>Use motion controls on supported devices</strong>
+              <strong>Let phone or tablet movement affect visuals</strong>
               <small>
-                Mostly useful on phones and tablets that can react to tilt.
+                Works on supported mobile devices after permission is granted.
               </small>
             </span>
           </label>
@@ -206,13 +206,13 @@ export function SettingsSheetPanel({
       </details>
 
       <section className="stims-shell__sheet-surface">
-        <p className="stims-shell__section-label">Renderer</p>
+        <p className="stims-shell__section-label">Graphics backend</p>
         <p className="stims-shell__meta-copy">
           {engineSnapshot?.backend
             ? `Running on ${engineSnapshot.backend === 'webgpu' ? 'WebGPU' : 'WebGL'}`
             : engine.engineReady
-              ? 'Renderer ready'
-              : 'Initializing renderer\u2026'}
+              ? 'Graphics backend ready'
+              : 'Starting graphics\u2026'}
           {engineSnapshot?.backend === 'webgl'
             ? ' — WebGPU was unavailable or disabled.'
             : ''}

--- a/assets/js/frontend/StimsControlDock.tsx
+++ b/assets/js/frontend/StimsControlDock.tsx
@@ -181,8 +181,8 @@ export function StimsControlDock({
           type="button"
           className="stims-shell__stage-tool"
           data-active={String(panel === 'browse')}
-          aria-label="Open browse panel"
-          title="Open browse panel"
+          aria-label="Browse presets"
+          title="Browse presets"
           onClick={() => ui.updatePanel('browse')}
         >
           <UiIcon
@@ -195,8 +195,8 @@ export function StimsControlDock({
           type="button"
           className="stims-shell__stage-tool"
           data-active={String(panel === 'settings')}
-          aria-label="Open settings panel"
-          title="Open settings panel"
+          aria-label="Adjust settings"
+          title="Adjust settings"
           onClick={() => ui.updatePanel('settings')}
         >
           <UiIcon
@@ -208,8 +208,8 @@ export function StimsControlDock({
         <button
           type="button"
           className="stims-shell__stage-tool"
-          aria-label="Shuffle preset"
-          title="Shuffle preset"
+          aria-label="Play a random preset"
+          title="Play a random preset"
           onClick={engine.handleShufflePreset}
         >
           <UiIcon
@@ -222,8 +222,8 @@ export function StimsControlDock({
           type="button"
           className="stims-shell__stage-tool"
           data-active={String(panel === 'editor')}
-          aria-label="Open editor panel"
-          title="Open editor panel"
+          aria-label="Edit the current preset"
+          title="Edit the current preset"
           onClick={() => ui.updatePanel('editor')}
         >
           <UiIcon
@@ -235,8 +235,8 @@ export function StimsControlDock({
         <button
           type="button"
           className="stims-shell__stage-tool"
-          aria-label="Generate from mood"
-          title="Generate from mood"
+          aria-label="Create a preset from a mood"
+          title="Create a preset from a mood"
           onClick={() => setShowMoods((s) => !s)}
         >
           <UiIcon
@@ -265,8 +265,8 @@ export function StimsControlDock({
           <button
             type="button"
             className="stims-shell__stage-tool"
-            aria-label="Stop audio"
-            title="Stop audio"
+            aria-label="Stop audio input"
+            title="Stop audio input"
             onClick={engine.handleAudioStop}
           >
             <UiIcon
@@ -288,14 +288,14 @@ export function StimsControlDock({
             className="stims-shell__stage-tool-icon stims-icon-slot stims-icon-slot--sm"
           />
           <span className="stims-shell__stage-tool-label">
-            {isFullscreen ? 'Exit' : 'Full'}
+            {isFullscreen ? 'Exit full screen' : 'Full screen'}
           </span>
         </button>
         <button
           type="button"
           className="stims-shell__stage-tool"
-          aria-label="Share current link"
-          title="Share current link"
+          aria-label="Copy a share link"
+          title="Copy a share link"
           onClick={() => void ui.handleShowCurrentLink()}
         >
           <UiIcon
@@ -307,8 +307,8 @@ export function StimsControlDock({
         <button
           type="button"
           className="cta-button stims-shell__stage-tool-ghost"
-          aria-label="Find similar presets"
-          title="More like this"
+          aria-label="Find presets that look similar"
+          title="Find presets that look similar"
           disabled={!runtimeReady || similarLoading}
           onClick={() => void handleMoreLikeThis()}
         >
@@ -317,14 +317,14 @@ export function StimsControlDock({
             className="stims-shell__stage-tool-icon stims-icon-slot stims-icon-slot--sm"
           />
           <span className="stims-shell__stage-tool-label">
-            {similarLoading ? 'Searching\u2026' : 'More like \u00D7'}
+            {similarLoading ? 'Searching\u2026' : 'More like this'}
           </span>
         </button>
         <button
           type="button"
           className="cta-button stims-shell__stage-tool-ghost"
-          aria-label="Save current look"
-          title="Save this look"
+          aria-label="Save the current look"
+          title="Save the current look"
           disabled={!runtimeReady}
           onClick={handleSaveThisLook}
         >
@@ -334,8 +334,8 @@ export function StimsControlDock({
           <button
             type="button"
             className="stims-shell__stage-tool"
-            aria-label="Toggle theme"
-            title="Toggle theme"
+            aria-label="Switch light or dark theme"
+            title="Switch light or dark theme"
             onClick={onToggleTheme}
           >
             <UiIcon
@@ -357,7 +357,7 @@ export function StimsControlDock({
             }}
           >
             <h2 className="stims-shell__section-label" style={{ margin: 0 }}>
-              Similar presets
+              Similar looks
             </h2>
             <button
               type="button"


### PR DESCRIPTION
### Motivation

- Improve overall usability by replacing awkward/oblique UI copy with direct, task‑oriented wording so first‑time flows are clearer. 
- Make control labels, button titles, and status messages more accessible and actionable for both sighted users and assistive technologies.
- Clarify import/export, preview, and visual search actions so users understand what each control does immediately.

### Description

- Reworded launch/hero copy and audio startup text in `assets/js/frontend/NewHomePage.tsx` to make the demo/audio entry path and recommended preset actions explicit. 
- Simplified browse-panel language and controls in `assets/js/frontend/BrowseSheetPanel.tsx`, including search placeholders, shuffle text, preview tools, empty states, and import/export labels. 
- Made settings language friendlier in `assets/js/frontend/SettingsSheetPanel.tsx`, renaming quality/renderer sections and clarifying stability and motion controls. 
- Updated live stage control labels and accessibility/title text in `assets/js/frontend/StimsControlDock.tsx` and improved idle/low‑audio guidance and stage titles in `assets/js/frontend/App.tsx` to communicate visible outcomes.

### Testing

- Ran the lightweight quality gate with `bun run check:quick`, which completed assets/SEO/Biome/architecture checks but then surfaced an existing TypeScript failure in another file due to missing `@react-three/fiber` typings (not caused by these copy changes). 
- Verified formatting and linting for the edited files with `bash scripts/run-biome.sh format` and `bash scripts/run-biome.sh check` for the changed files, which passed for the targets. 
- Launched the dev server with `bun run dev -- --host 127.0.0.1` and captured a Playwright screenshot after running `bunx playwright install chromium` and `bunx playwright install-deps chromium`, which succeeded. 
- Ran `git diff --check` and local checks for the edited files as part of the quick validation steps, which passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30afd6992483329ab674ef5e4e77a7)