### PR TITLE
Reduce debounce/delay intervals and increase fallback capture FPS for snappier UI

### DIFF
--- a/assets/js/core/services/captured-video-texture.ts
+++ b/assets/js/core/services/captured-video-texture.ts
@@ -25,8 +25,8 @@ const DESKTOP_MAX_CAPTURE_WIDTH = 960;
 const DESKTOP_MAX_CAPTURE_HEIGHT = 540;
 const MOBILE_MAX_CAPTURE_WIDTH = 640;
 const MOBILE_MAX_CAPTURE_HEIGHT = 360;
-const DESKTOP_FALLBACK_CAPTURE_FPS = 30;
-const MOBILE_FALLBACK_CAPTURE_FPS = 15;
+const DESKTOP_FALLBACK_CAPTURE_FPS = 60;
+const MOBILE_FALLBACK_CAPTURE_FPS = 24;
 
 export function resolveCapturedVideoLimits(isMobile = isMobileDevice()) {
   return isMobile

--- a/assets/js/milkdrop/overlay/browse-panel.ts
+++ b/assets/js/milkdrop/overlay/browse-panel.ts
@@ -756,7 +756,7 @@ export class BrowsePanel {
     return sections;
   }
 
-  private scheduleRender(delayMs = 120) {
+  private scheduleRender(delayMs = 48) {
     this.browseDirty = true;
     if (!this.visible) {
       return;

--- a/assets/js/milkdrop/overlay/editor-panel.ts
+++ b/assets/js/milkdrop/overlay/editor-panel.ts
@@ -158,7 +158,7 @@ const historyEditorKeymap = historyKeymap as readonly KeyBinding[];
 const indentWithTabKeybinding = indentWithTab as KeyBinding;
 
 const EDITOR_FLOW_TIPS = [
-  'Queued edits patch the stage after 220ms of calm typing.',
+  'Queued edits patch the stage after 120ms of calm typing.',
   'Cmd/Ctrl+Enter punches the current draft in immediately.',
   'Compiler errors keep the last stable frame visible while you recover.',
 ] as const;
@@ -407,7 +407,7 @@ function createEditorView({
           debounceId = window.setTimeout(() => {
             debounceId = null;
             onDocChange(update.state.doc.toString());
-          }, 220);
+          }, 120);
         }),
       ],
     }),
@@ -487,7 +487,7 @@ export class EditorPanel {
     this.editorLiveBadge = document.createElement('span');
     this.editorLiveBadge.className =
       'milkdrop-overlay__editor-badge milkdrop-overlay__editor-badge--live';
-    this.editorLiveBadge.textContent = 'Auto 220ms';
+    this.editorLiveBadge.textContent = 'Auto 120ms';
     this.editorSyncBadge = document.createElement('span');
     this.editorSyncBadge.className =
       'milkdrop-overlay__editor-badge milkdrop-overlay__editor-badge--sync';
@@ -910,7 +910,7 @@ export class EditorPanel {
     this.editorStatus.hidden = !shouldShowStatus;
     this.editorLiveBadge.textContent = hasErrors
       ? 'Last good frame'
-      : 'Auto 220ms';
+      : 'Auto 120ms';
     this.editorLiveBadge.dataset.tone = hasErrors ? 'warning' : 'accent';
     this.editorLiveBadge.hidden = false;
     this.editorSyncBadge.textContent = this.hasBufferedEdits

--- a/assets/js/milkdrop/overlay/inspector-panel.ts
+++ b/assets/js/milkdrop/overlay/inspector-panel.ts
@@ -420,7 +420,7 @@ export class InspectorPanel {
       typeof performance !== 'undefined' ? performance.now() : Date.now();
     if (
       metricsSignature === this.lastMetricsSignature &&
-      now - this.lastMetricsRenderAt < 240
+      now - this.lastMetricsRenderAt < 120
     ) {
       this.syncSceneSelectionSummary();
       return;

--- a/assets/js/milkdrop/runtime/experience-frame-loop.ts
+++ b/assets/js/milkdrop/runtime/experience-frame-loop.ts
@@ -311,7 +311,7 @@ export function createMilkdropExperienceFrameLoop({
       });
       if (
         overlay?.shouldRenderInspectorMetrics() &&
-        now - getLastInspectorOverlaySyncAt() >= 180
+        now - getLastInspectorOverlaySyncAt() >= 120
       ) {
         setLastInspectorOverlaySyncAt(now);
         presentationController.syncInspectorState();

--- a/assets/js/milkdrop/runtime/presentation-controller.ts
+++ b/assets/js/milkdrop/runtime/presentation-controller.ts
@@ -37,7 +37,7 @@ export function createMilkdropPresentationController({
   setDebugSnapshot: (tool: string, snapshot: unknown) => void;
   getPerformanceMetrics: () => MilkdropRuntimePerformanceSnapshot | null;
 }) {
-  const DEBUG_SNAPSHOT_INTERVAL_MS = 120;
+  const DEBUG_SNAPSHOT_INTERVAL_MS = 60;
   let lastDebugSnapshotAt = 0;
 
   const updateAgentDebugSnapshot = (force = false) => {

--- a/assets/js/milkdrop/runtime/runtime-signal-hub.ts
+++ b/assets/js/milkdrop/runtime/runtime-signal-hub.ts
@@ -21,7 +21,7 @@ export function createMilkdropRuntimeSignalHub<TSnapshot>({
     deferredCatalogSyncTimeoutId = null;
   };
 
-  const scheduleDeferredCatalogSync = (delayMs = 180) => {
+  const scheduleDeferredCatalogSync = (delayMs = 48) => {
     clearDeferredCatalogSync();
     deferredCatalogSyncTimeoutId = window.setTimeout(() => {
       deferredCatalogSyncTimeoutId = null;


### PR DESCRIPTION
### Motivation
- Make the editor, browse, inspector, presentation debug snapshots, runtime signaling, and fallback video capture respond more quickly by reducing debounce and polling intervals.
- Improve perceived interactivity and smoother captured-video fallback frame rates on desktop and mobile.

### Description
- Increased fallback capture frame rates by changing `DESKTOP_FALLBACK_CAPTURE_FPS` from `30` to `60` and `MOBILE_FALLBACK_CAPTURE_FPS` from `15` to `24`, which shortens `fallbackFrameIntervalMs` in `resolveCapturedVideoLimits`.
- Reduced browse panel render debounce from `120ms` to `48ms` in `browse-panel.ts`.
- Reduced editor document-change debounce and associated UI text from `220ms` to `120ms`, updated `EDITOR_FLOW_TIPS` and the live badge text in `editor-panel.ts`, and applied the same debounce change in the editor view creation logic.
- Tightened various inspector/runtime timing thresholds: inspector metrics render check from `240ms` to `120ms` in `inspector-panel.ts`, inspector-overlay sync threshold from `180ms` to `120ms` in `experience-frame-loop.ts`, agent debug snapshot interval from `120ms` to `60ms` in `presentation-controller.ts`, and deferred catalog sync default delay from `180ms` to `48ms` in `runtime-signal-hub.ts`.

### Testing
- Ran TypeScript build (`tsc`) to verify type correctness and compilation; it succeeded.
- Executed the project's unit test suite (`yarn test`) to validate behavior; tests passed.
- Ran linting (`yarn lint`) and basic runtime smoke checks to ensure no obvious regressions; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507cb7e55c8332bda8203bf0278323)