### PR TITLE
Normalize legacy bUseDots, isolate custom-wave locals, and avoid mutating point-locals

### DIFF
--- a/assets/js/milkdrop/compiler/preset-normalization.ts
+++ b/assets/js/milkdrop/compiler/preset-normalization.ts
@@ -27,6 +27,7 @@ const legacyCustomWaveSuffixMap: Record<string, string | null> = {
   mode: 'spectrum',
   bspectrum: 'spectrum',
   bdrawthick: 'thick',
+  busedots: 'usedots',
   badditive: 'additive',
 };
 

--- a/assets/js/milkdrop/vm.ts
+++ b/assets/js/milkdrop/vm.ts
@@ -339,6 +339,12 @@ class MilkdropPresetVM implements MilkdropVM {
       g: wave.fields.g ?? this.state[`custom_wave_${wave.index}_g`] ?? 1,
       b: wave.fields.b ?? this.state[`custom_wave_${wave.index}_b`] ?? 1,
       a: wave.fields.a ?? this.state[`custom_wave_${wave.index}_a`] ?? 0.4,
+      ...Object.fromEntries(
+        Array.from({ length: MAX_CUSTOM_WAVE_SLOTS }, (_, index) => [
+          `t${index + 1}`,
+          0,
+        ]),
+      ),
     };
   }
 
@@ -452,13 +458,14 @@ class MilkdropPresetVM implements MilkdropVM {
     value: number,
     locals: MutableState | null = null,
   ) {
-    const registerMatch = target.toLowerCase().match(/^([qt])(\d+)$/u);
-    if (registerMatch) {
-      this.registers[target.toLowerCase()] = value;
+    const normalizedTarget = target.toLowerCase();
+    const registerMatch = normalizedTarget.match(/^([qt])(\d+)$/u);
+    if (locals && registerMatch?.[1] !== 'q') {
+      locals[target] = value;
       return;
     }
-    if (locals && objectHasOwn(locals, target)) {
-      locals[target] = value;
+    if (registerMatch) {
+      this.registers[normalizedTarget] = value;
       return;
     }
     this.state[target] = value;

--- a/assets/js/milkdrop/vm/wave-builder.ts
+++ b/assets/js/milkdrop/vm/wave-builder.ts
@@ -168,11 +168,8 @@ export function buildCustomWaves({
       drawMode,
     );
     const useProcedural = proceduralDescriptor !== null;
-    waveState.pointLocalsScratch = Object.assign(
-      waveState.pointLocalsScratch,
-      frameLocals,
-    );
-    const pointLocals = waveState.pointLocalsScratch;
+    const pointLocals = { ...frameLocals };
+    waveState.pointLocalsScratch = pointLocals;
     const pointEnv = useProcedural
       ? null
       : createEnv(signals, pointLocals, { reuseExtraAsEnv: true });

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -295,6 +295,70 @@ wave_0_per_point2=y = sin(sample * pi * 8) * 0.25;
     expect(frameState.customWaves[0]?.positions.length).toBe(512 * 3);
   });
 
+  test('normalizes legacy bUseDots custom-wave fields to dot draw mode', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Legacy Dot Custom Wave
+wavecode_0_enabled=1
+wavecode_0_bUseDots=1
+wavecode_0_samples=16
+wave_0_per_point1=x = sample * 2 - 1;
+      `.trim(),
+      { id: 'legacy-dot-custom-wave' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
+
+    expect(frameState.customWaves).toHaveLength(1);
+    expect(frameState.customWaves[0]?.drawMode).toBe('dots');
+  });
+
+  test('keeps custom-wave t registers local to each wave slot', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Wave Local T Registers
+wavecode_0_enabled=1
+wavecode_0_samples=8
+wave_0_per_frame1=t1=0.1;
+wave_0_per_point1=y=t1;
+wavecode_1_enabled=1
+wavecode_1_samples=8
+wave_1_per_frame1=t1=0.4;
+wave_1_per_point1=y=t1;
+      `.trim(),
+      { id: 'wave-local-t-registers' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
+
+    expect(frameState.customWaves).toHaveLength(2);
+    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.1, 6);
+    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(0.4, 6);
+    expect(frameState.variables.t1).toBeCloseTo(0, 6);
+  });
+
+  test('does not leak arbitrary custom-wave point locals between wave slots', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Wave Point Local Isolation
+wavecode_0_enabled=1
+wavecode_0_samples=8
+wave_0_per_point1=xp=999;
+wave_0_per_point2=y=0.25;
+wavecode_1_enabled=1
+wavecode_1_samples=8
+wave_1_per_point1=y=xp;
+      `.trim(),
+      { id: 'wave-point-local-isolation' },
+    );
+
+    const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
+
+    expect(frameState.customWaves).toHaveLength(2);
+    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.25, 6);
+    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(0, 6);
+  });
+
   test('keeps shape texture-control locals and projectM instance aliases available at runtime', () => {
     const signals = makeSignals({ frame: 1 });
     const preset = compileMilkdropPresetSource(


### PR DESCRIPTION
### Motivation
- Support legacy `bUseDots` custom-wave fields so imported projectM presets render in dot mode. 
- Ensure `t` registers and arbitrary point-local variables for custom waves remain local to each wave slot and do not leak into global registers/state. 
- Prevent cross-wave interference caused by mutating a shared point-locals scratch object during wave building.

### Description
- Map legacy `bUseDots` to `usedots` by adding `busedots: 'usedots'` to `legacyCustomWaveSuffixMap` in `preset-normalization.ts`.
- Seed per-wave `t` registers in `seedCustomWaveState` by spreading zero-initialized `t1..tN` entries so they exist per wave slot.
- Normalize assignment targets in `setValue` by lowercasing the target and change assignment ordering to (a) write non-`q` register targets into `locals` when present, (b) update `this.registers` for register targets, and (c) fallback to `this.state` otherwise, avoiding case/lookup inconsistencies.
- Stop mutating the shared `pointLocalsScratch` in `wave-builder.ts` by cloning `frameLocals` into a fresh object and then assigning it back to the scratch reference.
- Add unit tests covering legacy-dot normalization, per-wave `t` register locality, and point-local isolation.

### Testing
- Added tests in `tests/milkdrop-vm.test.ts`: `normalizes legacy bUseDots custom-wave fields to dot draw mode`, `keeps custom-wave t registers local to each wave slot`, and `does not leak arbitrary custom-wave point locals between wave slots` which exercise the changes and assertions.
- Ran the automated test suite (`npm test`) and the new tests and existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb5edb25c833296181506e44ff988)