### PR TITLE
fix(ui): correct preset mood labels and style legacy stage overlay controls

### DIFF
--- a/assets/css/app-shell.css
+++ b/assets/css/app-shell.css
@@ -1321,6 +1321,72 @@ body[data-page="workspace"][data-live="true"] {
     min-width: 80px;
   }
 
+  /*
+   * The compact overlay's transport buttons, autoplay checkbox, and blend
+   * slider only ever received their fill/border styling on the standalone
+   * /milkdrop page (now a redirect to the workspace). Inside the shell they
+   * fell back to native UA controls (grey `outset` buttons, default checkbox
+   * and slider). Give them shell-consistent styling so the legacy controls
+   * match the rest of the live chrome.
+   */
+  .stims-shell__stage-frame[data-mode="live"] .milkdrop-overlay--compact
+    .milkdrop-overlay__toolbar
+    button {
+    min-height: 36px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    border: 1px solid
+      var(--milkdrop-overlay-button-border, rgba(119, 201, 255, 0.4));
+    background: var(--milkdrop-overlay-button, rgba(108, 176, 255, 0.22));
+    color: rgba(231, 242, 255, 0.92);
+    font: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background 0.18s ease,
+      border-color 0.18s ease;
+  }
+
+  .stims-shell__stage-frame[data-mode="live"]
+    .milkdrop-overlay--compact
+    .milkdrop-overlay__toolbar
+    button:hover {
+    background: rgba(119, 201, 255, 0.32);
+    border-color: rgba(119, 201, 255, 0.6);
+  }
+
+  .stims-shell__stage-frame[data-mode="live"]
+    .milkdrop-overlay--compact
+    .milkdrop-overlay__toolbar
+    button:focus-visible {
+    outline: 2px solid rgba(119, 201, 255, 0.7);
+    outline-offset: 2px;
+  }
+
+  .stims-shell__stage-frame[data-mode="live"]
+    .milkdrop-overlay--compact
+    .milkdrop-overlay__toolbar-group
+    > label {
+    color: rgba(231, 242, 255, 0.86);
+    font-size: 0.85rem;
+  }
+
+  .stims-shell__stage-frame[data-mode="live"]
+    .milkdrop-overlay--compact
+    input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: rgba(119, 201, 255, 0.9);
+    cursor: pointer;
+  }
+
+  .stims-shell__stage-frame[data-mode="live"]
+    .milkdrop-overlay--compact
+    input[type="range"] {
+    accent-color: rgba(119, 201, 255, 0.9);
+    cursor: pointer;
+  }
+
   .stims-shell__stage-dock-wrap[data-visible="false"] {
     opacity: 0;
     visibility: hidden;

--- a/assets/js/frontend/workspace-helpers.ts
+++ b/assets/js/frontend/workspace-helpers.ts
@@ -219,17 +219,23 @@ export function describePresetMood(entry: PresetCatalogEntry) {
   const index = buildPresetSearchIndex(entry);
   let mood: string;
 
-  if (/(glow|sun|flare|star|light|bloom)/u.test(index)) {
+  // Anchor keywords to a word boundary so a descriptive term is only matched
+  // as its own word — not as a substring buried inside an author name. Without
+  // this, "star" inside the prolific author "Rovastar" (and "light" inside
+  // "skylight", etc.) forced ~170 presets into "Bright pulse", making the browse
+  // list read as one repeated label. Compound titles that begin with a keyword
+  // ("Glowsticks", "Cubetrace") still match because the keyword starts the word.
+  if (/\b(?:glow|sun|flare|star|light|bloom)/u.test(index)) {
     mood = 'Bright pulse';
-  } else if (/(cube|matrix|square|line|grid|trace)/u.test(index)) {
+  } else if (/\b(?:cube|matrix|square|line|grid|trace)/u.test(index)) {
     mood = 'Sharp geometry';
   } else if (
-    /(quasar|ether|parallel|space|mars|radiation|vacuum)/u.test(index)
+    /\b(?:quasar|ether|parallel|space|mars|radiation|vacuum)/u.test(index)
   ) {
     mood = 'Space drift';
-  } else if (/(dark|ritual|apocalypse|demon|moon)/u.test(index)) {
+  } else if (/\b(?:dark|ritual|apocalypse|demon|moon)/u.test(index)) {
     mood = 'Moody sweep';
-  } else if (/(trippy|psychaos|rotation|spectro|glassworms)/u.test(index)) {
+  } else if (/\b(?:trippy|psychaos|rotation|spectro|glassworms)/u.test(index)) {
     mood = 'Psychedelic spin';
   } else if (entry.tags?.includes('collection:classic-milkdrop')) {
     mood = 'Classic rush';

--- a/tests/split-view-browse.test.ts
+++ b/tests/split-view-browse.test.ts
@@ -56,6 +56,30 @@ describe('describePresetMood', () => {
       describePresetMood(makePreset({ id: '5', title: 'Generic Preset' })),
     ).toBe('Instant pick');
   });
+
+  test('does not match keywords buried inside an author name', () => {
+    // "star" lives inside the prolific author "Rovastar"; the mood should come
+    // from the descriptive title ("Parallel" -> Space drift), not the author.
+    expect(
+      describePresetMood(
+        makePreset({
+          id: 'rovastar-parallel-universe',
+          title: 'Rovastar - Parallel Universe',
+          author: 'Rovastar',
+        }),
+      ),
+    ).toBe('Space drift');
+    // A real standalone "Star" word still classifies as Bright pulse.
+    expect(
+      describePresetMood(
+        makePreset({
+          id: 'rovastar-star-of-destiny',
+          title: 'Rovastar - Star Of Destiny',
+          author: 'Rovastar',
+        }),
+      ),
+    ).toBe('Bright pulse');
+  });
 });
 
 describe('getPresetCardSupportLabel', () => {


### PR DESCRIPTION
## Summary

Two UI defects found and fixed during a browser QA pass:

1. **Preset "mood" labels mislabeled across the catalog.** `describePresetMood` matched keywords as bare substrings against an index that includes the author name/id, so `star` matched inside the prolific author "Rovastar" (and `light` inside `skylight`, etc.), forcing ~170 presets into "Bright pulse" — the browse list read as one repeated label. Keywords are now anchored to a word boundary (`/\b(?:…)/`); compound titles that start with a keyword ("Glowsticks", "Cubetrace") still match.

2. **Legacy stage overlay controls rendered as raw native widgets.** The live stage's compact overlay (Prev/Next, Autoplay, Blend mode/time) only received fill/border styling from the old standalone `/milkdrop` page, which now redirects to the workspace, so the controls fell back to default browser UA styling in the shell. Added shell-consistent styling for the transport buttons, autoplay checkbox, and blend slider using the existing `--milkdrop-overlay-button` design tokens.

## Testing

- `bun run check` — Biome + typecheck + architecture + SEO + full test suite: **1100 pass, 0 fail**.
- `bun run check:quick` — passes.
- Verified both fixes live in the browser via Vite HMR: "Rovastar - Parallel Universe" changed from `BRIGHT PULSE` to `SPACE DRIFT`, and the overlay transport buttons/checkbox/slider render themed instead of native. Added a regression test in `tests/split-view-browse.test.ts` for the author-substring case.

## Docs touched

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)