### PR TITLE
Enhance mobile UX: thumb mode, gestures, PWA install & offline support

### DIFF
--- a/assets/css/MobileControlBar.module.css
+++ b/assets/css/MobileControlBar.module.css
@@ -195,3 +195,44 @@
     transition: none;
   }
 }
+
+.moreActions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  padding: 6px 10px 10px;
+  border-top: 1px solid var(--stims-line-soft);
+  background: rgba(5, 7, 13, 0.96);
+}
+
+.actions[data-thumb-mode="true"] {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+@media (orientation: landscape) and (width < 900px) and (pointer: coarse) {
+  .bar {
+    left: 18vw;
+    right: 18vw;
+    bottom: max(8px, env(safe-area-inset-bottom));
+    border: 1px solid var(--stims-line-soft);
+    border-radius: 18px;
+    overflow: hidden;
+    padding-bottom: 0;
+  }
+
+  .nowPlaying {
+    display: none;
+  }
+
+  .actions {
+    grid-auto-columns: minmax(54px, 1fr);
+  }
+
+  .actionLabel {
+    display: none;
+  }
+
+  .action {
+    min-height: 48px;
+  }
+}

--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -4153,3 +4153,77 @@ body[data-page="workspace"] {
     animation: 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
 }
+
+.stims-shell__mobile-notice,
+.stims-shell__rotate-hint {
+  position: fixed;
+  left: max(12px, env(safe-area-inset-left));
+  right: max(12px, env(safe-area-inset-right));
+  bottom: calc(
+    var(--mobile-bar-height, 86px) +
+    env(safe-area-inset-bottom) +
+    12px
+  );
+  z-index: var(--z-toast);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--stims-line-soft);
+  border-radius: 16px;
+  background: rgba(5, 7, 13, 0.94);
+  color: var(--stims-ink);
+  box-shadow: var(--stims-shadow);
+  backdrop-filter: blur(12px);
+  font-size: 0.82rem;
+}
+
+.stims-shell__mobile-notice button,
+.stims-shell__rotate-hint button {
+  border: 1px solid var(--stims-line-soft);
+  border-radius: 999px;
+  background: var(--stims-control-fill);
+  color: var(--stims-ink);
+  padding: 6px 10px;
+  font: inherit;
+}
+
+.stims-shell__thumb-actions {
+  display: none;
+}
+
+@media (width < 768px) and (pointer: coarse) {
+  .stims-shell__mobile-notice,
+  .stims-shell__rotate-hint {
+    display: flex;
+  }
+
+  .stims-shell[data-thumb-mode="true"] .stims-shell__thumb-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    padding: 10px 0 calc(10px + env(safe-area-inset-bottom));
+    background: linear-gradient(
+      0deg,
+      var(--stims-panel-fill-strong),
+      rgba(5, 7, 13, 0.78)
+    );
+    border-top: 1px solid var(--stims-line-soft);
+  }
+}
+
+@media (orientation: landscape) and (width < 900px) and (pointer: coarse) {
+  .stims-shell__rotate-hint {
+    display: none;
+  }
+
+  .stims-shell__mobile-notice {
+    left: 20vw;
+    right: 20vw;
+    bottom: 72px;
+  }
+}

--- a/assets/js/frontend/App.tsx
+++ b/assets/js/frontend/App.tsx
@@ -82,6 +82,18 @@ function StimsWorkspaceAppShell() {
     name: string;
     score: number;
   } | null>(null);
+  const [thumbMode, setThumbMode] = useState(() => {
+    try {
+      return localStorage.getItem('stims:mobile-thumb-mode') === 'true';
+    } catch {
+      return false;
+    }
+  });
+  const [offline, setOffline] = useState(() =>
+    typeof navigator === 'undefined' ? false : !navigator.onLine,
+  );
+  const [installPrompt, setInstallPrompt] = useState<Event | null>(null);
+  const [showRotateHint, setShowRotateHint] = useState(false);
 
   const liveMode = engine.audioActive;
   const currentAudioSource =
@@ -120,8 +132,31 @@ function StimsWorkspaceAppShell() {
 
   useStageGesture({
     enabled: liveMode,
+    stageRef: ui.stageRef,
     handleShufflePreset: engine.handleShufflePreset,
     handlePreviousPreset: engine.handlePreviousPreset,
+    openBrowse: () => ui.updatePanel('browse'),
+    closePanel: () => ui.updatePanel(null),
+    toggleFavoritePreset: () => {
+      const activePresetId = engineSnapshot?.activePresetId;
+      const activePreset = activePresetId
+        ? engine.catalog.find((preset) => preset.id === activePresetId)
+        : null;
+      if (!activePresetId) {
+        ui.setStatusMessage('Load a preset before saving it.');
+        return;
+      }
+      void engine.toggleFavoritePreset(
+        activePresetId,
+        !activePreset?.isFavorite,
+      );
+      ui.setStatusMessage(
+        activePreset?.isFavorite
+          ? 'Removed from saved presets.'
+          : 'Saved preset.',
+      );
+    },
+    setStatusMessage: ui.setStatusMessage,
   });
 
   useEffect(() => {
@@ -187,6 +222,64 @@ function StimsWorkspaceAppShell() {
     engineSnapshot?.audioActive,
     ui.setStatusMessage,
   ]);
+
+  useEffect(() => {
+    const syncOnlineState = () => setOffline(!navigator.onLine);
+    window.addEventListener('online', syncOnlineState);
+    window.addEventListener('offline', syncOnlineState);
+    return () => {
+      window.removeEventListener('online', syncOnlineState);
+      window.removeEventListener('offline', syncOnlineState);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setInstallPrompt(event);
+    };
+    window.addEventListener('beforeinstallprompt', handleInstallPrompt);
+    return () =>
+      window.removeEventListener('beforeinstallprompt', handleInstallPrompt);
+  }, []);
+
+  useEffect(() => {
+    const media = window.matchMedia(
+      '(orientation: portrait) and (pointer: coarse) and (max-width: 767px)',
+    );
+    const update = () => {
+      if (!liveMode || !media.matches) {
+        setShowRotateHint(false);
+        return;
+      }
+      try {
+        if (localStorage.getItem('stims:rotate-hint-dismissed') === 'true') {
+          setShowRotateHint(false);
+          return;
+        }
+      } catch {}
+      setShowRotateHint(true);
+    };
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, [liveMode]);
+
+  const updateThumbMode = useCallback((enabled: boolean) => {
+    setThumbMode(enabled);
+    try {
+      localStorage.setItem('stims:mobile-thumb-mode', String(enabled));
+    } catch {}
+  }, []);
+
+  const handleInstallApp = useCallback(() => {
+    const prompt = installPrompt as
+      | (Event & { prompt?: () => Promise<void> })
+      | null;
+    if (!prompt?.prompt) return;
+    void prompt.prompt();
+    setInstallPrompt(null);
+  }, [installPrompt]);
 
   const stageEyebrow = engine.loadingRequestedPreset
     ? 'Loading preset'
@@ -309,6 +402,8 @@ function StimsWorkspaceAppShell() {
       data-sheet-open={
         ui.routeState.panel && !stageAnchoredToolOpen ? 'true' : undefined
       }
+      data-thumb-mode={thumbMode ? 'true' : undefined}
+      data-offline={offline ? 'true' : undefined}
     >
       <a href="#stims-visualizer" className="skip-link">
         Skip to visualizer
@@ -362,6 +457,7 @@ function StimsWorkspaceAppShell() {
           {ui.routeState.panel === 'editor' ? <EditorPanel /> : null}
           {ui.routeState.panel === 'browse' ? (
             <BrowseSheetPanel
+              offline={offline}
               onCollectionTagChange={(collectionTag) =>
                 ui.commitRoute({ ...ui.routeState, collectionTag })
               }
@@ -372,6 +468,11 @@ function StimsWorkspaceAppShell() {
           ) : null}
           {ui.routeState.panel === 'settings' ? (
             <SettingsSheetPanel
+              thumbMode={thumbMode}
+              onThumbModeChange={updateThumbMode}
+              offline={offline}
+              installAvailable={installPrompt !== null}
+              onInstallApp={handleInstallApp}
               onCompatibilityModeChange={setCompatibilityMode}
               onMotionPreferenceChange={(enabled) =>
                 setMotionPreference({ enabled })
@@ -380,6 +481,39 @@ function StimsWorkspaceAppShell() {
           ) : null}
         </Suspense>
       </BottomSheet>
+
+      {offline ? (
+        <div className="stims-shell__mobile-notice" role="status">
+          Offline party mode: saved presets and cached previews still work.
+        </div>
+      ) : installPrompt ? (
+        <div className="stims-shell__mobile-notice" role="status">
+          <span>Install Stims for faster mobile launch.</span>
+          <button type="button" onClick={handleInstallApp}>
+            Install
+          </button>
+          <button type="button" onClick={() => setInstallPrompt(null)}>
+            Not now
+          </button>
+        </div>
+      ) : null}
+
+      {showRotateHint ? (
+        <div className="stims-shell__rotate-hint" role="status">
+          <span>Rotate your phone for theater mode.</span>
+          <button
+            type="button"
+            onClick={() => {
+              try {
+                localStorage.setItem('stims:rotate-hint-dismissed', 'true');
+              } catch {}
+              setShowRotateHint(false);
+            }}
+          >
+            Got it
+          </button>
+        </div>
+      ) : null}
 
       <ContextualHelp hint={visibleHint} onDismiss={dismissHint} />
 
@@ -395,6 +529,7 @@ function StimsWorkspaceAppShell() {
           isFullscreen={isFullscreen}
           onToggleFullscreen={handleToggleFullscreen}
           onToggleTheme={handleToggleTheme}
+          thumbMode={thumbMode}
         />
       ) : null}
       <AudioMatchToast

--- a/assets/js/frontend/BrowseSheetPanel.tsx
+++ b/assets/js/frontend/BrowseSheetPanel.tsx
@@ -22,9 +22,11 @@ const BROWSE_RESULT_BATCH_SIZE = 24;
 export function BrowseSheetPanel({
   onCollectionTagChange,
   onImport,
+  offline = false,
 }: {
   onCollectionTagChange: (collectionTag: string | null) => void;
   onImport: (files: FileList | null) => void;
+  offline?: boolean;
 }) {
   const { ui, engine } = useWorkspace();
   const { engineSnapshot } = useEngineSnapshot();
@@ -65,6 +67,10 @@ export function BrowseSheetPanel({
 
   const handleImageImport = async (files: FileList | null) => {
     if (!files || files.length === 0) return;
+    if (offline) {
+      ui.setStatusMessage('Image-to-preset needs a network connection.');
+      return;
+    }
     const file = files[0];
     const formData = new FormData();
     formData.append('image', file);
@@ -103,6 +109,12 @@ export function BrowseSheetPanel({
   };
 
   const loadCommunityPresets = useCallback(() => {
+    if (offline) {
+      setCommunityError(
+        'Community presets are unavailable in offline party mode.',
+      );
+      return;
+    }
     setCommunityLoading(true);
     setCommunityError(null);
     fetch('/api/presets?sort=top&limit=20')
@@ -121,13 +133,13 @@ export function BrowseSheetPanel({
         setCommunityError(err.message);
         setCommunityLoading(false);
       });
-  }, []);
+  }, [offline]);
 
   useEffect(() => {
-    if (routeState.collectionTag === 'collection:community') {
+    if (routeState.collectionTag === 'collection:community' && !offline) {
       loadCommunityPresets();
     }
-  }, [routeState.collectionTag, loadCommunityPresets]);
+  }, [routeState.collectionTag, loadCommunityPresets, offline]);
 
   const handleVisualSearch = async () => {
     const canvas = ui.stageRef.current?.querySelector(
@@ -395,6 +407,12 @@ export function BrowseSheetPanel({
             data-active={String(
               routeState.collectionTag === 'collection:community',
             )}
+            disabled={offline}
+            title={
+              offline
+                ? 'Community presets need a network connection'
+                : undefined
+            }
             onClick={() =>
               onCollectionTagChange(
                 routeState.collectionTag === 'collection:community'
@@ -759,11 +777,13 @@ export function BrowseSheetPanel({
           >
             {imageImportLoading
               ? 'Importing\u2026'
-              : 'Create preset from image'}
+              : offline
+                ? 'Image creation offline'
+                : 'Create preset from image'}
             <input
               type="file"
               accept="image/png,image/jpeg,image/webp,image/gif"
-              disabled={imageImportLoading}
+              disabled={imageImportLoading || offline}
               onChange={(event) => void handleImageImport(event.target.files)}
             />
           </label>
@@ -798,6 +818,34 @@ export function BrowseSheetPanel({
           </div>
         ) : null}
       </section>
+
+      <nav
+        className="stims-shell__thumb-actions"
+        aria-label="Thumb mode quick actions"
+      >
+        <button
+          type="button"
+          className="stims-shell__text-button"
+          onClick={engine.handleShufflePreset}
+        >
+          Surprise me
+        </button>
+        <button
+          type="button"
+          className="stims-shell__text-button"
+          onClick={() => ui.setSearchQuery('')}
+          disabled={!searchQuery}
+        >
+          Clear search
+        </button>
+        <button
+          type="button"
+          className="stims-shell__text-button"
+          onClick={() => void ui.handleShowCurrentLink()}
+        >
+          Share
+        </button>
+      </nav>
     </div>
   );
 }

--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -20,6 +20,7 @@ type MobileControlBarProps = {
   isFullscreen: boolean;
   onToggleFullscreen: () => void;
   onToggleTheme?: () => void;
+  thumbMode?: boolean;
 };
 
 export function MobileControlBar({
@@ -29,6 +30,7 @@ export function MobileControlBar({
   isFullscreen,
   onToggleFullscreen,
   onToggleTheme: _onToggleTheme,
+  thumbMode = false,
 }: MobileControlBarProps) {
   const { ui, engine } = useWorkspace();
   const { engineSnapshot } = useEngineSnapshot();
@@ -37,6 +39,7 @@ export function MobileControlBar({
   const [showMoods, setShowMoods] = useState(false);
   const [similarLoading, setSimilarLoading] = useState(false);
   const [generatingMood, setGeneratingMood] = useState<string | null>(null);
+  const [showMoreActions, setShowMoreActions] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const moodAbortRef = useRef<AbortController | null>(null);
   const similarAbortRef = useRef<AbortController | null>(null);
@@ -186,6 +189,123 @@ export function MobileControlBar({
     [resetHideTimer, ui],
   );
 
+  const mobileActions = [
+    {
+      id: 'browse',
+      label: 'Browse',
+      ariaLabel: 'Browse presets',
+      icon: 'sparkles' as const,
+      active: panel === 'browse',
+      onClick: handleBrowse,
+    },
+    {
+      id: 'shuffle',
+      label: 'Shuffle',
+      ariaLabel: 'Play a random preset',
+      icon: 'shuffle' as const,
+      onClick: handleShuffle,
+    },
+    {
+      id: 'previous',
+      label: 'Back',
+      ariaLabel: 'Previous preset',
+      icon: 'arrow-left' as const,
+      onClick: handlePrevious,
+    },
+    {
+      id: 'similar',
+      label: similarLoading ? 'Searching…' : 'Similar',
+      ariaLabel: 'Find similar presets',
+      icon: 'eye' as const,
+      disabled: similarLoading,
+      onClick: handleSimilar,
+    },
+    {
+      id: 'settings',
+      label: 'Settings',
+      ariaLabel: 'Settings panel',
+      icon: 'sliders' as const,
+      active: panel === 'settings',
+      onClick: handleSettings,
+    },
+    {
+      id: 'generate',
+      label: 'Generate',
+      ariaLabel: 'Generate from mood',
+      icon: 'wand' as const,
+      onClick: () => {
+        resetHideTimer();
+        const nextShowMoods = !showMoods;
+        setShowMoods(nextShowMoods);
+        if (nextShowMoods) {
+          ui.updatePanel(null);
+        }
+      },
+    },
+    {
+      id: 'fullscreen',
+      label: isFullscreen ? 'Exit' : 'Full',
+      ariaLabel: isFullscreen ? 'Exit full screen' : 'Full screen',
+      icon: 'expand' as const,
+      onClick: handleFullscreen,
+    },
+    {
+      id: 'share',
+      label: 'Share',
+      ariaLabel: 'Share link',
+      icon: 'link' as const,
+      onClick: handleShare,
+    },
+    {
+      id: 'editor',
+      label: 'Edit',
+      ariaLabel: 'Edit preset code',
+      icon: 'gauge' as const,
+      active: panel === 'editor',
+      onClick: handleEditor,
+    },
+    ...(engineSnapshot?.audioSource
+      ? [
+          {
+            id: 'stop',
+            label: 'Stop',
+            ariaLabel: 'Stop audio',
+            icon: 'close' as const,
+            onClick: engine.handleAudioStop,
+          },
+        ]
+      : []),
+  ];
+  const primaryActionIds = thumbMode
+    ? ['browse', 'shuffle', 'similar', 'settings']
+    : ['browse', 'shuffle', 'previous', 'similar', 'settings'];
+  const primaryActions = mobileActions.filter((action) =>
+    primaryActionIds.includes(action.id),
+  );
+  const overflowActions = mobileActions.filter(
+    (action) => !primaryActionIds.includes(action.id),
+  );
+
+  // Accessibility guard: panel toggles must use aria-expanded={panel === ...}.
+  const renderAction = (action: (typeof mobileActions)[number]) => (
+    <button
+      key={action.id}
+      type="button"
+      className={styles.action}
+      data-active={String(Boolean(action.active))}
+      aria-expanded={action.active === undefined ? undefined : action.active}
+      onClick={action.onClick}
+      aria-label={action.ariaLabel}
+      disabled={action.disabled}
+    >
+      <UiIcon
+        name={action.icon}
+        className="stims-icon-slot stims-icon-slot--sm"
+      />
+      <span className={styles.actionLabel}>{action.label}</span>
+    </button>
+  );
+
   return (
     <>
       <div className={styles.bar} data-visible={String(visible)}>
@@ -225,149 +345,35 @@ export function MobileControlBar({
             ))}
           </fieldset>
         )}
-        <div className={styles.actions}>
+        <div className={styles.actions} data-thumb-mode={String(thumbMode)}>
+          {primaryActions.map(renderAction)}
           <button
             type="button"
             className={styles.action}
-            data-active={String(panel === 'browse')}
-            aria-expanded={panel === 'browse'}
-            onClick={handleBrowse}
-            aria-label="Browse presets"
+            data-active={String(showMoreActions)}
+            aria-expanded={showMoreActions}
+            onClick={() => {
+              resetHideTimer();
+              setShowMoreActions((current) => !current);
+            }}
+            aria-label="More mobile actions"
           >
             <UiIcon
               name="sparkles"
               className="stims-icon-slot stims-icon-slot--sm"
             />
-            <span className={styles.actionLabel}>Browse</span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            data-active={String(panel === 'settings')}
-            aria-expanded={panel === 'settings'}
-            onClick={handleSettings}
-            aria-label="Settings panel"
-          >
-            <UiIcon
-              name="sliders"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Settings</span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            onClick={handlePrevious}
-            aria-label="Previous preset"
-          >
-            <UiIcon
-              name="arrow-left"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Back</span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            onClick={handleShuffle}
-            aria-label="Play a random preset"
-          >
-            <UiIcon
-              name="shuffle"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Shuffle</span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            onClick={handleSimilar}
-            aria-label="Find similar presets"
-            disabled={similarLoading}
-          >
-            <UiIcon
-              name="eye"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>
-              {similarLoading ? 'Searching…' : 'Similar'}
-            </span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            data-active={String(panel === 'editor')}
-            aria-expanded={panel === 'editor'}
-            onClick={handleEditor}
-            aria-label="Edit preset code"
-          >
-            <UiIcon
-              name="gauge"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Edit</span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            onClick={() => {
-              resetHideTimer();
-              const nextShowMoods = !showMoods;
-              setShowMoods(nextShowMoods);
-              if (nextShowMoods) {
-                ui.updatePanel(null);
-              }
-            }}
-            aria-label="Generate from mood"
-          >
-            <UiIcon
-              name="wand"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Generate</span>
-          </button>
-          {engineSnapshot?.audioSource ? (
-            <button
-              type="button"
-              className={styles.action}
-              aria-label="Stop audio"
-              title="Stop audio"
-              onClick={engine.handleAudioStop}
-            >
-              <UiIcon
-                name="close"
-                className="stims-icon-slot stims-icon-slot--sm"
-              />
-              <span className={styles.actionLabel}>Stop</span>
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className={styles.action}
-            onClick={handleFullscreen}
-            aria-label={isFullscreen ? 'Exit full screen' : 'Full screen'}
-          >
-            <UiIcon
-              name="expand"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>
-              {isFullscreen ? 'Exit' : 'Full'}
-            </span>
-          </button>
-          <button
-            type="button"
-            className={styles.action}
-            onClick={handleShare}
-            aria-label="Share link"
-          >
-            <UiIcon
-              name="link"
-              className="stims-icon-slot stims-icon-slot--sm"
-            />
-            <span className={styles.actionLabel}>Share</span>
+            <span className={styles.actionLabel}>More</span>
           </button>
         </div>
+        {showMoreActions ? (
+          <div
+            className={styles.moreActions}
+            role="menu"
+            aria-label="More mobile actions"
+          >
+            {overflowActions.map(renderAction)}
+          </div>
+        ) : null}
       </div>
       {!visible ? (
         <button

--- a/assets/js/frontend/SettingsSheetPanel.tsx
+++ b/assets/js/frontend/SettingsSheetPanel.tsx
@@ -148,9 +148,19 @@ function PerformanceSection() {
 export function SettingsSheetPanel({
   onCompatibilityModeChange,
   onMotionPreferenceChange,
+  thumbMode = false,
+  onThumbModeChange,
+  offline = false,
+  installAvailable = false,
+  onInstallApp,
 }: {
   onCompatibilityModeChange: (enabled: boolean) => void;
   onMotionPreferenceChange: (enabled: boolean) => void;
+  thumbMode?: boolean;
+  onThumbModeChange?: (enabled: boolean) => void;
+  offline?: boolean;
+  installAvailable?: boolean;
+  onInstallApp?: () => void;
 }) {
   const { ui, engine } = useWorkspace();
   const { engineSnapshot } = useEngineSnapshot();
@@ -209,6 +219,44 @@ export function SettingsSheetPanel({
             Reset to recommended
           </button>
         ) : null}
+      </section>
+
+      <section className="stims-shell__sheet-surface">
+        <h3 className="stims-shell__settings-section-heading">
+          Mobile experience
+        </h3>
+        <label className="stims-shell__toggle-card">
+          <input
+            type="checkbox"
+            checked={thumbMode}
+            onChange={(event) => onThumbModeChange?.(event.target.checked)}
+          />
+          <span className="stims-shell__toggle-copy">
+            <strong>Thumb mode</strong>
+            <small>
+              Keeps quick browse and sharing actions at the bottom of mobile
+              sheets.
+            </small>
+          </span>
+        </label>
+        {offline ? (
+          <p className="stims-shell__meta-copy">
+            Offline party mode is active. Community and AI-backed imports are
+            paused.
+          </p>
+        ) : installAvailable ? (
+          <button
+            type="button"
+            className="stims-shell__text-button"
+            onClick={onInstallApp}
+          >
+            Install Stims on this device
+          </button>
+        ) : (
+          <p className="stims-shell__meta-copy">
+            Rotate your phone in a live session for a cleaner theater layout.
+          </p>
+        )}
       </section>
 
       <section className="stims-shell__sheet-surface">

--- a/assets/js/frontend/hooks/useStageGesture.ts
+++ b/assets/js/frontend/hooks/useStageGesture.ts
@@ -1,36 +1,76 @@
-import { useEffect, useRef } from 'react';
+import { type RefObject, useEffect, useRef } from 'react';
 
 const WHEEL_DEBOUNCE_MS = 400;
+const SWIPE_MIN_DISTANCE_PX = 64;
+const SWIPE_MAX_OFF_AXIS_PX = 72;
+const SWIPE_DEBOUNCE_MS = 450;
+const LONG_PRESS_MS = 650;
+const LONG_PRESS_MOVE_TOLERANCE_PX = 14;
+
+function isInteractiveTarget(target: EventTarget | null) {
+  return (
+    target instanceof HTMLElement &&
+    Boolean(
+      target.closest('.stims-shell__sheet') ||
+        target.closest('[role="dialog"]') ||
+        target.closest('.cm-editor') ||
+        target.closest('button') ||
+        target.closest('a') ||
+        target.closest('input') ||
+        target.closest('select') ||
+        target.closest('textarea'),
+    )
+  );
+}
+
+function supportsTouchShortcutInput() {
+  return (
+    typeof window !== 'undefined' &&
+    (window.matchMedia('(pointer: coarse)').matches ||
+      navigator.maxTouchPoints > 0)
+  );
+}
 
 export function useStageGesture({
   enabled,
+  stageRef,
   handleShufflePreset,
   handlePreviousPreset,
+  openBrowse,
+  closePanel,
+  toggleFavoritePreset,
+  setStatusMessage,
 }: {
   enabled: boolean;
+  stageRef?: RefObject<HTMLElement | null>;
   handleShufflePreset: () => void;
   handlePreviousPreset: () => void;
+  openBrowse?: () => void;
+  closePanel?: () => void;
+  toggleFavoritePreset?: () => void;
+  setStatusMessage?: (message: string) => void;
 }) {
   const shuffleRef = useRef(handleShufflePreset);
   shuffleRef.current = handleShufflePreset;
   const prevRef = useRef(handlePreviousPreset);
   prevRef.current = handlePreviousPreset;
+  const openBrowseRef = useRef(openBrowse);
+  openBrowseRef.current = openBrowse;
+  const closePanelRef = useRef(closePanel);
+  closePanelRef.current = closePanel;
+  const toggleFavoriteRef = useRef(toggleFavoritePreset);
+  toggleFavoriteRef.current = toggleFavoritePreset;
+  const statusRef = useRef(setStatusMessage);
+  statusRef.current = setStatusMessage;
   const lastWheelRef = useRef(0);
+  const lastSwipeRef = useRef(0);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
 
     const handleWheel = (event: WheelEvent) => {
-      if (
-        event.target instanceof HTMLElement &&
-        (event.target.closest('.stims-shell__sheet') ||
-          event.target.closest('[role="dialog"]') ||
-          event.target.closest('.cm-editor') ||
-          event.target.closest('input') ||
-          event.target.closest('textarea'))
-      ) {
-        return;
-      }
+      if (isInteractiveTarget(event.target)) return;
 
       const now = performance.now();
       if (now - lastWheelRef.current < WHEEL_DEBOUNCE_MS) return;
@@ -48,4 +88,107 @@ export function useStageGesture({
     document.addEventListener('wheel', handleWheel, { passive: false });
     return () => document.removeEventListener('wheel', handleWheel);
   }, [enabled]);
+
+  useEffect(() => {
+    const stage = stageRef?.current;
+    if (!enabled || !stage || !supportsTouchShortcutInput()) return;
+
+    let startX = 0;
+    let startY = 0;
+    let trackingPointerId: number | null = null;
+    let longPressFired = false;
+
+    const clearLongPress = () => {
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = null;
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.pointerType !== 'touch' || isInteractiveTarget(event.target))
+        return;
+      trackingPointerId = event.pointerId;
+      startX = event.clientX;
+      startY = event.clientY;
+      longPressFired = false;
+      clearLongPress();
+      longPressTimerRef.current = setTimeout(() => {
+        longPressFired = true;
+        toggleFavoriteRef.current?.();
+      }, LONG_PRESS_MS);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (trackingPointerId !== event.pointerId) return;
+      if (
+        Math.hypot(event.clientX - startX, event.clientY - startY) >
+        LONG_PRESS_MOVE_TOLERANCE_PX
+      ) {
+        clearLongPress();
+      }
+    };
+
+    const handlePointerEnd = (event: PointerEvent) => {
+      if (trackingPointerId !== event.pointerId) return;
+      trackingPointerId = null;
+      clearLongPress();
+      if (longPressFired) return;
+
+      const dx = event.clientX - startX;
+      const dy = event.clientY - startY;
+      const absX = Math.abs(dx);
+      const absY = Math.abs(dy);
+      const now = performance.now();
+      if (now - lastSwipeRef.current < SWIPE_DEBOUNCE_MS) return;
+
+      if (absX >= SWIPE_MIN_DISTANCE_PX && absY <= SWIPE_MAX_OFF_AXIS_PX) {
+        lastSwipeRef.current = now;
+        if (dx > 0) {
+          prevRef.current();
+          statusRef.current?.(
+            'Previous preset. Swipe left for another surprise.',
+          );
+        } else {
+          shuffleRef.current();
+          statusRef.current?.('Shuffled preset. Swipe right to go back.');
+        }
+        return;
+      }
+
+      if (absY >= SWIPE_MIN_DISTANCE_PX && absX <= SWIPE_MAX_OFF_AXIS_PX) {
+        lastSwipeRef.current = now;
+        if (dy < 0) {
+          openBrowseRef.current?.();
+          statusRef.current?.(
+            'Browse opened. Swipe down on the stage to close.',
+          );
+        } else {
+          closePanelRef.current?.();
+          statusRef.current?.('Panel closed.');
+        }
+      }
+    };
+
+    const handlePointerCancel = (event: PointerEvent) => {
+      if (trackingPointerId !== event.pointerId) return;
+      trackingPointerId = null;
+      clearLongPress();
+    };
+
+    stage.addEventListener('pointerdown', handlePointerDown, { passive: true });
+    stage.addEventListener('pointermove', handlePointerMove, { passive: true });
+    stage.addEventListener('pointerup', handlePointerEnd, { passive: true });
+    stage.addEventListener('pointercancel', handlePointerCancel, {
+      passive: true,
+    });
+
+    return () => {
+      clearLongPress();
+      stage.removeEventListener('pointerdown', handlePointerDown);
+      stage.removeEventListener('pointermove', handlePointerMove);
+      stage.removeEventListener('pointerup', handlePointerEnd);
+      stage.removeEventListener('pointercancel', handlePointerCancel);
+    };
+  }, [enabled, stageRef]);
 }

--- a/assets/js/milkdrop/runtime.ts
+++ b/assets/js/milkdrop/runtime.ts
@@ -32,6 +32,11 @@ import { createMilkdropEditorActions } from './runtime/editor-actions';
 import { createMilkdropExperienceAttachmentController } from './runtime/experience-attachment.ts';
 import { createMilkdropExperienceFrameLoop } from './runtime/experience-frame-loop.ts';
 import { createMilkdropRuntimeInteractionPresenter } from './runtime/interaction-presenter';
+import {
+  applyMilkdropInteractionResponse as applyMilkdropInteractionResponseImpl,
+  buildMilkdropInputSignalOverrides as buildMilkdropInputSignalOverridesImpl,
+  getMilkdropDetailScale as getMilkdropDetailScaleImpl,
+} from './runtime/interaction-response';
 import { createMilkdropRuntimeLifetime } from './runtime/lifetime';
 import { createMilkdropRuntimePerformanceTracker } from './runtime/performance-tracker';
 import { createMilkdropPresentationController } from './runtime/presentation-controller';
@@ -61,11 +66,11 @@ import {
 
 const log = createLogger('MilkdropRuntime');
 
-export {
-  applyMilkdropInteractionResponse,
-  buildMilkdropInputSignalOverrides,
-  getMilkdropDetailScale,
-} from './runtime/interaction-response';
+export const applyMilkdropInteractionResponse =
+  applyMilkdropInteractionResponseImpl;
+export const buildMilkdropInputSignalOverrides =
+  buildMilkdropInputSignalOverridesImpl;
+export const getMilkdropDetailScale = getMilkdropDetailScaleImpl;
 
 export function createMilkdropExperience({
   container,

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-bun = "latest"
+bun = "1.3.8"
 node = "22"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -39,5 +39,32 @@
   "related_applications": [],
   "prefer_related_applications": false,
   "dir": "ltr",
-  "lang": "en-US"
+  "lang": "en-US",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
+  "shortcuts": [
+    {
+      "name": "Start visualizer",
+      "short_name": "Play",
+      "description": "Open Stims ready to play visuals.",
+      "url": "/?source=pwa",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    },
+    {
+      "name": "Browse presets",
+      "short_name": "Browse",
+      "description": "Open directly to the preset browser.",
+      "url": "/?panel=browse&source=pwa",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    }
+  ]
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,7 +3,7 @@
 // Hashed assets (/assets/*) are immutable with 1-year Cache-Control
 // and are served from browser HTTP cache — no SW intervention needed.
 
-const CACHE_NAME = 'stims-shell-v4';
+const CACHE_NAME = 'stims-shell-v5';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
@@ -12,6 +12,12 @@ const SHELL_ASSETS = [
   '/icons/favicon.svg',
   '/icons/favicon-32.png',
   '/icons/icon-192.png',
+  '/icons/icon-512.png',
+  '/screenshots/hero-narrow.png',
+  '/screenshots/hero-wide.png',
+  '/milkdrop-presets/previews/eos-dark-side-of-the-moon-clean-mix.png',
+  '/milkdrop-presets/previews/rovastar-mosaics-of-ages.png',
+  '/milkdrop-presets/previews/geiss-bipolar-x.png',
 ];
 
 self.addEventListener('install', (event) => {
@@ -56,8 +62,8 @@ self.addEventListener('fetch', (event) => {
       // Try network first for the freshest content
       try {
         const networkResponse = await fetch(request);
-        // Cache successful responses for future offline use
-        if (networkResponse.ok) {
+        // Cache successful responses for future offline party mode use.
+        if (networkResponse.ok && !url.pathname.startsWith('/api/')) {
           const cache = await caches.open(CACHE_NAME);
           cache.put(request, networkResponse.clone());
         }


### PR DESCRIPTION
### Motivation
- Improve the mobile experience with a thumb-friendly control layout, richer touch gestures, and clearer guidance for installing or rotating devices.  
- Provide an offline-first experience and PWA improvements so mobile users have faster launches and predictable behavior when network is unavailable.

### Description
- Added mobile UI styles and new elements including `stims-shell__mobile-notice`, `stims-shell__rotate-hint`, thumb-actions layout, and an overflow `moreActions` grid in `MobileControlBar.module.css` and `app-shell.css`.  
- Extended `App.tsx` with `thumbMode`, `offline`, `installPrompt`, and `showRotateHint` state plus event listeners for `online/offline`, `beforeinstallprompt`, and a media-query driven rotate hint; expose these to `SettingsSheetPanel`, `BrowseSheetPanel`, and `MobileControlBar`.  
- Updated `MobileControlBar.tsx` to support a thumb-optimized action set, primary vs overflow actions, and a togglable `moreActions` menu; integrated accessibility attributes and preserved idle-hide behavior.  
- Updated `BrowseSheetPanel.tsx` to accept an `offline` prop and disable/guard community preset fetches and image-to-preset imports when offline, and added a thumb-mode quick-action nav.  
- Implemented richer stage gestures in `useStageGesture.ts` including swipe up/down/left/right for browse/open/close/shuffle, long-press to toggle favorite, and interaction guards for sheet/dialog targets.  
- Re-exported interaction helpers from `milkdrop/runtime.ts` for external use and bumped a few application assets.  
- PWA updates: added `shortcuts` and `display_override` to `public/manifest.json`, bumped `mise.toml` Bun version, and updated `public/service-worker.js` cache name and cached assets along with a small cache policy change to avoid caching `'/api/'` responses.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fae57794c8332ad5387663127c331)