### PR TITLE
Mobile: add haptics, party-remote mode, preset queueing, and bottom-sheet snap points

### DIFF
--- a/assets/css/BottomSheet.module.css
+++ b/assets/css/BottomSheet.module.css
@@ -45,11 +45,24 @@
   left: 0;
   right: 0;
   bottom: 0;
-  max-height: 85vh;
+  height: min(55dvh, 85vh);
+  max-height: calc(100dvh - max(10px, env(safe-area-inset-top)));
   border-bottom: none;
   border-radius: 20px 20px 0 0;
   padding-bottom: max(16px, env(safe-area-inset-bottom));
   animation: sheet-rise 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.sheet[data-position="bottom"][data-snap="compact"] {
+  height: min(34dvh, 420px);
+}
+
+.sheet[data-position="bottom"][data-snap="half"] {
+  height: min(58dvh, 720px);
+}
+
+.sheet[data-position="bottom"][data-snap="full"] {
+  height: calc(100dvh - max(10px, env(safe-area-inset-top)));
 }
 
 .sheet[data-position="bottom"][data-exiting="true"] {

--- a/assets/css/MobileControlBar.module.css
+++ b/assets/css/MobileControlBar.module.css
@@ -152,15 +152,18 @@
 
 .handle {
   position: fixed;
-  bottom: max(8px, env(safe-area-inset-bottom));
+  bottom: max(10px, env(safe-area-inset-bottom));
   left: 50%;
   transform: translateX(-50%);
   z-index: var(--z-dock);
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  padding: 6px 14px;
-  border-radius: 999px;
+  min-width: min(360px, calc(100vw - 32px));
+  min-height: 48px;
+  padding: 10px 18px;
+  border-radius: 18px;
   background: rgba(5, 7, 13, 0.9);
   color: var(--stims-ink);
   border: 1px solid var(--stims-line-soft);

--- a/assets/js/frontend/App.tsx
+++ b/assets/js/frontend/App.tsx
@@ -89,6 +89,20 @@ function StimsWorkspaceAppShell() {
       return false;
     }
   });
+  const [partyRemoteMode, setPartyRemoteMode] = useState(() => {
+    try {
+      return localStorage.getItem('stims:mobile-party-remote') === 'true';
+    } catch {
+      return false;
+    }
+  });
+  const [hapticsEnabled, setHapticsEnabled] = useState(() => {
+    try {
+      return localStorage.getItem('stims:mobile-haptics') !== 'false';
+    } catch {
+      return true;
+    }
+  });
   const [offline, setOffline] = useState(() =>
     typeof navigator === 'undefined' ? false : !navigator.onLine,
   );
@@ -157,6 +171,7 @@ function StimsWorkspaceAppShell() {
       );
     },
     setStatusMessage: ui.setStatusMessage,
+    hapticsEnabled,
   });
 
   useEffect(() => {
@@ -269,6 +284,20 @@ function StimsWorkspaceAppShell() {
     setThumbMode(enabled);
     try {
       localStorage.setItem('stims:mobile-thumb-mode', String(enabled));
+    } catch {}
+  }, []);
+
+  const updatePartyRemoteMode = useCallback((enabled: boolean) => {
+    setPartyRemoteMode(enabled);
+    try {
+      localStorage.setItem('stims:mobile-party-remote', String(enabled));
+    } catch {}
+  }, []);
+
+  const updateHapticsEnabled = useCallback((enabled: boolean) => {
+    setHapticsEnabled(enabled);
+    try {
+      localStorage.setItem('stims:mobile-haptics', String(enabled));
     } catch {}
   }, []);
 
@@ -430,6 +459,12 @@ function StimsWorkspaceAppShell() {
           isWideEnough && ui.routeState.panel !== 'browse' ? 'right' : 'bottom'
         }
         withBackdrop={!stageAnchoredToolOpen}
+        snapPoints={
+          ui.routeState.panel === 'browse'
+            ? ['half', 'full']
+            : ['compact', 'half', 'full']
+        }
+        defaultSnapPoint={ui.routeState.panel === 'browse' ? 'half' : 'compact'}
         tabs={
           ui.routeState.panel
             ? TOOL_TABS.filter(
@@ -470,6 +505,10 @@ function StimsWorkspaceAppShell() {
             <SettingsSheetPanel
               thumbMode={thumbMode}
               onThumbModeChange={updateThumbMode}
+              partyRemoteMode={partyRemoteMode}
+              onPartyRemoteModeChange={updatePartyRemoteMode}
+              hapticsEnabled={hapticsEnabled}
+              onHapticsEnabledChange={updateHapticsEnabled}
               offline={offline}
               installAvailable={installPrompt !== null}
               onInstallApp={handleInstallApp}
@@ -530,6 +569,8 @@ function StimsWorkspaceAppShell() {
           onToggleFullscreen={handleToggleFullscreen}
           onToggleTheme={handleToggleTheme}
           thumbMode={thumbMode}
+          partyRemoteMode={partyRemoteMode}
+          hapticsEnabled={hapticsEnabled}
         />
       ) : null}
       <AudioMatchToast

--- a/assets/js/frontend/BottomSheet.tsx
+++ b/assets/js/frontend/BottomSheet.tsx
@@ -17,6 +17,7 @@ type BottomSheetTab = {
 };
 
 type SheetPosition = 'bottom' | 'right' | 'left';
+type BottomSheetSnapPoint = 'compact' | 'half' | 'full';
 
 type BottomSheetProps = {
   open: boolean;
@@ -28,6 +29,8 @@ type BottomSheetProps = {
   position?: SheetPosition;
   onOpen?: () => void;
   withBackdrop?: boolean;
+  snapPoints?: BottomSheetSnapPoint[];
+  defaultSnapPoint?: BottomSheetSnapPoint;
 };
 
 export function BottomSheet({
@@ -40,8 +43,12 @@ export function BottomSheet({
   position = 'bottom',
   onOpen,
   withBackdrop = true,
+  snapPoints = ['half'],
+  defaultSnapPoint = 'half',
 }: BottomSheetProps) {
   const [exiting, setExiting] = useState(false);
+  const [snapPoint, setSnapPoint] =
+    useState<BottomSheetSnapPoint>(defaultSnapPoint);
   const sheetRef = useRef<HTMLDivElement>(null);
   const dragStart = useRef(0);
   const dragCurrent = useRef(0);
@@ -74,6 +81,7 @@ export function BottomSheet({
   useEffect(() => {
     if (open) {
       setExiting(false);
+      setSnapPoint(defaultSnapPoint);
       const activeElement = document.activeElement;
       previouslyFocusedRef.current =
         activeElement instanceof HTMLElement ? activeElement : null;
@@ -82,7 +90,7 @@ export function BottomSheet({
         requestAnimationFrame(onOpen);
       }
     }
-  }, [open, onOpen]);
+  }, [open, onOpen, defaultSnapPoint]);
 
   useEffect(() => {
     if (open || !wasOpenRef.current) return;
@@ -170,12 +178,21 @@ export function BottomSheet({
         ? delta > 0
         : (position === 'left' && delta < 0) ||
           (position === 'right' && delta > 0);
-    if (isClosingDirection && Math.abs(delta) > dragThreshold) {
+    const snapIndex = snapPoints.indexOf(snapPoint);
+    if (position === 'bottom' && Math.abs(delta) > dragThreshold) {
+      if (delta < 0 && snapIndex < snapPoints.length - 1) {
+        setSnapPoint(snapPoints[snapIndex + 1]);
+      } else if (delta > 0 && snapIndex > 0) {
+        setSnapPoint(snapPoints[snapIndex - 1]);
+      } else if (isClosingDirection) {
+        startClose();
+      }
+    } else if (isClosingDirection && Math.abs(delta) > dragThreshold) {
       startClose();
     }
     dragStart.current = 0;
     dragCurrent.current = 0;
-  }, [position, startClose]);
+  }, [position, snapPoint, snapPoints, startClose]);
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
@@ -217,6 +234,7 @@ export function BottomSheet({
         ref={sheetRef}
         className={styles.sheet}
         data-position={position}
+        data-snap={position === 'bottom' ? snapPoint : undefined}
         data-exiting={String(exiting)}
         role="dialog"
         aria-modal="true"

--- a/assets/js/frontend/BrowseSheetPanel.tsx
+++ b/assets/js/frontend/BrowseSheetPanel.tsx
@@ -60,6 +60,7 @@ export function BrowseSheetPanel({
   } | null>(null);
   const [imageImportLoading, setImageImportLoading] = useState(false);
   const [fileImportStatus, setFileImportStatus] = useState('');
+  const [presetQueue, setPresetQueue] = useState<PresetCatalogEntry[]>([]);
   const [visibleCatalogState, setVisibleCatalogState] = useState({
     key: '',
     limit: BROWSE_RESULT_BATCH_SIZE,
@@ -175,6 +176,22 @@ export function BrowseSheetPanel({
   const handleDeselectVisualSearch = () => {
     setVisualSearchActive(false);
     setVisualSearchResults([]);
+  };
+  const handleQueuePreset = (presetId: string) => {
+    const entry = catalog.find((preset) => preset.id === presetId);
+    if (!entry) return;
+    setPresetQueue((current) =>
+      current.some((preset) => preset.id === presetId)
+        ? current
+        : [...current, entry].slice(-12),
+    );
+    ui.setStatusMessage(`${entry.title} added to queue.`);
+  };
+  const playNextQueuedPreset = () => {
+    const [next, ...rest] = presetQueue;
+    if (!next) return;
+    setPresetQueue(rest);
+    engine.handlePresetSelection(next.id);
   };
 
   const showStarterPresets =
@@ -498,6 +515,7 @@ export function BrowseSheetPanel({
           summary=""
           title="Recent"
           onSelect={engine.handlePresetSelection}
+          onQueue={handleQueuePreset}
           presetPreviews={presetPreviews}
         />
       ) : null}
@@ -512,8 +530,46 @@ export function BrowseSheetPanel({
           summary=""
           title="Saved"
           onSelect={engine.handlePresetSelection}
+          onQueue={handleQueuePreset}
           presetPreviews={presetPreviews}
         />
+      ) : null}
+
+      {presetQueue.length > 0 ? (
+        <section className="stims-shell__sheet-surface">
+          <div className="stims-shell__section-heading">
+            <h2 className="stims-shell__section-label">Up next</h2>
+            <p className="stims-shell__meta-copy">
+              Long-press cards to build a quick phone-friendly queue.
+            </p>
+          </div>
+          <div className="stims-shell__chip-list">
+            {presetQueue.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                className="stims-shell__chip"
+                onClick={() =>
+                  setPresetQueue((current) =>
+                    current.filter((preset) => preset.id !== entry.id),
+                  )
+                }
+              >
+                <span className="stims-shell__chip-copy">
+                  <strong>{entry.title}</strong>
+                  <small>Tap to remove</small>
+                </span>
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="cta-button"
+            onClick={playNextQueuedPreset}
+          >
+            Play next queued preset
+          </button>
+        </section>
       ) : null}
 
       <section className="stims-shell__sheet-surface">
@@ -783,6 +839,19 @@ export function BrowseSheetPanel({
             <input
               type="file"
               accept="image/png,image/jpeg,image/webp,image/gif"
+              disabled={imageImportLoading || offline}
+              onChange={(event) => void handleImageImport(event.target.files)}
+            />
+          </label>
+          <label
+            className="cta-button stims-shell__file-button"
+            aria-disabled={imageImportLoading || offline}
+          >
+            Camera vibe
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
               disabled={imageImportLoading || offline}
               onChange={(event) => void handleImageImport(event.target.files)}
             />

--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import styles from '../../css/MobileControlBar.module.css';
 import { searchByFrame } from '../core/services/visual-embedding.ts';
+import { pulseHaptic } from './haptics.ts';
 import { UiIcon } from './UiIcon.tsx';
 import { useEngineSnapshot, useWorkspace } from './workspace-context';
 
@@ -21,6 +22,8 @@ type MobileControlBarProps = {
   onToggleFullscreen: () => void;
   onToggleTheme?: () => void;
   thumbMode?: boolean;
+  partyRemoteMode?: boolean;
+  hapticsEnabled?: boolean;
 };
 
 export function MobileControlBar({
@@ -31,6 +34,8 @@ export function MobileControlBar({
   onToggleFullscreen,
   onToggleTheme: _onToggleTheme,
   thumbMode = false,
+  partyRemoteMode = false,
+  hapticsEnabled = true,
 }: MobileControlBarProps) {
   const { ui, engine } = useWorkspace();
   const { engineSnapshot } = useEngineSnapshot();
@@ -88,13 +93,15 @@ export function MobileControlBar({
 
   const handleShuffle = useCallback(() => {
     resetHideTimer();
+    pulseHaptic(12, hapticsEnabled);
     void engine.handleShufflePreset();
-  }, [engine, resetHideTimer]);
+  }, [engine, hapticsEnabled, resetHideTimer]);
 
   const handlePrevious = useCallback(() => {
     resetHideTimer();
+    pulseHaptic(12, hapticsEnabled);
     void engine.handlePreviousPreset();
-  }, [engine, resetHideTimer]);
+  }, [engine, hapticsEnabled, resetHideTimer]);
 
   const handleSimilar = useCallback(async () => {
     resetHideTimer();
@@ -137,8 +144,30 @@ export function MobileControlBar({
 
   const handleFullscreen = useCallback(() => {
     resetHideTimer();
+    pulseHaptic(10, hapticsEnabled);
     onToggleFullscreen();
-  }, [onToggleFullscreen, resetHideTimer]);
+  }, [hapticsEnabled, onToggleFullscreen, resetHideTimer]);
+
+  const handleFavorite = useCallback(() => {
+    resetHideTimer();
+    const presetId = engineSnapshot?.activePresetId;
+    if (!presetId) {
+      ui.setStatusMessage('No preset is active yet.');
+      return;
+    }
+    pulseHaptic(24, hapticsEnabled);
+    const favorite = !engine.favoritePresets.some(
+      (entry) => entry.id === presetId,
+    );
+    void engine.toggleFavoritePreset(presetId, favorite);
+    ui.setStatusMessage(favorite ? 'Preset saved.' : 'Preset unsaved.');
+  }, [
+    engine,
+    engineSnapshot?.activePresetId,
+    hapticsEnabled,
+    resetHideTimer,
+    ui,
+  ]);
 
   const handleMoodGenerate = useCallback(
     (mood: { label: string; desc: string }) => {
@@ -190,6 +219,17 @@ export function MobileControlBar({
   );
 
   const mobileActions = [
+    {
+      id: 'favorite',
+      label: engine.favoritePresets.some(
+        (entry) => entry.id === engineSnapshot?.activePresetId,
+      )
+        ? 'Saved'
+        : 'Save',
+      ariaLabel: 'Save current preset',
+      icon: 'sparkles' as const,
+      onClick: handleFavorite,
+    },
     {
       id: 'browse',
       label: 'Browse',
@@ -277,8 +317,10 @@ export function MobileControlBar({
       : []),
   ];
   const primaryActionIds = thumbMode
-    ? ['browse', 'shuffle', 'similar', 'settings']
-    : ['browse', 'shuffle', 'previous', 'similar', 'settings'];
+    ? ['browse', 'shuffle', 'favorite', 'settings']
+    : partyRemoteMode
+      ? ['shuffle', 'favorite', 'fullscreen']
+      : ['browse', 'shuffle', 'previous', 'similar', 'settings'];
   const primaryActions = mobileActions.filter((action) =>
     primaryActionIds.includes(action.id),
   );
@@ -354,6 +396,7 @@ export function MobileControlBar({
             aria-expanded={showMoreActions}
             onClick={() => {
               resetHideTimer();
+              pulseHaptic(8, hapticsEnabled);
               setShowMoreActions((current) => !current);
             }}
             aria-label="More mobile actions"
@@ -384,7 +427,7 @@ export function MobileControlBar({
             resetHideTimer();
           }}
         >
-          <span aria-hidden="true">^</span>
+          <span aria-hidden="true">⌃</span>
           <span className={styles.handleLabel}>Controls</span>
         </button>
       ) : null}

--- a/assets/js/frontend/PresetShelfSection.tsx
+++ b/assets/js/frontend/PresetShelfSection.tsx
@@ -34,6 +34,7 @@ export function PresetShelfSection({
   title,
   titleAction,
   onSelect,
+  onQueue,
   presetPreviews,
   onVisible,
 }: {
@@ -46,11 +47,14 @@ export function PresetShelfSection({
   title: string;
   titleAction?: { label: string; onClick: () => void };
   onSelect: (presetId: string) => void;
+  onQueue?: (presetId: string) => void;
   presetPreviews: Record<string, MilkdropPresetRenderPreview>;
   onVisible?: () => void;
 }) {
   const sectionRef = useRef<HTMLElement>(null);
   const [hasTriggered, setHasTriggered] = useState(false);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queuedByLongPressRef = useRef(false);
 
   useEffect(() => {
     if (!onVisible || hasTriggered) {
@@ -82,6 +86,13 @@ export function PresetShelfSection({
   if (entries.length === 0) {
     return null;
   }
+
+  const clearLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
   const sectionId = `stims-shelf-${title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
@@ -114,7 +125,25 @@ export function PresetShelfSection({
             key={`${title}-${entry.id}`}
             type="button"
             className="stims-shell__starter-card"
-            onClick={() => onSelect(entry.id)}
+            onPointerDown={(event) => {
+              if (!onQueue || event.pointerType !== 'touch') return;
+              queuedByLongPressRef.current = false;
+              longPressTimerRef.current = setTimeout(() => {
+                queuedByLongPressRef.current = true;
+                onQueue(entry.id);
+              }, 550);
+            }}
+            onPointerMove={clearLongPress}
+            onPointerCancel={clearLongPress}
+            onPointerUp={clearLongPress}
+            onClick={(event) => {
+              if (queuedByLongPressRef.current) {
+                queuedByLongPressRef.current = false;
+                event.preventDefault();
+                return;
+              }
+              onSelect(entry.id);
+            }}
           >
             <PresetArtwork
               entry={entry}
@@ -123,6 +152,11 @@ export function PresetShelfSection({
             <span className="stims-shell__starter-label">{label}</span>
             <strong>{entry.title}</strong>
             <span className="stims-shell__meta-copy">{cardSummary}</span>
+            {onQueue ? (
+              <span className="stims-shell__meta-copy">
+                Long-press to queue
+              </span>
+            ) : null}
           </button>
         ))}
       </div>

--- a/assets/js/frontend/SettingsSheetPanel.tsx
+++ b/assets/js/frontend/SettingsSheetPanel.tsx
@@ -150,6 +150,10 @@ export function SettingsSheetPanel({
   onMotionPreferenceChange,
   thumbMode = false,
   onThumbModeChange,
+  partyRemoteMode = false,
+  onPartyRemoteModeChange,
+  hapticsEnabled = true,
+  onHapticsEnabledChange,
   offline = false,
   installAvailable = false,
   onInstallApp,
@@ -158,6 +162,10 @@ export function SettingsSheetPanel({
   onMotionPreferenceChange: (enabled: boolean) => void;
   thumbMode?: boolean;
   onThumbModeChange?: (enabled: boolean) => void;
+  partyRemoteMode?: boolean;
+  onPartyRemoteModeChange?: (enabled: boolean) => void;
+  hapticsEnabled?: boolean;
+  onHapticsEnabledChange?: (enabled: boolean) => void;
   offline?: boolean;
   installAvailable?: boolean;
   onInstallApp?: () => void;
@@ -236,6 +244,36 @@ export function SettingsSheetPanel({
             <small>
               Keeps quick browse and sharing actions at the bottom of mobile
               sheets.
+            </small>
+          </span>
+        </label>
+        <label className="stims-shell__toggle-card">
+          <input
+            type="checkbox"
+            checked={partyRemoteMode}
+            onChange={(event) =>
+              onPartyRemoteModeChange?.(event.target.checked)
+            }
+          />
+          <span className="stims-shell__toggle-copy">
+            <strong>Party remote</strong>
+            <small>
+              Simplifies the phone bar to shuffle, save, fullscreen, and audio
+              controls.
+            </small>
+          </span>
+        </label>
+        <label className="stims-shell__toggle-card">
+          <input
+            type="checkbox"
+            checked={hapticsEnabled}
+            onChange={(event) => onHapticsEnabledChange?.(event.target.checked)}
+          />
+          <span className="stims-shell__toggle-copy">
+            <strong>Touch haptics</strong>
+            <small>
+              Adds a subtle vibration for swipes, long-press saves, and key
+              controls when supported.
             </small>
           </span>
         </label>

--- a/assets/js/frontend/haptics.ts
+++ b/assets/js/frontend/haptics.ts
@@ -1,0 +1,12 @@
+export function canUseHaptics(enabled = true) {
+  return (
+    enabled &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.vibrate === 'function'
+  );
+}
+
+export function pulseHaptic(pattern: number | number[] = 12, enabled = true) {
+  if (!canUseHaptics(enabled)) return;
+  navigator.vibrate(pattern);
+}

--- a/assets/js/frontend/hooks/useStageGesture.ts
+++ b/assets/js/frontend/hooks/useStageGesture.ts
@@ -1,4 +1,5 @@
 import { type RefObject, useEffect, useRef } from 'react';
+import { pulseHaptic } from '../haptics.ts';
 
 const WHEEL_DEBOUNCE_MS = 400;
 const SWIPE_MIN_DISTANCE_PX = 64;
@@ -40,6 +41,7 @@ export function useStageGesture({
   closePanel,
   toggleFavoritePreset,
   setStatusMessage,
+  hapticsEnabled = true,
 }: {
   enabled: boolean;
   stageRef?: RefObject<HTMLElement | null>;
@@ -49,6 +51,7 @@ export function useStageGesture({
   closePanel?: () => void;
   toggleFavoritePreset?: () => void;
   setStatusMessage?: (message: string) => void;
+  hapticsEnabled?: boolean;
 }) {
   const shuffleRef = useRef(handleShufflePreset);
   shuffleRef.current = handleShufflePreset;
@@ -115,6 +118,7 @@ export function useStageGesture({
       clearLongPress();
       longPressTimerRef.current = setTimeout(() => {
         longPressFired = true;
+        pulseHaptic(24, hapticsEnabled);
         toggleFavoriteRef.current?.();
       }, LONG_PRESS_MS);
     };
@@ -146,11 +150,13 @@ export function useStageGesture({
         lastSwipeRef.current = now;
         if (dx > 0) {
           prevRef.current();
+          pulseHaptic(12, hapticsEnabled);
           statusRef.current?.(
             'Previous preset. Swipe left for another surprise.',
           );
         } else {
           shuffleRef.current();
+          pulseHaptic(12, hapticsEnabled);
           statusRef.current?.('Shuffled preset. Swipe right to go back.');
         }
         return;
@@ -160,11 +166,13 @@ export function useStageGesture({
         lastSwipeRef.current = now;
         if (dy < 0) {
           openBrowseRef.current?.();
+          pulseHaptic([8, 20, 8], hapticsEnabled);
           statusRef.current?.(
             'Browse opened. Swipe down on the stage to close.',
           );
         } else {
           closePanelRef.current?.();
+          pulseHaptic(10, hapticsEnabled);
           statusRef.current?.('Panel closed.');
         }
       }
@@ -190,5 +198,5 @@ export function useStageGesture({
       stage.removeEventListener('pointerup', handlePointerEnd);
       stage.removeEventListener('pointercancel', handlePointerCancel);
     };
-  }, [enabled, stageRef]);
+  }, [enabled, stageRef, hapticsEnabled]);
 }


### PR DESCRIPTION
### Motivation
- Improve mobile UX by adding subtle tactile feedback and a simplified "party remote" control layout for phone use.
- Make the bottom sheet more adaptable on mobile with discrete snap points and safer full-height handling around safe areas.
- Provide quick preset queueing and a camera import flow to speed up mobile content creation.
- Expose mobile toggles for these behaviors in settings and persist preferences across sessions.

### Description
- Added a small haptics utility (`assets/js/frontend/haptics.ts`) and wired haptic pulses into stage gestures (`useStageGesture`), the mobile control bar (`MobileControlBar`), and related actions via `pulseHaptic` calls.
- Extended the bottom sheet with snap support by adding `snapPoints` and `defaultSnapPoint` props in `BottomSheet.tsx`, handling `data-snap`, snap transition logic on drag end, and CSS for `compact|half|full` snap sizes in `BottomSheet.module.css` while improving safe-area handling.
- Implemented a mobile preset queue in `BrowseSheetPanel.tsx` with `handleQueuePreset`, `playNextQueuedPreset`, an "Up next" UI block, and a camera input button for direct image import.
- Added long-press-to-queue support in `PresetShelfSection.tsx` using pointer events and timers and surfaced an `onQueue` callback; updated browse-related shelf usages to pass `onQueue`.
- Enhanced mobile controls in `MobileControlBar.tsx` by adding a `favorite` action, respecting `partyRemoteMode` and `hapticsEnabled` flags, adjusting primary action sets, and refining the handle styling and labels; CSS updates in `MobileControlBar.module.css` reflect the new look/spacing.
- Exposed and persisted mobile settings in `App.tsx` (localStorage keys `stims:mobile-party-remote` and `stims:mobile-haptics`), and passed `partyRemoteMode`/`hapticsEnabled` into `SettingsSheetPanel`, `MobileControlBar`, and the `BottomSheet` settings panel.
- Added settings UI toggles for `Party remote` and `Touch haptics` in `SettingsSheetPanel.tsx`.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) against the changed files and the project type system, which succeeded.
- Performed a production build (`yarn build`) as a smoke test, which completed successfully without build errors.
- No automated unit tests were modified by this change and the existing test suite (if present) was not altered by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb5b9e98c8332b5ae6d1bc4bd4199)