### PR TITLE
fix: Keep mobile controls visible during expanded actions

### DIFF
--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -69,14 +69,33 @@ export function MobileControlBar({
   const similarAbortRef = useRef<AbortController | null>(null);
   const energyPercent = `${Math.min(100, Math.max(0, audioEnergy * 100)).toFixed(0)}%`;
 
+  const {
+    generatingMood,
+    generate: generateMoodPreset,
+    cancel: cancelMoodGeneration,
+    retry: retryMoodGeneration,
+    canRetry: canRetryMoodGeneration,
+  } = useMoodPresetGeneration({
+    offline: typeof navigator !== 'undefined' && !navigator.onLine,
+    setStatusMessage: ui.setStatusMessage,
+    openEditor: () => ui.updatePanel('editor'),
+  });
+
+  const keepBarVisible =
+    showMoreActions || showMoods || generatingMood !== null;
+
   const resetHideTimer = useCallback(() => {
     setVisible(true);
     if (hideTimer.current) clearTimeout(hideTimer.current);
+    hideTimer.current = null;
+
+    if (keepBarVisible) return;
+
     hideTimer.current = setTimeout(
       () => setVisible(false),
       MOBILE_CONTROL_IDLE_MS,
     );
-  }, []);
+  }, [keepBarVisible]);
 
   useEffect(() => {
     resetHideTimer();
@@ -187,18 +206,6 @@ export function MobileControlBar({
     resetHideTimer,
     ui,
   ]);
-
-  const {
-    generatingMood,
-    generate: generateMoodPreset,
-    cancel: cancelMoodGeneration,
-    retry: retryMoodGeneration,
-    canRetry: canRetryMoodGeneration,
-  } = useMoodPresetGeneration({
-    offline: typeof navigator !== 'undefined' && !navigator.onLine,
-    setStatusMessage: ui.setStatusMessage,
-    openEditor: () => ui.updatePanel('editor'),
-  });
 
   useEffect(() => {
     const handleOutsidePointer = (event: PointerEvent) => {

--- a/tests/app-shell-mobile-layout.test.ts
+++ b/tests/app-shell-mobile-layout.test.ts
@@ -9,6 +9,20 @@ function readAppShellCss() {
   );
 }
 
+function readMobileControlBar() {
+  return readFileSync(
+    join(
+      import.meta.dir,
+      '..',
+      'assets',
+      'js',
+      'frontend',
+      'MobileControlBar.tsx',
+    ),
+    'utf8',
+  );
+}
+
 describe('Workspace shell mobile layout regression', () => {
   test('turns the home state into a stage-first hero on phones', () => {
     const css = readAppShellCss();
@@ -93,5 +107,17 @@ describe('Workspace shell mobile layout regression', () => {
     expect(css).toMatch(
       /@media \(max-width: 420px\)[\s\S]*?:scope\[data-mode="live"\]\s*\{[\s\S]*?--mobile-bar-height:\s*132px;/u,
     );
+  });
+
+  test('keeps the mobile control bar visible while expanded actions or mood generation are active', () => {
+    const source = readMobileControlBar();
+
+    expect(source).toMatch(
+      /const keepBarVisible =\s*showMoreActions \|\| showMoods \|\| generatingMood !== null;/u,
+    );
+    expect(source).toMatch(
+      /if \(hideTimer\.current\) clearTimeout\(hideTimer\.current\);[\s\S]*?hideTimer\.current = null;[\s\S]*?if \(keepBarVisible\) return;[\s\S]*?hideTimer\.current = setTimeout\(/u,
+    );
+    expect(source).toMatch(/\}, \[resetHideTimer\]\);/u);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the mobile control bar from auto-hiding while the More actions menu, the mood picker, or mood generation are active so controls remain available during interaction. 
- Restart the idle hide timer when expanded panels close and no generation is active, restoring the previous idle behavior. 
- Preserve the current handle behavior when the bar is actually hidden so tapping the handle still reveals controls normally.

### Description
- Added a `keepBarVisible` guard computed from `showMoreActions`, `showMoods`, and `generatingMood !== null` inside `MobileControlBar.tsx`. 
- Updated `resetHideTimer` to clear any existing timeout, set `hideTimer.current = null`, and skip scheduling a new hide timeout while `keepBarVisible` is true, and added `keepBarVisible` to the hook dependency list. 
- Reordered the `useMoodPresetGeneration` hook placement so `generatingMood` is available for the visibility guard. 
- Added a unit test in `tests/app-shell-mobile-layout.test.ts` that reads `MobileControlBar.tsx` and asserts the new `keepBarVisible` guard and the updated `resetHideTimer` scheduling pattern exist.

### Testing
- Ran `bun run test tests/app-shell-mobile-layout.test.ts`, which passed (new test included). 
- Ran `bun run check:quick`, which completed successfully. 
- Ran the full gate `bun run check`; it failed due to unrelated existing test-suite issues (fast-suite failures including a missing export `applyMilkdropInteractionResponse` from `assets/js/milkdrop/runtime.ts`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507de63c588332848837ac21dad373)