### PR TITLE
fix: Preserve shader text certification limits

### DIFF
--- a/assets/js/milkdrop/compiler/shader-analysis-glsl.ts
+++ b/assets/js/milkdrop/compiler/shader-analysis-glsl.ts
@@ -509,8 +509,8 @@ export function injectDirectShaderGlsl(
     // Replace the warp section between markers
     const warpStartMarker = '// --- DIRECT_WARP_START ---';
     const warpEndMarker = '// --- DIRECT_WARP_END ---';
-    const warpStartIndex = modified.indexOf(warpStartMarker);
-    const warpEndIndex = modified.indexOf(warpEndMarker);
+    const warpStartIndex = modified.lastIndexOf(warpStartMarker);
+    const warpEndIndex = modified.indexOf(warpEndMarker, warpStartIndex);
 
     if (warpStartIndex >= 0 && warpEndIndex > warpStartIndex) {
       // There's already a marker block - replace its content
@@ -527,8 +527,8 @@ export function injectDirectShaderGlsl(
     // Replace the comp section between markers
     const compStartMarker = '// --- DIRECT_COMP_START ---';
     const compEndMarker = '// --- DIRECT_COMP_END ---';
-    const compStartIndex = modified.indexOf(compStartMarker);
-    const compEndIndex = modified.indexOf(compEndMarker);
+    const compStartIndex = modified.lastIndexOf(compStartMarker);
+    const compEndIndex = modified.indexOf(compEndMarker, compStartIndex);
 
     if (compStartIndex >= 0 && compEndIndex > compStartIndex) {
       const before = modified.substring(

--- a/public/milkdrop-presets/catalog.json
+++ b/public/milkdrop-presets/catalog.json
@@ -3496,7 +3496,7 @@
     },
     {
       "id": "aderrasi-contortion-escher-s-tunnel-mix",
-      "title": "Aderrasi - Contortion (Escher′s Tunnel Mix)",
+      "title": "Aderrasi - Contortion (Escher\u2032s Tunnel Mix)",
       "author": "Aderrasi",
       "order": 119,
       "file": "/milkdrop-presets/butterchurn/aderrasi-contortion-escher-s-tunnel-mix.milk",
@@ -3796,7 +3796,7 @@
     },
     {
       "id": "aderrasi-horvath-s-holistic-abyss",
-      "title": "Aderrasi - Horvath′s Holistic Abyss",
+      "title": "Aderrasi - Horvath\u2032s Holistic Abyss",
       "author": "Aderrasi",
       "order": 129,
       "file": "/milkdrop-presets/butterchurn/aderrasi-horvath-s-holistic-abyss.milk",
@@ -4066,7 +4066,7 @@
     },
     {
       "id": "aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix",
-      "title": "Aderrasi - Songflower (Hybrid Plant+ NEOhm′s Internet Ghosts Remix)",
+      "title": "Aderrasi - Songflower (Hybrid Plant+ NEOhm\u2032s Internet Ghosts Remix)",
       "author": "Aderrasi",
       "order": 138,
       "file": "/milkdrop-presets/butterchurn/aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix.milk",
@@ -4366,7 +4366,7 @@
     },
     {
       "id": "anandamide-i-don-t-want-to-go-back-to-earth",
-      "title": "Anandamide_I_Don′t_Want_To_Go_Back_To_Earth",
+      "title": "Anandamide_I_Don\u2032t_Want_To_Go_Back_To_Earth",
       "author": "Unknown",
       "order": 148,
       "file": "/milkdrop-presets/butterchurn/anandamide-i-don-t-want-to-go-back-to-earth.milk",
@@ -4426,7 +4426,7 @@
     },
     {
       "id": "anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color",
-      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit + random color)",
+      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen\u2032s Geiss Chaos Tile edit + random color)",
       "author": "Anandmide _ Shifter",
       "order": 150,
       "file": "/milkdrop-presets/butterchurn/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color.milk",
@@ -4456,7 +4456,7 @@
     },
     {
       "id": "anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2",
-      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit 2)",
+      "title": "Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen\u2032s Geiss Chaos Tile edit 2)",
       "author": "Anandmide _ Shifter",
       "order": 151,
       "file": "/milkdrop-presets/butterchurn/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2.milk",
@@ -4666,7 +4666,7 @@
     },
     {
       "id": "benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle",
-      "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle′",
+      "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle\u2032",
       "author": "Benjam and Zylot",
       "order": 158,
       "file": "/milkdrop-presets/butterchurn/benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle.milk",
@@ -4756,7 +4756,7 @@
     },
     {
       "id": "bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage",
-      "title": "Bmelgren & Rovastar - Schisathing 2 - mash0000 - schrodinger′s dog massage",
+      "title": "Bmelgren & Rovastar - Schisathing 2 - mash0000 - schrodinger\u2032s dog massage",
       "author": "Bmelgren & Rovastar",
       "order": 161,
       "file": "/milkdrop-presets/butterchurn/bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage.milk",
@@ -4786,7 +4786,7 @@
     },
     {
       "id": "bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness",
-      "title": "Bmelgren & Rovastar - Schisathing 6 - mash0001 - hellraiser′s molten consciousness",
+      "title": "Bmelgren & Rovastar - Schisathing 6 - mash0001 - hellraiser\u2032s molten consciousness",
       "author": "Bmelgren & Rovastar",
       "order": 162,
       "file": "/milkdrop-presets/butterchurn/bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness.milk",
@@ -4816,7 +4816,7 @@
     },
     {
       "id": "bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz",
-      "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+",
+      "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother\u2032s skin nz+",
       "author": "Bmelgren & Unchained",
       "order": 163,
       "file": "/milkdrop-presets/butterchurn/bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz.milk",
@@ -4936,7 +4936,7 @@
     },
     {
       "id": "boz-flip-d-moshun-mash0000-forced-to-exist-freely",
-      "title": "Boz - Flip′d Moshun - mash0000 - forced to exist freely",
+      "title": "Boz - Flip\u2032d Moshun - mash0000 - forced to exist freely",
       "author": "Boz",
       "order": 167,
       "file": "/milkdrop-presets/butterchurn/boz-flip-d-moshun-mash0000-forced-to-exist-freely.milk",
@@ -6106,7 +6106,7 @@
     },
     {
       "id": "eo-s-phat-last-of-it-s-kind-sinking",
-      "title": "Eo.S. + Phat - last of it′s kind_sinking",
+      "title": "Eo.S. + Phat - last of it\u2032s kind_sinking",
       "author": "Eo.S. + Phat",
       "order": 206,
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-last-of-it-s-kind-sinking.milk",
@@ -6316,7 +6316,7 @@
     },
     {
       "id": "eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix",
-      "title": "Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b + illumination (Stahl′s Mix)",
+      "title": "Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix02b + illumination (Stahl\u2032s Mix)",
       "author": "Eo.S. + flexi",
       "order": 213,
       "file": "/milkdrop-presets/butterchurn/eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix.milk",
@@ -6526,7 +6526,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat",
-      "title": "Eo.S. - glowsticks v2 03 music shifter edit b (Stahl′s Reactive RMX V2i2 - feat. flexi + phat)",
+      "title": "Eo.S. - glowsticks v2 03 music shifter edit b (Stahl\u2032s Reactive RMX V2i2 - feat. flexi + phat)",
       "author": "Eo.S.",
       "order": 220,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat.milk",
@@ -6616,7 +6616,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) ",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) ",
       "author": "Eo.S.",
       "order": 223,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code.milk",
@@ -6646,7 +6646,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix02b",
       "author": "Eo.S.",
       "order": 224,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b.milk",
@@ -6676,7 +6676,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix03 madhatter_v2",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix03 madhatter_v2",
       "author": "Eo.S.",
       "order": 225,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2.milk",
@@ -6706,7 +6706,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 recursive demons",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix07 recursive demons",
       "author": "Eo.S.",
       "order": 226,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons.milk",
@@ -6736,7 +6736,7 @@
     },
     {
       "id": "eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07",
-      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07",
+      "title": "Eo.S. - glowsticks v2 05 and proton lights (+Krash\u2032s beat code) _Phat_remix07",
       "author": "Eo.S.",
       "order": 227,
       "file": "/milkdrop-presets/butterchurn/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07.milk",
@@ -6766,7 +6766,7 @@
     },
     {
       "id": "eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum",
-      "title": "Eo.S. - heater core C_Phat′s_class + sparks_mix - mash0000 - flaring colored zebra gum",
+      "title": "Eo.S. - heater core C_Phat\u2032s_class + sparks_mix - mash0000 - flaring colored zebra gum",
       "author": "Eo.S.",
       "order": 228,
       "file": "/milkdrop-presets/butterchurn/eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum.milk",
@@ -6796,7 +6796,7 @@
     },
     {
       "id": "eo-s-heater-core-c-phat-s-class-sparks-mix",
-      "title": "Eo.S. - heater core C_Phat′s_class + sparks_mix",
+      "title": "Eo.S. - heater core C_Phat\u2032s_class + sparks_mix",
       "author": "Eo.S.",
       "order": 229,
       "file": "/milkdrop-presets/butterchurn/eo-s-heater-core-c-phat-s-class-sparks-mix.milk",
@@ -7546,7 +7546,7 @@
     },
     {
       "id": "eo-s-phat-cool-bug-v2-krash-s-beat-detection",
-      "title": "Eo.S.+Phat Cool Bug v2 + (Krash′s beat detection)",
+      "title": "Eo.S.+Phat Cool Bug v2 + (Krash\u2032s beat detection)",
       "author": "Unknown",
       "order": 254,
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-cool-bug-v2-krash-s-beat-detection.milk",
@@ -8626,7 +8626,7 @@
     },
     {
       "id": "flexi-geiss-the-deep-diver-s-manifesto-metaphorfree",
-      "title": "Flexi + geiss - the deep diver′s manifesto [metaphorfree]",
+      "title": "Flexi + geiss - the deep diver\u2032s manifesto [metaphorfree]",
       "author": "Flexi + geiss",
       "order": 290,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-the-deep-diver-s-manifesto-metaphorfree.milk",
@@ -8866,7 +8866,7 @@
     },
     {
       "id": "flexi-milkcore-martin-s-ripple-on-water-insertion",
-      "title": "Flexi - Milkcore [Martin′s ripple on water insertion]",
+      "title": "Flexi - Milkcore [Martin\u2032s ripple on water insertion]",
       "author": "Flexi",
       "order": 298,
       "file": "/milkdrop-presets/butterchurn/flexi-milkcore-martin-s-ripple-on-water-insertion.milk",
@@ -9646,7 +9646,7 @@
     },
     {
       "id": "flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4",
-      "title": "Flexi - invisible chains securing you don′t move (cn bc jelly 4)",
+      "title": "Flexi - invisible chains securing you don\u2032t move (cn bc jelly 4)",
       "author": "Flexi",
       "order": 324,
       "file": "/milkdrop-presets/butterchurn/flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4.milk",
@@ -10216,7 +10216,7 @@
     },
     {
       "id": "flexi-predator-prey-spirals-geiss-laplacian-finish",
-      "title": "Flexi - predator-prey-spirals [geiss′ laplacian finish]",
+      "title": "Flexi - predator-prey-spirals [geiss\u2032 laplacian finish]",
       "author": "Flexi",
       "order": 343,
       "file": "/milkdrop-presets/butterchurn/flexi-predator-prey-spirals-geiss-laplacian-finish.milk",
@@ -10516,7 +10516,7 @@
     },
     {
       "id": "flexi-smashing-fractals-geiss-bas-relief-finish",
-      "title": "Flexi - smashing fractals [Geiss′ bas relief finish]",
+      "title": "Flexi - smashing fractals [Geiss\u2032 bas relief finish]",
       "author": "Flexi",
       "order": 353,
       "file": "/milkdrop-presets/butterchurn/flexi-smashing-fractals-geiss-bas-relief-finish.milk",
@@ -13906,7 +13906,7 @@
     },
     {
       "id": "geiss-cruzin",
-      "title": "Geiss - Cruzin′",
+      "title": "Geiss - Cruzin\u2032",
       "author": "Geiss",
       "order": 466,
       "file": "/milkdrop-presets/butterchurn/geiss-cruzin.milk",
@@ -16036,7 +16036,7 @@
     },
     {
       "id": "geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx",
-      "title": "Geiss - Motion Blur 2 (Stahl′s Neon Jelly 2 RMX)",
+      "title": "Geiss - Motion Blur 2 (Stahl\u2032s Neon Jelly 2 RMX)",
       "author": "Geiss",
       "order": 537,
       "file": "/milkdrop-presets/butterchurn/geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx.milk",
@@ -19426,7 +19426,7 @@
     },
     {
       "id": "hexcollie-personal-mashup3-flexi-s-portal-mix",
-      "title": "Hexcollie - Personal Mashup3 [Flexi′s portal mix]",
+      "title": "Hexcollie - Personal Mashup3 [Flexi\u2032s portal mix]",
       "author": "Hexcollie",
       "order": 650,
       "file": "/milkdrop-presets/butterchurn/hexcollie-personal-mashup3-flexi-s-portal-mix.milk",
@@ -19486,7 +19486,7 @@
     },
     {
       "id": "hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
-      "title": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It′s a start",
+      "title": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It\u2032s a start",
       "author": "Hexcollie, Aderassi, BDRV, AdamFX n Flexi",
       "order": 652,
       "file": "/milkdrop-presets/butterchurn/hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start.milk",
@@ -20536,7 +20536,7 @@
     },
     {
       "id": "krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix",
-      "title": "Krash + Geiss + martin - War Machine (Stahl′s ultimate Mash Mix)",
+      "title": "Krash + Geiss + martin - War Machine (Stahl\u2032s ultimate Mash Mix)",
       "author": "Krash + Geiss + martin",
       "order": 687,
       "file": "/milkdrop-presets/butterchurn/krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix.milk",
@@ -20656,7 +20656,7 @@
     },
     {
       "id": "krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision",
-      "title": "Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren′s Compelling Vision)",
+      "title": "Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren\u2032s Compelling Vision)",
       "author": "Krash + Rovastar",
       "order": 691,
       "file": "/milkdrop-presets/butterchurn/krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision.milk",
@@ -20986,7 +20986,7 @@
     },
     {
       "id": "lux-life-s-game-1",
-      "title": "LuX - Life′s Game 1",
+      "title": "LuX - Life\u2032s Game 1",
       "author": "LuX",
       "order": 702,
       "file": "/milkdrop-presets/butterchurn/lux-life-s-game-1.milk",
@@ -21016,7 +21016,7 @@
     },
     {
       "id": "luxxx-ain-t-life-a-motherfucker-iv",
-      "title": "LuxXx - Ain′t Life a Motherfucker iv",
+      "title": "LuxXx - Ain\u2032t Life a Motherfucker iv",
       "author": "LuxXx",
       "order": 703,
       "file": "/milkdrop-presets/butterchurn/luxxx-ain-t-life-a-motherfucker-iv.milk",
@@ -22240,7 +22240,8 @@
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "No measured WebGPU reference capture is recorded yet.",
+          "Direct native shader_body extraction now recognizes this warp/comp shader text and standard 2D sampler aliases; retained at partial/runtime because q-register uniform binding and custom anandamide sampler parity are not yet measured against projectM."
         ]
       }
     },
@@ -25036,7 +25037,7 @@
     },
     {
       "id": "rovastar-idiot24-7-marphet-s-shrine",
-      "title": "Rovastar & Idiot24-7 - Marphet′s Shrine",
+      "title": "Rovastar & Idiot24-7 - Marphet\u2032s Shrine",
       "author": "Rovastar & Idiot24-7",
       "order": 837,
       "file": "/milkdrop-presets/butterchurn/rovastar-idiot24-7-marphet-s-shrine.milk",
@@ -26446,7 +26447,7 @@
     },
     {
       "id": "rovastar-zylot-narell-s-fever",
-      "title": "Rovastar + Zylot - Narell′s Fever",
+      "title": "Rovastar + Zylot - Narell\u2032s Fever",
       "author": "Rovastar + Zylot",
       "order": 884,
       "file": "/milkdrop-presets/butterchurn/rovastar-zylot-narell-s-fever.milk",
@@ -26476,7 +26477,7 @@
     },
     {
       "id": "rovastar-zylot-urza-s-revenge",
-      "title": "Rovastar + Zylot - Urza′s Revenge",
+      "title": "Rovastar + Zylot - Urza\u2032s Revenge",
       "author": "Rovastar + Zylot",
       "order": 885,
       "file": "/milkdrop-presets/butterchurn/rovastar-zylot-urza-s-revenge.milk",
@@ -26536,7 +26537,7 @@
     },
     {
       "id": "rovastar-altars-of-harlequin-s-madness-dark-disorder-mix",
-      "title": "Rovastar - Altars Of Harlequin′s Madness (Dark Disorder Mix)",
+      "title": "Rovastar - Altars Of Harlequin\u2032s Madness (Dark Disorder Mix)",
       "author": "Rovastar",
       "order": 887,
       "file": "/milkdrop-presets/butterchurn/rovastar-altars-of-harlequin-s-madness-dark-disorder-mix.milk",
@@ -26566,7 +26567,7 @@
     },
     {
       "id": "rovastar-altars-of-harlequin-s-madness",
-      "title": "Rovastar - Altars Of Harlequin′s Madness",
+      "title": "Rovastar - Altars Of Harlequin\u2032s Madness",
       "author": "Rovastar",
       "order": 888,
       "file": "/milkdrop-presets/butterchurn/rovastar-altars-of-harlequin-s-madness.milk",
@@ -27046,7 +27047,7 @@
     },
     {
       "id": "rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix",
-      "title": "Rovastar - Harlequin′s & Jester′s Dual Delight (Chaotic Nightmare Mix)",
+      "title": "Rovastar - Harlequin\u2032s & Jester\u2032s Dual Delight (Chaotic Nightmare Mix)",
       "author": "Rovastar",
       "order": 904,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix.milk",
@@ -27076,7 +27077,7 @@
     },
     {
       "id": "rovastar-harlequin-s-dynamic-fractal-3",
-      "title": "Rovastar - Harlequin′s Dynamic Fractal 3",
+      "title": "Rovastar - Harlequin\u2032s Dynamic Fractal 3",
       "author": "Rovastar",
       "order": 905,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-dynamic-fractal-3.milk",
@@ -27106,7 +27107,7 @@
     },
     {
       "id": "rovastar-harlequin-s-fractal-encounter-cancer-of-saints",
-      "title": "Rovastar - Harlequin′s Fractal Encounter - cancer of saints",
+      "title": "Rovastar - Harlequin\u2032s Fractal Encounter - cancer of saints",
       "author": "Rovastar",
       "order": 906,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-fractal-encounter-cancer-of-saints.milk",
@@ -27136,7 +27137,7 @@
     },
     {
       "id": "rovastar-harlequin-s-fractal-encounter",
-      "title": "Rovastar - Harlequin′s Fractal Encounter",
+      "title": "Rovastar - Harlequin\u2032s Fractal Encounter",
       "author": "Rovastar",
       "order": 907,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-fractal-encounter.milk",
@@ -27166,7 +27167,7 @@
     },
     {
       "id": "rovastar-harlequin-s-liquid-dragon",
-      "title": "Rovastar - Harlequin′s Liquid Dragon",
+      "title": "Rovastar - Harlequin\u2032s Liquid Dragon",
       "author": "Rovastar",
       "order": 908,
       "file": "/milkdrop-presets/butterchurn/rovastar-harlequin-s-liquid-dragon.milk",
@@ -27316,7 +27317,7 @@
     },
     {
       "id": "rovastar-jester-s-calling-2",
-      "title": "Rovastar - Jester′s Calling 2",
+      "title": "Rovastar - Jester\u2032s Calling 2",
       "author": "Rovastar",
       "order": 913,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-calling-2.milk",
@@ -27346,7 +27347,7 @@
     },
     {
       "id": "rovastar-jester-s-surreal-tornado-further-vortex-mix",
-      "title": "Rovastar - Jester′s Surreal Tornado (Further Vortex Mix)",
+      "title": "Rovastar - Jester\u2032s Surreal Tornado (Further Vortex Mix)",
       "author": "Rovastar",
       "order": 914,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-surreal-tornado-further-vortex-mix.milk",
@@ -27376,7 +27377,7 @@
     },
     {
       "id": "rovastar-jester-s-surreal-tornado",
-      "title": "Rovastar - Jester′s Surreal Tornado",
+      "title": "Rovastar - Jester\u2032s Surreal Tornado",
       "author": "Rovastar",
       "order": 915,
       "file": "/milkdrop-presets/butterchurn/rovastar-jester-s-surreal-tornado.milk",
@@ -27826,7 +27827,7 @@
     },
     {
       "id": "rovastar-voov-s-light-pattern",
-      "title": "Rovastar - VooV′s Light Pattern",
+      "title": "Rovastar - VooV\u2032s Light Pattern",
       "author": "Rovastar",
       "order": 930,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-light-pattern.milk",
@@ -27856,7 +27857,7 @@
     },
     {
       "id": "rovastar-voov-s-movement-after-dark-mix-painterly",
-      "title": "Rovastar - VooV′s Movement (After Dark Mix) - Painterly",
+      "title": "Rovastar - VooV\u2032s Movement (After Dark Mix) - Painterly",
       "author": "Rovastar",
       "order": 931,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-movement-after-dark-mix-painterly.milk",
@@ -27886,7 +27887,7 @@
     },
     {
       "id": "rovastar-voov-s-movement-after-dark-mix",
-      "title": "Rovastar - VooV′s Movement (After Dark Mix)",
+      "title": "Rovastar - VooV\u2032s Movement (After Dark Mix)",
       "author": "Rovastar",
       "order": 932,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-movement-after-dark-mix.milk",
@@ -27916,7 +27917,7 @@
     },
     {
       "id": "rovastar-voov-s-naked-movement-pincushion-mix",
-      "title": "Rovastar - VooV′s Naked Movement (Pincushion Mix)",
+      "title": "Rovastar - VooV\u2032s Naked Movement (Pincushion Mix)",
       "author": "Rovastar",
       "order": 933,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-naked-movement-pincushion-mix.milk",
@@ -27946,7 +27947,7 @@
     },
     {
       "id": "rovastar-voov-s-organic-light",
-      "title": "Rovastar - VooV′s Organic Light",
+      "title": "Rovastar - VooV\u2032s Organic Light",
       "author": "Rovastar",
       "order": 934,
       "file": "/milkdrop-presets/butterchurn/rovastar-voov-s-organic-light.milk",
@@ -28636,7 +28637,7 @@
     },
     {
       "id": "stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon",
-      "title": "Stahlregen & AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack′s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon",
+      "title": "Stahlregen & AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack\u2032s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon",
       "author": "Stahlregen & AdamFX + flexi + Geiss",
       "order": 957,
       "file": "/milkdrop-presets/butterchurn/stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon.milk",
@@ -28876,7 +28877,7 @@
     },
     {
       "id": "stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1",
-      "title": "Stahlregen & Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester′s Smashing Atoms RMX)_1",
+      "title": "Stahlregen & Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester\u2032s Smashing Atoms RMX)_1",
       "author": "Stahlregen & Benski + Fvese + Geiss + Rovastar",
       "order": 965,
       "file": "/milkdrop-presets/butterchurn/stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1.milk",
@@ -29806,7 +29807,7 @@
     },
     {
       "id": "stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics",
-      "title": "Stahlregen & flexi + Geiss + martin + Rovastar - Tides (martin′s metallics)",
+      "title": "Stahlregen & flexi + Geiss + martin + Rovastar - Tides (martin\u2032s metallics)",
       "author": "Stahlregen & flexi + Geiss + martin + Rovastar",
       "order": 996,
       "file": "/milkdrop-presets/butterchurn/stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics.milk",
@@ -31816,7 +31817,7 @@
     },
     {
       "id": "unchained-morat-s-final-voyage",
-      "title": "Unchained - Morat′s Final Voyage",
+      "title": "Unchained - Morat\u2032s Final Voyage",
       "author": "Unchained",
       "order": 1063,
       "file": "/milkdrop-presets/butterchurn/unchained-morat-s-final-voyage.milk",
@@ -32746,7 +32747,7 @@
     },
     {
       "id": "zylot-rovastar-sully-s-trip-the-worstest-mix",
-      "title": "Zylot & Rovastar - Sully′s Trip (The Worstest Mix)",
+      "title": "Zylot & Rovastar - Sully\u2032s Trip (The Worstest Mix)",
       "author": "Zylot & Rovastar",
       "order": 1094,
       "file": "/milkdrop-presets/butterchurn/zylot-rovastar-sully-s-trip-the-worstest-mix.milk",
@@ -33706,7 +33707,7 @@
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-broth-mix",
-      "title": "_Flexi + Geiss - mindblob [where it′s at now] (broth mix)",
+      "title": "_Flexi + Geiss - mindblob [where it\u2032s at now] (broth mix)",
       "author": "_Flexi + Geiss",
       "order": 1126,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-mindblob-where-it-s-at-now-broth-mix.milk",
@@ -33736,7 +33737,7 @@
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-emboss-mix",
-      "title": "_Flexi + Geiss - mindblob [where it′s at now] (emboss mix)",
+      "title": "_Flexi + Geiss - mindblob [where it\u2032s at now] (emboss mix)",
       "author": "_Flexi + Geiss",
       "order": 1127,
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-mindblob-where-it-s-at-now-emboss-mix.milk",
@@ -33766,7 +33767,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now-2",
-      "title": "_Flexi - mindblob [where it′s at now] 2",
+      "title": "_Flexi - mindblob [where it\u2032s at now] 2",
       "author": "_Flexi",
       "order": 1128,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now-2.milk",
@@ -33796,7 +33797,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now-3",
-      "title": "_Flexi - mindblob [where it′s at now] 3",
+      "title": "_Flexi - mindblob [where it\u2032s at now] 3",
       "author": "_Flexi",
       "order": 1129,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now-3.milk",
@@ -33826,7 +33827,7 @@
     },
     {
       "id": "flexi-mindblob-where-it-s-at-now",
-      "title": "_Flexi - mindblob [where it′s at now]",
+      "title": "_Flexi - mindblob [where it\u2032s at now]",
       "author": "_Flexi",
       "order": 1130,
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-where-it-s-at-now.milk",
@@ -37636,7 +37637,7 @@
     },
     {
       "id": "amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter",
-      "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter",
+      "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don\u2032t matter",
       "author": "amandio c",
       "order": 1257,
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter.milk",
@@ -38506,7 +38507,7 @@
     },
     {
       "id": "beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital",
-      "title": "beta106i - Brilliance (Space-Time Breaking) - mash0000 - it′s 2009 and you haven′t replaced your analog tv with digital",
+      "title": "beta106i - Brilliance (Space-Time Breaking) - mash0000 - it\u2032s 2009 and you haven\u2032t replaced your analog tv with digital",
       "author": "beta106i",
       "order": 1286,
       "file": "/milkdrop-presets/butterchurn/beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital.milk",
@@ -38626,7 +38627,7 @@
     },
     {
       "id": "beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy",
-      "title": "beta106i - It′s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy",
+      "title": "beta106i - It\u2032s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy",
       "author": "beta106i",
       "order": 1290,
       "file": "/milkdrop-presets/butterchurn/beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy.milk",
@@ -40156,7 +40157,7 @@
     },
     {
       "id": "fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix",
-      "title": "fiShbRaiN + geiss - witchcraft (Stahl′s Mirror Crossfire Mix)",
+      "title": "fiShbRaiN + geiss - witchcraft (Stahl\u2032s Mirror Crossfire Mix)",
       "author": "fiShbRaiN + geiss",
       "order": 1341,
       "file": "/milkdrop-presets/butterchurn/fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix.milk",
@@ -41776,7 +41777,7 @@
     },
     {
       "id": "flexi-stahlregen-a-car-crash-you-can-t-defocus-2",
-      "title": "flexi + stahlregen - a car crash you can′t defocus_2",
+      "title": "flexi + stahlregen - a car crash you can\u2032t defocus_2",
       "author": "flexi + stahlregen",
       "order": 1395,
       "file": "/milkdrop-presets/butterchurn/flexi-stahlregen-a-car-crash-you-can-t-defocus-2.milk",
@@ -42526,7 +42527,7 @@
     },
     {
       "id": "flexi-can-t-think-of-mosaic-cages",
-      "title": "flexi - can′t think of mosaic cages",
+      "title": "flexi - can\u2032t think of mosaic cages",
       "author": "flexi",
       "order": 1420,
       "file": "/milkdrop-presets/butterchurn/flexi-can-t-think-of-mosaic-cages.milk",
@@ -43366,7 +43367,7 @@
     },
     {
       "id": "flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2",
-      "title": "flexi - lorenz chaser (Stahl′s rainbow multiply mix 2 - Jelly V2)",
+      "title": "flexi - lorenz chaser (Stahl\u2032s rainbow multiply mix 2 - Jelly V2)",
       "author": "flexi",
       "order": 1448,
       "file": "/milkdrop-presets/butterchurn/flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2.milk",
@@ -44746,7 +44747,7 @@
     },
     {
       "id": "lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch",
-      "title": "lit claw (explorers grid) - i don′t have either a belfry or bats bitch",
+      "title": "lit claw (explorers grid) - i don\u2032t have either a belfry or bats bitch",
       "author": "lit claw",
       "order": 1494,
       "file": "/milkdrop-presets/butterchurn/lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch.milk",
@@ -45736,7 +45737,7 @@
     },
     {
       "id": "martin-bombyx-mori-flexi-s-logarithmic-edit",
-      "title": "martin - bombyx mori [flexi′s logarithmic edit]",
+      "title": "martin - bombyx mori [flexi\u2032s logarithmic edit]",
       "author": "martin",
       "order": 1527,
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-flexi-s-logarithmic-edit.milk",
@@ -45910,7 +45911,8 @@
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "No measured WebGPU reference capture is recorded yet.",
+          "Direct native shader_body extraction now recognizes this warp/comp shader text, feedback texture reads, and noise sampler aliases; retained at partial/runtime because q-register uniform binding and projectM visual reference parity are not yet complete."
         ]
       }
     },
@@ -46060,7 +46062,8 @@
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "No measured WebGPU reference capture is recorded yet.",
+          "Direct native shader_body extraction now recognizes this comp shader text and framebuffer sampling path; retained at partial/runtime because the shader-text output still lacks measured projectM reference parity."
         ]
       }
     },
@@ -46600,7 +46603,8 @@
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "No measured WebGPU reference capture is recorded yet.",
+          "Direct native shader_body extraction now recognizes volume-noise shader text, texsize_noisevol_hq aliases, and feedback sampler reads; retained at partial/runtime because volume sampler translation remains approximate and unmeasured."
         ]
       }
     },
@@ -48766,7 +48770,7 @@
     },
     {
       "id": "martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix",
-      "title": "martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix]",
+      "title": "martin - the forge of isengard [flexi\u2032s moebius transformation vs. logarithmic spiral mix]",
       "author": "martin",
       "order": 1628,
       "file": "/milkdrop-presets/butterchurn/martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix.milk",
@@ -48940,7 +48944,8 @@
         "requiredBackend": "webgpu",
         "actualBackend": null,
         "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
+          "No measured WebGPU reference capture is recorded yet.",
+          "Direct native shader_body extraction now recognizes this warp/comp shader text, feedback texture reads, and standard noise samplers; retained at partial/runtime because q-register uniform binding and projectM visual reference parity are not yet complete."
         ]
       }
     },
@@ -49426,7 +49431,7 @@
     },
     {
       "id": "niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy",
-      "title": "niko radiative bunchess - i′m gonna break my rusty cage, and run (the fuck grunge isn′t the source of anarchy)",
+      "title": "niko radiative bunchess - i\u2032m gonna break my rusty cage, and run (the fuck grunge isn\u2032t the source of anarchy)",
       "author": "niko radiative bunchess",
       "order": 1650,
       "file": "/milkdrop-presets/butterchurn/niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy.milk",
@@ -49966,7 +49971,7 @@
     },
     {
       "id": "phat-it-sjustnumbers",
-      "title": "phat_It′sJustNumbers=)",
+      "title": "phat_It\u2032sJustNumbers=)",
       "author": "Unknown",
       "order": 1668,
       "file": "/milkdrop-presets/butterchurn/phat-it-sjustnumbers.milk",
@@ -49996,7 +50001,7 @@
     },
     {
       "id": "phat-it-sjustnumbers-remix3",
-      "title": "phat_It′sJustNumbers_remix3",
+      "title": "phat_It\u2032sJustNumbers_remix3",
       "author": "Unknown",
       "order": 1669,
       "file": "/milkdrop-presets/butterchurn/phat-it-sjustnumbers-remix3.milk",
@@ -50416,7 +50421,7 @@
     },
     {
       "id": "shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader",
-      "title": "shadow harlequin - babylon warp drive resurrection call [Flexi′s insertion of Martin′s ripple on water shader]",
+      "title": "shadow harlequin - babylon warp drive resurrection call [Flexi\u2032s insertion of Martin\u2032s ripple on water shader]",
       "author": "shadow harlequin",
       "order": 1683,
       "file": "/milkdrop-presets/butterchurn/shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader.milk",
@@ -50476,7 +50481,7 @@
     },
     {
       "id": "shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2",
-      "title": "shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v′many times′2",
+      "title": "shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v\u2032many times\u20322",
       "author": "shadowharlequin, loadus, fishbrain + geiss",
       "order": 1685,
       "file": "/milkdrop-presets/butterchurn/shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2.milk",
@@ -51676,7 +51681,7 @@
     },
     {
       "id": "skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful",
-      "title": "skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful",
+      "title": "skipper skipper kiss me hard - if it weren\u2032t for you wonderful role playing \u2032people\u2032 parts of my solipsistic overmind, i\u2032d be ungrateful",
       "author": "skipper skipper kiss me hard",
       "order": 1725,
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful.milk",
@@ -51916,7 +51921,7 @@
     },
     {
       "id": "studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive",
-      "title": "studio music & unchained + phat and e.o.s - how it feel′s to be alive",
+      "title": "studio music & unchained + phat and e.o.s - how it feel\u2032s to be alive",
       "author": "studio music & unchained + phat and e.o.s",
       "order": 1733,
       "file": "/milkdrop-presets/butterchurn/studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive.milk",
@@ -51976,7 +51981,7 @@
     },
     {
       "id": "suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz",
-      "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+",
+      "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter\u2032s esc shader] nz+",
       "author": "suksma + aderassi geiss",
       "order": 1735,
       "file": "/milkdrop-presets/butterchurn/suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz.milk",
@@ -52366,7 +52371,7 @@
     },
     {
       "id": "suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored",
-      "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored",
+      "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you\u2032re bored",
       "author": "suksma",
       "order": 1748,
       "file": "/milkdrop-presets/butterchurn/suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored.milk",
@@ -52906,7 +52911,7 @@
     },
     {
       "id": "suksma-vector-exp-1-couldn-t-not",
-      "title": "suksma - vector exp 1 - couldn′t not",
+      "title": "suksma - vector exp 1 - couldn\u2032t not",
       "author": "suksma",
       "order": 1766,
       "file": "/milkdrop-presets/butterchurn/suksma-vector-exp-1-couldn-t-not.milk",
@@ -53026,7 +53031,7 @@
     },
     {
       "id": "various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money",
-      "title": "various artists - 1200774354134 - mash0000 - what the writer′s guild is doing with the extra money",
+      "title": "various artists - 1200774354134 - mash0000 - what the writer\u2032s guild is doing with the extra money",
       "author": "various artists",
       "order": 1770,
       "file": "/milkdrop-presets/butterchurn/various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money.milk",
@@ -53116,7 +53121,7 @@
     },
     {
       "id": "yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak",
-      "title": "yin - 051 - Van Gogh′s nightmare (in depth) - bitcore tweak",
+      "title": "yin - 051 - Van Gogh\u2032s nightmare (in depth) - bitcore tweak",
       "author": "yin",
       "order": 1773,
       "file": "/milkdrop-presets/butterchurn/yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak.milk",
@@ -53356,7 +53361,7 @@
     },
     {
       "id": "yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix",
-      "title": "yin - 250 - Artificial poles of the continuum_Phat′s_Orbit_mix",
+      "title": "yin - 250 - Artificial poles of the continuum_Phat\u2032s_Orbit_mix",
       "author": "yin",
       "order": 1781,
       "file": "/milkdrop-presets/butterchurn/yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix.milk",

--- a/scripts/sync-bundled-catalog-fidelity.ts
+++ b/scripts/sync-bundled-catalog-fidelity.ts
@@ -21,6 +21,28 @@ export function inferredCatalogFidelityWithoutMeasuredResult(): MilkdropFidelity
   return 'partial';
 }
 
+const SHADER_TEXT_CERTIFICATION_REASONS: Record<string, string> = {
+  'martin-anandamide-mandelbox-explorer-quantum-timepiece-remix':
+    'Direct native shader_body extraction now recognizes this warp/comp shader text and standard 2D sampler aliases; retained at partial/runtime because q-register uniform binding and custom anandamide sampler parity are not yet measured against projectM.',
+  'martin-castle-in-the-air':
+    'Direct native shader_body extraction now recognizes this warp/comp shader text, feedback texture reads, and noise sampler aliases; retained at partial/runtime because q-register uniform binding and projectM visual reference parity are not yet complete.',
+  'martin-city-of-shadows':
+    'Direct native shader_body extraction now recognizes this comp shader text and framebuffer sampling path; retained at partial/runtime because the shader-text output still lacks measured projectM reference parity.',
+  'martin-elusive-impressions-mix2-flacc-mess-proph-nz-2':
+    'Direct native shader_body extraction now recognizes volume-noise shader text, texsize_noisevol_hq aliases, and feedback sampler reads; retained at partial/runtime because volume sampler translation remains approximate and unmeasured.',
+  'martin-tunnel-race':
+    'Direct native shader_body extraction now recognizes this warp/comp shader text, feedback texture reads, and standard noise samplers; retained at partial/runtime because q-register uniform binding and projectM visual reference parity are not yet complete.',
+};
+
+function buildInferredCertificationReasons(presetId: string) {
+  const reasons = ['No measured WebGPU reference capture is recorded yet.'];
+  const shaderTextReason = SHADER_TEXT_CERTIFICATION_REASONS[presetId];
+  if (shaderTextReason) {
+    reasons.push(shaderTextReason);
+  }
+  return reasons;
+}
+
 export function syncBundledCatalogPresetFidelity(
   preset: MilkdropBundledCatalogEntry,
   measuredResult: MeasuredVisualPresetResult | undefined,
@@ -38,7 +60,7 @@ export function syncBundledCatalogPresetFidelity(
         visualEvidenceTier: 'runtime',
         requiredBackend: 'webgpu',
         actualBackend: null,
-        reasons: ['No measured WebGPU reference capture is recorded yet.'],
+        reasons: buildInferredCertificationReasons(preset.id),
       },
     };
   }

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -2214,50 +2214,51 @@ comp_3=ret = texture(sampler_fc_main, packed + noisePacked.xy).xyz;
       ]),
     );
   });
-test('detects custom shader sampler declarations and reports missing bundled textures', () => {
-  const source = readFileSync(
-    join(
-      process.cwd(),
-      'public/milkdrop-presets/butterchurn/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.milk',
-    ),
-    'utf8',
-  );
-  const compiled = compileMilkdropPresetSource(source, {
-    id: 'anandamide-custom-sampler',
-    origin: 'bundled',
+  test('detects custom shader sampler declarations and reports missing bundled textures', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'public/milkdrop-presets/butterchurn/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.milk',
+      ),
+      'utf8',
+    );
+    const compiled = compileMilkdropPresetSource(source, {
+      id: 'anandamide-custom-sampler',
+      origin: 'bundled',
+    });
+
+    expect(compiled.ir.shaderText.customSamplers).toContainEqual({
+      name: 'sampler_anandamideCTFree00',
+      textureFile: null,
+    });
+    expect(compiled.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'preset_missing_custom_sampler_texture',
+        severity: 'warning',
+      }),
+    );
   });
 
-  expect(compiled.ir.shaderText.customSamplers).toContainEqual({
-    name: 'sampler_anandamideCTFree00',
-    textureFile: null,
-  });
-  expect(compiled.diagnostics).toContainEqual(
-    expect.objectContaining({
-      code: 'preset_missing_custom_sampler_texture',
-      severity: 'warning',
-    }),
-  );
-});
-
-test('resolves custom shader sampler declarations to bundled texture assets', () => {
-  const compiled = compileMilkdropPresetSource(
-    `
+  test('resolves custom shader sampler declarations to bundled texture assets', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
 shader=1
 comp_shader=uniform sampler2D sampler_water_caustics; ret = texture(sampler_water_caustics, uv).rgb
     `.trim(),
-    { id: 'custom-sampler-texture', origin: 'bundled' },
-  );
+      { id: 'custom-sampler-texture', origin: 'bundled' },
+    );
 
-  expect(compiled.ir.shaderText.customSamplers).toEqual([
-    {
-      name: 'sampler_water_caustics',
-      textureFile: 'water_caustics.png',
-    },
-  ]);
-  expect(
-    compiled.diagnostics.some(
-      (diagnostic) =>
-        diagnostic.code === 'preset_missing_custom_sampler_texture',
-    ),
-  ).toBe(false);
+    expect(compiled.ir.shaderText.customSamplers).toEqual([
+      {
+        name: 'sampler_water_caustics',
+        textureFile: 'water_caustics.png',
+      },
+    ]);
+    expect(
+      compiled.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === 'preset_missing_custom_sampler_texture',
+      ),
+    ).toBe(false);
+  });
 });

--- a/tests/shader-dependent-presets.test.ts
+++ b/tests/shader-dependent-presets.test.ts
@@ -91,10 +91,15 @@ test('elusive impressions fixture exercises MilkDrop volume-noise shader text wi
 
   expect(source).toContain('texture (sampler_noisevol_hq,');
   expect(source).toContain('texsize_noisevol_hq.zww');
-  expect(preset?.supports).toEqual({ webgl: false, webgpu: false });
+  expect(preset?.supports).toEqual({ webgl: true, webgpu: true });
   expect(preset?.visualCertification).toMatchObject({
     status: 'uncertified',
     measured: false,
     source: 'inferred',
+    fidelityClass: 'partial',
+    visualEvidenceTier: 'runtime',
   });
+  expect(preset?.visualCertification?.reasons).toContain(
+    'Direct native shader_body extraction now recognizes volume-noise shader text, texsize_noisevol_hq aliases, and feedback sampler reads; retained at partial/runtime because volume sampler translation remains approximate and unmeasured.',
+  );
 });

--- a/tests/sync-bundled-catalog-fidelity.test.ts
+++ b/tests/sync-bundled-catalog-fidelity.test.ts
@@ -146,8 +146,10 @@ test('unmeasured native shader-text presets sync to runtime fidelity like other 
       },
       undefined,
     ),
-  ).toMatchObject({
+  ).toEqual({
     id: 'martin-tunnel-race',
+    title: 'martin - tunnel race',
+    file: '/milkdrop-presets/butterchurn/martin-tunnel-race.milk',
     expectedFidelityClass: 'partial',
     visualEvidenceTier: 'runtime',
     supports: { webgl: true, webgpu: true },
@@ -159,7 +161,10 @@ test('unmeasured native shader-text presets sync to runtime fidelity like other 
       visualEvidenceTier: 'runtime',
       requiredBackend: 'webgpu',
       actualBackend: null,
-      reasons: ['No measured WebGPU reference capture is recorded yet.'],
+      reasons: [
+        'No measured WebGPU reference capture is recorded yet.',
+        'Direct native shader_body extraction now recognizes this warp/comp shader text, feedback texture reads, and standard noise samplers; retained at partial/runtime because q-register uniform binding and projectM visual reference parity are not yet complete.',
+      ],
     },
   });
 });


### PR DESCRIPTION
### Motivation
- The catalog must not be upgraded to visual/certified unless WebGPU/WebGL shader-text outputs are validated against projectM references, so shader-text presets that compile successfully should remain `partial`/`runtime` until measured parity is acceptable.
- Provide clear, per-preset reasons describing what shader-text features are now recognized and what parity/translation limitations remain so future certification is traceable.

### Description
- Keep the five Martin shader-text presets marked as supported but `partial` with `visualEvidenceTier: 'runtime'` and add feature-specific notes for each preset in `public/milkdrop-presets/catalog.json` (presets: `martin-anandamide-mandelbox-explorer-quantum-timepiece-remix`, `martin-castle-in-the-air`, `martin-city-of-shadows`, `martin-elusive-impressions-mix2-flacc-mess-proph-nz-2`, `martin-tunnel-race`).
- Preserve those per-preset certification reasons when syncing the bundled catalog by adding `SHADER_TEXT_CERTIFICATION_REASONS` and `buildInferredCertificationReasons()` in `scripts/sync-bundled-catalog-fidelity.ts` and using it for inferred entries.
- Fix GLSL injection to replace the in-main marker when duplicate markers exist by switching to `lastIndexOf` for the warp/comp start markers in `assets/js/milkdrop/compiler/shader-analysis-glsl.ts` and using `indexOf(..., startIndex)` for the corresponding end marker.
- Adjust and reformat tests to assert the updated supported-but-uncertified metadata and restore a missing test brace in `tests/milkdrop-compiler.test.ts` so the quality gate parses.

### Testing
- Ran the shader-focused unit tests `bun run test tests/shader-dependent-presets.test.ts`; all tests passed (3/3).
- Ran the catalog sync unit tests `bun run test tests/sync-bundled-catalog-fidelity.test.ts`; all tests passed (3/3).
- Attempted automated visual capture with `bun run scripts/play-toy.ts ... --renderer-profile webgpu` for the shader presets; captures succeeded but browser console logged GLSL/validation errors and undeclared identifiers indicating remaining runtime gaps, so certification labels remain `partial`/`runtime` as intended (no upgrade performed).
- Ran the repo quality gates `bun run check:quick` and `bun run check`; the quick checks and full `check` completed with the test suite and linters passing on the updated branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513a0269988332be611c6bda99bf25)