### PR TITLE
ci: Restore Cloudflare Pages deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,151 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run quality gate
+        run: bun run check
+
+      - name: Build production bundle
+        run: bun run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run integration tests
+        run: bun run test:integration
+
+  deploy_preview:
+    name: Deploy Pages preview
+    runs-on: ubuntu-latest
+    needs:
+      - quality
+      - integration
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      vars.CLOUDFLARE_PAGES_DEPLOYS_DISABLED != 'true'
+    permissions:
+      contents: read
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download Pages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pages-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist
+
+      - name: Deploy preview to Cloudflare Pages
+        if: env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_API_TOKEN != ''
+        env:
+          CF_PAGES_BRANCH: ${{ github.head_ref }}
+        run: bun run pages:deploy:preview:reuse
+
+      - name: Skip preview deploy when Cloudflare secrets are missing
+        if: env.CLOUDFLARE_ACCOUNT_ID == '' || env.CLOUDFLARE_API_TOKEN == ''
+        run: echo "Cloudflare Pages preview deploy skipped because CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN is not configured."
+
+  deploy_production:
+    name: Deploy Pages production
+    runs-on: ubuntu-latest
+    needs:
+      - quality
+      - integration
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      vars.CLOUDFLARE_PAGES_DEPLOYS_DISABLED != 'true'
+    permissions:
+      contents: read
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download Pages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pages-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist
+
+      - name: Deploy production to Cloudflare Pages
+        if: env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_API_TOKEN != ''
+        run: bun run pages:deploy:production:reuse
+
+      - name: Skip production deploy when Cloudflare secrets are missing
+        if: env.CLOUDFLARE_ACCOUNT_ID == '' || env.CLOUDFLARE_API_TOKEN == ''
+        run: echo "Cloudflare Pages production deploy skipped because CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN is not configured."


### PR DESCRIPTION
### Motivation

- Restore a missing CI workflow that runs the repository quality gate, builds the production `dist/` artifact once, and enables Cloudflare Pages preview and production deploys that reuse the checked build artifact.

### Description

- Add `.github/workflows/ci.yml` which defines a `quality` job that sets up Bun, runs `bun run check`, runs `bun run build`, and uploads the `dist/` artifact for reuse.  
- Add an `integration` job that installs Playwright Chromium and runs `bun run test:integration` so deploys wait for browser-level verification.  
- Add `deploy_preview` and `deploy_production` jobs that download the uploaded `dist/` artifact and run `bun run pages:deploy:preview:reuse` / `bun run pages:deploy:production:reuse`, and skip deployments when Cloudflare secrets are not present.  
- Workflow includes concurrency/cancel-in-progress and uses read-only default `contents: read` permissions.

### Testing

- Ran `mise trust && bun run check:quick`, which completed successfully (Biome check, architecture check, TypeScript typecheck paths exercised).  
- Ran `bun run build`, which produced `dist/` and `.vite/manifest.json` successfully.  
- Verified workflow YAML parses with `bun -e "import {parseDocument} from 'yaml'..."` and it returned a valid parse.  
- Attempted `bunx actionlint .github/workflows/ci.yml`, which did not complete in this environment due to an executable resolution limitation (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50154b6f948332886d4e0762f7f3b0)