### PR TITLE
feat: Support custom MilkDrop texture samplers

### DIFF
--- a/assets/js/milkdrop/compiler-types.ts
+++ b/assets/js/milkdrop/compiler-types.ts
@@ -390,6 +390,11 @@ export type MilkdropPostEffects = {
   videoEchoOrientation: MilkdropVideoEchoOrientation;
 };
 
+export type MilkdropCustomSamplerDeclaration = {
+  name: string;
+  textureFile: string | null;
+};
+
 export type MilkdropPresetIR = {
   title: string;
   author?: string;
@@ -417,6 +422,7 @@ export type MilkdropPresetIR = {
     unsupportedLines: string[];
     controls: MilkdropShaderControls;
     controlExpressions: MilkdropShaderControlExpressions;
+    customSamplers: MilkdropCustomSamplerDeclaration[];
   };
   post: MilkdropPostEffects;
   compatibility: MilkdropCompatibilityReport;

--- a/assets/js/milkdrop/compiler/custom-samplers.ts
+++ b/assets/js/milkdrop/compiler/custom-samplers.ts
@@ -1,0 +1,47 @@
+import { MILKDROP_TEXTURE_FILES } from '../feedback-manager-webgpu-composite';
+
+export type MilkdropCustomSamplerDeclaration = {
+  name: string;
+  textureFile: string | null;
+};
+
+const BUNDLED_TEXTURE_FILES = new Set<string>([
+  ...Object.values(MILKDROP_TEXTURE_FILES),
+  'radial_rainbow_gradient.png',
+]);
+
+const DECLARATION_PATTERN =
+  /\buniform\s+sampler2D\s+(sampler_[A-Za-z_][A-Za-z0-9_]*)\s*;/gu;
+
+export function resolveCustomSamplerTextureFile(name: string): string | null {
+  const rawTextureName = name.startsWith('sampler_')
+    ? name.slice('sampler_'.length)
+    : name;
+  const candidates = rawTextureName.includes('.')
+    ? [rawTextureName]
+    : [
+        `${rawTextureName}.png`,
+        `${rawTextureName}.jpg`,
+        `${rawTextureName}.jpeg`,
+        `${rawTextureName}.webp`,
+      ];
+  return (
+    candidates.find((candidate) => BUNDLED_TEXTURE_FILES.has(candidate)) ?? null
+  );
+}
+
+export function extractCustomSamplerDeclarations(
+  shaderText: string | null,
+): MilkdropCustomSamplerDeclaration[] {
+  if (!shaderText) return [];
+  const declarations = new Map<string, MilkdropCustomSamplerDeclaration>();
+  for (const match of shaderText.matchAll(DECLARATION_PATTERN)) {
+    const name = match[1];
+    if (!name) continue;
+    declarations.set(name, {
+      name,
+      textureFile: resolveCustomSamplerTextureFile(name),
+    });
+  }
+  return [...declarations.values()];
+}

--- a/assets/js/milkdrop/compiler/ir.ts
+++ b/assets/js/milkdrop/compiler/ir.ts
@@ -16,6 +16,7 @@ import type {
   MilkdropVisualCertification,
   MilkdropWaveDefinition,
 } from '../types';
+import { extractCustomSamplerDeclarations } from './custom-samplers';
 import type { buildWebGpuDescriptorPlan } from './gpu-descriptor-plan';
 import type {
   buildBackendSupport,
@@ -697,6 +698,25 @@ export function createMilkdropIr({
         `Unsupported feature "${feature}" from preset field "${key}": ${message}`,
     ),
   ];
+  const customSamplers = [
+    ...extractCustomSamplerDeclarations(warpShaderText),
+    ...extractCustomSamplerDeclarations(compShaderText),
+    ...extractCustomSamplerDeclarations(ast.source),
+  ].filter(
+    (sampler, index, samplers) =>
+      samplers.findIndex((candidate) => candidate.name === sampler.name) ===
+      index,
+  );
+  customSamplers
+    .filter((sampler) => sampler.textureFile === null)
+    .forEach((sampler) => {
+      fieldHelpers.addDiagnostic(
+        diagnostics,
+        'warning',
+        'preset_missing_custom_sampler_texture',
+        `Custom shader sampler "${sampler.name}" does not match a bundled MilkDrop texture asset.`,
+      );
+    });
   const unsupportedVolumeSamplerWarnings =
     shaderHelpers.buildUnsupportedVolumeSamplerWarnings(
       mergedShaderControls.controls,
@@ -946,6 +966,7 @@ export function createMilkdropIr({
       unsupportedLines: approximatedShaderLines,
       controls: mergedShaderControls.controls,
       controlExpressions: mergedShaderControls.expressions,
+      customSamplers,
     },
     borders: {
       outer: {

--- a/assets/js/milkdrop/feedback-manager-webgpu-composite.ts
+++ b/assets/js/milkdrop/feedback-manager-webgpu-composite.ts
@@ -77,6 +77,11 @@ const AUX_TEXTURE_SPECS = {
 
 type AuxTextureName = keyof typeof AUX_TEXTURE_SPECS;
 type SharedAuxTextureName = AuxTextureName | 'video';
+export type MilkdropCustomSamplerTextureBinding = {
+  name: string;
+  textureFile: string;
+  texture: Texture;
+};
 
 const sharedMilkdropTextureCache = new Map<string, Texture>();
 const milkdropTextureLoader = new TextureLoader();
@@ -133,6 +138,18 @@ export function getSharedMilkdropTexture(
 
 export function getSharedMilkdropTexturePlaceholder() {
   return sharedMilkdropTexturePlaceholder;
+}
+
+export function bindCustomMilkdropSamplerTexture(
+  name: string,
+  textureFile: string | null,
+): MilkdropCustomSamplerTextureBinding | null {
+  if (!textureFile) return null;
+  return {
+    name,
+    textureFile,
+    texture: getSharedMilkdropTexture(textureFile, true),
+  };
 }
 
 let sharedSimplex3dTexture: Data3DTexture | null = null;

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -2148,3 +2148,51 @@ wave_0_per_point2=y = y + sin(sample * pi) * 0.08;
     );
   });
 });
+
+test('detects custom shader sampler declarations and reports missing bundled textures', () => {
+  const source = readFileSync(
+    join(
+      process.cwd(),
+      'public/milkdrop-presets/butterchurn/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.milk',
+    ),
+    'utf8',
+  );
+  const compiled = compileMilkdropPresetSource(source, {
+    id: 'anandamide-custom-sampler',
+    origin: 'bundled',
+  });
+
+  expect(compiled.ir.shaderText.customSamplers).toContainEqual({
+    name: 'sampler_anandamideCTFree00',
+    textureFile: null,
+  });
+  expect(compiled.diagnostics).toContainEqual(
+    expect.objectContaining({
+      code: 'preset_missing_custom_sampler_texture',
+      severity: 'warning',
+    }),
+  );
+});
+
+test('resolves custom shader sampler declarations to bundled texture assets', () => {
+  const compiled = compileMilkdropPresetSource(
+    `
+shader=1
+comp_shader=uniform sampler2D sampler_water_caustics; ret = texture(sampler_water_caustics, uv).rgb
+    `.trim(),
+    { id: 'custom-sampler-texture', origin: 'bundled' },
+  );
+
+  expect(compiled.ir.shaderText.customSamplers).toEqual([
+    {
+      name: 'sampler_water_caustics',
+      textureFile: 'water_caustics.png',
+    },
+  ]);
+  expect(
+    compiled.diagnostics.some(
+      (diagnostic) =>
+        diagnostic.code === 'preset_missing_custom_sampler_texture',
+    ),
+  ).toBe(false);
+});

--- a/tests/milkdrop-feedback-manager-webgpu.test.ts
+++ b/tests/milkdrop-feedback-manager-webgpu.test.ts
@@ -7,6 +7,7 @@ import {
   resolveDirectShaderSwizzle,
 } from '../assets/js/milkdrop/feedback-manager-webgpu.ts';
 import {
+  bindCustomMilkdropSamplerTexture,
   configureMilkdropTexture,
   getSharedMilkdropAuxTextures,
   resolveAuxTextureName,
@@ -422,4 +423,21 @@ describe('milkdrop webgpu feedback manager helpers', () => {
       sharedTextures.noise.dispose = originalDispose;
     }
   });
+});
+
+test('binds resolved custom sampler textures through the shared MilkDrop texture cache', () => {
+  const first = bindCustomMilkdropSamplerTexture(
+    'sampler_water_caustics',
+    'water_caustics.png',
+  );
+  const second = bindCustomMilkdropSamplerTexture(
+    'sampler_water_caustics',
+    'water_caustics.png',
+  );
+
+  expect(first).not.toBeNull();
+  expect(first?.name).toBe('sampler_water_caustics');
+  expect(first?.textureFile).toBe('water_caustics.png');
+  expect(first?.texture).toBe(second?.texture);
+  expect(bindCustomMilkdropSamplerTexture('sampler_missing', null)).toBeNull();
 });


### PR DESCRIPTION
### Motivation

- Some bundled presets declare custom GLSL samplers (e.g. `uniform sampler2D sampler_anandamideCTFree00`) that should be bound to milkdrop texture assets instead of silently falling back.  
- The runtime/compiler should detect these declarations, map them to bundled texture files, and surface compatibility diagnostics when no matching asset exists.

### Description

- Add a small parser and resolver for `uniform sampler2D sampler_*` declarations in `assets/js/milkdrop/compiler/custom-samplers.ts`.  
- Extend the IR to carry detected custom sampler declarations by adding `MilkdropCustomSamplerDeclaration` and `shaderText.customSamplers` to `assets/js/milkdrop/compiler-types.ts`.  
- Wire detection into IR creation (`assets/js/milkdrop/compiler/ir.ts`) by extracting declarations from warp/comp shader chunks and the raw section text, de-duplicating them, attaching them to the IR, and emitting a `preset_missing_custom_sampler_texture` diagnostic for any sampler that does not map to a bundled texture file.  
- Add `bindCustomMilkdropSamplerTexture` to `assets/js/milkdrop/feedback-manager-webgpu-composite.ts` which reuses the existing shared MilkDrop texture cache/loading helpers so resolved custom sampler textures are bound consistently for WebGPU composite usage.  
- Add regression tests: `tests/milkdrop-compiler.test.ts` covers detection and missing-texture diagnostics (Anandamide preset) and successful resolution; `tests/milkdrop-feedback-manager-webgpu.test.ts` covers cache-backed binding behavior.

### Testing

- Ran focused tests: `bun run test tests/milkdrop-compiler.test.ts tests/milkdrop-feedback-manager-webgpu.test.ts` and the added tests passed (all assertions in those files succeeded).  
- Ran quick quality gate: `bun run check:quick` succeeded.  
- Ran full checks: `bun run check` (typecheck, Biome, and fast test suite) completed successfully with the fast test suite passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5122194238833289310d322dee96a3)