### PR TITLE
fix: Wrap workspace sidecar actions

### DIFF
--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -1419,6 +1419,13 @@ body[data-page="workspace"] {
     pointer-events: auto;
   }
 
+  .stims-shell__frame-sidecar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px 12px;
+  }
+
   .stims-shell__rail-actions {
     display: flex;
     flex-wrap: nowrap;
@@ -2651,6 +2658,10 @@ body[data-page="workspace"] {
       justify-items: start;
     }
 
+    .stims-shell__frame-sidecar-actions {
+      justify-content: flex-start;
+    }
+
     .stims-shell__stage-hero {
       width: min(46rem, calc(100% - 64px));
     }
@@ -3059,6 +3070,10 @@ body[data-page="workspace"] {
     .stims-shell__rail-actions,
     .stims-shell__frame-sidecar {
       justify-items: start;
+    }
+
+    .stims-shell__frame-sidecar-actions {
+      justify-content: flex-start;
     }
 
     .stims-shell__rail-actions {

--- a/assets/js/frontend/workspace-ui.tsx
+++ b/assets/js/frontend/workspace-ui.tsx
@@ -84,62 +84,67 @@ export function WorkspaceStagePanel({
           </div>
           {liveMode ? (
             <div className="stims-shell__frame-sidecar">
-              <button
-                type="button"
-                className="stims-shell__text-button stims-shell__audio-bridge-link"
-                onClick={engine.handleAudioStop}
-              >
-                ← Back to library
-              </button>
-              {audioSource === 'demo' ? (
+              <div className="stims-shell__frame-sidecar-actions">
                 <button
                   type="button"
                   className="stims-shell__text-button stims-shell__audio-bridge-link"
-                  style={{ marginLeft: 12 }}
-                  onClick={ui.toggleExtendedSources}
+                  onClick={engine.handleAudioStop}
                 >
-                  {ui.showExtendedSources
-                    ? 'Hide sources'
-                    : 'Switch to your music \u2192'}
+                  ← Back to library
                 </button>
-              ) : null}
-              <button
-                type="button"
-                className="stims-shell__text-button stims-shell__shortcuts-trigger"
-                style={{ marginLeft: 12 }}
-                onClick={() =>
-                  window.dispatchEvent(new CustomEvent('stims:shortcuts:open'))
-                }
-              >
-                Shortcuts
-              </button>
+                {audioSource === 'demo' ? (
+                  <button
+                    type="button"
+                    className="stims-shell__text-button stims-shell__audio-bridge-link"
+                    onClick={ui.toggleExtendedSources}
+                  >
+                    {ui.showExtendedSources
+                      ? 'Hide sources'
+                      : 'Switch to your music \u2192'}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="stims-shell__text-button stims-shell__shortcuts-trigger"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('stims:shortcuts:open'),
+                    )
+                  }
+                >
+                  Shortcuts
+                </button>
+              </div>
               {audioSource === 'demo' && ui.showExtendedSources ? (
                 <AudioSourcePanel />
               ) : null}
             </div>
           ) : (
             <div className="stims-shell__frame-sidecar">
-              {audioSource === 'demo' ? (
+              <div className="stims-shell__frame-sidecar-actions">
+                {audioSource === 'demo' ? (
+                  <button
+                    type="button"
+                    className="stims-shell__text-button stims-shell__audio-bridge-link"
+                    onClick={ui.toggleExtendedSources}
+                  >
+                    {ui.showExtendedSources
+                      ? 'Hide sources'
+                      : 'Switch to your music \u2192'}
+                  </button>
+                ) : null}
                 <button
                   type="button"
-                  className="stims-shell__text-button stims-shell__audio-bridge-link"
-                  onClick={ui.toggleExtendedSources}
+                  className="stims-shell__text-button stims-shell__shortcuts-trigger"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('stims:shortcuts:open'),
+                    )
+                  }
                 >
-                  {ui.showExtendedSources
-                    ? 'Hide sources'
-                    : 'Switch to your music \u2192'}
+                  Shortcuts
                 </button>
-              ) : null}
-              <button
-                type="button"
-                className="stims-shell__text-button stims-shell__shortcuts-trigger"
-                style={{ marginLeft: 12 }}
-                onClick={() =>
-                  window.dispatchEvent(new CustomEvent('stims:shortcuts:open'))
-                }
-              >
-                Shortcuts
-              </button>
+              </div>
               {audioSource === 'demo' && ui.showExtendedSources ? (
                 <AudioSourcePanel />
               ) : null}


### PR DESCRIPTION
### Motivation

- Replace inline spacing on the Workspace sidecar buttons with a dedicated action row so sidecar controls can wrap responsively across breakpoints.

### Description

- Wrap the sidecar buttons in `WorkspaceStagePanel` with a new container `stims-shell__frame-sidecar-actions` and remove inline `style={{ marginLeft: 12 }}` usages.
- Add CSS for `.stims-shell__frame-sidecar-actions` with `display: flex; flex-wrap: wrap; gap: 8px 12px;` and override alignment for narrower layouts so buttons align to the start where appropriate.
- Apply the same action-row wrapper to both live and non-live sidecar variants and tidy up related click handlers/formatting.

### Testing

- Ran repository setup and quick checks with `bun run setup:codex`, `bun run setup:codex --print-plan`, and `bun run check:quick`, and the quick gate passed.
- Ran the dev server with `bun run dev -- --host 127.0.0.1` and performed an automated Playwright layout probe which verified the action row uses `display: flex`, `flex-wrap: wrap`, `gap: 8px 12px`, and that the Back / Switch to your music / Shortcuts buttons wrap cleanly on desktop, tablet, and mobile viewports.
- Ran the full quality gate with `bun run check`, which passed most checks (Biome, TS typecheck, architecture), but the fast test suite failed 3 environment-sensitive WebGPU renderer adapter tests in this CI-like environment; these failures are unrelated to the UI changes and are noted here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507de898ec8332b6eabaf52238e75a)