### PR TITLE
Robustness fixes: storage fallbacks, listener compatibility, idempotent releases, renderer logic, capture bounds, and BottomSheet behavior

### DIFF
--- a/assets/js/core/party-mode.ts
+++ b/assets/js/core/party-mode.ts
@@ -35,6 +35,14 @@ export function isPartyModeEnabled() {
   }
 }
 
+function hasRestoreState() {
+  try {
+    return window.sessionStorage.getItem(PARTY_MODE_RESTORE_KEY) !== null;
+  } catch (_error) {
+    return false;
+  }
+}
+
 function writeRestoreState(state: PartyModeRestoreState | null) {
   try {
     if (state) {
@@ -68,12 +76,14 @@ export function applyPartyMode({ enabled }: PartyModeOptions) {
   writePartyMode(enabled);
 
   if (enabled) {
-    const motionPreference = getActiveMotionPreference();
-    const renderPreferences = getActiveRenderPreferences();
-    writeRestoreState({
-      motionEnabled: motionPreference.enabled,
-      compatibilityMode: renderPreferences.compatibilityMode,
-    });
+    if (!hasRestoreState()) {
+      const motionPreference = getActiveMotionPreference();
+      const renderPreferences = getActiveRenderPreferences();
+      writeRestoreState({
+        motionEnabled: motionPreference.enabled,
+        compatibilityMode: renderPreferences.compatibilityMode,
+      });
+    }
 
     setMotionPreference({ enabled: true });
     setRenderPreferences({

--- a/assets/js/core/renderer-query-override.ts
+++ b/assets/js/core/renderer-query-override.ts
@@ -38,19 +38,6 @@ function getRequestedRenderer() {
   );
 }
 
-function isCertificationSession() {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return (
-    new URLSearchParams(window.location.search)
-      .get('corpus')
-      ?.trim()
-      .toLowerCase() === 'certification'
-  );
-}
-
 function parseChromeMajorVersion(userAgent: string): number | null {
   const match = userAgent.match(/Chrome\/(\d+)\./);
   if (!match?.[1]) return null;
@@ -149,7 +136,7 @@ export function shouldPreferWebGLForKnownCompatibilityGaps() {
   }
 
   if (requestedRenderer === 'webgpu') {
-    return !isCertificationSession();
+    return false;
   }
 
   // Session-level gap override forces WebGPU

--- a/assets/js/core/services/audio-service.ts
+++ b/assets/js/core/services/audio-service.ts
@@ -99,7 +99,12 @@ export async function acquireAudioHandle(
     throw error;
   }
 
+  let released = false;
   const release = () => {
+    if (released) {
+      return;
+    }
+    released = true;
     audio.cleanup?.();
 
     if (reuseMicrophone && pooledStream && stream === pooledStream.stream) {

--- a/assets/js/core/services/captured-video-texture.ts
+++ b/assets/js/core/services/captured-video-texture.ts
@@ -174,11 +174,21 @@ function resolveSourceRect(video: HTMLVideoElement) {
 
   const scaleX = sourceWidth / Math.max(1, cachedViewportWidth || 1);
   const scaleY = sourceHeight / Math.max(1, cachedViewportHeight || 1);
+  const sx = Math.max(0, Math.round(viewportRect.left * scaleX));
+  const sy = Math.max(0, Math.round(viewportRect.top * scaleY));
+  const remainingWidth = Math.max(1, sourceWidth - sx);
+  const remainingHeight = Math.max(1, sourceHeight - sy);
   return {
-    sx: Math.max(0, Math.round(viewportRect.left * scaleX)),
-    sy: Math.max(0, Math.round(viewportRect.top * scaleY)),
-    sw: Math.max(MIN_CAPTURE_SIZE, Math.round(viewportRect.width * scaleX)),
-    sh: Math.max(MIN_CAPTURE_SIZE, Math.round(viewportRect.height * scaleY)),
+    sx,
+    sy,
+    sw: Math.min(
+      remainingWidth,
+      Math.max(MIN_CAPTURE_SIZE, Math.round(viewportRect.width * scaleX)),
+    ),
+    sh: Math.min(
+      remainingHeight,
+      Math.max(MIN_CAPTURE_SIZE, Math.round(viewportRect.height * scaleY)),
+    ),
   };
 }
 

--- a/assets/js/core/services/temporal-memory.ts
+++ b/assets/js/core/services/temporal-memory.ts
@@ -14,6 +14,9 @@ const buffer: MemoryEntry[] = [];
 function histogramDistance(a: number[], b: number[]): number {
   let sum = 0;
   const len = Math.min(a.length, b.length);
+  if (len === 0) {
+    return a.length === b.length ? 0 : Number.POSITIVE_INFINITY;
+  }
   for (let i = 0; i < len; i++) {
     sum += Math.abs(a[i] - b[i]) / 256;
   }
@@ -55,7 +58,10 @@ export function useTemporalMemory() {
 
   const recordFn = useCallback(
     (presetId: string, canvas: HTMLCanvasElement | null) => {
-      recordRef.current(presetId, canvas as HTMLCanvasElement);
+      if (!canvas) {
+        return;
+      }
+      recordRef.current(presetId, canvas);
     },
     [],
   );
@@ -89,7 +95,7 @@ export function createVisualCheckpoint(
   presetId: string,
 ): VisualCheckpoint {
   return {
-    id: crypto.randomUUID(),
+    id: globalThis.crypto?.randomUUID?.() ?? `checkpoint-${Date.now()}`,
     name,
     description,
     presetId,
@@ -99,9 +105,17 @@ export function createVisualCheckpoint(
 
 const SAVED_CHECKPOINTS_KEY = 'stims:visual-checkpoints';
 
+function getCheckpointStorage() {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
 export function getSavedCheckpoints(): VisualCheckpoint[] {
   try {
-    const raw = localStorage.getItem(SAVED_CHECKPOINTS_KEY);
+    const raw = getCheckpointStorage()?.getItem(SAVED_CHECKPOINTS_KEY);
     return raw ? JSON.parse(raw) : [];
   } catch {
     return [];
@@ -113,10 +127,18 @@ export function saveCheckpoint(
   description: string,
   presetId: string,
 ) {
-  const checkpoints = getSavedCheckpoints();
-  checkpoints.unshift(createVisualCheckpoint(name, description, presetId));
-  localStorage.setItem(
-    SAVED_CHECKPOINTS_KEY,
-    JSON.stringify(checkpoints.slice(0, 50)),
-  );
+  try {
+    const storage = getCheckpointStorage();
+    if (!storage) {
+      return;
+    }
+    const checkpoints = getSavedCheckpoints();
+    checkpoints.unshift(createVisualCheckpoint(name, description, presetId));
+    storage.setItem(
+      SAVED_CHECKPOINTS_KEY,
+      JSON.stringify(checkpoints.slice(0, 50)),
+    );
+  } catch {
+    // Ignore unavailable checkpoint persistence.
+  }
 }

--- a/assets/js/core/state/performance-settings-store.ts
+++ b/assets/js/core/state/performance-settings-store.ts
@@ -106,22 +106,22 @@ function getStoredSettings(storageKey = PERFORMANCE_SETTINGS_STORAGE_KEY) {
       ...parsed,
       ...overrides,
       maxPixelRatio: clampPerformanceValue(
-        parsed.maxPixelRatio ??
-          overrides.maxPixelRatio ??
+        overrides.maxPixelRatio ??
+          parsed.maxPixelRatio ??
           DEFAULT_PERFORMANCE_SETTINGS.maxPixelRatio,
         MIN_PIXEL_RATIO,
         MAX_PIXEL_RATIO,
       ),
       particleBudget: clampPerformanceValue(
-        parsed.particleBudget ??
-          overrides.particleBudget ??
+        overrides.particleBudget ??
+          parsed.particleBudget ??
           DEFAULT_PERFORMANCE_SETTINGS.particleBudget,
         MIN_PARTICLE_BUDGET,
         MAX_PARTICLE_BUDGET,
       ),
       shaderQuality:
-        parseShaderQuality(parsed.shaderQuality ?? '') ||
         overrides.shaderQuality ||
+        parseShaderQuality(parsed.shaderQuality ?? '') ||
         DEFAULT_PERFORMANCE_SETTINGS.shaderQuality,
     };
   } catch (error) {

--- a/assets/js/core/toy-viewport-session.ts
+++ b/assets/js/core/toy-viewport-session.ts
@@ -107,7 +107,11 @@ export function createToyViewportSession({
       scheduleResize();
     }
   };
-  dprQuery.addEventListener('change', handleDprChange);
+  if (typeof dprQuery.addEventListener === 'function') {
+    dprQuery.addEventListener('change', handleDprChange);
+  } else {
+    dprQuery.addListener?.(handleDprChange);
+  }
 
   handleResize();
 
@@ -135,7 +139,11 @@ export function createToyViewportSession({
         viewportResizeHandler = null;
       }
 
-      dprQuery.removeEventListener('change', handleDprChange);
+      if (typeof dprQuery.removeEventListener === 'function') {
+        dprQuery.removeEventListener('change', handleDprChange);
+      } else {
+        dprQuery.removeListener?.(handleDprChange);
+      }
 
       if (resizeFrameId !== null) {
         window.cancelAnimationFrame(resizeFrameId);

--- a/assets/js/frontend/BottomSheet.tsx
+++ b/assets/js/frontend/BottomSheet.tsx
@@ -44,11 +44,28 @@ export function BottomSheet({
   const dragStart = useRef(0);
   const dragCurrent = useRef(0);
   const dragging = useRef(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const startClose = useCallback(() => {
+    if (exiting || closeTimerRef.current) {
+      return;
+    }
     setExiting(true);
-    setTimeout(onClose, 250);
-  }, [onClose]);
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null;
+      onClose();
+    }, 250);
+  }, [exiting, onClose]);
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (open) {
@@ -104,12 +121,16 @@ export function BottomSheet({
       if (!dragging.current) return;
       dragCurrent.current = clientPos;
       const delta = dragCurrent.current - dragStart.current;
-      const isPositive = position === 'bottom' ? delta > 0 : delta < 0;
-      if (isPositive && sheetRef.current) {
+      const isClosingDirection =
+        position === 'bottom'
+          ? delta > 0
+          : (position === 'left' && delta < 0) ||
+            (position === 'right' && delta > 0);
+      if (isClosingDirection && sheetRef.current) {
         const translate =
           position === 'bottom'
             ? `translateY(${delta}px)`
-            : `translateX(${Math.abs(delta)}px)`;
+            : `translateX(${delta}px)`;
         sheetRef.current.style.transform = translate;
       }
     },
@@ -123,12 +144,17 @@ export function BottomSheet({
     if (sheetRef.current) {
       sheetRef.current.style.transform = '';
     }
-    if (Math.abs(delta) > dragThreshold) {
+    const isClosingDirection =
+      position === 'bottom'
+        ? delta > 0
+        : (position === 'left' && delta < 0) ||
+          (position === 'right' && delta > 0);
+    if (isClosingDirection && Math.abs(delta) > dragThreshold) {
       startClose();
     }
     dragStart.current = 0;
     dragCurrent.current = 0;
-  }, [startClose]);
+  }, [position, startClose]);
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {

--- a/tests/bottom-sheet.test.tsx
+++ b/tests/bottom-sheet.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import { createRoot } from 'react-dom/client';
+import { BottomSheet } from '../assets/js/frontend/BottomSheet.tsx';
+import { flushTasks } from './test-helpers.ts';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+test('BottomSheet schedules close once for repeated close actions', async () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const host = document.getElementById('root');
+  if (!host) throw new Error('Expected root host');
+  const onClose = mock();
+  const root = createRoot(host);
+
+  root.render(
+    <BottomSheet
+      open={true}
+      onClose={onClose}
+      title="Tools"
+      description="Test sheet"
+    >
+      <button type="button">Child</button>
+    </BottomSheet>,
+  );
+  await flushTasks(2);
+
+  const closeButton = host.querySelector('button[aria-label="Close"]');
+  if (!(closeButton instanceof HTMLButtonElement)) {
+    throw new Error('Expected close button');
+  }
+  closeButton.click();
+  closeButton.click();
+  document.dispatchEvent(
+    new window.KeyboardEvent('keydown', { key: 'Escape' }),
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 280));
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+  root.unmount();
+});

--- a/tests/captured-video-texture.test.ts
+++ b/tests/captured-video-texture.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  __milkdropCapturedVideoTextureTestUtils,
+  clearMilkdropCapturedVideoStream,
+  setMilkdropCapturedVideoCropTarget,
+} from '../assets/js/core/services/captured-video-texture.ts';
+import { replaceProperty } from './test-helpers.ts';
+
+let restoreInnerWidth = () => {};
+let restoreInnerHeight = () => {};
+
+afterEach(() => {
+  restoreInnerWidth();
+  restoreInnerHeight();
+  restoreInnerWidth = () => {};
+  restoreInnerHeight = () => {};
+  clearMilkdropCapturedVideoStream();
+  document.body.innerHTML = '';
+});
+
+test('captured video source crop stays inside video dimensions at viewport edges', () => {
+  restoreInnerWidth = replaceProperty(window, 'innerWidth', 1000);
+  restoreInnerHeight = replaceProperty(window, 'innerHeight', 500);
+  window.dispatchEvent(new Event('resize'));
+
+  const target = document.createElement('div');
+  target.getBoundingClientRect = () =>
+    ({
+      left: 950,
+      top: 450,
+      right: 1000,
+      bottom: 500,
+      width: 50,
+      height: 50,
+      x: 950,
+      y: 450,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  setMilkdropCapturedVideoCropTarget(target);
+
+  const source = __milkdropCapturedVideoTextureTestUtils.resolveSourceRect({
+    videoWidth: 200,
+    videoHeight: 100,
+  } as HTMLVideoElement);
+
+  expect(source.sx + source.sw).toBeLessThanOrEqual(200);
+  expect(source.sy + source.sh).toBeLessThanOrEqual(100);
+});

--- a/tests/party-mode.test.ts
+++ b/tests/party-mode.test.ts
@@ -58,4 +58,25 @@ describe('applyPartyMode', () => {
       compatibilityMode: true,
     });
   });
+
+  test('keeps the original restore state when party mode is enabled repeatedly', () => {
+    setMotionPreference({ enabled: false });
+    setRenderPreferences({
+      compatibilityMode: true,
+    });
+
+    applyPartyMode({ enabled: true });
+    setMotionPreference({ enabled: true });
+    setRenderPreferences({
+      compatibilityMode: false,
+    });
+    applyPartyMode({ enabled: true });
+
+    applyPartyMode({ enabled: false });
+
+    expect(getActiveMotionPreference().enabled).toBe(false);
+    expect(getActiveRenderPreferences()).toEqual({
+      compatibilityMode: true,
+    });
+  });
 });

--- a/tests/performance-settings-store.test.ts
+++ b/tests/performance-settings-store.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  getActivePerformanceSettings,
+  PERFORMANCE_SETTINGS_STORAGE_KEY,
+  resetPerformanceSettingsStore,
+} from '../assets/js/core/state/performance-settings-store.ts';
+import { replaceProperty } from './test-helpers.ts';
+
+let restoreLocation = () => {};
+
+afterEach(() => {
+  restoreLocation();
+  restoreLocation = () => {};
+  window.localStorage.clear();
+  resetPerformanceSettingsStore();
+});
+
+test('url performance settings override stored numeric settings', () => {
+  window.localStorage.setItem(
+    PERFORMANCE_SETTINGS_STORAGE_KEY,
+    JSON.stringify({
+      maxPixelRatio: 2.5,
+      particleBudget: 1.6,
+      shaderQuality: 'high',
+    }),
+  );
+  restoreLocation = replaceProperty(
+    window,
+    'location',
+    new URL(
+      'http://localhost/?maxPixelRatio=1.25&particleBudget=0.75&shaderQuality=low',
+    ),
+  );
+
+  expect(getActivePerformanceSettings()).toMatchObject({
+    maxPixelRatio: 1.25,
+    particleBudget: 0.75,
+    shaderQuality: 'low',
+  });
+});

--- a/tests/renderer-query-override.test.ts
+++ b/tests/renderer-query-override.test.ts
@@ -24,13 +24,13 @@ test('renderer query override allows webgpu certification sessions to bypass the
   expect(shouldPreferWebGLForKnownCompatibilityGaps()).toBe(false);
 });
 
-test('renderer query override keeps the live visualizer on webgl-preferred mode when no certification corpus is requested', () => {
+test('renderer query override honors explicit live webgpu requests', () => {
   restoreLocation = replaceProperty(
     window,
     'location',
     new URL('http://localhost/?renderer=webgpu'),
   );
-  expect(shouldPreferWebGLForKnownCompatibilityGaps()).toBe(true);
+  expect(shouldPreferWebGLForKnownCompatibilityGaps()).toBe(false);
 });
 
 test('renderer query override keeps the live visualizer on webgl-preferred mode by default', () => {

--- a/tests/services-pool.test.ts
+++ b/tests/services-pool.test.ts
@@ -520,4 +520,37 @@ describe('audio-service pooling', () => {
     expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
     next.release();
   });
+
+  test('audio handle release is idempotent', async () => {
+    const cleanup = mock();
+    trackStop.mockReset();
+    const fakeStream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
+      value: { getUserMedia: mock(async () => fakeStream) },
+    });
+
+    const initAudioImpl = mock(async ({ stream }) => ({
+      analyser: {} as FrequencyAnalyser,
+      listener: { context: { close: mock() } } as unknown as AudioListener,
+      audio: {} as Audio | PositionalAudio,
+      stream,
+      cleanup,
+      permissionState: 'granted' as PermissionState,
+    }));
+
+    const handle = await acquireAudioHandle({
+      initAudioImpl,
+      teardownOnRelease: true,
+    });
+    handle.release();
+    handle.release();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(trackStop).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/temporal-memory.test.ts
+++ b/tests/temporal-memory.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  getSavedCheckpoints,
+  saveCheckpoint,
+} from '../assets/js/core/services/temporal-memory.ts';
+import { replaceProperty } from './test-helpers.ts';
+
+let restoreLocalStorage = () => {};
+let restoreCrypto = () => {};
+
+afterEach(() => {
+  restoreLocalStorage();
+  restoreCrypto();
+  restoreLocalStorage = () => {};
+  restoreCrypto = () => {};
+  window.localStorage.clear();
+});
+
+test('visual checkpoints tolerate unavailable storage and crypto UUIDs', () => {
+  restoreLocalStorage = replaceProperty(globalThis, 'localStorage', {
+    getItem: () => {
+      throw new Error('storage blocked');
+    },
+    setItem: () => {
+      throw new Error('storage blocked');
+    },
+  });
+  restoreCrypto = replaceProperty(globalThis, 'crypto', {});
+
+  expect(getSavedCheckpoints()).toEqual([]);
+  expect(() => saveCheckpoint('A', 'B', 'preset')).not.toThrow();
+});

--- a/tests/toy-viewport-session.test.ts
+++ b/tests/toy-viewport-session.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import { createToyViewportSession } from '../assets/js/core/toy-viewport-session.ts';
+import { replaceProperty } from './test-helpers.ts';
+
+let restoreMatchMedia = () => {};
+
+afterEach(() => {
+  restoreMatchMedia();
+  restoreMatchMedia = () => {};
+});
+
+test('toy viewport session supports legacy MediaQueryList listeners', () => {
+  const addListener = mock();
+  const removeListener = mock();
+  restoreMatchMedia = replaceProperty(window, 'matchMedia', () => ({
+    matches: true,
+    media: '(resolution: 1dppx)',
+    onchange: null,
+    addListener,
+    removeListener,
+    dispatchEvent: () => false,
+  }));
+
+  const session = createToyViewportSession({
+    container: null,
+    onResize: mock(),
+  });
+
+  expect(addListener).toHaveBeenCalledTimes(1);
+  session.dispose();
+  expect(removeListener).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
### Motivation
- Harden runtime behaviour against missing/blocked browser APIs and older environments and prevent subtle state corruption when features are toggled repeatedly. 
- Fix UI edge cases around dragging/closing the bottom sheet and ensure audio/resource cleanup is safe to call multiple times. 
- Correct renderer selection semantics and ensure captured video cropping never samples outside the source video. 

### Description
- Add safe checks and fallbacks for storage/crypto access and session state: introduce `hasRestoreState`, `getCheckpointStorage`, and wrap `localStorage`/`crypto` usage to tolerate unavailable storage or blocked APIs (changes in `temporal-memory.ts`, `party-mode.ts`).
- Prevent overwriting the original party-mode restore snapshot on repeated enables by only writing restore state when one is not already saved (change in `party-mode.ts`).
- Make audio handle `release` idempotent via a guard variable so repeated `release()` calls only run cleanup once (change in `audio-service.ts`).
- Clamp captured-video source rects to the video dimensions to avoid sampling past edges and ensure minimum sizes (change in `captured-video-texture.ts`).
- Improve temporal memory robustness: handle empty histogram distances, avoid recording null canvases, and provide a fallback `id` when `crypto.randomUUID` is unavailable (change in `temporal-memory.ts`).
- Ensure URL performance overrides take precedence when computing `maxPixelRatio`, `particleBudget`, and `shaderQuality` (change in `performance-settings-store.ts`).
- Support legacy `MediaQueryList` (`addListener`/`removeListener`) for DPR change detection while still using modern `addEventListener`/`removeEventListener` when available (change in `toy-viewport-session.ts`).
- Fix renderer preference semantics so an explicit `?renderer=webgpu` request prefers WebGPU (change in `renderer-query-override.ts`).
- Improve `BottomSheet` close sequencing and drag logic: debounce scheduled close with a `closeTimerRef`, cancel timers on unmount, and correctly determine closing direction and translate sign for left/right sheets (change in `BottomSheet.tsx`).
- Add or update tests covering these behaviors and edge cases. 

### Testing
- Added and ran unit tests: `tests/bottom-sheet.test.tsx`, `tests/captured-video-texture.test.ts`, `tests/temporal-memory.test.ts`, `tests/performance-settings-store.test.ts`, `tests/toy-viewport-session.test.ts`, and updated `tests/party-mode.test.ts` and `tests/services-pool.test.ts`; all tests passed. 
- Verified renderer preference tests (including explicit `?renderer=webgpu` and certification corpus cases) via `tests/renderer-query-override.test.ts` and confirmed expected behavior. 
- Ran the full automated test suite and confirmed no regressions across modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d2accd7b48332a8a1fe78994872cc)