### PR TITLE
fix: Align mobile bar offsets with expanded states

### DIFF
--- a/assets/css/MobileControlBar.module.css
+++ b/assets/css/MobileControlBar.module.css
@@ -1,5 +1,4 @@
 .bar {
-  --mobile-bar-height: 56px;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -119,10 +118,6 @@
 }
 
 @media (width <= 420px) {
-  .bar {
-    --mobile-bar-height: 132px;
-  }
-
   .nowPlaying {
     padding-inline: 10px;
   }

--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -2863,6 +2863,17 @@ body[data-page="workspace"] {
 
     :scope[data-mode="live"] {
       --mobile-bar-height: 86px;
+      --mobile-bar-height-expanded: 206px;
+      --mobile-bar-height-mood-open: 150px;
+      --mobile-control-offset: var(--mobile-bar-height);
+    }
+
+    :scope[data-mode="live"]:has(.mc-bar[data-expanded="true"]) {
+      --mobile-control-offset: var(--mobile-bar-height-expanded);
+    }
+
+    :scope[data-mode="live"]:has(.mc-bar[data-mood-open="true"]) {
+      --mobile-control-offset: var(--mobile-bar-height-mood-open);
     }
 
     .stims-shell[data-has-toast="true"] {
@@ -3181,13 +3192,13 @@ body[data-page="workspace"] {
 
     :scope[data-mode="live"] .stims-shell__sheet {
       bottom: calc(
-        var(--mobile-bar-height, 86px) +
+        var(--mobile-control-offset, var(--mobile-bar-height, 86px)) +
         10px +
         env(safe-area-inset-bottom)
       );
       max-height: calc(
         100dvh -
-        var(--mobile-bar-height, 86px) -
+        var(--mobile-control-offset, var(--mobile-bar-height, 86px)) -
         20px -
         env(safe-area-inset-bottom)
       );
@@ -3208,7 +3219,7 @@ body[data-page="workspace"] {
 
     :scope[data-mode="live"] .stims-shell__toast {
       bottom: calc(
-        var(--mobile-bar-height, 86px) +
+        var(--mobile-control-offset, var(--mobile-bar-height, 86px)) +
         6px +
         env(safe-area-inset-bottom)
       );
@@ -3218,6 +3229,8 @@ body[data-page="workspace"] {
   @media (max-width: 420px) {
     :scope[data-mode="live"] {
       --mobile-bar-height: 132px;
+      --mobile-bar-height-expanded: 252px;
+      --mobile-bar-height-mood-open: 200px;
     }
   }
 
@@ -4176,7 +4189,7 @@ body[data-page="workspace"] {
   left: max(12px, env(safe-area-inset-left));
   right: max(12px, env(safe-area-inset-right));
   bottom: calc(
-    var(--mobile-bar-height, 86px) +
+    var(--mobile-control-offset, var(--mobile-bar-height, 86px)) +
     env(safe-area-inset-bottom) +
     12px
   );

--- a/assets/js/frontend/MobileControlBar.tsx
+++ b/assets/js/frontend/MobileControlBar.tsx
@@ -367,7 +367,12 @@ export function MobileControlBar({
 
   return (
     <>
-      <div className={styles.bar} data-visible={String(visible)}>
+      <div
+        className={`${styles.bar} mc-bar`}
+        data-visible={String(visible)}
+        data-expanded={String(showMoreActions)}
+        data-mood-open={String(showMoods)}
+      >
         {/* biome-ignore lint/a11y/useSemanticElements: custom visual div designed specifically for visual status/metering */}
         <div
           className={styles.energyMeter}

--- a/tests/app-shell-skip-flow.test.ts
+++ b/tests/app-shell-skip-flow.test.ts
@@ -58,7 +58,7 @@ describe('launch shell skip-to-visualizer flow', () => {
       /\{liveMode \? \(\s*<MobileControlBar[\s\S]*?\) : null\}/u,
     );
     expect(mobileBarSource).toMatch(
-      /<>\s*<div className=\{styles\.bar\}[\s\S]*?<\/div>\s*\{!visible \? \(/u,
+      /<>\s*<div[\s\S]*?className=\{`\$\{styles\.bar\} mc-bar`\}[\s\S]*?<\/div>\s*\{!visible \? \(/u,
     );
     expect(mobileBarSource).toContain('const MOBILE_CONTROL_IDLE_MS = 4_000;');
     expect(mobileBarSource).toContain('ui.updatePanel(null);');


### PR DESCRIPTION
### Motivation
- Ensure mobile sheet, toast, and other bottom-offset surfaces read a shared, accurate mobile-bar height so they clear the real control bar in live mode. 
- Allow the shell to account for expanded mobile bar states (overflow actions, mood generation) so offsets match the bar’s visual size.

### Description
- Move ownership of the mobile-bar height into the live shell by adding variables on `:scope[data-mode="live"]`: `--mobile-bar-height`, `--mobile-bar-height-expanded`, `--mobile-bar-height-mood-open`, and a computed `--mobile-control-offset` that downstream surfaces consume. (`assets/css/app-shell.css`).
- Map expanded/mood states to offsets using a global selector and the mobile bar’s presence via a new `mc-bar` hook class and `data-expanded` / `data-mood-open` attributes. (`assets/js/frontend/MobileControlBar.tsx`).
- Replace usages of `var(--mobile-bar-height, 86px)` in sheet, toast, and mobile notice positioning with `var(--mobile-control-offset, var(--mobile-bar-height, 86px))` so the live shell controls the fallback and expanded offsets. (`assets/css/app-shell.css`).
- Remove private `--mobile-bar-height` declarations from the mobile control bar module so the module only controls layout and the shell owns offset values. (`assets/css/MobileControlBar.module.css`).
- Update tests to expect the new `mc-bar` class and attribute-based expanded/mood hooks. (`tests/app-shell-skip-flow.test.ts`).

### Testing
- Ran the quick checks with `bun run check:quick` which passed. 
- Ran targeted tests `bun run test tests/app-shell-mobile-layout.test.ts tests/app-shell-route-sync.test.ts` which passed. 
- Ran the skip-flow test `bun run test tests/app-shell-skip-flow.test.ts` which passed after updating the expected class name pattern. 
- Ran the full quality gate with `bun run check` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508a3e3db083329b38753762b8ac65)