### PR TITLE
fix: Correct mobile control semantics

### DIFF
--- a/assets/css/MobileControlBar.module.css
+++ b/assets/css/MobileControlBar.module.css
@@ -201,6 +201,8 @@
 
 .moreActions {
   display: grid;
+  min-inline-size: 0;
+  margin: 0;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
   padding: 6px 10px 10px;

--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -3758,6 +3758,9 @@ body[data-page="workspace"] {
 /* ===== Macro moods in mobile bar ===== */
 .mc-bar__mood-row {
   display: flex;
+  min-inline-size: 0;
+  margin: 0;
+  border: 0;
   gap: 8px;
   padding: 8px 12px;
   overflow-x: auto;

--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -14,6 +14,8 @@ const moods = [
 ];
 
 const MOBILE_CONTROL_IDLE_MS = 4_000;
+const MOBILE_MORE_ACTIONS_ID = 'mobile-control-more-actions';
+const MOBILE_MOOD_ACTIONS_ID = 'mobile-control-mood-actions';
 
 type MobileAction = {
   id: string;
@@ -387,7 +389,8 @@ export function MobileControlBar({
           </div>
         ) : null}
         {showMoods && (
-          <fieldset className="mc-bar__mood-row" aria-label="Mood presets">
+          <fieldset id={MOBILE_MOOD_ACTIONS_ID} className="mc-bar__mood-row">
+            <legend className="sr-only">Mood presets</legend>
             {moods.map((mood) => (
               <button
                 key={mood.label}
@@ -428,6 +431,7 @@ export function MobileControlBar({
             className={styles.action}
             data-active={String(showMoreActions)}
             aria-expanded={showMoreActions}
+            aria-controls={showMoreActions ? MOBILE_MORE_ACTIONS_ID : undefined}
             onClick={() => {
               resetHideTimer();
               pulseHaptic(8, hapticsEnabled);
@@ -443,11 +447,8 @@ export function MobileControlBar({
           </button>
         </div>
         {showMoreActions ? (
-          <div
-            className={styles.moreActions}
-            role="menu"
-            aria-label="More mobile actions"
-          >
+          <fieldset id={MOBILE_MORE_ACTIONS_ID} className={styles.moreActions}>
+            <legend className="sr-only">More mobile actions</legend>
             {overflowActions.map((action) =>
               renderAction({
                 ...action,
@@ -457,7 +458,7 @@ export function MobileControlBar({
                 },
               }),
             )}
-          </div>
+          </fieldset>
         ) : null}
       </div>
       {!visible ? (


### PR DESCRIPTION
### Motivation
- Mobile overflow and mood action groups used menu semantics that conflicted with simple button interactions and accessibility expectations.
- The change aims to present these controls as grouped action panels (not an ARIA menu) and wire-up expanded-state relationships so screen readers can follow the UI state.

### Description
- Added stable IDs (`MOBILE_MORE_ACTIONS_ID`, `MOBILE_MOOD_ACTIONS_ID`) and wired the More trigger with `aria-controls` when expanded in `MobileControlBar.tsx`.
- Replaced the overflow `role="menu"` pattern with a labeled `<fieldset>` (with an sr-only `<legend>`) so overflow actions remain simple buttons rather than menu items.
- Converted the mood action row to a labeled `<fieldset>` with an sr-only `<legend>` so mood buttons are grouped with non-menu semantics.
- Reset fieldset defaults and adjusted layout rules in `assets/css/MobileControlBar.module.css` and `assets/css/app-shell.css` to avoid browser default spacing/borders after the semantic change.

### Testing
- Ran the quick quality gate with `bun run check:quick` which passed.
- Ran the full quality gate with `bun run check` which completed successfully.
- Executed the fast test suite during the full check (959 tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508a3f411483328a4e0015a3072afb)