### PR TITLE
fix: Tune agent debug snapshot throttling (configurable interval + tests)

### DIFF
--- a/assets/js/milkdrop/runtime/presentation-controller.ts
+++ b/assets/js/milkdrop/runtime/presentation-controller.ts
@@ -7,6 +7,8 @@ import { buildAgentMilkdropDebugSnapshot } from './debug-snapshot.ts';
 import type { MilkdropRuntimePerformanceSnapshot } from './performance-tracker.ts';
 import type { ReturnTypeOfCreateMilkdropVM } from './presentation-types.ts';
 
+export const DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS = 32;
+
 type PresentationState = {
   activePresetId: string;
   compiledPreset: MilkdropCompiledPreset;
@@ -26,6 +28,8 @@ export function createMilkdropPresentationController({
   isAgentMode,
   setDebugSnapshot,
   getPerformanceMetrics,
+  debugSnapshotIntervalMs = DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS,
+  getNow = () => performance.now(),
 }: {
   getOverlay: () => MilkdropOverlay | null;
   session: Pick<ReturnType<typeof createMilkdropEditorSession>, 'getState'>;
@@ -36,8 +40,9 @@ export function createMilkdropPresentationController({
   isAgentMode: () => boolean;
   setDebugSnapshot: (tool: string, snapshot: unknown) => void;
   getPerformanceMetrics: () => MilkdropRuntimePerformanceSnapshot | null;
+  debugSnapshotIntervalMs?: number;
+  getNow?: () => number;
 }) {
-  const DEBUG_SNAPSHOT_INTERVAL_MS = 120;
   let lastDebugSnapshotAt = 0;
 
   const updateAgentDebugSnapshot = (force = false) => {
@@ -45,8 +50,8 @@ export function createMilkdropPresentationController({
       return;
     }
 
-    const now = performance.now();
-    if (!force && now - lastDebugSnapshotAt < DEBUG_SNAPSHOT_INTERVAL_MS) {
+    const now = getNow();
+    if (!force && now - lastDebugSnapshotAt < debugSnapshotIntervalMs) {
       return;
     }
     lastDebugSnapshotAt = now;

--- a/tests/milkdrop-runtime-performance.test.ts
+++ b/tests/milkdrop-runtime-performance.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from 'bun:test';
 import { buildAgentMilkdropDebugSnapshot } from '../assets/js/milkdrop/runtime/debug-snapshot.ts';
 import { buildBlendStateForRender } from '../assets/js/milkdrop/runtime/lifecycle.ts';
 import { createMilkdropRuntimePerformanceTracker } from '../assets/js/milkdrop/runtime/performance-tracker.ts';
-import { createMilkdropPresentationController } from '../assets/js/milkdrop/runtime/presentation-controller.ts';
+import {
+  createMilkdropPresentationController,
+  DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS,
+} from '../assets/js/milkdrop/runtime/presentation-controller.ts';
 
 test('tracks rolling performance metrics and exposes p95 frame time', () => {
   const tracker = createMilkdropRuntimePerformanceTracker(5);
@@ -76,6 +79,8 @@ test('buildBlendStateForRender reuses the active blend payload', () => {
 
 test('presentation controller throttles agent debug snapshot refreshes', () => {
   const setDebugSnapshotCalls: Array<{ tool: string; snapshot: unknown }> = [];
+  let now = 0;
+  let status: string | null = null;
 
   const controller = createMilkdropPresentationController({
     getOverlay: () => null,
@@ -95,7 +100,7 @@ test('presentation controller throttles agent debug snapshot refreshes', () => {
       } as never,
       frameState: null,
       backend: 'webgpu',
-      status: null,
+      status,
       adaptiveQuality: null,
     }),
     setCompiledState: () => {},
@@ -113,12 +118,95 @@ test('presentation controller throttles agent debug snapshot refreshes', () => {
       maxFrameMs: 12,
       gpuTimings: null,
     }),
+    getNow: () => now,
   });
 
+  status = 'initial';
   controller.updateAgentDebugSnapshot(true);
+  expect(setDebugSnapshotCalls).toHaveLength(1);
+
+  status = 'same-frame update';
+  now = 16;
   controller.updateAgentDebugSnapshot();
   expect(setDebugSnapshotCalls).toHaveLength(1);
 
-  controller.updateAgentDebugSnapshot(true);
+  status = 'second-frame update';
+  now = DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS - 1;
+  controller.updateAgentDebugSnapshot();
+  expect(setDebugSnapshotCalls).toHaveLength(1);
+
+  status = 'interval update';
+  now = DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS;
+  controller.updateAgentDebugSnapshot();
   expect(setDebugSnapshotCalls).toHaveLength(2);
+  expect(
+    (
+      setDebugSnapshotCalls[setDebugSnapshotCalls.length - 1]?.snapshot as {
+        status: string;
+      }
+    ).status,
+  ).toBe('interval update');
+
+  status = 'forced update';
+  now = DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS + 1;
+  controller.updateAgentDebugSnapshot(true);
+  expect(setDebugSnapshotCalls).toHaveLength(3);
+  expect(
+    (
+      setDebugSnapshotCalls[setDebugSnapshotCalls.length - 1]?.snapshot as {
+        status: string;
+      }
+    ).status,
+  ).toBe('forced update');
+});
+
+test('presentation controller supports tighter debug snapshot intervals', () => {
+  const setDebugSnapshotCalls: Array<{ tool: string; snapshot: unknown }> = [];
+  let now = 0;
+  let status = 'initial';
+
+  const controller = createMilkdropPresentationController({
+    getOverlay: () => null,
+    session: {
+      getState: () => ({}),
+    } as never,
+    vm: {
+      setPreset: () => {},
+      setRenderBackend: () => {},
+    } as never,
+    getAdapter: () => null,
+    getState: () => ({
+      activePresetId: 'rovastar-parallel-universe',
+      compiledPreset: {
+        source: { id: 'rovastar-parallel-universe' },
+        title: 'Rovastar Parallel Universe',
+      } as never,
+      frameState: null,
+      backend: 'webgpu',
+      status,
+      adaptiveQuality: null,
+    }),
+    setCompiledState: () => {},
+    isAgentMode: () => true,
+    setDebugSnapshot: (tool, snapshot) => {
+      setDebugSnapshotCalls.push({ tool, snapshot });
+    },
+    getPerformanceMetrics: () => null,
+    debugSnapshotIntervalMs: 16,
+    getNow: () => now,
+  });
+
+  controller.updateAgentDebugSnapshot(true);
+  status = 'captured on next frame';
+  now = 16;
+  controller.updateAgentDebugSnapshot();
+
+  expect(setDebugSnapshotCalls).toHaveLength(2);
+  expect(
+    (
+      setDebugSnapshotCalls[setDebugSnapshotCalls.length - 1]?.snapshot as {
+        status: string;
+      }
+    ).status,
+  ).toBe('captured on next frame');
 });


### PR DESCRIPTION
### Motivation
- Reduce the default agent debug snapshot throttle so agent/debug modes can capture higher-fidelity runtime state without per-frame overhead. 
- Make the snapshot interval configurable and testable to allow tighter sampling during debug/agent runs while preserving coalescing in normal operation.

### Description
- Exported `DEFAULT_AGENT_DEBUG_SNAPSHOT_INTERVAL_MS` and replaced the hardcoded constant with an injectable `debugSnapshotIntervalMs` option in `createMilkdropPresentationController`. 
- Added an injectable `getNow` hook to make timing deterministic for tests and to avoid direct `performance.now()` coupling. 
- Updated the throttling logic to use `debugSnapshotIntervalMs` and preserved forced-update bypass behavior. 
- Expanded `tests/milkdrop-runtime-performance.test.ts` with deterministic coverage that verifies coalesced unforced updates, forced bypasses, default-interval captures, and a tighter 16ms interval option.

### Testing
- Ran `bun run test tests/milkdrop-runtime-performance.test.ts` and the file tests passed (5 pass / 0 fail). 
- Ran the fast quality gate with `bun run check:quick` which completed successfully. 
- Ran the full checks with `bun run check` which completed successfully (full test suite and type checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507d10c3708332be6bfc98cb15094c)