### PR TITLE
fix: convert custom-wave per-point coordinates to renderer space

### DIFF
--- a/assets/js/milkdrop/vm/wave-builder.ts
+++ b/assets/js/milkdrop/vm/wave-builder.ts
@@ -20,6 +20,9 @@ import {
 
 const MAX_CUSTOM_WAVE_SAMPLES = 1024;
 
+const toRendererWaveX = (value: number) => (value - 0.5) * 2;
+const toRendererWaveY = (value: number) => (0.5 - value) * 2;
+
 export function buildMainWave({
   state,
   signals,
@@ -168,6 +171,12 @@ export function buildCustomWaves({
       drawMode,
     );
     const useProcedural = proceduralDescriptor !== null;
+    const perPointWritesX = wave.programs.perPoint.statements.some(
+      (statement) => statement.target === 'x',
+    );
+    const perPointWritesY = wave.programs.perPoint.statements.some(
+      (statement) => statement.target === 'y',
+    );
     const pointLocals = { ...frameLocals };
     waveState.pointLocalsScratch = pointLocals;
     const pointEnv = useProcedural
@@ -287,8 +296,12 @@ export function buildCustomWaves({
       }
       const writeIndex = point * 3;
       if (positions) {
-        positions[writeIndex] = pointLocals.x;
-        positions[writeIndex + 1] = pointLocals.y;
+        positions[writeIndex] = perPointWritesX
+          ? toRendererWaveX(pointLocals.x)
+          : pointLocals.x;
+        positions[writeIndex + 1] = perPointWritesY
+          ? toRendererWaveY(pointLocals.y)
+          : pointLocals.y;
         positions[writeIndex + 2] = 0.28;
       }
     }

--- a/tests/milkdrop-vm.test.ts
+++ b/tests/milkdrop-vm.test.ts
@@ -277,6 +277,53 @@ per_frame_2=wave_a = beat_pulse;
     expect(second.mainWave.alpha).toBeCloseTo(0.35, 6);
   });
 
+  test('converts MilkDrop custom-wave per-point coordinates to renderer space', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Custom Wave Coordinate Conversion
+wavecode_0_enabled=1
+wavecode_0_samples=8
+wave_0_per_point1=x=0.5;y=0.5;
+      `.trim(),
+      { id: 'custom-wave-coordinate-conversion' },
+    );
+
+    const frameState = createMilkdropVM(preset, {
+      ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
+      proceduralCustomWaves: false,
+    }).step(makeSignals({ frame: 1 }));
+    const firstPoint = frameState.customWaves[0]?.positions;
+
+    expect(firstPoint).toBeDefined();
+    expect(firstPoint?.[0]).toBeCloseTo(0, 6);
+    expect(firstPoint?.[1]).toBeCloseTo(0, 6);
+    expect(firstPoint?.[0]).not.toBeCloseTo(0.5, 6);
+    expect(firstPoint?.[1]).not.toBeCloseTo(0.5, 6);
+  });
+
+  test('converts bundled-style projected custom-wave coordinates to renderer space', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Custom Wave Projection Coordinate Conversion
+wavecode_0_enabled=1
+wavecode_0_samples=8
+wave_0_per_point1=xp=0;yp=0;zp=1;
+wave_0_per_point2=x=xp/zp+0.5;y=yp/zp+0.5;
+      `.trim(),
+      { id: 'custom-wave-projection-coordinate-conversion' },
+    );
+
+    const frameState = createMilkdropVM(preset, {
+      ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
+      proceduralCustomWaves: false,
+    }).step(makeSignals({ frame: 1 }));
+    const firstPoint = frameState.customWaves[0]?.positions;
+
+    expect(firstPoint).toBeDefined();
+    expect(firstPoint?.[0]).toBeCloseTo(0, 6);
+    expect(firstPoint?.[1]).toBeCloseTo(0, 6);
+  });
+
   test('preserves 512-sample custom waves for imported projectM presets', () => {
     const preset = compileMilkdropPresetSource(
       `
@@ -332,8 +379,8 @@ wave_1_per_point1=y=t1;
     const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
 
     expect(frameState.customWaves).toHaveLength(2);
-    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.1, 6);
-    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(0.4, 6);
+    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.8, 6);
+    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(0.2, 6);
     expect(frameState.variables.t1).toBeCloseTo(0, 6);
   });
 
@@ -355,8 +402,8 @@ wave_1_per_point1=y=xp;
     const frameState = createMilkdropVM(preset).step(makeSignals({ frame: 1 }));
 
     expect(frameState.customWaves).toHaveLength(2);
-    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.25, 6);
-    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(0, 6);
+    expect(frameState.customWaves[0]?.positions[1]).toBeCloseTo(0.5, 6);
+    expect(frameState.customWaves[1]?.positions[1]).toBeCloseTo(1, 6);
   });
 
   test('keeps shape texture-control locals and projectM instance aliases available at runtime', () => {
@@ -610,8 +657,8 @@ wave_0_per_point2=y = value2;
     const firstPoint = frameState.customWaves[0]?.positions;
 
     expect(firstPoint).toBeDefined();
-    expect(firstPoint?.[0]).toBeCloseTo(normalizedValue * 2, 6);
-    expect(firstPoint?.[1]).toBeCloseTo(normalizedValue, 6);
+    expect(firstPoint?.[0]).toBeCloseTo((normalizedValue * 2 - 0.5) * 2, 6);
+    expect(firstPoint?.[1]).toBeCloseTo((0.5 - normalizedValue) * 2, 6);
   });
 
   test('applies legacy cx/cy/sx/sy/dx/dy mesh transforms', () => {


### PR DESCRIPTION
### Motivation

- MilkDrop custom-wave per-point programs emit coordinates in MilkDrop's 0..1 per-point space while the renderer expects NDC-style coordinates, which caused points like `x=0.5;y=0.5` to appear at `(0.5, 0.5)` instead of renderer center `(0, 0)`.
- The change must avoid double-converting fallback/generated defaults that are already in renderer space before per-point code runs.

### Description

- Added `toRendererWaveX` and `toRendererWaveY` helpers that map MilkDrop outputs to renderer space (`(value - 0.5) * 2` and `(0.5 - value) * 2`).
- Detect whether a custom wave's `perPoint` program writes `x` or `y` by checking `wave.programs.perPoint.statements` and only apply the conversion for the axes written by per-point code.
- Apply the conversion when writing positions after `runProgram(wave.programs.perPoint, ...)` so generated fallback `pointLocals.x/y` remain unmodified unless overwritten by per-point statements.
- Added regression tests in `tests/milkdrop-vm.test.ts` to verify `x=0.5;y=0.5` yields renderer center `(0, 0)` and a bundled-style projection case using `xp/yp/zp`.

### Testing

- Ran the focused VM tests with `bun run test tests/milkdrop-vm.test.ts` and the MilkDrop VM test file passed (targeted regressions green).
- Ran the fast check with `bun run check:quick` and it completed successfully.
- Ran the full quality gate with `bun run check`, which surfaced pre-existing unrelated failures in other fast-suite tests (import/export mismatches in unrelated modules), but the custom-wave VM regressions added here remained passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50108c94e48332893f9d1cb83d6464)