### PR TITLE
fix: Gate WebGPU feedback fallback parity

### DIFF
--- a/assets/js/milkdrop/compiler/gpu-descriptor-plan.ts
+++ b/assets/js/milkdrop/compiler/gpu-descriptor-plan.ts
@@ -177,12 +177,14 @@ export function buildWebGpuDescriptorPlan({
       : featureAnalysis.shaderTextExecution.webgpu === 'none'
         ? 'none'
         : 'controls';
-  const feedback: MilkdropFeedbackPostEffectDescriptorPlan | null =
+  const feedbackNeedsCompatibilityFallback =
     post.videoEchoEnabled ||
     post.feedbackTexture ||
     feedbackUsesShaderPrograms ||
     feedbackUsesShaderTextures ||
-    feedbackUsesPostEffects
+    feedbackUsesPostEffects;
+  const feedback: MilkdropFeedbackPostEffectDescriptorPlan | null =
+    feedbackNeedsCompatibilityFallback
       ? {
           kind: 'feedback-post-effect',
           shaderExecution,
@@ -197,20 +199,17 @@ export function buildWebGpuDescriptorPlan({
             feedbackUsesPostEffects
               ? 'scene'
               : 'adaptive',
-          fallbackToLegacyFeedback: webgpu.evidence.some(
-            (entry) =>
-              entry.code === 'video-echo-gap' ||
-              entry.code === 'post-effects-gap',
-          ),
+          fallbackToLegacyFeedback: feedbackNeedsCompatibilityFallback,
         }
       : null;
 
   return {
-    routing:
-      proceduralWaves.length > 0 ||
-      proceduralMesh ||
-      proceduralMotionVectors ||
-      feedback
+    routing: feedbackNeedsCompatibilityFallback
+      ? 'fallback-webgl'
+      : proceduralWaves.length > 0 ||
+          proceduralMesh ||
+          proceduralMotionVectors ||
+          feedback
         ? 'descriptor-plan'
         : 'generic-frame-payload',
     proceduralWaves,

--- a/assets/js/milkdrop/renderer-adapter-core.ts
+++ b/assets/js/milkdrop/renderer-adapter-core.ts
@@ -915,6 +915,8 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       directFeedbackShaders: this.webgpuOptimizationFlags.directFeedbackShaders,
       webgpuFeedbackPlanShaderExecution:
         this.webgpuDescriptorPlan?.feedback?.shaderExecution,
+      webgpuFeedbackPlanFallback:
+        this.webgpuDescriptorPlan?.feedback?.fallbackToLegacyFeedback ?? false,
       getShaderTextureSourceId,
       getShaderTextureBlendModeId,
       getShaderSampleDimensionId,

--- a/assets/js/milkdrop/renderer-helpers/feedback-composite.ts
+++ b/assets/js/milkdrop/renderer-helpers/feedback-composite.ts
@@ -8,6 +8,7 @@ export function buildFeedbackCompositeState({
   backend,
   directFeedbackShaders,
   webgpuFeedbackPlanShaderExecution,
+  webgpuFeedbackPlanFallback = false,
   getShaderTextureSourceId,
   getShaderTextureBlendModeId,
   getShaderSampleDimensionId,
@@ -16,6 +17,7 @@ export function buildFeedbackCompositeState({
   backend: 'webgl' | 'webgpu';
   directFeedbackShaders: boolean;
   webgpuFeedbackPlanShaderExecution: 'direct' | 'controls' | 'none' | undefined;
+  webgpuFeedbackPlanFallback?: boolean;
   getShaderTextureSourceId: (source: string) => number;
   getShaderTextureBlendModeId: (mode: string) => number;
   getShaderSampleDimensionId: (dimension: '2d' | '3d') => number;
@@ -23,9 +25,18 @@ export function buildFeedbackCompositeState({
   const controls = frameState.post.shaderControls;
   const feedbackOptimizationEnabled =
     backend !== 'webgpu' || directFeedbackShaders;
+  const plannedShaderExecution =
+    backend === 'webgpu'
+      ? feedbackOptimizationEnabled && !webgpuFeedbackPlanFallback
+        ? (webgpuFeedbackPlanShaderExecution ?? 'controls')
+        : 'controls'
+      : null;
+  const allowDirectShaderPrograms =
+    backend !== 'webgpu' || plannedShaderExecution === 'direct';
   const shaderPrograms = {
     warp:
       feedbackOptimizationEnabled &&
+      allowDirectShaderPrograms &&
       frameState.post.shaderPrograms.warp?.execution.supportedBackends.includes(
         backend,
       )
@@ -33,18 +44,13 @@ export function buildFeedbackCompositeState({
         : null,
     comp:
       feedbackOptimizationEnabled &&
+      allowDirectShaderPrograms &&
       frameState.post.shaderPrograms.comp?.execution.supportedBackends.includes(
         backend,
       )
         ? frameState.post.shaderPrograms.comp
         : null,
   };
-  const plannedShaderExecution =
-    backend === 'webgpu'
-      ? feedbackOptimizationEnabled
-        ? webgpuFeedbackPlanShaderExecution
-        : 'controls'
-      : null;
   const usesDirectShaderPrograms =
     plannedShaderExecution === 'direct'
       ? true

--- a/tests/milkdrop-parity.test.ts
+++ b/tests/milkdrop-parity.test.ts
@@ -321,7 +321,12 @@ describe('milkdrop parity corpus harness', () => {
         );
         expect(
           compiled.ir.compatibility.gpuDescriptorPlans.webgpu.routing,
-        ).toBe('descriptor-plan');
+        ).toBe(
+          compiled.ir.compatibility.gpuDescriptorPlans.webgpu.feedback
+            ?.fallbackToLegacyFeedback
+            ? 'fallback-webgl'
+            : 'descriptor-plan',
+        );
         expect(compiled.ir.compatibility.parity.backendDivergence).toEqual(
           expect.arrayContaining(expected.divergence),
         );
@@ -411,12 +416,12 @@ test('keeps former shader-gap parity fixtures out of the allowlist when only vid
   expect(compiled.ir.compatibility.parity.blockingConstructDetails).toEqual([]);
   expect(compiled.ir.compatibility.gpuDescriptorPlans.webgpu).toEqual(
     expect.objectContaining({
-      routing: 'descriptor-plan',
+      routing: 'fallback-webgl',
       feedback: expect.objectContaining({
         kind: 'feedback-post-effect',
         shaderExecution: 'direct',
         usesVideoEcho: true,
-        fallbackToLegacyFeedback: false,
+        fallbackToLegacyFeedback: true,
       }),
       unsupported: [],
     }),

--- a/tests/milkdrop-renderer-adapter.test.ts
+++ b/tests/milkdrop-renderer-adapter.test.ts
@@ -1948,11 +1948,11 @@ comp_shader=ret = tex2d(sampler_main, uv).rgb * 1.2;
       }),
     ).toBe(true);
 
-    expect(compositeStates[0]?.shaderExecution).toBe('direct');
-    expect(compositeStates[0]?.shaderPrograms.comp).not.toBeNull();
+    expect(compositeStates[0]?.shaderExecution).toBe('controls');
+    expect(compositeStates[0]?.shaderPrograms.comp).toBeNull();
   });
 
-  test('forwards direct shader programs into the webgpu feedback composite state', async () => {
+  test('keeps direct shader programs off the webgpu feedback composite state without proven fallback parity', async () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Direct Shader Program Feedback
@@ -1998,20 +1998,11 @@ comp_shader=mix = 0.35; ret = tex2d(sampler_main, uv).rgb + vec3(mix, 0.0, 0.0)
       }),
     ).toBe(true);
 
-    expect(compositeStates[0]?.shaderExecution).toBe('direct');
-    expect(compositeStates[0]?.shaderPrograms.comp).toEqual(
-      expect.objectContaining({
-        source: 'ret = tex2d(sampler_main, uv).rgb + vec3(mix, 0.0, 0.0)',
-        execution: expect.objectContaining({
-          kind: 'direct-feedback-program',
-          stage: 'comp',
-          requiresControlFallback: true,
-        }),
-      }),
-    );
+    expect(compositeStates[0]?.shaderExecution).toBe('controls');
+    expect(compositeStates[0]?.shaderPrograms.comp).toBeNull();
   });
 
-  test('forwards direct warp shader_body programs into the webgpu feedback composite state', async () => {
+  test('keeps direct warp shader_body programs off the webgpu feedback composite state without proven fallback parity', async () => {
     const preset = compileMilkdropPresetSource(
       `
 title=Direct Warp Shader Body Feedback
@@ -2057,15 +2048,31 @@ warp_shader=shader_body=uv + vec2(time * 0.02, 0.0)
       }),
     ).toBe(true);
 
-    expect(compositeStates[0]?.shaderExecution).toBe('direct');
-    expect(compositeStates[0]?.shaderPrograms.warp).toEqual(
+    expect(compositeStates[0]?.shaderExecution).toBe('controls');
+    expect(compositeStates[0]?.shaderPrograms.warp).toBeNull();
+  });
+
+  test('marks feedback-heavy WebGPU descriptor plans for WebGL compatibility fallback', () => {
+    const preset = compileMilkdropPresetSource(
+      `
+title=Feedback Heavy WebGPU Fallback
+fShader=1
+video_echo=1
+feedback_texture=1
+comp_shader=ret = tex2d(sampler_main, uv).rgb * 1.1
+      `.trim(),
+      { id: 'feedback-heavy-webgpu-fallback' },
+    );
+
+    expect(preset.ir.compatibility.gpuDescriptorPlans.webgpu).toEqual(
       expect.objectContaining({
-        source: 'shader_body=uv + vec2(time * 0.02, 0.0)',
-        execution: expect.objectContaining({
-          kind: 'direct-feedback-program',
-          stage: 'warp',
-          entryTarget: 'uv',
-          supportedBackends: expect.arrayContaining(['webgpu']),
+        routing: 'fallback-webgl',
+        feedback: expect.objectContaining({
+          kind: 'feedback-post-effect',
+          shaderExecution: 'direct',
+          usesFeedbackTexture: true,
+          usesVideoEcho: true,
+          fallbackToLegacyFeedback: true,
         }),
       }),
     );

--- a/tests/milkdrop-runtime-seams.test.ts
+++ b/tests/milkdrop-runtime-seams.test.ts
@@ -332,7 +332,7 @@ describe('milkdrop runtime lifecycle seams', () => {
 });
 
 describe('milkdrop backend failover seams', () => {
-  test('keeps orientation-only echo and custom-shape presets on webgpu when descriptor planning stays native', () => {
+  test('falls back orientation-only echo presets while keeping native custom-shape descriptor plans', () => {
     const videoEchoPreset = compileMilkdropPresetSource(
       `
 title=Video Echo Orientation Gap
@@ -364,7 +364,7 @@ warp=0.08
         activeBackend: 'webgpu',
         webgpuOptimizationFlags: DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldPresetFallbackToWebgl({
         compiled: customShapePreset,


### PR DESCRIPTION
### Motivation

- Ensure WebGPU does not opt into direct/additive feedback shader paths for presets where feedback/video-echo output is known to diverge from the WebGL compatibility baseline. 
- Keep feedback-heavy presets on the safer WebGL compatibility path (or clearly mark them as legacy/fallback) until pass ordering and feedback effects parity are proven. 

### Description

- Determine `feedbackNeedsCompatibilityFallback` in `buildWebGpuDescriptorPlan` when any of video echo, feedback texture, shader programs/textures, or post effects are in use, and mark `feedback.fallbackToLegacyFeedback` accordingly. 
- Route descriptor plans to `fallback-webgl` when `feedbackNeedsCompatibilityFallback` is true instead of optimistically selecting the WebGPU descriptor plan. 
- Add a `webgpuFeedbackPlanFallback` flag to `buildFeedbackCompositeState` and make the composite builder refuse to expose direct shader programs on WebGPU when the descriptor plan is marked for legacy fallback. 
- Propagate the `fallbackToLegacyFeedback` signal from the renderer adapter into the feedback composite construction and update tests to assert the safer behavior and explicit fallback marking for feedback-heavy presets. 

### Testing

- Ran `bun run test tests/milkdrop-renderer-adapter.test.ts` and the related adapter feedback expectations passed (no failures). 
- Ran `bun run test tests/milkdrop-runtime-seams.test.ts` and the updated failover semantics passed. 
- Ran `bun run check:quick` (format/biome/quick checks) and `bun run check` (full quality gate including typecheck and fast test suite) and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52526153948332b0181f56759871cc)