### PR TITLE
fix: Make mobile live stage viewport-safe

### DIFF
--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -2987,14 +2987,15 @@ body[data-page="workspace"] {
       grid-column: 1 / -1;
     }
 
-    .stims-shell__stage-frame {
-      min-height: max(72svh, 640px);
+    .stims-shell__stage-frame[data-mode="live"] {
+      min-height: min(640px, calc(100svh - 20px));
       border-radius: 14px;
     }
 
     .stims-shell__stage-frame[data-mode="home"] {
       min-height: auto;
       overflow: visible;
+      border-radius: 14px;
     }
 
     .stims-shell__stage-frame[data-mode="home"] .stims-shell__launch {


### PR DESCRIPTION
### Motivation
- Prevent the live stage from forcing a large fixed minimum height on small phones by using a viewport-safe minimum so the live visualizer fits shorter viewports. 
- Preserve the launch/home page behavior so the home surface still scrolls naturally and the editorial launch flow remains unchanged.

### Description
- Split the mobile `@media (max-width: 720px)` rule by replacing the shared `.stims-shell__stage-frame` rule with ` .stims-shell__stage-frame[data-mode="live"]` and ` .stims-shell__stage-frame[data-mode="home"]` variants.
- For live mode, replaced `min-height: max(72svh, 640px)` with `min-height: min(640px, calc(100svh - 20px))` to keep the stage height bounded to the viewport on short screens.
- Kept home-mode behavior as `min-height: auto` with `overflow: visible` so the launch page continues to scroll; applied `border-radius: 14px` in both variants to retain visual treatment.
- Change is localized to `assets/css/app-shell.css` inside the mobile media block.

### Testing
- Ran `bun run check:quick` and `bun run check` (quality gate and typechecks) and they completed successfully. 
- Launched the dev server with `bun run dev --host 127.0.0.1` and exercised the UI with Playwright checks that computed styles at `360×640`, `390×844`, and landscape `640×360` and confirmed `data-mode="home"` reports `min-height: auto` while `data-mode="live"` reports the viewport-safe min-height; the Playwright screenshot captures were saved (e.g. `/tmp/stims-mobile-check/live-360x640.png`).
- Ran the test suite as part of `bun run check` (fast tests) which completed with all tests passing (`958 pass, 0 fail`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507dc580b48332a42d974236dad7e3)