### PR TITLE
fix: keep control dock visible during interactions

### DIFF
--- a/assets/js/frontend/StimsControlDock.tsx
+++ b/assets/js/frontend/StimsControlDock.tsx
@@ -134,19 +134,79 @@ export function StimsControlDock({
     '--stims-audio-glow',
     energyNorm,
   );
+  const dockWrapRef = useRef<HTMLDivElement>(null);
 
   const { visible, signalActivity } = useAutoHideActivity(3000, false);
+  const [focusInsideDock, setFocusInsideDock] = useState(false);
+  const similarResultsOpen =
+    similarLoading ||
+    similarError ||
+    (similarSearched && similarPresets.length === 0) ||
+    similarPresets.length > 0;
+  const pauseAutoHide =
+    showMore || showMoods || similarResultsOpen || focusInsideDock;
+  const dockVisible = visible || pauseAutoHide;
+  const wasPausedRef = useRef(pauseAutoHide);
+  const focusOutTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const handleMove = () => signalActivity();
-    document.addEventListener('mousemove', handleMove, { passive: true });
-    return () => document.removeEventListener('mousemove', handleMove);
+    const passiveOptions = { passive: true };
+    const handleActivity = () => signalActivity();
+    const handleFocusIn = (event: FocusEvent) => {
+      if (dockWrapRef.current?.contains(event.target as Node | null)) {
+        setFocusInsideDock(true);
+        signalActivity();
+      }
+    };
+    const handleFocusOut = () => {
+      if (focusOutTimerRef.current) {
+        window.clearTimeout(focusOutTimerRef.current);
+      }
+      focusOutTimerRef.current = window.setTimeout(() => {
+        const activeElement = document.activeElement;
+        focusOutTimerRef.current = null;
+        if (!dockWrapRef.current?.contains(activeElement)) {
+          setFocusInsideDock(false);
+          signalActivity();
+        }
+      }, 0);
+    };
+
+    document.addEventListener('mousemove', handleActivity, passiveOptions);
+    document.addEventListener('pointerdown', handleActivity, passiveOptions);
+    document.addEventListener('pointermove', handleActivity, passiveOptions);
+    document.addEventListener('wheel', handleActivity, passiveOptions);
+    document.addEventListener('keydown', handleActivity);
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      if (focusOutTimerRef.current) {
+        window.clearTimeout(focusOutTimerRef.current);
+        focusOutTimerRef.current = null;
+      }
+      document.removeEventListener('mousemove', handleActivity);
+      document.removeEventListener('pointerdown', handleActivity);
+      document.removeEventListener('pointermove', handleActivity);
+      document.removeEventListener('wheel', handleActivity);
+      document.removeEventListener('keydown', handleActivity);
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
   }, [signalActivity]);
+
+  useEffect(() => {
+    if (wasPausedRef.current && !pauseAutoHide) {
+      signalActivity();
+    }
+    wasPausedRef.current = pauseAutoHide;
+  }, [pauseAutoHide, signalActivity]);
 
   return (
     <div
+      ref={dockWrapRef}
       className="stims-shell__stage-dock-wrap"
-      data-visible={String(visible)}
+      data-visible={String(dockVisible)}
     >
       {runtimeReady && presetTitle ? (
         <div className="stims-shell__now-playing">


### PR DESCRIPTION
### Motivation
- Improve the dock auto-hide UX so user interactions (pointer/keyboard/focus/wheel) keep the control dock visible while the user is actively interacting with it or its overflow UI.
- Avoid the dock hiding when focus moves between controls inside the dock or when secondary sheets like "More"/mood UI or similar-results are open.

### Description
- Expanded the activity listener effect to track `pointerdown`, `pointermove`, `mousemove`, `wheel`, and `keydown` in addition to focus events via `focusin`/`focusout`, using passive listeners where appropriate and cleaning up all listeners on effect teardown.
- Added a `dockWrapRef` to detect when focus is inside `.stims-shell__stage-dock-wrap` and a deferred focus-out timer (`focusOutTimerRef`) so focus transitions inside the dock don’t prematurely hide it.
- Derived a `pauseAutoHide` flag (based on `showMore`, `showMoods`, similar-results state, and `focusInsideDock`) and exposed `dockVisible` to the wrapper’s `data-visible` so the dock remains visible while paused.
- Resume the auto-hide timer when the pause state clears and ensure any pending timers are cleared during cleanup.

### Testing
- Ran the quick quality gate with `bun run check:quick` and it passed successfully.
- Ran the full quality gate with `bun run check` including typecheck and biome formatting and it passed successfully.
- Executed the fast test suite (`bun test` / the repository test runner) and all tests passed: `958` tests, `0` failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507de225048332882f9169219b0206)