### PR TITLE
Improve mobile performance and reduce resource churn (capture limits, adaptive quality, pointer throttling, reuse buffers)

### DIFF
--- a/assets/js/core/audio-handler.ts
+++ b/assets/js/core/audio-handler.ts
@@ -29,6 +29,7 @@ const DEFAULT_FREQUENCY_BAND_RANGES = {
   treble: { minHz: 2800, maxHz: 12000 },
 } as const;
 const DEFAULT_SAMPLE_RATE = 44_100;
+const stylizedFrequencyBuffers = new WeakMap<object, Uint8Array>();
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -982,8 +983,15 @@ export async function initAudio(options: AudioInitOptions = {}) {
 
 export function getFrequencyData(analyser: FrequencyAnalyser) {
   const rawFrequencyData = analyser.getFrequencyData();
+  const key = analyser as unknown as object;
+  let stylized = stylizedFrequencyBuffers.get(key);
+  if (!stylized || stylized.length !== rawFrequencyData.length) {
+    stylized = new Uint8Array(rawFrequencyData.length);
+    stylizedFrequencyBuffers.set(key, stylized);
+  }
+  stylized.set(rawFrequencyData);
 
-  return stylizeFrequencyData(rawFrequencyData.slice());
+  return stylizeFrequencyData(stylized);
 }
 
 /**

--- a/assets/js/core/renderer-settings.ts
+++ b/assets/js/core/renderer-settings.ts
@@ -31,7 +31,7 @@ export function getRendererBackendMaxPixelRatioCap({
 }) {
   if (isMobile) {
     if (platformFamily === 'ios' && browserFamily === 'safari') {
-      return backend === 'webgpu' ? 1.4 : 1.15;
+      return backend === 'webgpu' ? 1.2 : 1;
     }
 
     if (
@@ -40,10 +40,10 @@ export function getRendererBackendMaxPixelRatioCap({
       browserFamily === 'edge' ||
       browserFamily === 'samsung-internet'
     ) {
-      return backend === 'webgpu' ? 1.35 : 1.1;
+      return backend === 'webgpu' ? 1.2 : 1;
     }
 
-    return backend === 'webgpu' ? 1.4 : 1.15;
+    return backend === 'webgpu' ? 1.2 : 1;
   }
 
   return backend === 'webgpu' ? 4 : 1.75;

--- a/assets/js/core/renderer-setup.ts
+++ b/assets/js/core/renderer-setup.ts
@@ -84,7 +84,7 @@ function disposeRenderer(renderer: Partial<WebGLRenderer | WebGPURenderer>) {
 export async function initRenderer(
   canvas: HTMLCanvasElement,
   config: RendererInitConfig = {
-    antialias: true,
+    antialias: !isMobileUserAgent,
     exposure: 1,
     maxPixelRatio: isMobileUserAgent ? 1.1 : 1.5,
     alpha: false,
@@ -104,7 +104,7 @@ export async function initRenderer(
   currentState = validateTransition(currentState, FallbackState.ProbingWebgl);
 
   const {
-    antialias = true,
+    antialias = !isMobileUserAgent,
     exposure = 1,
     maxPixelRatio = isMobileUserAgent ? 1.1 : 1.5,
     alpha = false,

--- a/assets/js/core/services/adaptive-quality-controller.ts
+++ b/assets/js/core/services/adaptive-quality-controller.ts
@@ -1,3 +1,4 @@
+import { isMobileDevice } from '../../utils/device-detect.ts';
 import type {
   RendererBackend,
   WebGPUCapabilitySummary,
@@ -121,8 +122,10 @@ function updateEma(previous: number | null, next: number) {
   return previous + (next - previous) * EMA_ALPHA;
 }
 
-function getDisplayRefreshRate(): number {
+export function getAdaptiveQualityDisplayRefreshRate(): number {
   if (typeof window === 'undefined') return 60;
+
+  if (isMobileDevice()) return 60;
 
   if (typeof screen !== 'undefined' && 'refreshRate' in screen) {
     const rate = (screen as unknown as { refreshRate: number }).refreshRate;
@@ -142,7 +145,7 @@ function getDisplayRefreshRate(): number {
 }
 
 function estimateFrameBudgetMs(): number {
-  const hz = getDisplayRefreshRate();
+  const hz = getAdaptiveQualityDisplayRefreshRate();
   return 1000 / hz;
 }
 
@@ -211,6 +214,13 @@ function buildHeuristicProfile(
   ) {
     reasons.push(
       'Balanced startup quality is preferred on touch-first devices for steadier frame pacing.',
+    );
+  }
+
+  if (isMobileDevice()) {
+    initialStep = Math.max(initialStep, 2);
+    reasons.push(
+      'Touch-first mobile sessions start from balanced quality for steadier sustained performance.',
     );
   }
 

--- a/assets/js/core/services/captured-video-texture.ts
+++ b/assets/js/core/services/captured-video-texture.ts
@@ -6,6 +6,7 @@ import {
   SRGBColorSpace,
   Texture,
 } from 'three';
+import { isMobileDevice } from '../../utils/device-detect.ts';
 
 type CaptureDrawSurface = {
   canvas: HTMLCanvasElement;
@@ -20,8 +21,26 @@ type VideoFrameCallbackVideo = HTMLVideoElement & {
 };
 
 const MIN_CAPTURE_SIZE = 64;
-const MAX_CAPTURE_WIDTH = 960;
-const MAX_CAPTURE_HEIGHT = 540;
+const DESKTOP_MAX_CAPTURE_WIDTH = 960;
+const DESKTOP_MAX_CAPTURE_HEIGHT = 540;
+const MOBILE_MAX_CAPTURE_WIDTH = 640;
+const MOBILE_MAX_CAPTURE_HEIGHT = 360;
+const DESKTOP_FALLBACK_CAPTURE_FPS = 30;
+const MOBILE_FALLBACK_CAPTURE_FPS = 15;
+
+export function resolveCapturedVideoLimits(isMobile = isMobileDevice()) {
+  return isMobile
+    ? {
+        maxWidth: MOBILE_MAX_CAPTURE_WIDTH,
+        maxHeight: MOBILE_MAX_CAPTURE_HEIGHT,
+        fallbackFrameIntervalMs: 1000 / MOBILE_FALLBACK_CAPTURE_FPS,
+      }
+    : {
+        maxWidth: DESKTOP_MAX_CAPTURE_WIDTH,
+        maxHeight: DESKTOP_MAX_CAPTURE_HEIGHT,
+        fallbackFrameIntervalMs: 1000 / DESKTOP_FALLBACK_CAPTURE_FPS,
+      };
+}
 
 let activeStream: MediaStream | null = null;
 let captureReady = false;
@@ -85,8 +104,9 @@ function ensureCaptureSurface() {
   }
 
   const canvas = document.createElement('canvas');
-  canvas.width = MAX_CAPTURE_WIDTH;
-  canvas.height = MAX_CAPTURE_HEIGHT;
+  const limits = resolveCapturedVideoLimits();
+  canvas.width = limits.maxWidth;
+  canvas.height = limits.maxHeight;
   const context = canvas.getContext('2d', {
     alpha: false,
     desynchronized: true,
@@ -200,8 +220,8 @@ function resizeCaptureSurface(width: number, height: number) {
 
   const scale = Math.min(
     1,
-    MAX_CAPTURE_WIDTH / Math.max(1, width),
-    MAX_CAPTURE_HEIGHT / Math.max(1, height),
+    resolveCapturedVideoLimits().maxWidth / Math.max(1, width),
+    resolveCapturedVideoLimits().maxHeight / Math.max(1, height),
   );
   const nextWidth = Math.max(MIN_CAPTURE_SIZE, Math.round(width * scale));
   const nextHeight = Math.max(MIN_CAPTURE_SIZE, Math.round(height * scale));
@@ -260,8 +280,13 @@ function startCaptureLoop() {
     return;
   }
 
-  const step = () => {
-    drawCaptureFrame();
+  const limits = resolveCapturedVideoLimits();
+  let lastDrawAt = -Infinity;
+  const step = (now: number) => {
+    if (now - lastDrawAt >= limits.fallbackFrameIntervalMs) {
+      drawCaptureFrame();
+      lastDrawAt = now;
+    }
     captureFrameId = requestAnimationFrame(step);
   };
 
@@ -402,4 +427,5 @@ export function clearMilkdropCapturedVideoStream() {
 export const __milkdropCapturedVideoTextureTestUtils = {
   resolveViewportRect,
   resolveSourceRect,
+  resolveCapturedVideoLimits,
 };

--- a/assets/js/core/toy-runtime.ts
+++ b/assets/js/core/toy-runtime.ts
@@ -313,6 +313,7 @@ export function createToyRuntime({
   let previewActive = false;
   let previewStart = 0;
   let previewLastFrame = 0;
+  let previewLastDataUpdate = -Infinity;
   let previewVisibilityCleanup: (() => void) | null = null;
 
   const updatePreviewFrequencyData = (time: number) => {
@@ -377,7 +378,16 @@ export function createToyRuntime({
       frameState.time = time;
       frameState.realTimeMs = now;
       frameState.analyser = null;
-      updatePreviewFrequencyData(time);
+      const previewDataIntervalMs =
+        typeof navigator !== 'undefined' &&
+        ((navigator.maxTouchPoints ?? 0) > 0 ||
+          /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent ?? ''))
+          ? 1000 / 30
+          : 0;
+      if (now - previewLastDataUpdate >= previewDataIntervalMs) {
+        updatePreviewFrequencyData(time);
+        previewLastDataUpdate = now;
+      }
       frameState.frequencyData = previewFrequencyData;
       frameState.waveformData = previewWaveformData;
       frameState.input = inputController.getState();

--- a/assets/js/core/unified-input.ts
+++ b/assets/js/core/unified-input.ts
@@ -171,6 +171,7 @@ export function createUnifiedInput({
   const activePointers = new Map<number, UnifiedPointer>();
   let hoverPointer: UnifiedPointer | null = null;
   const pendingPointerEvents: PointerEvent[] = [];
+  const pendingPointerMoveIndexes = new Map<number, number>();
   const keyState = new Set<string>();
   let keyboardPointer = { normalizedX: 0, normalizedY: 0 };
   let gamepadPointer = { normalizedX: 0, normalizedY: 0 };
@@ -256,6 +257,18 @@ export function createUnifiedInput({
   };
 
   const queuePointerEvent = (event: PointerEvent) => {
+    if (event.type === 'pointermove') {
+      const existingIndex = pendingPointerMoveIndexes.get(event.pointerId);
+      if (typeof existingIndex === 'number') {
+        pendingPointerEvents[existingIndex] = event;
+        scheduleFrame();
+        return;
+      }
+      pendingPointerMoveIndexes.set(
+        event.pointerId,
+        pendingPointerEvents.length,
+      );
+    }
     pendingPointerEvents.push(event);
     scheduleFrame();
   };
@@ -447,7 +460,9 @@ export function createUnifiedInput({
   };
 
   const processPointerEvents = () => {
-    for (const event of pendingPointerEvents.splice(0)) {
+    const events = pendingPointerEvents.splice(0);
+    pendingPointerMoveIndexes.clear();
+    for (const event of events) {
       if (event.type === 'pointerup' || event.type === 'pointercancel') {
         activePointers.delete(event.pointerId);
         if (hoverPointer && hoverPointer.id === event.pointerId) {

--- a/assets/js/milkdrop/feedback-manager-shared.ts
+++ b/assets/js/milkdrop/feedback-manager-shared.ts
@@ -631,6 +631,7 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
   currentFeedbackResolutionScale: number;
   viewportWidth: number;
   viewportHeight: number;
+  private adaptiveResizeFrameId: number | null = null;
   private lastWarpGlsl: string | null = null;
   private lastCompGlsl: string | null = null;
   private index = 0;
@@ -1192,10 +1193,29 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
     ) {
       return;
     }
+    const previousFeedbackResolutionScale = this.currentFeedbackResolutionScale;
     this.adaptiveFeedbackResolutionMultiplier = nextMultiplier;
     this.currentFeedbackResolutionScale =
       this.feedbackResolutionScale * this.adaptiveFeedbackResolutionMultiplier;
-    this.resize(this.viewportWidth, this.viewportHeight);
+    if (this.currentFeedbackResolutionScale < previousFeedbackResolutionScale) {
+      this.resize(this.viewportWidth, this.viewportHeight);
+      return;
+    }
+    this.scheduleAdaptiveResize();
+  }
+
+  private scheduleAdaptiveResize() {
+    if (this.adaptiveResizeFrameId !== null) {
+      return;
+    }
+    if (typeof requestAnimationFrame !== 'function') {
+      this.resize(this.viewportWidth, this.viewportHeight);
+      return;
+    }
+    this.adaptiveResizeFrameId = requestAnimationFrame(() => {
+      this.adaptiveResizeFrameId = null;
+      this.resize(this.viewportWidth, this.viewportHeight);
+    });
   }
 
   resize(width: number, height: number) {
@@ -1238,6 +1258,13 @@ class SharedMilkdropFeedbackManager implements MilkdropFeedbackManager {
   }
 
   dispose() {
+    if (
+      this.adaptiveResizeFrameId !== null &&
+      typeof cancelAnimationFrame === 'function'
+    ) {
+      cancelAnimationFrame(this.adaptiveResizeFrameId);
+      this.adaptiveResizeFrameId = null;
+    }
     this.sceneTarget.dispose();
     this.warpTarget.dispose();
     this.targets.forEach((target) => target.dispose());

--- a/assets/js/milkdrop/feedback-manager-webgpu-tsl.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu-tsl.ts
@@ -1206,6 +1206,7 @@ class WebGPUMilkdropFeedbackManager {
   currentFeedbackResolutionScale = this.feedbackResolutionScale;
   viewportWidth: number;
   viewportHeight: number;
+  private adaptiveResizeFrameId: number | null = null;
   private index = 0;
 
   constructor(width: number, height: number) {
@@ -1439,12 +1440,29 @@ class WebGPUMilkdropFeedbackManager {
     ) {
       return;
     }
+    const previousFeedbackResolutionScale = this.currentFeedbackResolutionScale;
     this.adaptiveFeedbackResolutionMultiplier = nextMultiplier;
-    this.currentFeedbackResolutionScale = Math.min(
-      this.currentFeedbackResolutionScale,
-      this.feedbackResolutionScale * this.adaptiveFeedbackResolutionMultiplier,
-    );
-    this.resize(this.viewportWidth, this.viewportHeight);
+    this.currentFeedbackResolutionScale =
+      this.feedbackResolutionScale * this.adaptiveFeedbackResolutionMultiplier;
+    if (this.currentFeedbackResolutionScale < previousFeedbackResolutionScale) {
+      this.resize(this.viewportWidth, this.viewportHeight);
+      return;
+    }
+    this.scheduleAdaptiveResize();
+  }
+
+  private scheduleAdaptiveResize() {
+    if (this.adaptiveResizeFrameId !== null) {
+      return;
+    }
+    if (typeof requestAnimationFrame !== 'function') {
+      this.resize(this.viewportWidth, this.viewportHeight);
+      return;
+    }
+    this.adaptiveResizeFrameId = requestAnimationFrame(() => {
+      this.adaptiveResizeFrameId = null;
+      this.resize(this.viewportWidth, this.viewportHeight);
+    });
   }
 
   render(renderer: FeedbackRendererLike, scene: Scene, camera: Camera) {
@@ -1491,6 +1509,13 @@ class WebGPUMilkdropFeedbackManager {
   }
 
   dispose() {
+    if (
+      this.adaptiveResizeFrameId !== null &&
+      typeof cancelAnimationFrame === 'function'
+    ) {
+      cancelAnimationFrame(this.adaptiveResizeFrameId);
+      this.adaptiveResizeFrameId = null;
+    }
     this.sceneTarget.dispose();
     this.targets.forEach((target) => target.dispose());
     disposeMaterial(this.compositeMaterial);

--- a/tests/adaptive-quality-controller.test.ts
+++ b/tests/adaptive-quality-controller.test.ts
@@ -191,4 +191,76 @@ describe('createAdaptiveQualityController', () => {
       'Balanced startup quality is preferred on touch-first devices for steadier frame pacing.',
     );
   });
+
+  test('uses a sustained 60hz budget and balanced start on mobile webgpu', () => {
+    const originalMaxTouchPoints = navigator.maxTouchPoints;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: 5,
+    });
+    window.matchMedia = ((query: string) =>
+      ({
+        media: query,
+        matches: query === '(pointer: coarse)' || query === '(hover: none)',
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList) as typeof window.matchMedia;
+
+    try {
+      const controller = createAdaptiveQualityController({
+        backend: 'webgpu',
+        capabilities: {
+          preferredCanvasFormat: 'bgra8unorm',
+          performanceTier: 'high-end',
+          recommendedQualityPreset: 'hi-fi',
+          workers: {
+            workers: true,
+            offscreenCanvas: true,
+            transferControlToOffscreen: true,
+          },
+          optimization: {
+            timestampQuery: true,
+            shaderF16: true,
+            subgroups: true,
+            workers: true,
+            offscreenCanvas: true,
+            transferControlToOffscreen: true,
+            workerOffscreenPipeline: true,
+          },
+          features: {
+            bgra8unormStorage: true,
+            float32Blendable: true,
+            float32Filterable: true,
+            shaderF16: true,
+            subgroups: true,
+            timestampQuery: true,
+          },
+          limits: {
+            maxColorAttachments: 8,
+            maxComputeInvocationsPerWorkgroup: 1024,
+            maxStorageBufferBindingSize: 4294967292,
+            maxTextureDimension2D: 16384,
+          },
+        },
+      });
+
+      const state = controller.getState();
+      expect(state.qualityStep).toBe(2);
+      expect(state.frameBudgetMs).toBeCloseTo(1000 / 60, 4);
+      expect(state.reasons).toContain(
+        'Touch-first mobile sessions start from balanced quality for steadier sustained performance.',
+      );
+    } finally {
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        configurable: true,
+        value: originalMaxTouchPoints,
+      });
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });

--- a/tests/audio-handler.test.js
+++ b/tests/audio-handler.test.js
@@ -320,6 +320,8 @@ describe('audio-handler utilities', () => {
 
     expect(result).toHaveLength(data.length);
     expect(result).not.toBe(data);
+    const second = getFrequencyData(analyser);
+    expect(second).toBe(result);
     expect([...data]).toEqual([8, 12, 17, 15, 10, 7, 4, 2]);
     expect(Math.max(...result)).toBeLessThan(17);
     expect(analyser.getFrequencyData).toHaveBeenCalled();

--- a/tests/captured-video-texture.test.ts
+++ b/tests/captured-video-texture.test.ts
@@ -46,3 +46,16 @@ test('captured video source crop stays inside video dimensions at viewport edges
   expect(source.sx + source.sw).toBeLessThanOrEqual(200);
   expect(source.sy + source.sh).toBeLessThanOrEqual(100);
 });
+
+test('captured video limits use smaller mobile caps and lower fallback upload cadence', () => {
+  const mobile =
+    __milkdropCapturedVideoTextureTestUtils.resolveCapturedVideoLimits(true);
+  const desktop =
+    __milkdropCapturedVideoTextureTestUtils.resolveCapturedVideoLimits(false);
+
+  expect(mobile.maxWidth).toBeLessThan(desktop.maxWidth);
+  expect(mobile.maxHeight).toBeLessThan(desktop.maxHeight);
+  expect(mobile.fallbackFrameIntervalMs).toBeGreaterThan(
+    desktop.fallbackFrameIntervalMs,
+  );
+});

--- a/tests/renderer-settings.test.ts
+++ b/tests/renderer-settings.test.ts
@@ -30,7 +30,7 @@ describe('applyRendererSettings', () => {
         browserFamily: 'safari',
         platformFamily: 'ios',
       }),
-    ).toBe(1.15);
+    ).toBe(1);
     expect(
       getRendererBackendMaxPixelRatioCap({
         backend: 'webgpu',
@@ -38,7 +38,7 @@ describe('applyRendererSettings', () => {
         browserFamily: 'safari',
         platformFamily: 'ios',
       }),
-    ).toBe(1.4);
+    ).toBe(1.2);
     expect(
       getRendererBackendMaxPixelRatioCap({
         backend: 'webgpu',
@@ -46,7 +46,7 @@ describe('applyRendererSettings', () => {
         browserFamily: 'chrome',
         platformFamily: 'android',
       }),
-    ).toBe(1.35);
+    ).toBe(1.2);
   });
 
   test('applies explicit viewport dimensions when provided', () => {


### PR DESCRIPTION
### Motivation

- Reduce CPU/GPU work and memory churn on touch-first / mobile sessions by lowering rendering caps, throttling periodic updates, and avoiding unnecessary allocations.
- Make adaptive-quality heuristics favor steadier, balanced startup and sustained budgets on mobile devices to improve frame pacing.
- Reduce redundant DOM/event work by coalescing pointer-move events and batching expensive resizes for feedback pipelines.

### Description

- Reuse frequency data buffers via `stylizedFrequencyBuffers` to avoid allocating a new `Uint8Array` on every `getFrequencyData` call and return a stylized view from the cached buffer.
- Make renderer defaults and caps device-aware by disabling antialiasing on mobile (`antialias: !isMobileUserAgent`) and lowering mobile pixel-ratio caps in `getRendererBackendMaxPixelRatioCap` for both WebGPU and WebGL backends.
- Add `resolveCapturedVideoLimits` and apply smaller `maxWidth`/`maxHeight` and a lower `fallbackFrameIntervalMs` for mobile captures, use those limits when creating/resizing the capture canvas, and throttle fallback frame uploads in the capture loop.
- Throttle preview frequency updates in `createToyRuntime` on touch/mobile devices to reduce update cadence (approx 30fps) and avoid unnecessary work while previewing.
- Coalesce pointer-move events in `createUnifiedInput` using `pendingPointerMoveIndexes` so only the most recent move per pointer is processed each frame.
- Adaptive quality: export `getAdaptiveQualityDisplayRefreshRate` and force a 60Hz budget on mobile, bump the balanced initial quality step for mobile WebGPU sessions and add a mobile-specific reason message.
- Milkdrop feedback managers (WebGL and WebGPU): introduce `scheduleAdaptiveResize` to defer upscaling resizes via `requestAnimationFrame` (and run immediate resize for downscales), track `adaptiveResizeFrameId`, and cancel pending frames in `dispose` to avoid stray callbacks.
- Minor: import `isMobileDevice` where needed and expose `resolveCapturedVideoLimits` in test utils.

### Testing

- Ran unit tests covering renderer settings, adaptive-quality-controller, audio-handler, and captured-video-texture (`tests/renderer-settings.test.ts`, `tests/adaptive-quality-controller.test.ts`, `tests/audio-handler.test.js`, `tests/captured-video-texture.test.ts`).
- Added tests verifying mobile WebGPU starts with a 60hz budget and balanced quality, captured video uses smaller mobile caps and lower upload cadence, and `getFrequencyData` returns a stylized copy without mutating analyser buffers; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5042151ee883329e1cc5ffdd4006a9)