### PR TITLE
feat: Extract direct shader UV transforms

### DIFF
--- a/assets/js/milkdrop/compiler/shader-analysis-helpers.ts
+++ b/assets/js/milkdrop/compiler/shader-analysis-helpers.ts
@@ -962,7 +962,7 @@ export function extractScaledShaderSampleExpression(
   };
 }
 
-function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
+export type ShaderUvTransformAnalysis = {
   scaleX: number;
   scaleY: number;
   offsetX: number;
@@ -973,7 +973,11 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
     offsetX: MilkdropExpressionNode | null;
     offsetY: MilkdropExpressionNode | null;
   };
-} | null {
+};
+
+export function analyzeShaderUvTransform(
+  node: MilkdropShaderExpressionNode,
+): ShaderUvTransformAnalysis | null {
   if (isShaderUvIdentifier(node)) {
     return {
       scaleX: 1,
@@ -1034,40 +1038,12 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
   }
 
   if (node.type === 'binary' && node.operator === '*') {
-    const uvSide = isShaderUvIdentifier(node.left)
-      ? node.left
-      : isShaderUvIdentifier(node.right)
-        ? node.right
-        : null;
-    const scaleSide =
-      uvSide === node.left
-        ? node.right
-        : uvSide === node.right
-          ? node.left
-          : null;
-    if (!uvSide || !scaleSide) {
+    const leftBase = analyzeShaderUvTransform(node.left);
+    const rightBase = leftBase ? null : analyzeShaderUvTransform(node.right);
+    const base = leftBase ?? rightBase;
+    const scaleSide = leftBase ? node.right : rightBase ? node.left : null;
+    if (!base || !scaleSide) {
       return null;
-    }
-
-    const scalar = evaluateShaderScalarResult(
-      scaleSide,
-      { uv: { kind: 'vec2', value: [0, 0] } },
-      DEFAULT_MILKDROP_STATE,
-      {},
-    );
-    if (scalar) {
-      return {
-        scaleX: scalar.value,
-        scaleY: scalar.value,
-        offsetX: 0,
-        offsetY: 0,
-        expressions: {
-          scaleX: scalar.expression,
-          scaleY: scalar.expression,
-          offsetX: null,
-          offsetY: null,
-        },
-      };
     }
 
     const vector = evaluateShaderVectorResult(
@@ -1077,19 +1053,40 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
       DEFAULT_MILKDROP_STATE,
       {},
     );
-    if (!vector) {
+    if (vector) {
+      return {
+        scaleX: base.scaleX * vector.values[0],
+        scaleY: base.scaleY * vector.values[1],
+        offsetX: base.offsetX * vector.values[0],
+        offsetY: base.offsetY * vector.values[1],
+        expressions: {
+          scaleX: vector.expressions[0] ?? base.expressions.scaleX,
+          scaleY: vector.expressions[1] ?? base.expressions.scaleY,
+          offsetX: base.expressions.offsetX,
+          offsetY: base.expressions.offsetY,
+        },
+      };
+    }
+
+    const scalar = evaluateShaderScalarResult(
+      scaleSide,
+      { uv: { kind: 'vec2', value: [0, 0] } },
+      DEFAULT_MILKDROP_STATE,
+      {},
+    );
+    if (!scalar) {
       return null;
     }
     return {
-      scaleX: vector.values[0],
-      scaleY: vector.values[1],
-      offsetX: 0,
-      offsetY: 0,
+      scaleX: base.scaleX * scalar.value,
+      scaleY: base.scaleY * scalar.value,
+      offsetX: base.offsetX * scalar.value,
+      offsetY: base.offsetY * scalar.value,
       expressions: {
-        scaleX: vector.expressions[0] ?? null,
-        scaleY: vector.expressions[1] ?? null,
-        offsetX: null,
-        offsetY: null,
+        scaleX: scalar.expression ?? base.expressions.scaleX,
+        scaleY: scalar.expression ?? base.expressions.scaleY,
+        offsetX: base.expressions.offsetX,
+        offsetY: base.expressions.offsetY,
       },
     };
   }
@@ -1126,6 +1123,89 @@ function analyzeShaderUvTransform(node: MilkdropShaderExpressionNode): {
   }
 
   return null;
+}
+
+function invertUvScaleExpression(expression: MilkdropExpressionNode | null) {
+  if (!expression) {
+    return null;
+  }
+  return {
+    type: 'binary',
+    operator: '/',
+    left: createLiteralExpression(1),
+    right: expression,
+  } satisfies MilkdropExpressionNode;
+}
+
+function buildCenteredUvOffsetExpression(
+  scaleExpression: MilkdropExpressionNode | null,
+  offsetExpression: MilkdropExpressionNode | null,
+) {
+  if (!scaleExpression && !offsetExpression) {
+    return null;
+  }
+  const centeredScaleOffset = {
+    type: 'binary',
+    operator: '*',
+    left: createLiteralExpression(0.5),
+    right: {
+      type: 'binary',
+      operator: '-',
+      left: scaleExpression ?? createLiteralExpression(1),
+      right: createLiteralExpression(1),
+    },
+  } satisfies MilkdropExpressionNode;
+  if (!offsetExpression) {
+    return centeredScaleOffset;
+  }
+  return {
+    type: 'binary',
+    operator: '+',
+    left: offsetExpression,
+    right: centeredScaleOffset,
+  } satisfies MilkdropExpressionNode;
+}
+
+export function applyMainUvTransformControls({
+  transform,
+  controls,
+  expressions,
+  shaderEnv,
+}: {
+  transform: ShaderUvTransformAnalysis;
+  controls: MilkdropShaderControls;
+  expressions: MilkdropShaderControlExpressions;
+  shaderEnv: Record<string, number>;
+}) {
+  if (
+    Math.abs(transform.scaleX - transform.scaleY) > 0.000001 ||
+    transform.scaleX === 0
+  ) {
+    return false;
+  }
+
+  const zoom = 1 / transform.scaleX;
+  const offsetX = transform.offsetX + transform.scaleX * 0.5 - 0.5;
+  const offsetY = transform.offsetY + transform.scaleY * 0.5 - 0.5;
+  controls.zoom = zoom;
+  controls.offsetX = offsetX;
+  controls.offsetY = offsetY;
+  expressions.zoom = invertUvScaleExpression(transform.expressions.scaleX);
+  expressions.offsetX = buildCenteredUvOffsetExpression(
+    transform.expressions.scaleX,
+    transform.expressions.offsetX,
+  );
+  expressions.offsetY = buildCenteredUvOffsetExpression(
+    transform.expressions.scaleY,
+    transform.expressions.offsetY,
+  );
+  shaderEnv.zoom = zoom;
+  shaderEnv.scale = zoom;
+  shaderEnv.offset_x = offsetX;
+  shaderEnv.offset_y = offsetY;
+  shaderEnv.dx = offsetX;
+  shaderEnv.dy = offsetY;
+  return true;
 }
 
 function analyzeShaderVolumeSlice(node: MilkdropShaderExpressionNode | null): {

--- a/assets/js/milkdrop/compiler/shader-analysis.ts
+++ b/assets/js/milkdrop/compiler/shader-analysis.ts
@@ -18,6 +18,8 @@ import {
 } from './shader-analysis-direct-program';
 import { mergeShaderControlAnalysis } from './shader-analysis-evaluation';
 import {
+  analyzeShaderUvTransform,
+  applyMainUvTransformControls,
   applyShaderControlValue,
   applyShaderExpressionOperator,
   applyTextureLayerSample,
@@ -236,6 +238,26 @@ function applyShaderAstStatement({
   }
 
   if (key === 'uv') {
+    if (operator === '=') {
+      const transform = analyzeShaderUvTransform(resolvedExpression);
+      if (
+        transform &&
+        applyMainUvTransformControls({
+          transform,
+          controls,
+          expressions,
+          shaderEnv,
+        })
+      ) {
+        shaderValueEnv.uv = {
+          kind: 'vec2',
+          value: [0, 0],
+        };
+        shaderExpressionEnv[key] = resolvedExpression;
+        return true;
+      }
+    }
+
     const directVec = vec2Result();
     if ((operator === '+=' || operator === '-=') && directVec) {
       const sign = operator === '-=' ? -1 : 1;

--- a/assets/js/milkdrop/compiler/shader-control-application.ts
+++ b/assets/js/milkdrop/compiler/shader-control-application.ts
@@ -5,6 +5,8 @@ import type {
   MilkdropShaderExpressionNode,
 } from '../types';
 import {
+  analyzeShaderUvTransform,
+  applyMainUvTransformControls,
   applyShaderExpressionOperator,
   isAuxShaderSamplerName,
   normalizeShaderSamplerName,
@@ -619,6 +621,18 @@ export function applyShaderAstControlStatement({
   }
 
   if (key === 'uv') {
+    if (operator === '=') {
+      const transform = analyzeShaderUvTransform(resolvedExpression);
+      if (transform) {
+        return applyMainUvTransformControls({
+          transform,
+          controls: context.controls,
+          expressions: context.expressions,
+          shaderEnv: context.shaderEnv,
+        });
+      }
+    }
+
     if ((operator === '+=' || operator === '-=') && vec2Result) {
       const sign = operator === '-=' ? -1 : 1;
       const nextX = applyNumericControlValue({

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -831,6 +831,49 @@ warp_shader=uv=(uv-0.5)/1.25+0.5+vec2(0.03,-0.02);
     expect(compiled.ir.post.shaderControls.offsetY).toBeCloseTo(-0.02, 6);
   });
 
+  test('maps direct scalar uv shader transforms into compatible controls', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Direct Scalar UV Shader
+warp_shader=uv=uv*2.0+vec2(0.1,-0.2); shader_body=tex2d(sampler_main,uv).rgb;
+      `.trim(),
+      { id: 'direct-scalar-uv-shader' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.shaderText.unsupportedLines).toEqual([]);
+    expect(compiled.ir.compatibility.backends.webgl.status).toBe('supported');
+    expect(compiled.ir.post.shaderControls.zoom).toBeCloseTo(0.5, 6);
+    expect(compiled.ir.post.shaderControls.offsetX).toBeCloseTo(0.6, 6);
+    expect(compiled.ir.post.shaderControls.offsetY).toBeCloseTo(0.3, 6);
+  });
+
+  test('keeps per-axis uv shader transforms on the direct-program path when controls cannot preserve them', () => {
+    const compiled = compileMilkdropPresetSource(
+      `
+title=Direct Per Axis UV Shader
+warp_shader=uv=uv*vec2(1.5,0.75); shader_body=tex2d(sampler_main,uv).rgb;
+      `.trim(),
+      { id: 'direct-per-axis-uv-shader' },
+    );
+
+    expect(compiled.ir.shaderText.supported).toBe(true);
+    expect(compiled.ir.shaderText.unsupportedLines).toEqual([]);
+    expect(compiled.ir.shaderText.warpProgram).not.toBeNull();
+    expect(compiled.ir.shaderText.warpProgram?.source).toContain(
+      'uv=uv*vec2(1.5,0.75)',
+    );
+    expect(
+      compiled.ir.shaderText.warpProgram?.execution.requiresControlFallback,
+    ).toBe(false);
+    expect(compiled.ir.post.shaderControls.zoom).toBeCloseTo(1, 6);
+    expect(compiled.ir.post.shaderControls.offsetX).toBeCloseTo(0, 6);
+    expect(compiled.ir.post.shaderControls.offsetY).toBeCloseTo(0, 6);
+    expect(compiled.ir.compatibility.parity.approximatedShaderLines).toEqual(
+      [],
+    );
+  });
+
   test('supports mix-based shader-body post patterns', () => {
     const compiled = compileMilkdropPresetSource(
       `


### PR DESCRIPTION
### Motivation
- Improve compatibility analysis by extracting direct `uv` transforms so simple UV scale/offsets can be represented by existing shader controls instead of forcing a direct-program fallback. 
- Preserve fidelity: emit an explicit direct-program path when control-model cannot represent a transform (e.g. per-axis scale) while providing evidence that the transform was observed.

### Description
- Exported a `ShaderUvTransformAnalysis` type and `analyzeShaderUvTransform` helper to recognize affine UV patterns and composed transforms, and augmented the analyzer to combine base and scale/offset components. (`assets/js/milkdrop/compiler/shader-analysis-helpers.ts`)
- Added `applyMainUvTransformControls` to convert scalar UV scale+offset into `zoom`/`offsetX`/`offsetY` controls and to preserve expression nodes for control expressions and `shaderEnv` when possible. (`assets/js/milkdrop/compiler/shader-analysis-helpers.ts`)
- Wired UV transform extraction into both the AST analysis and control-application paths so `uv = uv * <scalar> + vec2(...)` style assignments produce meaningful controls before identity-sample passthrough hides them. (`assets/js/milkdrop/compiler/shader-analysis.ts`, `assets/js/milkdrop/compiler/shader-control-application.ts`)
- Extended the `analyzeShaderUvTransform` logic to handle left/right composition, vector vs scalar multipliers, and propagation of existing transform state so composed expressions (including `uv * vec2(...)`) are analyzed correctly; per-axis multipliers remain on the direct-program compatibility path when controls cannot faithfully represent them. (`assets/js/milkdrop/compiler/shader-analysis-helpers.ts`)
- Added tests that cover mapping of direct scalar UV transforms into controls and the behavior for per-axis transforms that must remain on direct-program execution. (`tests/milkdrop-compiler.test.ts`)

### Testing
- Ran the targeted compiler suite with `bun run test tests/milkdrop-compiler.test.ts`, which passed.
- Ran the quick quality gate with `bun run check:quick`, which passed.
- Ran the full quality gate `bun run check` early in the rollout and it failed due to pre-existing fast-suite import/module errors (export `recordRendererOptimizationTelemetry`) unrelated to the shader changes; targeted compiler tests and the quick gate passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51cd5fc15c8332aae4499f40ad8f40)