### PR TITLE
test(e2e): assert microphone constraints disable voice DSP

### DIFF
--- a/tests/e2e-engine-mount.test.ts
+++ b/tests/e2e-engine-mount.test.ts
@@ -247,7 +247,21 @@ test(
       });
 
       expect(info.calls).toBe(1);
-      expect(info.constraints).toEqual({ audio: true });
+
+      // The visualizer reacts to the raw spectrum, so the browser's voice DSP
+      // has to stay off — AGC, echo cancellation and noise suppression all
+      // reshape the signal the shaders read from. Mirrors
+      // DEFAULT_MICROPHONE_CONSTRAINTS in assets/js/core/audio-handler.ts.
+      const audioConstraints = info.constraints?.audio as
+        | MediaTrackConstraints
+        | undefined;
+      expect(audioConstraints).toBeTypeOf('object');
+      expect(audioConstraints).toMatchObject({
+        echoCancellation: { ideal: false },
+        noiseSuppression: { ideal: false },
+        autoGainControl: { ideal: false },
+      });
+
       expect(info.route).toContain('audio=microphone');
     } finally {
       await ctx.close();


### PR DESCRIPTION
## Summary

Companion to #1078. The engine-mount e2e still asserted the microphone stream was requested with a bare `{ audio: true }` — precisely the behaviour #1078 fixed — so `main` briefly carried a test contradicting its own source.

Asserts the shared constraints (`echoCancellation`, `noiseSuppression`, `autoGainControl` all `{ ideal: false }`) instead, matching `DEFAULT_MICROPHONE_CONSTRAINTS`.

`tests/e2e-engine-mount.test.ts` is in `SLOW_TESTS` in `scripts/run-tests.ts`, so it is excluded from the `fast` profile CI runs. The stale assertion would only have surfaced under the `all` or `unit` profiles, which is why #1078 went green.

## Testing

`bun run test tests/e2e-engine-mount.test.ts` passes locally (3 pass, 0 fail, 13.12s). This drives a real Chromium via the Playwright-backed harness, so it is genuine end-to-end confirmation that the constraints reach `getUserMedia` — the strongest verification any of this mobile audio work has had, since the jsdom suites cannot exercise the audio pipeline at all.

## Docs touched

None — test-only change, no behaviour or documented interface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)