### PR TITLE
fix: Preserve file audio route state

### DIFF
--- a/assets/js/frontend/url-state.ts
+++ b/assets/js/frontend/url-state.ts
@@ -11,6 +11,7 @@ const VALID_PANELS = new Set<Exclude<PanelState, null>>([
 ]);
 const VALID_AUDIO_SOURCES = new Set<AudioSource>([
   'demo',
+  'file',
   'microphone',
   'tab',
   'youtube',

--- a/tests/frontend-url-state.test.ts
+++ b/tests/frontend-url-state.test.ts
@@ -51,6 +51,43 @@ describe('frontend url state', () => {
     expect(state.audioSource).toBe('youtube');
   });
 
+  test('preserves file audio route state in canonical session urls', () => {
+    const state = readSessionRouteState('?audio=file');
+
+    expect(state.audioSource).toBe('file');
+
+    const search = stringifyPlainSearch(
+      buildSessionRouteSearch(
+        {
+          presetId: null,
+          collectionTag: null,
+          panel: null,
+          audioSource: 'file',
+          agentMode: false,
+          previewMode: false,
+        },
+        parsePlainSearch('?landing=1&audio=demo'),
+      ),
+    );
+
+    expect(search).toBe('?landing=1&audio=file');
+
+    const url = buildCanonicalUrl(
+      {
+        presetId: null,
+        collectionTag: null,
+        panel: null,
+        audioSource: 'file',
+        agentMode: false,
+        previewMode: false,
+      },
+      'https://toil.fyi/milkdrop/?landing=1&audio=demo',
+    );
+
+    expect(url.pathname).toBe('/');
+    expect(url.search).toBe('?landing=1&audio=file');
+  });
+
   test('preserves unrelated query params while writing canonical urls', () => {
     const url = buildCanonicalUrl(
       {


### PR DESCRIPTION
### Motivation
- The `AudioSource` union in `assets/js/frontend/contracts.ts` includes `'file'` but the URL route validation omitted it, causing route-state parsing and canonicalization to drop or ignore `audio=file`.
- Ensure frontend URL state handling and canonical URL builders accept and preserve `file` audio routes so the route behavior matches the typed contract.

### Description
- Add `'file'` to `VALID_AUDIO_SOURCES` in `assets/js/frontend/url-state.ts` so `normalizeAudioSource` recognizes file audio routes.
- Add a route-state test in `tests/frontend-url-state.test.ts` that asserts `readSessionRouteState('?audio=file')` returns `audioSource: 'file'` and that `buildSessionRouteSearch` and `buildCanonicalUrl` preserve `audio=file` when writing canonical URLs.

### Testing
- Ran the unit file: `bun run test tests/frontend-url-state.test.ts`, which passed all assertions for the new and existing tests.
- Ran the quick quality gate: `bun run check:quick`, which completed successfully.
- Ran the full quality gate: `bun run check`, which completed successfully without type or lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51d2ae7f78833289450b146f316ae4)