### PR TITLE
WebGPU: add retry/backoff policy, MilkDrop feature routing, render-bundles & WGSL helpers

### DIFF
--- a/assets/js/core/renderer-capabilities.ts
+++ b/assets/js/core/renderer-capabilities.ts
@@ -16,6 +16,13 @@ import {
   DEFAULT_WEBGPU_INIT_TIMEOUT_MS,
   resolveWithTimeout,
 } from './renderer-init-timeout.ts';
+import {
+  getRendererRetrySnapshot,
+  type RendererRetrySnapshot,
+  recordRendererRetryFailure,
+  recordRendererRetrySuccess,
+  resetRendererRetryPolicy,
+} from './renderer-retry-policy.ts';
 
 export type RendererBackend = 'webgl' | 'webgpu';
 
@@ -72,6 +79,7 @@ export type RendererCapabilities = {
   shouldRetryWebGPU: boolean;
   forceWebGL: boolean;
   webgpu: WebGPUCapabilitySummary | null;
+  retry?: RendererRetrySnapshot;
 };
 
 export type RendererTelemetryEvent = {
@@ -81,6 +89,7 @@ export type RendererTelemetryEvent = {
   isWebGPUSupported: boolean;
   forceWebGL: boolean;
   webgpu: WebGPUCapabilitySummary | null;
+  retry?: RendererRetrySnapshot;
 };
 
 export type RendererTelemetryHandler = (
@@ -102,7 +111,11 @@ export type KnownOptimizationTelemetryCounter =
   | 'timestampQueryUsage'
   | 'shaderF16Usage'
   | 'subgroupsUsage'
-  | 'workerOffscreenUsage';
+  | 'workerOffscreenUsage'
+  | 'renderBundlesUsage'
+  | 'renderBundleUnavailable'
+  | 'milkdropWebGpuFeatureDisabled'
+  | 'milkdropWebGpuFallbackRouting';
 
 export type RendererOptimizationTelemetryCounterName =
   | KnownOptimizationTelemetryCounter
@@ -148,6 +161,7 @@ const buildFallback = (
   shouldRetryWebGPU,
   forceWebGL,
   webgpu: null,
+  retry: getRendererRetrySnapshot(String(cachedEnvironmentKey ?? 'default')),
 });
 
 const reportRendererTelemetry = (result: RendererCapabilities) => {
@@ -161,6 +175,7 @@ const reportRendererTelemetry = (result: RendererCapabilities) => {
     isWebGPUSupported: result.preferredBackend === 'webgpu',
     forceWebGL: result.forceWebGL,
     webgpu: result.webgpu,
+    retry: result.retry,
   };
   telemetryHandler?.('renderer_capabilities', detail);
 };
@@ -187,6 +202,21 @@ function getEnvironmentKey({
     ? 'webgpu-gap-guard-on'
     : 'webgpu-gap-guard-off';
   return `${hasGpu}:${userAgent}:${compatibilityMode}:${webgpuCompatibilityMode}`;
+}
+
+function getCurrentRetrySnapshot() {
+  return getRendererRetrySnapshot(String(cachedEnvironmentKey ?? 'default'));
+}
+
+function recordRetryableWebGPUFailure(
+  failureKind: Parameters<typeof recordRendererRetryFailure>[0]['failureKind'],
+  reason: string,
+) {
+  return recordRendererRetryFailure({
+    environmentKey: String(cachedEnvironmentKey ?? getEnvironmentKey()),
+    failureKind,
+    reason,
+  });
 }
 
 function isGuardedMobileWebGPUEnvironment() {
@@ -437,6 +467,7 @@ function observeCapabilityDevice(device: GPUDevice) {
         backend: getFallbackBackend(),
         shouldRetryWebGPU: true,
       });
+      recordRetryableWebGPUFailure('device-lost', message);
     })
     .catch(() => {
       observedCapabilityDevices.delete(device);
@@ -497,6 +528,16 @@ async function probeRendererCapabilities({
   preferWebGLForKnownCompatibilityGaps?: boolean;
   webgpuInitTimeoutMs?: number;
 } = {}): Promise<RendererCapabilities> {
+  const retry = getCurrentRetrySnapshot();
+  if (!retry.canRetryNow && retry.attempts > 0) {
+    return cacheResult(
+      buildFallback(
+        `WebGPU retry is cooling down after ${retry.lastFailureKind ?? 'unknown'} failure. Using WebGL until the retry backoff expires.`,
+        { shouldRetryWebGPU: true },
+      ),
+    );
+  }
+
   if (typeof navigator === 'undefined') {
     return cacheResult(
       buildFallback(
@@ -595,6 +636,12 @@ async function probeRendererCapabilities({
         'WebGPU device request failed. Falling back to WebGL.',
         error,
       );
+      recordRetryableWebGPUFailure(
+        'device-request',
+        getRendererFallbackReasonMessage(
+          RENDERER_FALLBACK_REASON_CODES.noDevice,
+        ),
+      );
       return cacheResult(
         buildFallback(
           getRendererFallbackReasonMessage(
@@ -608,6 +655,10 @@ async function probeRendererCapabilities({
     }
 
     if (!device) {
+      recordRetryableWebGPUFailure(
+        'device-request',
+        'WebGPU device request returned no device.',
+      );
       return cacheResult(
         buildFallback('WebGPU device request returned no device.', {
           shouldRetryWebGPU: true,
@@ -628,6 +679,10 @@ async function probeRendererCapabilities({
 
     if (!hasPresentationContext) {
       device.destroy?.();
+      recordRetryableWebGPUFailure(
+        'presentation-context',
+        'WebGPU presentation context is not supported in this browser.',
+      );
       return cacheResult(
         buildFallback(
           'WebGPU presentation context is not supported in this browser.',
@@ -639,6 +694,7 @@ async function probeRendererCapabilities({
     }
 
     observeCapabilityDevice(device);
+    recordRendererRetrySuccess(String(cachedEnvironmentKey ?? 'default'));
 
     return cacheResult({
       preferredBackend: 'webgpu',
@@ -649,9 +705,16 @@ async function probeRendererCapabilities({
       shouldRetryWebGPU: false,
       forceWebGL: false,
       webgpu: summarizeWebGPUCapabilities(adapter),
+      retry: getCurrentRetrySnapshot(),
     });
   } catch (error) {
     console.warn('WebGPU initialization failed. Falling back to WebGL.', error);
+    recordRetryableWebGPUFailure(
+      'unknown',
+      getRendererFallbackReasonMessage(
+        RENDERER_FALLBACK_REASON_CODES.webgpuInitFailed,
+      ),
+    );
     return cacheResult(
       buildFallback(
         getRendererFallbackReasonMessage(
@@ -668,6 +731,7 @@ async function probeRendererCapabilities({
 export function resetRendererCapabilities() {
   resetCache();
   cachedEnvironmentKey = null;
+  resetRendererRetryPolicy();
 }
 
 export function setRendererTelemetryHandler(
@@ -695,6 +759,9 @@ export function rememberRendererFallback(
     fallbackReasonCode && !fallbackReason
       ? getRendererFallbackReasonMessage(fallbackReasonCode)
       : fallbackReason;
+  if (shouldRetryWebGPU) {
+    recordRetryableWebGPUFailure('renderer-init', resolvedFallbackReason);
+  }
   const result = cacheResult({
     ...buildFallback(resolvedFallbackReason, {
       shouldRetryWebGPU,

--- a/assets/js/core/renderer-retry-policy.ts
+++ b/assets/js/core/renderer-retry-policy.ts
@@ -1,0 +1,108 @@
+export type RendererRetryFailureKind =
+  | 'device-request'
+  | 'renderer-init'
+  | 'device-lost'
+  | 'presentation-context'
+  | 'unknown';
+
+export type RendererRetryPolicyConfig = {
+  maxAttempts: number;
+  baseBackoffMs: number;
+  maxBackoffMs: number;
+  now: () => number;
+};
+
+export type RendererRetrySnapshot = {
+  attempts: number;
+  maxAttempts: number;
+  lastFailureKind: RendererRetryFailureKind | null;
+  lastFailureReason: string | null;
+  nextRetryAt: number | null;
+  canRetryNow: boolean;
+};
+
+const DEFAULT_POLICY: RendererRetryPolicyConfig = {
+  maxAttempts: 3,
+  baseBackoffMs: 1_000,
+  maxBackoffMs: 30_000,
+  now: () => Date.now(),
+};
+
+type RetryEntry = {
+  attempts: number;
+  lastFailureKind: RendererRetryFailureKind;
+  lastFailureReason: string;
+  nextRetryAt: number;
+};
+
+let policy = { ...DEFAULT_POLICY };
+const entries = new Map<string, RetryEntry>();
+
+function getBackoffMs(attempts: number) {
+  return Math.min(
+    policy.maxBackoffMs,
+    policy.baseBackoffMs * 2 ** Math.max(0, attempts - 1),
+  );
+}
+
+export function configureRendererRetryPolicy(
+  config: Partial<RendererRetryPolicyConfig>,
+) {
+  policy = { ...policy, ...config };
+}
+
+export function resetRendererRetryPolicy() {
+  policy = { ...DEFAULT_POLICY };
+  entries.clear();
+}
+
+export function recordRendererRetrySuccess(environmentKey: string) {
+  entries.delete(environmentKey);
+}
+
+export function recordRendererRetryFailure({
+  environmentKey,
+  failureKind,
+  reason,
+}: {
+  environmentKey: string;
+  failureKind: RendererRetryFailureKind;
+  reason: string;
+}): RendererRetrySnapshot {
+  const previous = entries.get(environmentKey);
+  const attempts = (previous?.attempts ?? 0) + 1;
+  const nextRetryAt = policy.now() + getBackoffMs(attempts);
+  entries.set(environmentKey, {
+    attempts,
+    lastFailureKind: failureKind,
+    lastFailureReason: reason,
+    nextRetryAt,
+  });
+  return getRendererRetrySnapshot(environmentKey);
+}
+
+export function getRendererRetrySnapshot(
+  environmentKey: string,
+): RendererRetrySnapshot {
+  const entry = entries.get(environmentKey);
+  if (!entry) {
+    return {
+      attempts: 0,
+      maxAttempts: policy.maxAttempts,
+      lastFailureKind: null,
+      lastFailureReason: null,
+      nextRetryAt: null,
+      canRetryNow: true,
+    };
+  }
+
+  return {
+    attempts: entry.attempts,
+    maxAttempts: policy.maxAttempts,
+    lastFailureKind: entry.lastFailureKind,
+    lastFailureReason: entry.lastFailureReason,
+    nextRetryAt: entry.nextRetryAt,
+    canRetryNow:
+      entry.attempts < policy.maxAttempts && policy.now() >= entry.nextRetryAt,
+  };
+}

--- a/assets/js/core/renderer-telemetry.ts
+++ b/assets/js/core/renderer-telemetry.ts
@@ -43,6 +43,7 @@ function installRendererSupportTelemetry() {
         lastPreferredCanvasFormat: detail.webgpu?.preferredCanvasFormat ?? null,
         lastPerformanceTier: detail.webgpu?.performanceTier ?? null,
         lastOptimizationSupport: detail.webgpu?.optimization ?? null,
+        lastRetryPolicy: detail.retry,
         optimizationCounters:
           existing.optimizationCounters &&
           typeof existing.optimizationCounters === 'object'

--- a/assets/js/milkdrop/renderer-adapter-core.ts
+++ b/assets/js/milkdrop/renderer-adapter-core.ts
@@ -9,8 +9,6 @@ import {
   MeshBasicMaterial,
   Vector2,
 } from 'three';
-// @ts-expect-error - BundleGroup available in three/webgpu at runtime
-import { BundleGroup as WebGpuBundleGroup } from 'three/webgpu';
 import { disposeGeometry, disposeMaterial } from '../utils/three-dispose';
 import {
   type MilkdropBackendBehavior,
@@ -47,6 +45,7 @@ import {
   trimGroupChildren,
   withRenderOrder,
 } from './renderer-adapter-shared';
+import { createMilkdropStaticBundleGroup } from './renderer-bundles.ts';
 import {
   createBorderObject as createBorderObjectHelper,
   renderBorderGroup as renderBorderGroupHelper,
@@ -373,14 +372,18 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     // lifetime instead of every frame.
     const useBundles =
       backend === 'webgpu' && this.webgpuOptimizationFlags.renderBundles;
-    if (useBundles && WebGpuBundleGroup) {
-      const staticBundle = new WebGpuBundleGroup();
-      staticBundle.add(this.background);
-      staticBundle.add(this.meshLines);
-      staticBundle.add(this.borderGroup);
-      staticBundle.add(this.motionVectorCpuGroup);
-      staticBundle.add(this.blendBorderGroup);
-      staticBundle.add(this.blendMotionVectorCpuGroup);
+    const staticBundle = createMilkdropStaticBundleGroup({
+      enabled: useBundles,
+      objects: [
+        this.background,
+        this.meshLines,
+        this.borderGroup,
+        this.motionVectorCpuGroup,
+        this.blendBorderGroup,
+        this.blendMotionVectorCpuGroup,
+      ],
+    });
+    if (staticBundle) {
       this.root.add(staticBundle);
     } else {
       this.root.add(this.background);

--- a/assets/js/milkdrop/renderer-adapter-webgpu.ts
+++ b/assets/js/milkdrop/renderer-adapter-webgpu.ts
@@ -1,3 +1,4 @@
+import { recordRendererOptimizationTelemetry } from '../core/renderer-capabilities.ts';
 import { WEBGPU_MILKDROP_BACKEND_BEHAVIOR } from './backend-behavior';
 import { createMilkdropWebGLFeedbackManager } from './feedback-manager-webgl.ts';
 import { createMilkdropWebGPUFeedbackManager } from './feedback-manager-webgpu.ts';
@@ -8,7 +9,10 @@ import {
   DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
   type MilkdropWebGpuOptimizationFlags,
 } from './webgpu-optimization-flags.ts';
-import { shouldUseSafeMilkdropWebGpuPath } from './webgpu-query-override.ts';
+import {
+  resolveMilkdropWebGpuFeatureRouting,
+  shouldUseSafeMilkdropWebGpuPath,
+} from './webgpu-query-override.ts';
 
 export type MilkdropWebGPURendererAdapterConfig = Omit<
   MilkdropRendererAdapterConfig,
@@ -25,15 +29,29 @@ const WEBGPU_BEHAVIOR = {
 function buildSafeWebGpuOptimizationFlags(
   flags: MilkdropWebGpuOptimizationFlags | undefined,
 ): MilkdropWebGpuOptimizationFlags {
+  const featureRouting = resolveMilkdropWebGpuFeatureRouting();
+  for (const [featureName, decision] of Object.entries(featureRouting)) {
+    if (!decision.enabled) {
+      recordRendererOptimizationTelemetry({
+        counter: 'milkdropWebGpuFeatureDisabled',
+      });
+      console.info(
+        `[Stims] MilkDrop WebGPU ${featureName} disabled: ${decision.reason}`,
+      );
+    }
+  }
+
   return {
     ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
     ...flags,
-    proceduralMainWave: false,
-    proceduralTrailWaves: false,
-    proceduralCustomWaves: false,
-    proceduralMesh: false,
-    proceduralMotionVectors: false,
-    directFeedbackShaders: false,
+    proceduralMainWave: featureRouting.proceduralMainWave.enabled,
+    proceduralTrailWaves: featureRouting.proceduralTrailWaves.enabled,
+    proceduralCustomWaves: featureRouting.proceduralCustomWaves.enabled,
+    proceduralMesh: featureRouting.proceduralMesh.enabled,
+    proceduralMotionVectors: featureRouting.proceduralMotionVectors.enabled,
+    directFeedbackShaders: featureRouting.directFeedbackShaders.enabled,
+    gpuComputeVM: featureRouting.gpuComputeVM.enabled,
+    renderBundles: featureRouting.renderBundles.enabled,
   };
 }
 

--- a/assets/js/milkdrop/renderer-bundles.ts
+++ b/assets/js/milkdrop/renderer-bundles.ts
@@ -13,6 +13,7 @@
 import type { Object3D } from 'three';
 // @ts-expect-error - BundleGroup is exposed by the WebGPU entrypoint at runtime.
 import { BundleGroup as WebGpuBundleGroup } from 'three/webgpu';
+import { recordRendererOptimizationTelemetry } from '../core/renderer-capabilities.ts';
 
 type BundleGroupLike = Object3D & {
   needsUpdate: boolean;
@@ -54,6 +55,8 @@ export class MilkdropRenderBundleManager {
 
     if (this.config.enabled && !hadGroup) {
       this.bundleGroup = new WebGpuBundleGroup() as BundleGroupLike;
+      this.bundleGroup.userData.stimsBundleKind = 'milkdrop-static';
+      recordRendererOptimizationTelemetry({ counter: 'renderBundlesUsage' });
     } else if (!this.config.enabled && hadGroup) {
       this.bundleGroup = null;
     }
@@ -114,4 +117,33 @@ export function getMilkdropRenderBundleManager(
 export function disposeMilkdropRenderBundleManager() {
   sharedBundleManager?.dispose();
   sharedBundleManager = null;
+}
+
+export function createMilkdropStaticBundleGroup({
+  enabled,
+  objects,
+}: {
+  enabled: boolean;
+  objects: Object3D[];
+}): Object3D | null {
+  if (!enabled) {
+    return null;
+  }
+
+  const manager = new MilkdropRenderBundleManager({ enabled: true });
+  manager.setConfig({ enabled: true });
+  const group = manager.getGroup();
+  if (!group) {
+    recordRendererOptimizationTelemetry({ counter: 'renderBundleUnavailable' });
+    return null;
+  }
+
+  for (const object of objects) {
+    manager.add(object);
+  }
+  return group;
+}
+
+export function isMilkdropBundleSupportAvailable() {
+  return Boolean(WebGpuBundleGroup);
 }

--- a/assets/js/milkdrop/webgpu-optimization-flags.ts
+++ b/assets/js/milkdrop/webgpu-optimization-flags.ts
@@ -1,3 +1,4 @@
+import { recordRendererOptimizationTelemetry } from '../core/renderer-capabilities.ts';
 import type {
   MilkdropGpuDescriptorRouting,
   MilkdropRenderBackend,
@@ -210,12 +211,17 @@ export function shouldFallbackMilkdropPresetToWebgl({
   descriptorPlan: MilkdropWebGpuDescriptorPlan;
   flags: MilkdropWebGpuOptimizationFlags;
 }) {
-  return (
+  const shouldFallback =
     backend === 'webgpu' &&
     !compatibilityMode &&
     applyMilkdropWebGpuOptimizationFlags(descriptorPlan, flags).routing ===
-      'fallback-webgl'
-  );
+      'fallback-webgl';
+  if (shouldFallback) {
+    recordRendererOptimizationTelemetry({
+      counter: 'milkdropWebGpuFallbackRouting',
+    });
+  }
+  return shouldFallback;
 }
 
 export function getDisabledMilkdropWebGpuOptimizationFlags(

--- a/assets/js/milkdrop/webgpu-query-override.ts
+++ b/assets/js/milkdrop/webgpu-query-override.ts
@@ -19,6 +19,26 @@ const URL_PARAM_CORPUS = 'corpus';
 /** Valid modes for the force-mode override. */
 export type WebGpuForceMode = 'auto' | 'safe' | 'full';
 
+export type MilkdropWebGpuFeatureName =
+  | 'proceduralMainWave'
+  | 'proceduralTrailWaves'
+  | 'proceduralCustomWaves'
+  | 'proceduralMesh'
+  | 'proceduralMotionVectors'
+  | 'directFeedbackShaders'
+  | 'gpuComputeVM'
+  | 'renderBundles';
+
+export type MilkdropWebGpuFeatureDecision = {
+  enabled: boolean;
+  reason: string | null;
+};
+
+export type MilkdropWebGpuFeatureRouting = Record<
+  MilkdropWebGpuFeatureName,
+  MilkdropWebGpuFeatureDecision
+>;
+
 /**
  * Persist a manual safe-path override to localStorage.
  * Use `null` to clear the override and return to auto-detection.
@@ -149,6 +169,34 @@ export function shouldUseFullMilkdropWebGpuPath(
   location?: Pick<Location, 'search'> | null,
 ): boolean {
   return !shouldUseSafeMilkdropWebGpuPath(location);
+}
+
+export function resolveMilkdropWebGpuFeatureRouting(
+  location?: Pick<Location, 'search'> | null,
+): MilkdropWebGpuFeatureRouting {
+  const description = getWebGpuPathDescription(location);
+  const safeMode = description.mode === 'safe';
+  const safeReason = safeMode
+    ? `disabled by ${description.source} WebGPU safe path`
+    : null;
+
+  return {
+    proceduralMainWave: { enabled: !safeMode, reason: safeReason },
+    proceduralTrailWaves: { enabled: !safeMode, reason: safeReason },
+    proceduralCustomWaves: { enabled: !safeMode, reason: safeReason },
+    proceduralMesh: { enabled: !safeMode, reason: safeReason },
+    proceduralMotionVectors: { enabled: !safeMode, reason: safeReason },
+    directFeedbackShaders: { enabled: !safeMode, reason: safeReason },
+    gpuComputeVM: { enabled: !safeMode, reason: safeReason },
+    renderBundles: {
+      enabled: !safeMode && description.source !== 'default',
+      reason:
+        safeReason ??
+        (description.source === 'default'
+          ? 'render bundles remain opt-in until parity telemetry is stable'
+          : null),
+    },
+  };
 }
 
 /**

--- a/assets/js/milkdrop/wgsl-vectorization.ts
+++ b/assets/js/milkdrop/wgsl-vectorization.ts
@@ -1,0 +1,59 @@
+export type WgslVectorWidth = 1 | 2 | 3 | 4;
+
+export type WgslVectorCandidate = {
+  target: string;
+  expression: string;
+};
+
+const VECTOR_CONSTRUCTORS: Record<WgslVectorWidth, string> = {
+  1: 'f32',
+  2: 'vec2f',
+  3: 'vec3f',
+  4: 'vec4f',
+};
+
+export function getWgslVectorConstructor(width: WgslVectorWidth) {
+  return VECTOR_CONSTRUCTORS[width];
+}
+
+export function emitWgslVectorAssignment({
+  target,
+  components,
+}: {
+  target: string;
+  components: string[];
+}) {
+  const width = components.length as WgslVectorWidth;
+  if (!VECTOR_CONSTRUCTORS[width]) {
+    throw new Error(`Unsupported WGSL vector width: ${components.length}`);
+  }
+
+  if (width === 1) {
+    return `${target} = ${components[0]};`;
+  }
+
+  return `${target} = ${VECTOR_CONSTRUCTORS[width]}(${components.join(', ')});`;
+}
+
+export function fuseAdjacentWgslScalars(
+  candidates: WgslVectorCandidate[],
+): WgslVectorCandidate[] {
+  const fused: WgslVectorCandidate[] = [];
+  for (let index = 0; index < candidates.length; index += 1) {
+    const current = candidates[index];
+    const next = candidates[index + 1];
+    if (next && current.target.endsWith('.x') && next.target.endsWith('.y')) {
+      const targetBase = current.target.slice(0, -2);
+      if (next.target.slice(0, -2) === targetBase) {
+        fused.push({
+          target: targetBase,
+          expression: `vec2f(${current.expression}, ${next.expression})`,
+        });
+        index += 1;
+        continue;
+      }
+    }
+    fused.push(current);
+  }
+  return fused;
+}

--- a/tests/milkdrop-webgpu-feature-routing.test.ts
+++ b/tests/milkdrop-webgpu-feature-routing.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  resolveMilkdropWebGpuFeatureRouting,
+  setWebGpuForceMode,
+} from '../assets/js/milkdrop/webgpu-query-override.ts';
+
+describe('MilkDrop WebGPU feature routing', () => {
+  test('disables feature-level routes in safe mode instead of using one opaque switch', () => {
+    setWebGpuForceMode('safe');
+
+    const routing = resolveMilkdropWebGpuFeatureRouting({ search: '' });
+
+    expect(routing.proceduralMainWave).toMatchObject({ enabled: false });
+    expect(routing.directFeedbackShaders.reason).toContain('safe path');
+    expect(routing.renderBundles.enabled).toBe(false);
+
+    setWebGpuForceMode('auto');
+  });
+
+  test('keeps render bundles opt-in even when full WebGPU is forced by URL', () => {
+    setWebGpuForceMode('auto');
+
+    const routing = resolveMilkdropWebGpuFeatureRouting({
+      search: '?renderer=webgpu&corpus=certification',
+    });
+
+    expect(routing.proceduralMesh.enabled).toBe(true);
+    expect(routing.directFeedbackShaders.enabled).toBe(true);
+    expect(routing.renderBundles.enabled).toBe(true);
+  });
+});

--- a/tests/milkdrop-wgsl-vectorization.test.ts
+++ b/tests/milkdrop-wgsl-vectorization.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  emitWgslVectorAssignment,
+  fuseAdjacentWgslScalars,
+} from '../assets/js/milkdrop/wgsl-vectorization.ts';
+
+describe('WGSL vectorization helpers', () => {
+  test('emits vector constructors for related scalar components', () => {
+    expect(
+      emitWgslVectorAssignment({
+        target: 'uv',
+        components: ['x + dx', 'y + dy'],
+      }),
+    ).toBe('uv = vec2f(x + dx, y + dy);');
+  });
+
+  test('fuses adjacent x/y assignments into a vec2 expression', () => {
+    expect(
+      fuseAdjacentWgslScalars([
+        { target: 'warpUv.x', expression: 'x + ox' },
+        { target: 'warpUv.y', expression: 'y + oy' },
+        { target: 'zoom', expression: '1.0' },
+      ]),
+    ).toEqual([
+      { target: 'warpUv', expression: 'vec2f(x + ox, y + oy)' },
+      { target: 'zoom', expression: '1.0' },
+    ]);
+  });
+});

--- a/tests/renderer-retry-policy.test.ts
+++ b/tests/renderer-retry-policy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  configureRendererRetryPolicy,
+  getRendererRetrySnapshot,
+  recordRendererRetryFailure,
+  recordRendererRetrySuccess,
+  resetRendererRetryPolicy,
+} from '../assets/js/core/renderer-retry-policy.ts';
+
+describe('renderer retry policy', () => {
+  test('backs off retryable WebGPU failures and resets after success', () => {
+    let now = 1_000;
+    resetRendererRetryPolicy();
+    configureRendererRetryPolicy({
+      maxAttempts: 3,
+      baseBackoffMs: 100,
+      maxBackoffMs: 1_000,
+      now: () => now,
+    });
+
+    const first = recordRendererRetryFailure({
+      environmentKey: 'desktop-chrome',
+      failureKind: 'device-request',
+      reason: 'Unable to acquire a WebGPU device.',
+    });
+
+    expect(first).toMatchObject({
+      attempts: 1,
+      maxAttempts: 3,
+      lastFailureKind: 'device-request',
+      canRetryNow: false,
+    });
+
+    now = 1_101;
+    expect(getRendererRetrySnapshot('desktop-chrome').canRetryNow).toBe(true);
+
+    recordRendererRetrySuccess('desktop-chrome');
+    expect(getRendererRetrySnapshot('desktop-chrome')).toMatchObject({
+      attempts: 0,
+      canRetryNow: true,
+      lastFailureKind: null,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Make WebGPU initialization more resilient by tracking retryable failures and applying backoff so unstable environments fall back to WebGL temporarily.  
- Improve observability by including retry state in renderer telemetry and recording optimization-related events.  
- Enable opt-in WebGPU render bundle support and fine-grained MilkDrop WebGPU feature routing, plus small WGSL helper utilities for shader vectorization.

### Description
- Introduce a new retry/backoff module `core/renderer-retry-policy.ts` implementing `recordRendererRetryFailure`, `recordRendererRetrySuccess`, `getRendererRetrySnapshot`, and policy configuration.  
- Integrate retry tracking into `core/renderer-capabilities.ts` to consult the retry snapshot before probing WebGPU, attach retry snapshots to capability results/telemetry, record failures on `device-request`, `presentation-context`, `device-lost`, `renderer-init`, and on generic init failure, and call `resetRendererRetryPolicy()` in `resetRendererCapabilities`.  
- Add render-bundle support in MilkDrop via `milkdrop/renderer-bundles.ts` (a `MilkdropRenderBundleManager`, `createMilkdropStaticBundleGroup`, availability check, and telemetry counters), and wire it into `renderer-adapter-core.ts` so static objects can be grouped when `renderBundles` is enabled.  
- Add feature-level WebGPU routing for MilkDrop in `milkdrop/webgpu-query-override.ts` with new types and `resolveMilkdropWebGpuFeatureRouting`, and apply routing to the adapter flags in `milkdrop/renderer-adapter-webgpu.ts` while recording telemetry for disabled features and fallback routing.  
- Add WGSL helper utilities in `milkdrop/wgsl-vectorization.ts` for emitting vector constructors and fusing adjacent scalar assignments.  
- Persist retry snapshot into renderer telemetry and record optimization telemetry counters (`renderBundlesUsage`, `renderBundleUnavailable`, `milkdropWebGpuFeatureDisabled`, `milkdropWebGpuFallbackRouting`) and expose `retry` on telemetry payloads.

### Testing
- Ran unit tests under `bun:test` including `tests/renderer-retry-policy.test.ts` which verifies backoff and reset behavior, and the test passed.  
- Ran `tests/milkdrop-webgpu-feature-routing.test.ts` which validates feature-level routing and render-bundles opt-in semantics, and the test passed.  
- Ran `tests/milkdrop-wgsl-vectorization.test.ts` which validates WGSL vector emission and fusion helpers, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5049b50fac8332b47fee3ee9bdde7c)