### PR TITLE
Mark shader-text-dependent MilkDrop presets as compatibility fallbacks and normalize catalog titles

### DIFF
--- a/public/milkdrop-presets/catalog.json
+++ b/public/milkdrop-presets/catalog.json
@@ -3496,7 +3496,7 @@
     },
     {
       "id": "aderrasi-contortion-escher-s-tunnel-mix",
-      "title": "Aderrasi - Contortion (Escher′s Tunnel Mix)",
+      "title": "Aderrasi - Contortion (Escher\u2032s Tunnel Mix)",
       "author": "Aderrasi",
       "order": 119,
       "file": "/milkdrop-presets/butterchurn/aderrasi-contortion-escher-s-tunnel-mix.milk",
@@ -3796,7 +3796,7 @@
     },
     {
       "id": "aderrasi-horvath-s-holistic-abyss",
-      "title": "Aderrasi - Horvath′s Holistic Abyss",
+      "title": "Aderrasi - Horvath\u2032s Holistic Abyss",
       "author": "Aderrasi",
       "order": 129,
       "file": "/milkdrop-presets/butterchurn/aderrasi-horvath-s-holistic-abyss.milk",
@@ -4066,7 +4066,7 @@
     },
     {
       "id": "aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix",
-      "title": "Aderrasi - Songflower (Hybrid Plant+ NEOhm′s Internet Ghosts Remix)",
+      "title": "Aderrasi - Songflower (Hybrid Plant+ NEOhm\u2032s Internet Ghosts Remix)",
       "author": "Aderrasi",
       "order": 138,
       "file": "/milkdrop-presets/butterchurn/aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix.milk",
@@ -4366,7 +4366,7 @@
     },
     {
       "id": "anandamide-i-don-t-want-to-go-back-to-earth",
-      "title": "Anandamide_I_Don′t_Want_To_Go_Back_To_Earth",
+      "title": "Anandamide_I_Don\u2032t_Want_To_Go_Back_To_Earth",
       "author": "Unknown",
       "order": 148,
       "file": "/milkdrop-presets/butterchurn/anandamide-i-don-t-want-to-go-back-to-earth.milk",
@@ -4426,7 +4426,7 @@
     },
     {
       "id": "anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color",
-      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit + random color)",
+      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen\u2032s Geiss Chaos Tile edit + random color)",
       "author": "Anandmide _ Shifter",
       "order": 150,
       "file": "/milkdrop-presets/butterchurn/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color.milk",
@@ -4456,7 +4456,7 @@
     },
     {
       "id": "anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2",
-      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit 2)",
+      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen\u2032s Geiss Chaos Tile edit 2)",
       "author": "Anandmide _ Shifter",
       "order": 151,
       "file": "/milkdrop-presets/butterchurn/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2.milk",
@@ -4666,7 +4666,7 @@
     },
     {
       "id": "benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle",
-      "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle′",
+      "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle\u2032",
       "author": "Benjam and Zylot",
       "order": 158,
       "file": "/milkdrop-presets/butterchurn/benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle.milk",
@@ -4756,7 +4756,7 @@
     },
     {
       "id": "bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage",
-      "title": "Bmelgren & Rovastar - Schisathing 2 - mash0000 - schrodinger′s dog massage",
+      "title": "Bmelgren & Rovastar - Schisathing 2 - mash0000 - schrodinger\u2032s dog massage",
       "author": "Bmelgren & Rovastar",
       "order": 161,
       "file": "/milkdrop-presets/butterchurn/bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage.milk",
@@ -4786,7 +4786,7 @@
     },
     {
       "id": "bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness",
-      "title": "Bmelgren & Rovastar - Schisathing 6 - mash0001 - hellraiser′s molten consciousness",
+      "title": "Bmelgren & Rovastar - Schisathing 6 - mash0001 - hellraiser\u2032s molten consciousness",
       "author": "Bmelgren & Rovastar",
       "order": 162,
       "file": "/milkdrop-presets/butterchurn/bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness.milk",
@@ -4816,7 +4816,7 @@
     },
     {
       "id": "bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz",
-      "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+",
+      "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother\u2032s skin nz+",
       "author": "Bmelgren & Unchained",
       "order": 163,
       "file": "/milkdrop-presets/butterchurn/bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz.milk",
@@ -4936,7 +4936,7 @@
     },
     {
       "id": "boz-flip-d-moshun-mash0000-forced-to-exist-freely",
-      "title": "Boz - Flip′d Moshun - mash0000 - forced to exist freely",
+      "title": "Boz - Flip\u2032d Moshun - mash0000 - forced to exist freely",
       "author": "Boz",
       "order": 167,
       "file": "/milkdrop-presets/butterchurn/boz-flip-d-moshun-mash0000-forced-to-exist-freely.milk",
@@ -6106,7 +6106,7 @@
     },
     {
       "id": "eo-s-phat-last-of-it-s-kind-sinking",
-      "title": "Eo.S. + Phat - last of it′s kind_sinking",
+      "title": "Eo.S. + Phat - last of it\u2032s kind_sinking",
       "author": "Eo.S. + Phat",
       "order": 206,
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-last-of-it-s-kind-sinking.milk",
@@ -6316,7 +6316,7 @@
     },
     {
       "id": "eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix",
-      "title": "Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b + illumination (Stahl′s Mix)",
+      "title": "Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix02b + illumination (Stahl\u2032s Mix)",
       "author": "Eo.S. + flexi",
       "order": 213,
       "file": "/milkdrop-presets/butterchurn/eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix.milk",
@@ -6526,7 +6526,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat",
-      "title": "Eo.S. - glowsticks v2 03 music shifter edit b (Stahl′s Reactive RMX V2i2 - feat. flexi + phat)",
+      "title": "Eo.S. - glowsticks v2 03 music shifter edit b (Stahl\u2032s Reactive RMX V2i2 - feat. flexi + phat)",
       "author": "Eo.S.",
       "order": 220,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat.milk",
@@ -6616,7 +6616,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) ",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) ",
       "author": "Eo.S.",
       "order": 223,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code.milk",
@@ -6646,7 +6646,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix02b",
       "author": "Eo.S.",
       "order": 224,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b.milk",
@@ -6676,7 +6676,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix03 madhatter_v2",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix03 madhatter_v2",
       "author": "Eo.S.",
       "order": 225,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2.milk",
@@ -6706,7 +6706,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 recursive demons",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix07 recursive demons",
       "author": "Eo.S.",
       "order": 226,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons.milk",
@@ -6736,7 +6736,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix07",
       "author": "Eo.S.",
       "order": 227,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07.milk",
@@ -6766,7 +6766,7 @@
     },
     {
       "id": "eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum",
-      "title": "Eo.S. - heater core C_Phat′s_class + sparks_mix - mash0000 - flaring colored zebra gum",
+      "title": "Eo.S. - heater core C_Phat\u2032s_class + sparks_mix - mash0000 - flaring colored zebra gum",
       "author": "Eo.S.",
       "order": 228,
       "file": "/milkdrop-presets/butterchurn/eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum.milk",
@@ -6796,7 +6796,7 @@
     },
     {
       "id": "eo-s-heater-core-c-phat-s-class-sparks-mix",
-      "title": "Eo.S. - heater core C_Phat′s_class + sparks_mix",
+      "title": "Eo.S. - heater core C_Phat\u2032s_class + sparks_mix",
       "author": "Eo.S.",
       "order": 229,
       "file": "/milkdrop-presets/butterchurn/eo-s-heater-core-c-phat-s-class-sparks-mix.milk",
@@ -7546,7 +7546,7 @@
     },
     {
       "id": "eo-s-phat-cool-bug-v2-krash-s-beat-detection",
-      "title": "Eo.S.+Phat Cool Bug v2 + (Krash′s beat detection)",
+      "title": "Eo.S.+Phat Cool Bug v2 + (Krash\u2032s beat detection)",
       "author": "Unknown",
       "order": 254,
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-cool-bug-v2-krash-s-beat-detection.milk",
@@ -8626,7 +8626,7 @@
     },
     {
       "id": "flexi-geiss-the-deep-diver-s-manifesto-metaphorfree",
-      "title": "Flexi + geiss - the deep diver′s manifesto [metaphorfree]",
+      "title": "Flexi + geiss - the deep diver\u2032s manifesto [metaphorfree]",
       "author": "Flexi + geiss",
       "order": 290,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-the-deep-diver-s-manifesto-metaphorfree.milk",
@@ -8866,7 +8866,7 @@
     },
     {
       "id": "flexi-milkcore-martin-s-ripple-on-water-insertion",
-      "title": "Flexi - Milkcore [Martin′s ripple on water insertion]",
+      "title": "Flexi - Milkcore [Martin\u2032s ripple on water insertion]",
       "author": "Flexi",
       "order": 298,
       "file": "/milkdrop-presets/butterchurn/flexi-milkcore-martin-s-ripple-on-water-insertion.milk",
@@ -9646,7 +9646,7 @@
     },
     {
       "id": "flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4",
-      "title": "Flexi - invisible chains securing you don′t move (cn bc jelly 4)",
+      "title": "Flexi - invisible chains securing you don\u2032t move (cn bc jelly 4)",
       "author": "Flexi",
       "order": 324,
       "file": "/milkdrop-presets/butterchurn/flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4.milk",
@@ -10216,7 +10216,7 @@
     },
     {
       "id": "flexi-predator-prey-spirals-geiss-laplacian-finish",
-      "title": "Flexi - predator-prey-spirals [geiss′ laplacian finish]",
+      "title": "Flexi - predator-prey-spirals [geiss\u2032 laplacian finish]",
       "author": "Flexi",
       "order": 343,
       "file": "/milkdrop-presets/butterchurn/flexi-predator-prey-spirals-geiss-laplacian-finish.milk",
@@ -10516,7 +10516,7 @@
     },
     {
       "id": "flexi-smashing-fractals-geiss-bas-relief-finish",
-      "title": "Flexi - smashing fractals [Geiss′ bas relief finish]",
+      "title": "Flexi - smashing fractals [Geiss\u2032 bas relief finish]",
       "author": "Flexi",
       "order": 353,
       "file": "/milkdrop-presets/butterchurn/flexi-smashing-fractals-geiss-bas-relief-finish.milk",
@@ -13906,7 +13906,7 @@
     },
     {
       "id": "geiss-cruzin",
-      "title": "Geiss - Cruzin′",
+      "title": "Geiss - Cruzin\u2032",
       "author": "Geiss",
       "order": 466,
       "file": "/milkdrop-presets/butterchurn/geiss-cruzin.milk",
@@ -16036,7 +16036,7 @@
     },
     {
       "id": "geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx",
-      "title": "Geiss - Motion Blur 2 (Stahl′s Neon Jelly 2 RMX)",
+      "title": "Geiss - Motion Blur 2 (Stahl\u2032s Neon Jelly 2 RMX)",
       "author": "Geiss",
       "order": 537,
       "file": "/milkdrop-presets/butterchurn/geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx.milk",
@@ -19426,7 +19426,7 @@
     },
     {
       "id": "hexcollie-personal-mashup3-flexi-s-portal-mix",
-      "title": "Hexcollie - Personal Mashup3 [Flexi′s portal mix]",
+      "title": "Hexcollie - Personal Mashup3 [Flexi\u2032s portal mix]",
       "author": "Hexcollie",
       "order": 650,
       "file": "/milkdrop-presets/butterchurn/hexcollie-personal-mashup3-flexi-s-portal-mix.milk",
@@ -19486,7 +19486,7 @@
     },
     {
       "id": "hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
-      "title": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It′s a start",
+      "title": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It\u2032s a start",
       "author": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi",
       "order": 652,
       "file": "/milkdrop-presets/butterchurn/hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start.milk",
@@ -20536,7 +20536,7 @@
     },
     {
       "id": "krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix",
-      "title": "Krash + Geiss + martin - War Machine (Stahl′s ultimate Mash Mix)",
+      "title": "Krash + Geiss + martin - War Machine (Stahl\u2032s ultimate Mash Mix)",
       "author": "Krash + Geiss + martin",
       "order": 687,
       "file": "/milkdrop-presets/butterchurn/krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix.milk",
@@ -20656,7 +20656,7 @@
     },
     {
       "id": "krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision",
-      "title": "Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren′s Compelling Vision)",
+      "title": "Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren\u2032s Compelling Vision)",
       "author": "Krash + Rovastar",
       "order": 691,
       "file": "/milkdrop-presets/butterchurn/krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision.milk",
@@ -20986,7 +20986,7 @@
     },
     {
       "id": "lux-life-s-game-1",
-      "title": "LuX - Life′s Game 1",
+      "title": "LuX - Life\u2032s Game 1",
       "author": "LuX",
       "order": 702,
       "file": "/milkdrop-presets/butterchurn/lux-life-s-game-1.milk",
@@ -21016,7 +21016,7 @@
     },
     {
       "id": "luxxx-ain-t-life-a-motherfucker-iv",
-      "title": "LuxXx - Ain′t Life a Motherfucker iv",
+      "title": "LuxXx - Ain\u2032t Life a Motherfucker iv",
       "author": "LuxXx",
       "order": 703,
       "file": "/milkdrop-presets/butterchurn/luxxx-ain-t-life-a-motherfucker-iv.milk",
@@ -22223,24 +22223,27 @@
       "preview": true,
       "tags": [
         "collection:butterchurn",
-        "preset"
+        "preset",
+        "shader-text-dependent",
+        "compatibility-fallback"
       ],
-      "expectedFidelityClass": "partial",
-      "visualEvidenceTier": "runtime",
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
       "supports": {
-        "webgl": true,
-        "webgpu": true
+        "webgl": false,
+        "webgpu": false
       },
       "visualCertification": {
         "status": "uncertified",
         "measured": false,
         "source": "inferred",
-        "fidelityClass": "partial",
-        "visualEvidenceTier": "runtime",
+        "fidelityClass": "fallback",
+        "visualEvidenceTier": "compile",
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "Embedded shader text uses previous-frame/noise samplers plus GLSL constructs that Stims cannot execute directly yet.",
+          "Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported."
         ]
       }
     },
@@ -25036,7 +25039,7 @@
     },
     {
       "id": "rovastar-idiot24-7-marphet-s-shrine",
-      "title": "Rovastar & Idiot24-7 - Marphet′s Shrine",
+      "title": "Rovastar & Idiot24-7 - Marphet\u2032s Shrine",
       "author": "Rovastar & Idiot24-7",
       "order": 837,
       "file": "/milkdrop-presets/butterchurn/rovastar-idiot24-7-marphet-s-shrine.milk",
@@ -26446,7 +26449,7 @@
     },
     {
       "id": "rovastar-zylot-narell-s-fever",
-      "title": "Rovastar + Zylot - Narell′s Fever",
+      "title": "Rovastar + Zylot - Narell\u2032s Fever",
       "author": "Rovastar + Zylot",
       "order": 884,
       "file": "/milkdrop-presets/butterchurn/rovastar-zylot-narell-s-fever.milk",
@@ -26476,7 +26479,7 @@
     },
     {
       "id": "rovastar-zylot-urza-s-revenge",
-      "title": "Rovastar + Zylot - Urza′s Revenge",
+      "title": "Rovastar + Zylot - Urza\u2032s Revenge",
       "author": "Rovastar + Zylot",
       "order": 885,
       "file": "/milkdrop-presets/butterchurn/rovastar-zylot-urza-s-revenge.milk",
@@ -26536,7 +26539,7 @@
     },
     {
       "id": "rovastar-altars-of-harlequin-s-madness-dark-disorder-mix",
-      "title": "Rovastar - Altars Of Harlequin′s Madness (Dark Disorder Mix)",
+      "title": "Rovastar - Altars Of Harlequin\u2032s Madness (Dark Disorder Mix)",
       "author": "Rovastar",
       "order": 887,
       "file": "/milkdrop-presets/butterchurn/rovastar-altars-of-harlequin-s-madness-dark-disorder-mix.milk",
@@ -26566,7 +26569,7 @@
     },
     {
       "id": "rovastar-altars-of-harlequin-s-madness",
-      "title": "Rovastar - Altars Of Harlequin′s Madness",
+      "title": "Rovastar - Altars Of Harlequin\u2032s Madness",
       "author": "Rovastar",
       "order": 888,
       "file": "/milkdrop-presets/butterchurn/rovastar-altars-of-harlequin-s-madness.milk",
@@ -27046,7 +27049,7 @@
     },
     {
       "id": "rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix",
-      "title": "Rovastar - Harlequin′s & Jester′s Dual Delight (Chaotic Nightmare Mix)",
+      "title": "Rovastar - Harlequin\u2032s & Jester\u2032s Dual Delight (Chaotic Nightmare Mix)",
       "author": "Rovastar",
       "order": 904,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix.milk",
@@ -27076,7 +27079,7 @@
     },
     {
       "id": "rovastar-harlequin-s-dynamic-fractal-3",
-      "title": "Rovastar - Harlequin′s Dynamic Fractal 3",
+      "title": "Rovastar - Harlequin\u2032s Dynamic Fractal 3",
       "author": "Rovastar",
       "order": 905,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-dynamic-fractal-3.milk",
@@ -27106,7 +27109,7 @@
     },
     {
       "id": "rovastar-harlequin-s-fractal-encounter-cancer-of-saints",
-      "title": "Rovastar - Harlequin′s Fractal Encounter - cancer of saints",
+      "title": "Rovastar - Harlequin\u2032s Fractal Encounter - cancer of saints",
       "author": "Rovastar",
       "order": 906,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-fractal-encounter-cancer-of-saints.milk",
@@ -27136,7 +27139,7 @@
     },
     {
       "id": "rovastar-harlequin-s-fractal-encounter",
-      "title": "Rovastar - Harlequin′s Fractal Encounter",
+      "title": "Rovastar - Harlequin\u2032s Fractal Encounter",
       "author": "Rovastar",
       "order": 907,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-fractal-encounter.milk",
@@ -27166,7 +27169,7 @@
     },
     {
       "id": "rovastar-harlequin-s-liquid-dragon",
-      "title": "Rovastar - Harlequin′s Liquid Dragon",
+      "title": "Rovastar - Harlequin\u2032s Liquid Dragon",
       "author": "Rovastar",
       "order": 908,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-liquid-dragon.milk",
@@ -27316,7 +27319,7 @@
     },
     {
       "id": "rovastar-jester-s-calling-2",
-      "title": "Rovastar - Jester′s Calling 2",
+      "title": "Rovastar - Jester\u2032s Calling 2",
       "author": "Rovastar",
       "order": 913,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-calling-2.milk",
@@ -27346,7 +27349,7 @@
     },
     {
       "id": "rovastar-jester-s-surreal-tornado-further-vortex-mix",
-      "title": "Rovastar - Jester′s Surreal Tornado (Further Vortex Mix)",
+      "title": "Rovastar - Jester\u2032s Surreal Tornado (Further Vortex Mix)",
       "author": "Rovastar",
       "order": 914,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-surreal-tornado-further-vortex-mix.milk",
@@ -27376,7 +27379,7 @@
     },
     {
       "id": "rovastar-jester-s-surreal-tornado",
-      "title": "Rovastar - Jester′s Surreal Tornado",
+      "title": "Rovastar - Jester\u2032s Surreal Tornado",
       "author": "Rovastar",
       "order": 915,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-surreal-tornado.milk",
@@ -27826,7 +27829,7 @@
     },
     {
       "id": "rovastar-voov-s-light-pattern",
-      "title": "Rovastar - VooV′s Light Pattern",
+      "title": "Rovastar - VooV\u2032s Light Pattern",
       "author": "Rovastar",
       "order": 930,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-light-pattern.milk",
@@ -27856,7 +27859,7 @@
     },
     {
       "id": "rovastar-voov-s-movement-after-dark-mix-painterly",
-      "title": "Rovastar - VooV′s Movement (After Dark Mix) - Painterly",
+      "title": "Rovastar - VooV\u2032s Movement (After Dark Mix) - Painterly",
       "author": "Rovastar",
       "order": 931,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-movement-after-dark-mix-painterly.milk",
@@ -27886,7 +27889,7 @@
     },
     {
       "id": "rovastar-voov-s-movement-after-dark-mix",
-      "title": "Rovastar - VooV′s Movement (After Dark Mix)",
+      "title": "Rovastar - VooV\u2032s Movement (After Dark Mix)",
       "author": "Rovastar",
       "order": 932,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-movement-after-dark-mix.milk",
@@ -27916,7 +27919,7 @@
     },
     {
       "id": "rovastar-voov-s-naked-movement-pincushion-mix",
-      "title": "Rovastar - VooV′s Naked Movement (Pincushion Mix)",
+      "title": "Rovastar - VooV\u2032s Naked Movement (Pincushion Mix)",
       "author": "Rovastar",
       "order": 933,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-naked-movement-pincushion-mix.milk",
@@ -27946,7 +27949,7 @@
     },
     {
       "id": "rovastar-voov-s-organic-light",
-      "title": "Rovastar - VooV′s Organic Light",
+      "title": "Rovastar - VooV\u2032s Organic Light",
       "author": "Rovastar",
       "order": 934,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-organic-light.milk",
@@ -28636,7 +28639,7 @@
     },
     {
       "id": "stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon",
-      "title": "Stahlregen & AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack′s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon",
+      "title": "Stahlregen & AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack\u2032s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon",
       "author": "Stahlregen & AdamFX + flexi + Geiss",
       "order": 957,
       "file": "/milkdrop-presets/butterchurn/stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon.milk",
@@ -28876,7 +28879,7 @@
     },
     {
       "id": "stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1",
-      "title": "Stahlregen & Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester′s Smashing Atoms RMX)_1",
+      "title": "Stahlregen & Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester\u2032s Smashing Atoms RMX)_1",
       "author": "Stahlregen & Benski + Fvese + Geiss + Rovastar",
       "order": 965,
       "file": "/milkdrop-presets/butterchurn/stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1.milk",
@@ -29806,7 +29809,7 @@
     },
     {
       "id": "stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics",
-      "title": "Stahlregen & flexi + Geiss + martin + Rovastar - Tides (martin′s metallics)",
+      "title": "Stahlregen & flexi + Geiss + martin + Rovastar - Tides (martin\u2032s metallics)",
       "author": "Stahlregen & flexi + Geiss + martin + Rovastar",
       "order": 996,
       "file": "/milkdrop-presets/butterchurn/stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics.milk",
@@ -31816,7 +31819,7 @@
     },
     {
       "id": "unchained-morat-s-final-voyage",
-      "title": "Unchained - Morat′s Final Voyage",
+      "title": "Unchained - Morat\u2032s Final Voyage",
       "author": "Unchained",
       "order": 1063,
       "file": "/milkdrop-presets/butterchurn/unchained-morat-s-final-voyage.milk",
@@ -32746,7 +32749,7 @@
     },
     {
       "id": "zylot-rovastar-sully-s-trip-the-worstest-mix",
-      "title": "Zylot & Rovastar - Sully′s Trip (The Worstest Mix)",
+      "title": "Zylot & Rovastar - Sully\u2032s Trip (The Worstest Mix)",
       "author": "Zylot & Rovastar",
       "order": 1094,
       "file": "/milkdrop-presets/butterchurn/zylot-rovastar-sully-s-trip-the-worstest-mix.milk",
@@ -33706,7 +33709,7 @@
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-broth-mix",
-      "title": "_Flexi + Geiss - mindblob [where it′s at now] (broth mix)",
+      "title": "_Flexi + Geiss - mindblob [where it\u2032s at now] (broth mix)",
       "author": "_Flexi + Geiss",
       "order": 1126,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-mindblob-where-it-s-at-now-broth-mix.milk",
@@ -33736,7 +33739,7 @@
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-emboss-mix",
-      "title": "_Flexi + Geiss - mindblob [where it′s at now] (emboss mix)",
+      "title": "_Flexi + Geiss - mindblob [where it\u2032s at now] (emboss mix)",
       "author": "_Flexi + Geiss",
       "order": 1127,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-mindblob-where-it-s-at-now-emboss-mix.milk",
@@ -33766,7 +33769,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now-2",
-      "title": "_Flexi - mindblob [where it′s at now] 2",
+      "title": "_Flexi - mindblob [where it\u2032s at now] 2",
       "author": "_Flexi",
       "order": 1128,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now-2.milk",
@@ -33796,7 +33799,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now-3",
-      "title": "_Flexi - mindblob [where it′s at now] 3",
+      "title": "_Flexi - mindblob [where it\u2032s at now] 3",
       "author": "_Flexi",
       "order": 1129,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now-3.milk",
@@ -33826,7 +33829,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now",
-      "title": "_Flexi - mindblob [where it′s at now]",
+      "title": "_Flexi - mindblob [where it\u2032s at now]",
       "author": "_Flexi",
       "order": 1130,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now.milk",
@@ -37636,7 +37639,7 @@
     },
     {
       "id": "amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter",
-      "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter",
+      "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don\u2032t matter",
       "author": "amandio c",
       "order": 1257,
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter.milk",
@@ -38506,7 +38509,7 @@
     },
     {
       "id": "beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital",
-      "title": "beta106i - Brilliance (Space-Time Breaking) - mash0000 - it′s 2009 and you haven′t replaced your analog tv with digital",
+      "title": "beta106i - Brilliance (Space-Time Breaking) - mash0000 - it\u2032s 2009 and you haven\u2032t replaced your analog tv with digital",
       "author": "beta106i",
       "order": 1286,
       "file": "/milkdrop-presets/butterchurn/beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital.milk",
@@ -38626,7 +38629,7 @@
     },
     {
       "id": "beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy",
-      "title": "beta106i - It′s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy",
+      "title": "beta106i - It\u2032s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy",
       "author": "beta106i",
       "order": 1290,
       "file": "/milkdrop-presets/butterchurn/beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy.milk",
@@ -40156,7 +40159,7 @@
     },
     {
       "id": "fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix",
-      "title": "fiShbRaiN + geiss - witchcraft (Stahl′s Mirror Crossfire Mix)",
+      "title": "fiShbRaiN + geiss - witchcraft (Stahl\u2032s Mirror Crossfire Mix)",
       "author": "fiShbRaiN + geiss",
       "order": 1341,
       "file": "/milkdrop-presets/butterchurn/fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix.milk",
@@ -41776,7 +41779,7 @@
     },
     {
       "id": "flexi-stahlregen-a-car-crash-you-can-t-defocus-2",
-      "title": "flexi + stahlregen - a car crash you can′t defocus_2",
+      "title": "flexi + stahlregen - a car crash you can\u2032t defocus_2",
       "author": "flexi + stahlregen",
       "order": 1395,
       "file": "/milkdrop-presets/butterchurn/flexi-stahlregen-a-car-crash-you-can-t-defocus-2.milk",
@@ -42526,7 +42529,7 @@
     },
     {
       "id": "flexi-can-t-think-of-mosaic-cages",
-      "title": "flexi - can′t think of mosaic cages",
+      "title": "flexi - can\u2032t think of mosaic cages",
       "author": "flexi",
       "order": 1420,
       "file": "/milkdrop-presets/butterchurn/flexi-can-t-think-of-mosaic-cages.milk",
@@ -43366,7 +43369,7 @@
     },
     {
       "id": "flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2",
-      "title": "flexi - lorenz chaser (Stahl′s rainbow multiply mix 2 - Jelly V2)",
+      "title": "flexi - lorenz chaser (Stahl\u2032s rainbow multiply mix 2 - Jelly V2)",
       "author": "flexi",
       "order": 1448,
       "file": "/milkdrop-presets/butterchurn/flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2.milk",
@@ -44746,7 +44749,7 @@
     },
     {
       "id": "lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch",
-      "title": "lit claw (explorers grid) - i don′t have either a belfry or bats bitch",
+      "title": "lit claw (explorers grid) - i don\u2032t have either a belfry or bats bitch",
       "author": "lit claw",
       "order": 1494,
       "file": "/milkdrop-presets/butterchurn/lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch.milk",
@@ -45736,7 +45739,7 @@
     },
     {
       "id": "martin-bombyx-mori-flexi-s-logarithmic-edit",
-      "title": "martin - bombyx mori [flexi′s logarithmic edit]",
+      "title": "martin - bombyx mori [flexi\u2032s logarithmic edit]",
       "author": "martin",
       "order": 1527,
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-flexi-s-logarithmic-edit.milk",
@@ -45893,24 +45896,27 @@
       "preview": true,
       "tags": [
         "collection:butterchurn",
-        "preset"
+        "preset",
+        "shader-text-dependent",
+        "compatibility-fallback"
       ],
-      "expectedFidelityClass": "partial",
-      "visualEvidenceTier": "runtime",
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
       "supports": {
-        "webgl": true,
-        "webgpu": true
+        "webgl": false,
+        "webgpu": false
       },
       "visualCertification": {
         "status": "uncertified",
         "measured": false,
         "source": "inferred",
-        "fidelityClass": "partial",
-        "visualEvidenceTier": "runtime",
+        "fidelityClass": "fallback",
+        "visualEvidenceTier": "compile",
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "Embedded shader text depends on blur, noise, and previous-frame samplers that need a shader-text compatibility path.",
+          "Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported."
         ]
       }
     },
@@ -46043,24 +46049,27 @@
       "preview": true,
       "tags": [
         "collection:butterchurn",
-        "preset"
+        "preset",
+        "shader-text-dependent",
+        "compatibility-fallback"
       ],
-      "expectedFidelityClass": "partial",
-      "visualEvidenceTier": "runtime",
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
       "supports": {
-        "webgl": true,
-        "webgpu": true
+        "webgl": false,
+        "webgpu": false
       },
       "visualCertification": {
         "status": "uncertified",
         "measured": false,
         "source": "inferred",
-        "fidelityClass": "partial",
-        "visualEvidenceTier": "runtime",
+        "fidelityClass": "fallback",
+        "visualEvidenceTier": "compile",
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "Embedded shader text depends on packed previous-frame and noise sampler reads that are not directly executable yet.",
+          "Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported."
         ]
       }
     },
@@ -46583,24 +46592,27 @@
       "preview": true,
       "tags": [
         "collection:butterchurn",
-        "preset"
+        "preset",
+        "shader-text-dependent",
+        "compatibility-fallback"
       ],
-      "expectedFidelityClass": "partial",
-      "visualEvidenceTier": "runtime",
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
       "supports": {
-        "webgl": true,
-        "webgpu": true
+        "webgl": false,
+        "webgpu": false
       },
       "visualCertification": {
         "status": "uncertified",
         "measured": false,
         "source": "inferred",
-        "fidelityClass": "partial",
-        "visualEvidenceTier": "runtime",
+        "fidelityClass": "fallback",
+        "visualEvidenceTier": "compile",
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "Embedded shader text uses noise-volume, blur, and main samplers that require native shader-text compatibility.",
+          "Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported."
         ]
       }
     },
@@ -48766,7 +48778,7 @@
     },
     {
       "id": "martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix",
-      "title": "martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix]",
+      "title": "martin - the forge of isengard [flexi\u2032s moebius transformation vs. logarithmic spiral mix]",
       "author": "martin",
       "order": 1628,
       "file": "/milkdrop-presets/butterchurn/martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix.milk",
@@ -48923,24 +48935,27 @@
       "preview": true,
       "tags": [
         "collection:butterchurn",
-        "preset"
+        "preset",
+        "shader-text-dependent",
+        "compatibility-fallback"
       ],
-      "expectedFidelityClass": "partial",
-      "visualEvidenceTier": "runtime",
+      "expectedFidelityClass": "fallback",
+      "visualEvidenceTier": "compile",
       "supports": {
-        "webgl": true,
-        "webgpu": true
+        "webgl": false,
+        "webgpu": false
       },
       "visualCertification": {
         "status": "uncertified",
         "measured": false,
         "source": "inferred",
-        "fidelityClass": "partial",
-        "visualEvidenceTier": "runtime",
+        "fidelityClass": "fallback",
+        "visualEvidenceTier": "compile",
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "Embedded shader text uses GLSL matrix/vector/texture constructs that are not supported by the current MilkDrop expression runtime.",
+          "Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported."
         ]
       }
     },
@@ -49426,7 +49441,7 @@
     },
     {
       "id": "niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy",
-      "title": "niko radiative bunchess - i′m gonna break my rusty cage, and run (the fuck grunge isn′t the source of anarchy)",
+      "title": "niko radiative bunchess - i\u2032m gonna break my rusty cage, and run (the fuck grunge isn\u2032t the source of anarchy)",
       "author": "niko radiative bunchess",
       "order": 1650,
       "file": "/milkdrop-presets/butterchurn/niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy.milk",
@@ -49966,7 +49981,7 @@
     },
     {
       "id": "phat-it-sjustnumbers",
-      "title": "phat_It′sJustNumbers=)",
+      "title": "phat_It\u2032sJustNumbers=)",
       "author": "Unknown",
       "order": 1668,
       "file": "/milkdrop-presets/butterchurn/phat-it-sjustnumbers.milk",
@@ -49996,7 +50011,7 @@
     },
     {
       "id": "phat-it-sjustnumbers-remix3",
-      "title": "phat_It′sJustNumbers_remix3",
+      "title": "phat_It\u2032sJustNumbers_remix3",
       "author": "Unknown",
       "order": 1669,
       "file": "/milkdrop-presets/butterchurn/phat-it-sjustnumbers-remix3.milk",
@@ -50416,7 +50431,7 @@
     },
     {
       "id": "shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader",
-      "title": "shadow harlequin - babylon warp drive resurrection call [Flexi′s insertion of Martin′s ripple on water shader]",
+      "title": "shadow harlequin - babylon warp drive resurrection call [Flexi\u2032s insertion of Martin\u2032s ripple on water shader]",
       "author": "shadow harlequin",
       "order": 1683,
       "file": "/milkdrop-presets/butterchurn/shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader.milk",
@@ -50476,7 +50491,7 @@
     },
     {
       "id": "shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2",
-      "title": "shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v′many times′2",
+      "title": "shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v\u2032many times\u20322",
       "author": "shadowharlequin, loadus, fishbrain + geiss",
       "order": 1685,
       "file": "/milkdrop-presets/butterchurn/shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2.milk",
@@ -51676,7 +51691,7 @@
     },
     {
       "id": "skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful",
-      "title": "skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful",
+      "title": "skipper skipper kiss me hard - if it weren\u2032t for you wonderful role playing \u2032people\u2032 parts of my solipsistic overmind, i\u2032d be ungrateful",
       "author": "skipper skipper kiss me hard",
       "order": 1725,
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful.milk",
@@ -51916,7 +51931,7 @@
     },
     {
       "id": "studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive",
-      "title": "studio music & unchained + phat and e.o.s - how it feel′s to be alive",
+      "title": "studio music & unchained + phat and e.o.s - how it feel\u2032s to be alive",
       "author": "studio music & unchained + phat and e.o.s",
       "order": 1733,
       "file": "/milkdrop-presets/butterchurn/studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive.milk",
@@ -51976,7 +51991,7 @@
     },
     {
       "id": "suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz",
-      "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+",
+      "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter\u2032s esc shader] nz+",
       "author": "suksma + aderassi geiss",
       "order": 1735,
       "file": "/milkdrop-presets/butterchurn/suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz.milk",
@@ -52366,7 +52381,7 @@
     },
     {
       "id": "suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored",
-      "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored",
+      "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you\u2032re bored",
       "author": "suksma",
       "order": 1748,
       "file": "/milkdrop-presets/butterchurn/suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored.milk",
@@ -52906,7 +52921,7 @@
     },
     {
       "id": "suksma-vector-exp-1-couldn-t-not",
-      "title": "suksma - vector exp 1 - couldn′t not",
+      "title": "suksma - vector exp 1 - couldn\u2032t not",
       "author": "suksma",
       "order": 1766,
       "file": "/milkdrop-presets/butterchurn/suksma-vector-exp-1-couldn-t-not.milk",
@@ -53026,7 +53041,7 @@
     },
     {
       "id": "various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money",
-      "title": "various artists - 1200774354134 - mash0000 - what the writer′s guild is doing with the extra money",
+      "title": "various artists - 1200774354134 - mash0000 - what the writer\u2032s guild is doing with the extra money",
       "author": "various artists",
       "order": 1770,
       "file": "/milkdrop-presets/butterchurn/various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money.milk",
@@ -53116,7 +53131,7 @@
     },
     {
       "id": "yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak",
-      "title": "yin - 051 - Van Gogh′s nightmare (in depth) - bitcore tweak",
+      "title": "yin - 051 - Van Gogh\u2032s nightmare (in depth) - bitcore tweak",
       "author": "yin",
       "order": 1773,
       "file": "/milkdrop-presets/butterchurn/yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak.milk",
@@ -53356,7 +53371,7 @@
     },
     {
       "id": "yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix",
-      "title": "yin - 250 - Artificial poles of the continuum_Phat′s_Orbit_mix",
+      "title": "yin - 250 - Artificial poles of the continuum_Phat\u2032s_Orbit_mix",
       "author": "yin",
       "order": 1781,
       "file": "/milkdrop-presets/butterchurn/yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix.milk",

--- a/scripts/sync-bundled-catalog-fidelity.ts
+++ b/scripts/sync-bundled-catalog-fidelity.ts
@@ -1,13 +1,103 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { MilkdropBundledCatalogEntry } from '../assets/js/milkdrop/catalog-types.ts';
-import type { MilkdropFidelityClass } from '../assets/js/milkdrop/common-types.ts';
+import type {
+  MilkdropFidelityClass,
+  MilkdropVisualCertification,
+} from '../assets/js/milkdrop/common-types.ts';
 import {
   loadMeasuredVisualResultsManifest,
   type MeasuredVisualPresetResult,
 } from './measured-visual-results.ts';
 
 export const BUNDLED_CATALOG_PATH = 'public/milkdrop-presets/catalog.json';
+
+type ShaderDependentPresetOverride = {
+  reason: string;
+};
+
+const SHADER_DEPENDENT_PRESET_OVERRIDES = new Map<
+  string,
+  ShaderDependentPresetOverride
+>([
+  [
+    'martin-anandamide-mandelbox-explorer-quantum-timepiece-remix',
+    {
+      reason:
+        'Embedded shader text uses previous-frame/noise samplers plus GLSL constructs that Stims cannot execute directly yet.',
+    },
+  ],
+  [
+    'martin-elusive-impressions-mix2-flacc-mess-proph-nz-2',
+    {
+      reason:
+        'Embedded shader text uses noise-volume, blur, and main samplers that require native shader-text compatibility.',
+    },
+  ],
+  [
+    'martin-city-of-shadows',
+    {
+      reason:
+        'Embedded shader text depends on packed previous-frame and noise sampler reads that are not directly executable yet.',
+    },
+  ],
+  [
+    'martin-tunnel-race',
+    {
+      reason:
+        'Embedded shader text uses GLSL matrix/vector/texture constructs that are not supported by the current MilkDrop expression runtime.',
+    },
+  ],
+  [
+    'martin-castle-in-the-air',
+    {
+      reason:
+        'Embedded shader text depends on blur, noise, and previous-frame samplers that need a shader-text compatibility path.',
+    },
+  ],
+]);
+
+function buildShaderDependentVisualCertification(
+  override: ShaderDependentPresetOverride,
+): MilkdropVisualCertification {
+  return {
+    status: 'uncertified',
+    measured: false,
+    source: 'inferred',
+    fidelityClass: 'fallback',
+    visualEvidenceTier: 'compile',
+    requiredBackend: 'webgpu',
+    actualBackend: null,
+    reasons: [
+      override.reason,
+      'Needs native shader-text sampler/uniform translation or a certified compatibility renderer before it can be marked supported.',
+    ],
+  };
+}
+
+function applyShaderDependentPresetOverride(
+  preset: MilkdropBundledCatalogEntry,
+): MilkdropBundledCatalogEntry | null {
+  const override = SHADER_DEPENDENT_PRESET_OVERRIDES.get(preset.id);
+  if (!override) {
+    return null;
+  }
+
+  return {
+    ...preset,
+    tags: Array.from(
+      new Set([
+        ...(preset.tags ?? []),
+        'shader-text-dependent',
+        'compatibility-fallback',
+      ]),
+    ),
+    supports: { webgl: false, webgpu: false },
+    expectedFidelityClass: 'fallback',
+    visualEvidenceTier: 'compile',
+    visualCertification: buildShaderDependentVisualCertification(override),
+  };
+}
 
 export type BundledCatalogDocument = {
   version: number;
@@ -25,6 +115,11 @@ export function syncBundledCatalogPresetFidelity(
   preset: MilkdropBundledCatalogEntry,
   measuredResult: MeasuredVisualPresetResult | undefined,
 ): MilkdropBundledCatalogEntry {
+  const shaderDependentOverride = applyShaderDependentPresetOverride(preset);
+  if (shaderDependentOverride) {
+    return shaderDependentOverride;
+  }
+
   if (!measuredResult) {
     return {
       ...preset,

--- a/tests/shader-dependent-presets.test.ts
+++ b/tests/shader-dependent-presets.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import type { MilkdropBundledCatalogEntry } from '../assets/js/milkdrop/types.ts';
+import catalogJson from '../public/milkdrop-presets/catalog.json' with {
+  type: 'json',
+};
+
+type BundledCatalogDocument = {
+  presets: MilkdropBundledCatalogEntry[];
+};
+
+const catalog = catalogJson as BundledCatalogDocument;
+
+const shaderDependentPresetIds = [
+  'martin-anandamide-mandelbox-explorer-quantum-timepiece-remix',
+  'martin-elusive-impressions-mix2-flacc-mess-proph-nz-2',
+  'martin-city-of-shadows',
+  'martin-tunnel-race',
+  'martin-castle-in-the-air',
+];
+
+test('known shader-text-dependent presets are conservatively classified', () => {
+  for (const presetId of shaderDependentPresetIds) {
+    const preset = catalog.presets.find((entry) => entry.id === presetId);
+
+    expect(preset, presetId).toBeDefined();
+    expect(preset?.expectedFidelityClass).toBe('fallback');
+    expect(preset?.visualEvidenceTier).toBe('compile');
+    expect(preset?.supports).toEqual({ webgl: false, webgpu: false });
+    expect(preset?.tags).toContain('shader-text-dependent');
+    expect(preset?.tags).toContain('compatibility-fallback');
+    expect(preset?.visualCertification).toMatchObject({
+      status: 'uncertified',
+      measured: false,
+      source: 'inferred',
+      fidelityClass: 'fallback',
+      visualEvidenceTier: 'compile',
+      requiredBackend: 'webgpu',
+      actualBackend: null,
+    });
+    expect(preset?.visualCertification?.reasons.join(' ')).toContain(
+      'shader-text',
+    );
+  }
+});

--- a/tests/sync-bundled-catalog-fidelity.test.ts
+++ b/tests/sync-bundled-catalog-fidelity.test.ts
@@ -132,3 +132,35 @@ test('measured bundled presets keep certified visual fidelity in the published c
     }),
   ]);
 });
+
+test('shader-text-dependent presets keep conservative fallback metadata during sync', () => {
+  expect(
+    syncBundledCatalogPresetFidelity(
+      {
+        id: 'martin-tunnel-race',
+        title: 'martin - tunnel race',
+        file: '/milkdrop-presets/butterchurn/martin-tunnel-race.milk',
+        expectedFidelityClass: 'near-exact',
+        visualEvidenceTier: 'visual',
+        supports: { webgl: true, webgpu: true },
+      },
+      undefined,
+    ),
+  ).toMatchObject({
+    id: 'martin-tunnel-race',
+    tags: ['shader-text-dependent', 'compatibility-fallback'],
+    expectedFidelityClass: 'fallback',
+    visualEvidenceTier: 'compile',
+    supports: { webgl: false, webgpu: false },
+    visualCertification: {
+      status: 'uncertified',
+      measured: false,
+      source: 'inferred',
+      fidelityClass: 'fallback',
+      visualEvidenceTier: 'compile',
+      requiredBackend: 'webgpu',
+      actualBackend: null,
+      reasons: expect.arrayContaining([expect.stringContaining('shader text')]),
+    },
+  });
+});


### PR DESCRIPTION
### Motivation

- Some bundled MilkDrop presets embed GLSL/shader-like text (previous-frame/noise samplers, blur, matrix/texture constructs) that the current runtime cannot execute directly, so they should be conservatively classified as compatibility fallbacks. 
- Catalog title text contained various prime/apostrophe characters that were normalized/escaped for consistent JSON encoding.

### Description

- Added a shader-dependent override map and helper functions in `scripts/sync-bundled-catalog-fidelity.ts` to mark known shader-text-dependent presets as conservative fallbacks, adding the `shader-text-dependent` and `compatibility-fallback` tags, setting `supports` to `{ webgl: false, webgpu: false }`, changing `expectedFidelityClass` to `fallback`, setting `visualEvidenceTier` to `compile`, and supplying explanatory `visualCertification.reasons`.
- Updated `syncBundledCatalogPresetFidelity` to apply the shader-dependent override before other logic.
- Updated `public/milkdrop-presets/catalog.json` entries: normalized many title apostrophe/prime characters and applied the fallback metadata for specific `martin-*` presets (and others where needed) so the catalog reflects the conservative classification.
- Added a unit test `tests/shader-dependent-presets.test.ts` and extended `tests/sync-bundled-catalog-fidelity.test.ts` to assert that shader-text-dependent presets are classified as fallbacks and carry the expected tags, support flags, evidence tier, and certification reasons.

### Testing

- Ran the automated test suite with `bun test` and the new `tests/shader-dependent-presets.test.ts` and updated `tests/sync-bundled-catalog-fidelity.test.ts` both passed. 
- Verified the existing measured/unmeasured preset fidelity assertions in `tests/sync-bundled-catalog-fidelity.test.ts` still pass. 
- No runtime changes to rendering code were included; tests focused on catalog metadata and sync logic and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511de776608332943157a4c6858943)