### PR TITLE
fix: Route fc main shaders through WebGPU compatibility

### DIFF
--- a/assets/js/milkdrop/compiler/ir.ts
+++ b/assets/js/milkdrop/compiler/ir.ts
@@ -552,6 +552,16 @@ export function createMilkdropIr({
     shaderWarpAnalysis,
     shaderCompAnalysis,
   );
+  const warpShaderReferencesFeedbackComposite = /\bsampler_fc_main\b/iu.test(
+    warpShaderText ?? '',
+  );
+  const compShaderReferencesFeedbackComposite = /\bsampler_fc_main\b/iu.test(
+    compShaderText ?? '',
+  );
+  const shaderReferencesFeedbackComposite =
+    warpShaderReferencesFeedbackComposite ||
+    compShaderReferencesFeedbackComposite;
+
   const warpShaderProgram = shaderWarpAnalysis.directProgramRequired
     ? shaderHelpers.buildShaderProgramPayload({
         stage: 'warp',
@@ -562,7 +572,9 @@ export function createMilkdropIr({
           shaderWarpAnalysis.statements.length,
         supportedBackends:
           shaderWarpAnalysis.unsupportedLines.length === 0
-            ? ['webgl', 'webgpu']
+            ? warpShaderReferencesFeedbackComposite
+              ? ['webgl']
+              : ['webgl', 'webgpu']
             : [],
         rawGlsl:
           shaderWarpAnalysis.directProgramStatements.length === 0
@@ -580,7 +592,9 @@ export function createMilkdropIr({
           shaderCompAnalysis.statements.length,
         supportedBackends:
           shaderCompAnalysis.unsupportedLines.length === 0
-            ? ['webgl', 'webgpu']
+            ? compShaderReferencesFeedbackComposite
+              ? ['webgl']
+              : ['webgl', 'webgpu']
             : [],
         rawGlsl:
           shaderCompAnalysis.directProgramStatements.length === 0
@@ -738,16 +752,12 @@ export function createMilkdropIr({
       message,
     );
   });
-  if (
-    /\bsampler_fc_main\b/iu.test(
-      `${warpShaderText ?? ''}\n${compShaderText ?? ''}`,
-    )
-  ) {
+  if (shaderReferencesFeedbackComposite) {
     fieldHelpers.addDiagnostic(
       diagnostics,
       'warning',
       'preset_shader_packed_sampler_backend_gap',
-      'Packed sampler sampler_fc_main maps to the feedback composite texture on WebGL; WebGPU direct shader execution does not expose this intermediate texture and will use the translated compatibility path when required.',
+      'Packed sampler sampler_fc_main maps to the feedback composite texture on WebGL; WebGPU direct shader execution is disabled for this preset and routes through the translated compatibility path for parity.',
     );
   }
   const backends = {

--- a/assets/js/milkdrop/compiler/parity.ts
+++ b/assets/js/milkdrop/compiler/parity.ts
@@ -236,6 +236,24 @@ export function buildBackendSupport({
     );
   });
 
+  if (
+    backend === 'webgpu' &&
+    featureAnalysis.shaderTextExecution.webgpu === 'translated' &&
+    featureAnalysis.shaderTextExecution.webgl === 'direct'
+  ) {
+    evidence.push(
+      createBackendEvidence({
+        backend,
+        scope: 'backend',
+        status: 'partial',
+        code: 'translated-shader-text-gap',
+        message:
+          'WebGPU routes direct shader text through translated compatibility controls while WebGL can execute the direct feedback shader.',
+        feature: 'unsupported-shader-text',
+      }),
+    );
+  }
+
   if (featureAnalysis.shaderTextExecution[backend] === 'unsupported') {
     const unsupportedMessage = backendShaderTextGaps[backend].unsupportedSubset;
     if (unsupportedMessage) {

--- a/assets/js/milkdrop/compiler/shader-analysis.ts
+++ b/assets/js/milkdrop/compiler/shader-analysis.ts
@@ -96,6 +96,9 @@ function extractNativeShaderBody(shaderText: string) {
     .replace(/\bsampler_main\b/giu, 'currentTex')
     .replace(/\bsampler_pc_main\b/giu, 'previousTex')
     .replace(/\bsampler_pw_main\b/giu, 'previousTex')
+    // fc_main is MilkDrop's feedback-composite sampler. WebGL direct
+    // shaders bind it as warpTex; WebGPU direct shaders are routed to the
+    // translated compatibility path before this normalized body is executed.
     .replace(/\bsampler_fc_main\b/giu, 'warpTex')
     .replace(/\bsampler_blur1\b/giu, 'blur1Tex')
     .replace(/\bsampler_blur2\b/giu, 'blur2Tex')

--- a/tests/milkdrop-compiler.test.ts
+++ b/tests/milkdrop-compiler.test.ts
@@ -2205,11 +2205,28 @@ comp_3=ret = texture(sampler_fc_main, packed + noisePacked.xy).xyz;
     expect(compiled.ir.shaderText.compProgram?.source).toContain(
       'sampler_fc_main',
     );
+    expect(
+      compiled.ir.compatibility.featureAnalysis.shaderTextExecution,
+    ).toEqual({
+      webgl: 'direct',
+      webgpu: 'translated',
+    });
+    expect(
+      compiled.ir.compatibility.gpuDescriptorPlans.webgpu.feedback,
+    ).toEqual(
+      expect.objectContaining({
+        shaderExecution: 'controls',
+        targetResolution: 'scene',
+      }),
+    );
+    expect(compiled.ir.compatibility.parity.visualFallbacks).toContain(
+      'webgpu->webgl',
+    );
     expect(compiled.diagnostics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           code: 'preset_shader_packed_sampler_backend_gap',
-          message: expect.stringContaining('sampler_fc_main'),
+          message: expect.stringContaining('translated compatibility path'),
         }),
       ]),
     );

--- a/tests/shader-dependent-presets.test.ts
+++ b/tests/shader-dependent-presets.test.ts
@@ -61,10 +61,16 @@ test('known native shader-text presets compile to direct shader-text programs', 
 
     expect(compiled.ir.shaderText.supported, presetId).toBe(true);
     expect(compiled.ir.shaderText.unsupportedLines, presetId).toEqual([]);
+    const expectsWebGpuTranslation =
+      presetId ===
+      'martin-anandamide-mandelbox-explorer-quantum-timepiece-remix';
     expect(
       compiled.ir.compatibility.featureAnalysis.shaderTextExecution,
       presetId,
-    ).toEqual({ webgl: 'direct', webgpu: 'direct' });
+    ).toEqual({
+      webgl: 'direct',
+      webgpu: expectsWebGpuTranslation ? 'translated' : 'direct',
+    });
     expect(compiled.ir.compatibility.backends.webgl.status, presetId).not.toBe(
       'fallback',
     );


### PR DESCRIPTION
### Motivation
- WebGPU direct shader execution cannot bind MilkDrop's packed feedback composite sampler (`sampler_fc_main`) the same way WebGL does, so presets that reference it must be routed to a WebGPU-compatible path with explicit parity evidence instead of only emitting a warning.

### Description
- Detect direct warp/comp shader programs that reference `sampler_fc_main` and mark their direct program `supportedBackends` as WebGL-only so WebGPU will use the translated/controls path (changes in `assets/js/milkdrop/compiler/ir.ts`).
- Update the packed-sampler diagnostic to state that WebGPU direct execution is disabled and the preset routes through the translated compatibility path for parity (compiler diagnostic text change in `assets/js/milkdrop/compiler/ir.ts`).
- Emit explicit backend-parity evidence when WebGL can run a direct feedback shader but WebGPU is routed to translated controls, adding a `translated-shader-text-gap` partial-evidence entry (changes in `assets/js/milkdrop/compiler/parity.ts`).
- Document the `sampler_fc_main` normalization and comment the WebGPU routing behavior, and update shader-analysis normalization logic (change in `assets/js/milkdrop/compiler/shader-analysis.ts`).
- Update unit tests to assert the new WebGPU routing, descriptor-plan expectations, and parity fallbacks for packed-sampler presets, and adjust known native-shader preset expectations where `sampler_fc_main` requires translation (changes in `tests/milkdrop-compiler.test.ts` and `tests/shader-dependent-presets.test.ts`).

### Testing
- Ran `bun run test tests/milkdrop-compiler.test.ts -- packed` and the packed-sampler compatibility assertions passed.
- Ran `bun run test tests/shader-dependent-presets.test.ts` and adjusted the native presets expectation for the known `sampler_fc_main` case; the test passed after the update.
- Ran targeted runtime tests `bun run test tests/milkdrop-input-signals.test.ts tests/milkdrop-runtime.test.ts` and they passed when executed directly.
- Ran `bun run check:quick` (fast syntax/format/type checks) and formatting/type checks completed; a full `bun run check` run exercised the fast test profile which reported two intermittent/unhandled Bun module export errors in the test harness (those specific tests pass when run directly), so the change set itself is covered by the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51cd5cf1108332b9e7e7102314e21b)