### PR TITLE
fix: Use bookmark icon for mobile favorites

### DIFF
--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -21,6 +21,7 @@ type MobileAction = {
   ariaLabel: string;
   icon:
     | 'arrow-left'
+    | 'bookmark'
     | 'close'
     | 'expand'
     | 'eye'
@@ -227,16 +228,16 @@ export function MobileControlBar({
     [generateMoodPreset, resetHideTimer],
   );
 
+  const favoriteActive = engine.favoritePresets.some(
+    (entry) => entry.id === engineSnapshot?.activePresetId,
+  );
+
   const mobileActions: MobileAction[] = [
     {
       id: 'favorite',
-      label: engine.favoritePresets.some(
-        (entry) => entry.id === engineSnapshot?.activePresetId,
-      )
-        ? 'Saved'
-        : 'Save',
-      ariaLabel: 'Save current preset',
-      icon: 'sparkles' as const,
+      label: favoriteActive ? 'Saved' : 'Save',
+      ariaLabel: favoriteActive ? 'Remove saved preset' : 'Save current preset',
+      icon: 'bookmark' as const,
       onClick: handleFavorite,
     },
     {


### PR DESCRIPTION
### Motivation
- Make the mobile "favorite" action use a distinct, semantically-appropriate icon instead of reusing `sparkles` so saved state is visually clear. 
- Ensure screen-reader labels announce saved vs unsaved states correctly.

### Description
- Add `'bookmark'` to the `MobileAction['icon']` union so mobile actions can reference the bookmark icon. 
- Swap the mobile `favorite` action icon from `'sparkles'` to `'bookmark'` and update its accessible label to report saved vs unsaved (`'Remove saved preset'` vs `'Save current preset'`). 
- Centralized the favorite state check into `favoriteActive` and reused it for the visible label and `ariaLabel` in `assets/js/frontend/MobileControlBar.tsx`, and verified that `bookmark` already exists in `assets/js/ui/icon-library.ts` and is rendered via `UiIcon`.

### Testing
- Ran the repository quality gate with `bun run check` after installing dependencies and formatting, and it completed successfully. 
- Ran the fast test suite as part of the check which reported `958 pass` and `0 fail`. 
- Ran formatter `bunx biome format --write` on the modified file to satisfy style rules before the final check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507de6fa1883329522c48291b391ac)