### PR TITLE
feat: Add per-point custom-wave colors

### DIFF
--- a/assets/js/milkdrop/renderer-helpers/wave-renderer.ts
+++ b/assets/js/milkdrop/renderer-helpers/wave-renderer.ts
@@ -2,6 +2,7 @@ import type { Group, Line, LineLoop, Points } from 'three';
 import {
   AdditiveBlending,
   BufferGeometry,
+  Float32BufferAttribute,
   LineBasicMaterial,
   NormalBlending,
   PointsMaterial,
@@ -19,6 +20,31 @@ import type { MilkdropColor, MilkdropWaveVisual } from '../types';
 type WaveLayerObject = Line | LineLoop | Points;
 
 const THICK_WAVE_BASE_OFFSET = 1 / 512;
+
+function syncWaveVertexColors(
+  geometry: BufferGeometry,
+  material: LineBasicMaterial | PointsMaterial,
+  colors: number[] | undefined,
+) {
+  if (!colors || colors.length === 0) {
+    geometry.deleteAttribute('color');
+    material.vertexColors = false;
+    return;
+  }
+
+  const existing = geometry.getAttribute('color');
+  if (
+    existing instanceof Float32BufferAttribute &&
+    existing.itemSize === 3 &&
+    existing.array.length === colors.length
+  ) {
+    existing.array.set(colors);
+    existing.needsUpdate = true;
+  } else {
+    geometry.setAttribute('color', new Float32BufferAttribute(colors, 3));
+  }
+  material.vertexColors = true;
+}
 
 function getWaveLayerCount(wave: MilkdropWaveVisual) {
   return wave.drawMode === 'dots' || wave.thickness > 1 ? 4 : 1;
@@ -80,6 +106,7 @@ function createWaveLayerObject(
       wave.color,
       wave.alpha * alphaMultiplier,
     );
+    syncWaveVertexColors(object.geometry, object.material, wave.colors);
     object.position.set(offsetX, offsetY, 0.24);
     return object;
   }
@@ -103,6 +130,7 @@ function createWaveLayerObject(
     wave.color,
     wave.alpha * alphaMultiplier,
   );
+  syncWaveVertexColors(object.geometry, object.material, wave.colors);
   object.position.set(offsetX, offsetY, 0.24);
   return object;
 }
@@ -163,6 +191,7 @@ function syncWaveLayerObject(
       wave.color,
       wave.alpha * alphaMultiplier,
     );
+    syncWaveVertexColors(existing.geometry, material, wave.colors);
   } else {
     const material = existing.material as LineBasicMaterial;
     material.linewidth = 1;
@@ -172,6 +201,7 @@ function syncWaveLayerObject(
       wave.color,
       wave.alpha * alphaMultiplier,
     );
+    syncWaveVertexColors(existing.geometry, material, wave.colors);
   }
   existing.position.set(offsetX, offsetY, 0.24);
   return existing;

--- a/assets/js/milkdrop/renderer-types.ts
+++ b/assets/js/milkdrop/renderer-types.ts
@@ -41,6 +41,8 @@ export type MilkdropPolyline = {
 };
 
 export type MilkdropWaveVisual = MilkdropPolyline & {
+  /** Optional RGB triplets, one per vertex, used for custom-wave per-point colors. */
+  colors?: number[];
   drawMode: 'line' | 'dots';
   additive: boolean;
   blendMode?: 'subtractive' | 'multiplicative';

--- a/assets/js/milkdrop/vm/wave-builder.ts
+++ b/assets/js/milkdrop/vm/wave-builder.ts
@@ -184,6 +184,11 @@ export function buildCustomWaves({
       spectrum: false,
     };
     const positions = useProcedural ? null : visualWave.positions;
+    const pointColors = useProcedural ? null : (visualWave.colors ?? []);
+    let hasPerPointColors = false;
+    if (pointColors) {
+      pointColors.length = sampleCount * 3;
+    }
     if (positions) {
       positions.length = sampleCount * 3;
     } else {
@@ -291,6 +296,18 @@ export function buildCustomWaves({
         positions[writeIndex + 1] = pointLocals.y;
         positions[writeIndex + 2] = 0.28;
       }
+      if (pointColors) {
+        const pointR = clamp(pointLocals.r ?? waveColor.r, 0, 1);
+        const pointG = clamp(pointLocals.g ?? waveColor.g, 0, 1);
+        const pointB = clamp(pointLocals.b ?? waveColor.b, 0, 1);
+        pointColors[writeIndex] = pointR;
+        pointColors[writeIndex + 1] = pointG;
+        pointColors[writeIndex + 2] = pointB;
+        hasPerPointColors ||=
+          pointR !== waveColor.r ||
+          pointG !== waveColor.g ||
+          pointB !== waveColor.b;
+      }
     }
 
     if (visualWave && (positions || useProcedural)) {
@@ -301,6 +318,11 @@ export function buildCustomWaves({
       visualWave.additive = additive;
       visualWave.pointSize = clamp((frameLocals.thick ?? 1) * 3.2, 1, 14);
       visualWave.spectrum = (frameLocals.spectrum ?? 0) >= 0.5;
+      if (hasPerPointColors && pointColors) {
+        visualWave.colors = pointColors;
+      } else {
+        visualWave.colors = undefined;
+      }
       waves[visualWaveCount] = visualWave;
       visualWaveCount += 1;
     }

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -295,6 +295,34 @@ wave_0_per_point2=y = sin(sample * pi * 8) * 0.25;
     expect(frameState.customWaves[0]?.positions.length).toBe(512 * 3);
   });
 
+  test('emits custom-wave per-point colors when points override frame color', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Per Point Color Custom Wave
+wavecode_0_enabled=1
+wavecode_0_samples=8
+wavecode_0_r=0.25
+wavecode_0_g=0.25
+wavecode_0_b=0.25
+wave_0_per_point1=r = if(equal(sample, 0), 1, if(equal(sample, 1), 0, r));
+wave_0_per_point2=g = if(equal(sample, 0), 0, if(equal(sample, 1), 1, g));
+wave_0_per_point3=b = if(equal(sample, 0), 0, if(equal(sample, 1), 1, b));
+      `.trim(),
+      { id: 'per-point-color-custom-wave' },
+    );
+
+    const frameState = createMilkdropVM(preset, {
+      ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
+      proceduralCustomWaves: false,
+    }).step(makeSignals({ frame: 1 }));
+
+    const customWave = frameState.customWaves[0];
+    expect(customWave?.colors).toBeDefined();
+    expect(customWave?.colors).toHaveLength(8 * 3);
+    expect(customWave?.colors?.slice(0, 3)).toEqual([1, 0, 0]);
+    expect(customWave?.colors?.slice(-3)).toEqual([0, 1, 1]);
+  });
+
   test('normalizes legacy bUseDots custom-wave fields to dot draw mode', () => {
     const preset = compileMilkdropPresetSource(
       `

--- a/tests/milkdrop-wave-renderer.test.ts
+++ b/tests/milkdrop-wave-renderer.test.ts
@@ -111,6 +111,63 @@ describe('milkdrop wave renderer', () => {
     expect((firstLayer.material as PointsMaterial).size).toBe(1);
   });
 
+  test('enables vertex colors when custom waves provide per-point color buffers', () => {
+    const helpers = makeHelpers();
+    const behavior = {
+      useLineLoopPrimitives: true,
+    } as MilkdropBackendBehavior;
+
+    const group = createWaveObject(
+      makeWave({
+        thickness: 1,
+        colors: [1, 0, 0, 0, 1, 1],
+      }),
+      behavior,
+      helpers,
+    ) as Group;
+
+    const line = group.children[0] as Line;
+    const material = line.material as LineBasicMaterial;
+    expect(material.vertexColors).toBe(true);
+    expect(Array.from(line.geometry.getAttribute('color').array)).toEqual([
+      1, 0, 0, 0, 1, 1,
+    ]);
+
+    syncWaveObject(
+      group,
+      makeWave({ thickness: 1, colors: undefined }),
+      behavior,
+      helpers,
+      1,
+    );
+
+    expect(material.vertexColors).toBe(false);
+    expect(line.geometry.getAttribute('color')).toBeUndefined();
+  });
+
+  test('enables vertex colors on dotted custom waves with per-point color buffers', () => {
+    const helpers = makeHelpers();
+    const behavior = {
+      useLineLoopPrimitives: true,
+    } as MilkdropBackendBehavior;
+
+    const group = createWaveObject(
+      makeWave({
+        drawMode: 'dots',
+        thickness: 1,
+        colors: [1, 0, 0, 0, 0, 1],
+      }),
+      behavior,
+      helpers,
+    ) as Group;
+
+    const points = group.children[0] as Points;
+    expect((points.material as PointsMaterial).vertexColors).toBe(true);
+    expect(Array.from(points.geometry.getAttribute('color').array)).toEqual([
+      1, 0, 0, 0, 0, 1,
+    ]);
+  });
+
   test('keeps existing thick wave groups stable across sync updates', () => {
     const helpers = makeHelpers();
     const behavior = {


### PR DESCRIPTION
### Motivation
- Allow custom waves to carry optional per-vertex colors so point-level `r/g/b` overrides can be rendered as vertex colors instead of only a single material color.

### Description
- Added an optional `colors?: number[]` RGB buffer on `MilkdropWaveVisual` in `assets/js/milkdrop/renderer-types.ts` to hold per-vertex triplets.
- Captured per-point `r/g/b` values in `assets/js/milkdrop/vm/wave-builder.ts` and attach the `colors` buffer only when at least one point differs from the frame-level wave color.
- Synced a Three.js `color` attribute and toggled `vertexColors` on `LineBasicMaterial` / `PointsMaterial` in `assets/js/milkdrop/renderer-helpers/wave-renderer.ts`, with removal/fallback to single material color when no per-point colors exist.
- Added regression tests verifying VM emission of first/last per-point colors and renderer behavior for line and dotted waves in `tests/milkdrop-vm.test.ts` and `tests/milkdrop-wave-renderer.test.ts`.

### Testing
- Ran `bun run test tests/milkdrop-vm.test.ts tests/milkdrop-wave-renderer.test.ts` and the added tests passed (VM and renderer tests passed).
- Ran `bun run check:quick` and `bun run check` (typecheck/biome) and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5010911a4c83328d3502ea7895c871)