### PR TITLE
fix(ci): unblock the e2e suite and guard the failure modes that kept shipping

### DIFF
--- a/.agent/skills/guard-agent-work/SKILL.md
+++ b/.agent/skills/guard-agent-work/SKILL.md
@@ -46,7 +46,7 @@ If you think you need it, you are wrong. Fix the type error or ask for help.
 
 ### 2. Never import across the engine boundary
 
-`assets/js/frontend/*` must not import from `assets/js/milkdrop/runtime.ts`, `vm.ts`, or `compiler/*`. Only `milkdrop-engine-adapter.ts` is allowed.
+`src/js/frontend/*` must not import from `src/js/milkdrop/runtime.ts`, `vm.ts`, or `compiler/*`. Only `milkdrop-engine-adapter.ts` is allowed.
 
 ### 3. Never leave `console.log` in production code
 

--- a/.agent/skills/iterate-visualizer-ui/SKILL.md
+++ b/.agent/skills/iterate-visualizer-ui/SKILL.md
@@ -23,7 +23,7 @@ bun run dev:ui
 ```
 
 This launches a secondary Vite server at `http://localhost:5174/` with:
-- HMR for `assets/js/frontend/*` and `assets/css/*`
+- HMR for `src/js/frontend/*` and `assets/css/*`
 - Component isolation harness
 - Responsive preview grid
 
@@ -42,7 +42,7 @@ http://localhost:5174/?component=WorkspaceLaunchPanel
 
 ### 3. Edit and observe
 
-1. Open a component file (e.g., `assets/js/frontend/workspace-ui.tsx`)
+1. Open a component file (e.g., `src/js/frontend/workspace-ui.tsx`)
 2. Save → dashboard auto-refreshes the isolated component
 3. Add `&grid=375,768,1024,1920` to see responsive behavior across breakpoints
 
@@ -56,7 +56,7 @@ The harness exposes mock wrappers for these components:
 - `WorkspaceToolSheet` — browse/settings sheet panel
 - `WorkspaceToast` — toast notifications
 
-Add more by editing `assets/js/frontend/ui-harness.tsx` and updating `COMPONENT_REGISTRY`.
+Add more by editing `src/js/frontend/ui-harness.tsx` and updating `COMPONENT_REGISTRY`.
 
 ### Mock data
 
@@ -94,7 +94,7 @@ Open `http://localhost:5173/?agent=true` and verify the same component in contex
 
 1. `bun run dev:ui`
 2. Open `http://localhost:5174/?component=WorkspaceLaunchPanel&grid=375,768,1024,1920`
-3. Edit `assets/js/frontend/workspace-ui.tsx`
+3. Edit `src/js/frontend/workspace-ui.tsx`
 4. See all breakpoints update simultaneously via HMR
 5. Switch to `bun run dev` to verify in the full app
 
@@ -102,7 +102,7 @@ Open `http://localhost:5173/?agent=true` and verify the same component in contex
 
 1. `bun run dev:ui`
 2. Open `http://localhost:5174/?component=WorkspaceStagePanel&grid=375,768`
-3. Edit `assets/js/frontend/workspace-ui.tsx` and `assets/css/app-shell.css`
+3. Edit `src/js/frontend/workspace-ui.tsx` and `assets/css/app-shell.css`
 4. See mobile vs desktop behavior side by side
 5. Commit with confidence
 

--- a/.agent/skills/modify-visualizer-runtime/SKILL.md
+++ b/.agent/skills/modify-visualizer-runtime/SKILL.md
@@ -16,7 +16,7 @@ Use this skill when the request changes how the main visualizer product behaves,
 
 ## Focus areas
 
-- shared runtime and lifecycle under `assets/js/core/`
+- shared runtime and lifecycle under `src/js/core/`
 - loader, route, and launch behavior around the canonical workspace entry
 - renderer selection, performance controls, and capability/preflight flows
 - audio startup, shell controls, and app-level interaction behavior

--- a/.agent/skills/review-module-loading/SKILL.md
+++ b/.agent/skills/review-module-loading/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-module-loading
-description: "Review changes to module loading, bootstrap, toy manifest, library resolution, or gamepad polling. Use when a PR touches assets/js/bootstrap/, assets/js/loader.ts, assets/js/router.ts, assets/js/toy-view.ts, assets/data/toys.json, or gamepad polling code."
+description: "Review changes to module loading, bootstrap, toy manifest, library resolution, or gamepad polling. Use when a PR touches src/js/bootstrap/, src/js/loader.ts, src/js/router.ts, src/js/toy-view.ts, src/data/toys.json, or gamepad polling code."
 ---
 
 # Review Module Loading and Bootstrap
 
-Use this skill when reviewing or authoring changes to `assets/js/bootstrap/*`, `assets/js/loader.ts`, `assets/js/library-view.js`, `assets/js/toy-view.ts`, `assets/js/milkdrop/catalog-store*.ts`, `assets/data/toys.json`, `index.html`, or gamepad polling code.
+Use this skill when reviewing or authoring changes to `src/js/bootstrap/*`, `src/js/loader.ts`, `src/js/library-view.js`, `src/js/toy-view.ts`, `src/js/milkdrop/catalog-store*.ts`, `src/data/toys.json`, `index.html`, or gamepad polling code.
 
 ## Why this exists
 
@@ -32,7 +32,7 @@ Use this skill when reviewing or authoring changes to `assets/js/bootstrap/*`, `
 
 ### 4. Library/manifest consistency
 
-- [ ] If changing `assets/data/toys.json`, the in-memory manifest matches the file
+- [ ] If changing `src/data/toys.json`, the in-memory manifest matches the file
 - [ ] Library resolution does not depend on file-system paths that differ between dev and production
 
 ### 5. Index.html entry points

--- a/.agent/skills/review-renderer-fallback/SKILL.md
+++ b/.agent/skills/review-renderer-fallback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-renderer-fallback
-description: "Review changes to renderer capability probing, fallback chains, timeout logic, or audio worklet initialization. Use when a PR touches assets/js/core/renderer-*, assets/js/core/audio-handler.ts, or assets/js/milkdrop/runtime/backend-fallback.ts."
+description: "Review changes to renderer capability probing, fallback chains, timeout logic, or audio worklet initialization. Use when a PR touches src/js/core/renderer-*, src/js/core/audio-handler.ts, or src/js/milkdrop/runtime/backend-fallback.ts."
 ---
 
 # Review Renderer Fallback and Capability Lifecycle

--- a/.agent/skills/review-webgpu-parity/SKILL.md
+++ b/.agent/skills/review-webgpu-parity/SKILL.md
@@ -5,7 +5,7 @@ description: "Review changes to WebGPU/WebGL dual-backend parity. Use when a PR 
 
 # Review WebGPU/WebGL Parity
 
-Use this skill when reviewing or authoring changes to `assets/js/milkdrop/feedback-manager-*`, `assets/js/milkdrop/renderer-adapter*`, `assets/js/milkdrop/backend-behavior.ts`, `assets/js/milkdrop/compiler/gpu-descriptor-plan.ts`, or any shader-lowering code.
+Use this skill when reviewing or authoring changes to `src/js/milkdrop/feedback-manager-*`, `src/js/milkdrop/renderer-adapter*`, `src/js/milkdrop/backend-behavior.ts`, `src/js/milkdrop/compiler/gpu-descriptor-plan.ts`, or any shader-lowering code.
 
 ## Why this exists
 

--- a/.agent/skills/review-workspace-ui-state/SKILL.md
+++ b/.agent/skills/review-workspace-ui-state/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-workspace-ui-state
-description: "Review changes to React workspace UI state, URL routing, toast/panel behavior, or engine adapter interactions. Use when a PR touches assets/js/frontend/*, especially App.tsx, workspace hooks, or url-state.ts."
+description: "Review changes to React workspace UI state, URL routing, toast/panel behavior, or engine adapter interactions. Use when a PR touches src/js/frontend/*, especially App.tsx, workspace hooks, or url-state.ts."
 ---
 
 # Review Workspace UI State and Engine Adapter Boundary
 
-Use this skill when reviewing or authoring changes to the React workspace shell, URL state, tool toggles, toast notifications, or any code that bridges `assets/js/frontend/` and `assets/js/milkdrop/`.
+Use this skill when reviewing or authoring changes to the React workspace shell, URL state, tool toggles, toast notifications, or any code that bridges `src/js/frontend/` and `src/js/milkdrop/`.
 
 ## Why this exists
 
@@ -15,7 +15,7 @@ Use this skill when reviewing or authoring changes to the React workspace shell,
 
 ### 1. All engine interaction goes through the adapter
 
-- [ ] `App.tsx` and workspace hooks do not import deep `assets/js/milkdrop/*` internals directly.
+- [ ] `App.tsx` and workspace hooks do not import deep `src/js/milkdrop/*` internals directly.
 - [ ] State exchange uses typed events or the adapter's public API, not imperative runtime calls.
 
 ### 2. URL state is canonicalized, not patched
@@ -48,7 +48,7 @@ Use this skill when reviewing or authoring changes to the React workspace shell,
 
 ## What to reject in review
 
-- Direct imports from `assets/js/milkdrop/runtime.ts` or `assets/js/milkdrop/vm.ts` into frontend components
+- Direct imports from `src/js/milkdrop/runtime.ts` or `src/js/milkdrop/vm.ts` into frontend components
 - URL state updates that append rather than replace query params
 - Toast or panel logic that reads `window.milkdropRuntime` or similar global
 - Missing cleanup for `useEffect` subscriptions that touch engine lifecycle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 /.github/ @zz-plant
 
 # Toy implementation and metadata
-/assets/js/toys/ @zz-plant
-/assets/data/toys.json @zz-plant
+/src/js/toys/ @zz-plant
+/src/data/toys.json @zz-plant
 /toys/ @zz-plant
 
 # Tests

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ bun run check
 
 - **Commit messages**: Sentence case, no trailing period (e.g., "Add audio frequency detection")
 - **PR title**: Same style, include test/docs summary in description
-- **Imports**: Relative paths within `assets/js/`, absolute paths for sibling packages
+- **Imports**: Relative paths within `src/js/`, absolute paths for sibling packages
 - **No `@ts-nocheck`**: All code must pass strict typecheck
 - **Tests**: Match your code file path (e.g., `foo.ts` → `tests/foo.test.ts`)
 
@@ -51,10 +51,10 @@ bun run check
 
 | Path | Purpose |
 |------|---------|
-| `assets/js/core/` | Shared runtime (loader, shell, renderer, audio) |
-| `assets/js/milkdrop/` | Preset engine (runner, editor, compiler, VM) |
-| `assets/js/bootstrap/` | Page wiring (home, library, visualizer) |
-| `assets/data/toys.json` | Preset manifest |
+| `src/js/core/` | Shared runtime (loader, shell, renderer, audio) |
+| `src/js/milkdrop/` | Preset engine (runner, editor, compiler, VM) |
+| `src/js/bootstrap/` | Page wiring (home, library, visualizer) |
+| `src/data/toys.json` | Preset manifest |
 | `tests/` | Test suite (unit + integration) |
 | `docs/agents/` | Agent guidance (task routing, tools, verification) |
 | `.agent/skills/` | Reusable agent workflows |

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,9 +12,25 @@ github:
 toys:
   - changed-files:
       - any-glob-to-any-file:
-          - 'assets/js/toys/**'
-          - 'assets/data/toys.json'
-          - 'toys/**'
+          - 'src/js/toys/**'
+          - 'src/data/toys.json'
+          - 'public/toys.json'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/js/frontend/**'
+
+renderer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/js/milkdrop/**'
+          - 'src/shaders/**'
+
+styles:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/css/**'
 
 tests:
   - changed-files:

--- a/.github/prompts/update-test.prompt.md
+++ b/.github/prompts/update-test.prompt.md
@@ -13,7 +13,7 @@ You're adding or fixing tests. Follow this flow.
 - [ ] Find a similar existing test as a template
 
 ```bash
-# For code in assets/js/milkdrop/foo.ts
+# For code in src/js/milkdrop/foo.ts
 # Look for: tests/milkdrop/foo.test.ts
 
 # List tests by type
@@ -40,7 +40,7 @@ bun run test:integration  # Browser-based (slower)
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { functionUnderTest } from "../assets/js/path/to/code";
+import { functionUnderTest } from "../src/js/path/to/code";
 
 describe("functionUnderTest", () => {
   it("should do the right thing", () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,13 +4,13 @@ This document describes the current shipped frontend architecture for Stims afte
 
 ## Current shape
 
-- `index.html` is the single app shell and bootstraps `assets/js/app.ts`.
-- `assets/js/app.ts` mounts the React workspace and global runtime affordances.
-- `assets/js/frontend/*` owns route state, workspace UI, and the engine adapter seam.
-- `assets/js/milkdrop/*` remains the imperative visualizer engine, overlay, compiler, and catalog runtime.
+- `index.html` is the single app shell and bootstraps `src/js/app.ts`.
+- `src/js/app.ts` mounts the React workspace and global runtime affordances.
+- `src/js/frontend/*` owns route state, workspace UI, and the engine adapter seam.
+- `src/js/milkdrop/*` remains the imperative visualizer engine, overlay, compiler, and catalog runtime.
 - Workspace-scene decorative layers are rendered with imperative Three.js, not a secondary React renderer.
-- `assets/js/core/*` owns shared renderer, audio, quality, persistence, and input systems.
-- `assets/js/loader.ts`, `assets/js/router.ts`, `assets/js/toy-view.ts`, `assets/js/library-view.js`, `assets/js/library-view/*`, and `assets/js/bootstrap/*` are legacy compatibility/test-support internals for older non-root shell flows. They are not the production root app surface anymore.
+- `src/js/core/*` owns shared renderer, audio, quality, persistence, and input systems.
+- `src/js/loader.ts`, `src/js/router.ts`, `src/js/toy-view.ts`, `src/js/library-view.js`, `src/js/library-view/*`, and `src/js/bootstrap/*` are legacy compatibility/test-support internals for older non-root shell flows. They are not the production root app surface anymore.
 
 ## Runtime map
 
@@ -18,11 +18,11 @@ This document describes the current shipped frontend architecture for Stims afte
 flowchart LR
   Entry["index.html<br/>root app shell"]
   Alias["milkdrop/index.html<br/>redirect alias"]
-  App["assets/js/app.ts<br/>React boot + globals"]
-  Frontend["assets/js/frontend/*<br/>workspace UI + URL state"]
+  App["src/js/app.ts<br/>React boot + globals"]
+  Frontend["src/js/frontend/*<br/>workspace UI + URL state"]
   Adapter["milkdrop-engine-adapter.ts<br/>strict engine seam"]
-  Core["assets/js/core/*<br/>renderer + audio + settings"]
-  Milkdrop["assets/js/milkdrop/*<br/>runtime + overlay + compiler"]
+  Core["src/js/core/*<br/>renderer + audio + settings"]
+  Milkdrop["src/js/milkdrop/*<br/>runtime + overlay + compiler"]
   Legacy["loader.ts / router.ts / toy-view.ts / library-view.* / bootstrap/*<br/>compatibility internals"]
 
   Entry --> App
@@ -61,21 +61,21 @@ Canonical query params written by the app:
 - Unsupported legacy `experience` slugs are surfaced as an invalid-experience state instead of silently booting another shell.
 
 Primary implementation:
-- [`assets/js/frontend/url-state.ts`](../assets/js/frontend/url-state.ts)
-- [`assets/js/frontend/contracts.ts`](../assets/js/frontend/contracts.ts)
-- URL synchronization hook: `useWorkspaceRouteState()` in [`assets/js/frontend/workspace-hooks.ts`](../assets/js/frontend/workspace-hooks.ts)
+- [`src/js/frontend/url-state.ts`](../src/js/frontend/url-state.ts)
+- [`src/js/frontend/contracts.ts`](../src/js/frontend/contracts.ts)
+- URL synchronization hook: `useWorkspaceRouteState()` in [`src/js/frontend/workspace-hooks.ts`](../src/js/frontend/workspace-hooks.ts)
 
 ## Frontend ownership
 
 ### App bootstrap
 
-- [`assets/js/app.ts`](../assets/js/app.ts) installs telemetry persistence, the agent API, and gamepad navigation.
-- It renders [`assets/js/frontend/App.tsx`](../assets/js/frontend/App.tsx) into `#app`.
+- [`src/js/app.ts`](../src/js/app.ts) installs telemetry persistence, the agent API, and gamepad navigation.
+- It renders [`src/js/frontend/App.tsx`](../src/js/frontend/App.tsx) into `#app`.
 - It no longer delegates root ownership to the old DOM loader stack.
 
 ### Workspace UI
 
-- [`assets/js/frontend/App.tsx`](../assets/js/frontend/App.tsx) owns:
+- [`src/js/frontend/App.tsx`](../src/js/frontend/App.tsx) owns:
   - top navigation
   - launch controls
   - preset browsing and search
@@ -87,8 +87,8 @@ Primary implementation:
 
 ### Engine seam
 
-- [`assets/js/frontend/engine/milkdrop-engine-adapter.ts`](../assets/js/frontend/engine/milkdrop-engine-adapter.ts) is the only frontend-facing engine boundary.
-- New UI code should not import deep `assets/js/milkdrop/*` runtime internals directly.
+- [`src/js/frontend/engine/milkdrop-engine-adapter.ts`](../src/js/frontend/engine/milkdrop-engine-adapter.ts) is the only frontend-facing engine boundary.
+- New UI code should not import deep `src/js/milkdrop/*` runtime internals directly.
 - Decorative shell visuals are handled with imperative Three.js, not a secondary React renderer. Keep actual MilkDrop rendering in the imperative engine.
 - The adapter owns:
   - mount and dispose
@@ -101,9 +101,9 @@ Primary implementation:
 
 ## MilkDrop engine ownership
 
-- [`assets/js/milkdrop/runtime.ts`](../assets/js/milkdrop/runtime.ts) remains the long-lived imperative session runtime.
-- [`assets/js/milkdrop/overlay.ts`](../assets/js/milkdrop/overlay.ts) and `overlay/*` still provide the editor, inspector, browse, and shortcut HUD surfaces.
-- [`assets/js/milkdrop/compiler.ts`](../assets/js/milkdrop/compiler.ts), `compiler/*`, and [`assets/js/milkdrop/vm.ts`](../assets/js/milkdrop/vm.ts) remain the preset compilation and execution path.
+- [`src/js/milkdrop/runtime.ts`](../src/js/milkdrop/runtime.ts) remains the long-lived imperative session runtime.
+- [`src/js/milkdrop/overlay.ts`](../src/js/milkdrop/overlay.ts) and `overlay/*` still provide the editor, inspector, browse, and shortcut HUD surfaces.
+- [`src/js/milkdrop/compiler.ts`](../src/js/milkdrop/compiler.ts), `compiler/*`, and [`src/js/milkdrop/vm.ts`](../src/js/milkdrop/vm.ts) remain the preset compilation and execution path.
 
 Important boundary rule:
 - The React shell may drive engine capabilities through the adapter.
@@ -111,23 +111,23 @@ Important boundary rule:
 
 ## Shared systems
 
-- [`assets/js/core/renderer-capabilities.ts`](../assets/js/core/renderer-capabilities.ts) probes WebGPU/WebGL support.
-- [`assets/js/core/settings-panel.ts`](../assets/js/core/settings-panel.ts) owns shared quality preset state.
-- [`assets/js/core/state/render-preference-store.ts`](../assets/js/core/state/render-preference-store.ts) owns renderer preferences.
-- [`assets/js/core/motion-preferences.ts`](../assets/js/core/motion-preferences.ts) owns motion-state persistence.
-- [`assets/js/core/agent-api.ts`](../assets/js/core/agent-api.ts) exposes automation-friendly session state and control hooks.
+- [`src/js/core/renderer-capabilities.ts`](../src/js/core/renderer-capabilities.ts) probes WebGPU/WebGL support.
+- [`src/js/core/settings-panel.ts`](../src/js/core/settings-panel.ts) owns shared quality preset state.
+- [`src/js/core/state/render-preference-store.ts`](../src/js/core/state/render-preference-store.ts) owns renderer preferences.
+- [`src/js/core/motion-preferences.ts`](../src/js/core/motion-preferences.ts) owns motion-state persistence.
+- [`src/js/core/agent-api.ts`](../src/js/core/agent-api.ts) exposes automation-friendly session state and control hooks.
 - The renderer support rule is: WebGL is the baseline compatibility path, and WebGPU is an additive path that should not regress WebGL behavior. See [`VERIFICATION_MATRIX.md`](./VERIFICATION_MATRIX.md) for the short verification matrix.
 
 ## Legacy compatibility modules
 
 These modules still exist and are tested, but they are not the production root app surface:
 
-- [`assets/js/loader.ts`](../assets/js/loader.ts)
-- [`assets/js/router.ts`](../assets/js/router.ts)
-- [`assets/js/toy-view.ts`](../assets/js/toy-view.ts)
-- [`assets/js/library-view.js`](../assets/js/library-view.js)
-- [`assets/js/library-view/*`](../assets/js/library-view)
-- [`assets/js/bootstrap/*`](../assets/js/bootstrap)
+- [`src/js/loader.ts`](../src/js/loader.ts)
+- [`src/js/router.ts`](../src/js/router.ts)
+- [`src/js/toy-view.ts`](../src/js/toy-view.ts)
+- [`src/js/library-view.js`](../src/js/library-view.js)
+- [`src/js/library-view/*`](../src/js/library-view)
+- [`src/js/bootstrap/*`](../src/js/bootstrap)
 
 Treat them as compatibility-support code for:
 - older route assumptions

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,7 @@ For a concise parallel execution map across parity, runtime performance, browser
 4. Run `bun run check:quick` while iterating.
 5. Run `bun run check` before finalizing changes.
 
-`bun run check` includes the toy/docs drift guard, SEO surface validation, and the architecture boundary guard, so it now verifies the documented `app` (root entry point `assets/js/app.ts`) / `frontend` / `core` / `ui` / `utils` / `milkdrop` dependency directions while treating the old `loader` / `bootstrap` / `toy-view` / `library-view` stack as explicit legacy compatibility code.
+`bun run check` includes the toy/docs drift guard, SEO surface validation, and the architecture boundary guard, so it now verifies the documented `app` (root entry point `src/js/app.ts`) / `frontend` / `core` / `ui` / `utils` / `milkdrop` dependency directions while treating the old `loader` / `bootstrap` / `toy-view` / `library-view` stack as explicit legacy compatibility code.
 
 For the short rendering and test matrix, see [`VERIFICATION_MATRIX.md`](./VERIFICATION_MATRIX.md).
 
@@ -108,7 +108,7 @@ bun scripts/play-toy.ts milkdrop \
 
 This keeps the capture focused on one preset and saves both the screenshot and the runtime debug snapshot for later comparison.
 
-To capture the certification corpus directly from `assets/data/milkdrop-parity/certification-corpus.json` instead of the checked-in visual-reference manifest (note: only 4 of the 23 corpus presets have measured results; the corpus represents certification targets, not completed certifications), use:
+To capture the certification corpus directly from `src/data/milkdrop-parity/certification-corpus.json` instead of the checked-in visual-reference manifest (note: only 4 of the 23 corpus presets have measured results; the corpus represents certification targets, not completed certifications), use:
 
 ```bash
 bun run parity:capture:corpus -- --group bundled-shipped
@@ -149,8 +149,8 @@ bun run parity:promote-reference -- \
   --strata feedback,shader-supported
 ```
 
-This copies the chosen reference artifact into `tests/fixtures/milkdrop/projectm-reference/` and upserts its entry in `assets/data/milkdrop-parity/visual-reference-manifest.json`.
-The checked-in certification target set itself lives in `assets/data/milkdrop-parity/certification-corpus.json`; visual references and measured results should only be added for presets in that bounded corpus.
+This copies the chosen reference artifact into `tests/fixtures/milkdrop/projectm-reference/` and upserts its entry in `src/data/milkdrop-parity/visual-reference-manifest.json`.
+The checked-in certification target set itself lives in `src/data/milkdrop-parity/certification-corpus.json`; visual references and measured results should only be added for presets in that bounded corpus.
 
 To run the parity suite against the checked-in visual reference manifest (currently 4 presets with projectM reference images):
 
@@ -158,7 +158,7 @@ To run the parity suite against the checked-in visual reference manifest (curren
 bun run parity:suite -- --output ./screenshots/parity --write-diff-images
 ```
 
-This reads `assets/data/milkdrop-parity/visual-reference-manifest.json`, resolves the latest Stims captures for each preset in the visual reference manifest, writes per-preset reports under `./screenshots/parity/suite/`, and emits a ranked `summary.json` with worst mismatches first.
+This reads `src/data/milkdrop-parity/visual-reference-manifest.json`, resolves the latest Stims captures for each preset in the visual reference manifest, writes per-preset reports under `./screenshots/parity/suite/`, and emits a ranked `summary.json` with worst mismatches first.
 
 To promote a suite report into the checked-in measured-results manifest:
 
@@ -168,7 +168,7 @@ bun run parity:promote-result -- \
   --preset eos-glowsticks-v2-03-music
 ```
 
-This upserts the preset into `assets/data/milkdrop-parity/measured-results.json`, which is the first repo-tracked source used to override inferred fidelity with measured visual evidence.
+This upserts the preset into `src/data/milkdrop-parity/measured-results.json`, which is the first repo-tracked source used to override inferred fidelity with measured visual evidence.
 
 To sync the shipped bundled catalog metadata with that measured-results manifest:
 
@@ -178,7 +178,7 @@ bun run parity:sync-catalog
 
 This rewrites `public/milkdrop-presets/catalog.json` so presets with measured visual results keep their certified fidelity labels, while unmeasured bundled presets are published as `partial` with `runtime` evidence instead of optimistic `exact`/`visual` metadata.
 
-`bun run check:quick` and `bun run check` now verify that `public/milkdrop-presets/catalog.json` is still synced with `assets/data/milkdrop-parity/measured-results.json`. If that check fails, rerun `bun run parity:sync-catalog`.
+`bun run check:quick` and `bun run check` now verify that `public/milkdrop-presets/catalog.json` is still synced with `src/data/milkdrop-parity/measured-results.json`. If that check fails, rerun `bun run parity:sync-catalog`.
 
 ### Bundled shipped preset lane
 
@@ -213,11 +213,11 @@ Keep the bundled shipped presets in evidence order:
 
 ## Frontend boundaries
 
-- `assets/js/app.ts` and `assets/js/frontend/*` are the active product frontend.
-- `assets/js/milkdrop/*` remains the visual engine behind the adapter seam.
-- `assets/js/frontend/` avoids adding a secondary React renderer for Three.js scenes; decorative visuals use imperative Three.js directly.
-- `assets/js/frontend/workspace-router.tsx` is a thin pass-through that renders `App.tsx` directly — the old `@tanstack/react-router` was removed in favor of the native History API (see `url-state.ts` + `workspace-hooks.ts` for URL sync).
-- `assets/js/loader.ts`, `assets/js/router.ts`, `assets/js/toy-view.ts`, `assets/js/library-view.js`, `assets/js/library-view/*`, and `assets/js/bootstrap/*` are legacy compatibility modules.
+- `src/js/app.ts` and `src/js/frontend/*` are the active product frontend.
+- `src/js/milkdrop/*` remains the visual engine behind the adapter seam.
+- `src/js/frontend/` avoids adding a secondary React renderer for Three.js scenes; decorative visuals use imperative Three.js directly.
+- `src/js/frontend/workspace-router.tsx` is a thin pass-through that renders `App.tsx` directly — the old `@tanstack/react-router` was removed in favor of the native History API (see `url-state.ts` + `workspace-hooks.ts` for URL sync).
+- `src/js/loader.ts`, `src/js/router.ts`, `src/js/toy-view.ts`, `src/js/library-view.js`, `src/js/library-view/*`, and `src/js/bootstrap/*` are legacy compatibility modules.
 - New product work should not add fresh route ownership or UI flows to those legacy modules.
 
 ## Testing layers

--- a/docs/DOCS_MAINTENANCE.md
+++ b/docs/DOCS_MAINTENANCE.md
@@ -27,7 +27,7 @@ When restructuring docs, keep these entry points in sync:
 | Change type | Required docs updates |
 | --- | --- |
 | New script or renamed script | `docs/DEVELOPMENT.md` plus `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `docs/agents/README.md`, `docs/agents/tooling-and-quality.md`, `docs/agents/visualizer-workflows.md`, and `docs/MCP_SERVER.md` when they reference the changed script. |
-| New toy / renamed toy slug | Update `assets/data/toys.json`, then run `bun run generate:toys` so `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md` stay aligned; update `docs/TOY_DEVELOPMENT.md` only if the workflow itself changed. |
+| New toy / renamed toy slug | Update `src/data/toys.json`, then run `bun run generate:toys` so `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md` stay aligned; update `docs/TOY_DEVELOPMENT.md` only if the workflow itself changed. |
 | Workflow behavior changes | Update the source workflow doc (for example `docs/DEVELOPMENT.md`, `docs/DEPLOYMENT.md`, `docs/QA_PLAN.md`). |
 | Repo-local agent skill/workflow changes | `AGENTS.md`, `docs/agents/README.md`, `docs/agents/custom-capabilities.md`, `docs/agents/visual-testing.md`, `docs/agents/visualizer-workflows.md`, and `docs/MCP_SERVER.md` when they mention the changed route, command, or capability. |
 | Docs restructuring | Update links and references across all entry points listed above. |

--- a/docs/FEATURE_SPECIFICATIONS.md
+++ b/docs/FEATURE_SPECIFICATIONS.md
@@ -6,14 +6,14 @@ This document describes the shipped React workspace frontend and the preserved M
 
 | Area | Current state | Primary sources |
 | --- | --- | --- |
-| Root app route | `/` is the canonical workspace route and owns launch, browse, session, and settings surfaces. | `index.html`, `assets/js/app.ts`, `assets/js/frontend/App.tsx` |
+| Root app route | `/` is the canonical workspace route and owns launch, browse, session, and settings surfaces. | `index.html`, `src/js/app.ts`, `src/js/frontend/App.tsx` |
 | Legacy alias | `/milkdrop/` preserves older links by redirecting into `/` with query state intact. | `milkdrop/index.html`, `docs/PAGE_SPECIFICATIONS.md` |
-| URL normalization | Legacy `experience`, `panel`, `collection`, `preset`, `audio`, and `agent` params are read; canonical URLs are written back from typed route state. | `assets/js/frontend/url-state.ts` |
-| Engine seam | The React shell talks to the MilkDrop engine only through the adapter contract. | `assets/js/frontend/engine/milkdrop-engine-adapter.ts` |
-| Preset runtime | MilkDrop compiler, runtime, overlay, editor, and inspector remain live behind the adapter. | `assets/js/milkdrop/runtime.ts`, `assets/js/milkdrop/overlay.ts` |
-| Audio inputs | Demo, microphone, tab capture, and YouTube-backed capture are available from the workspace launch surface. | `assets/js/frontend/App.tsx`, `assets/js/ui/audio-advanced-sources.ts`, `assets/js/ui/youtube-controller.ts` |
-| Quality + fallback | WebGPU is preferred, WebGL fallback is supported, and users can tune quality, render scale, pixel ratio, and compatibility mode. | `assets/js/core/renderer-capabilities.ts`, `assets/js/core/settings-panel.ts`, `assets/js/core/state/render-preference-store.ts` |
-| Automation + QA | Agent mode, canonical route testing, and browser-backed smoke coverage are live on the root route. | `assets/js/core/agent-api.ts`, `tests/agent-integration.test.ts` |
+| URL normalization | Legacy `experience`, `panel`, `collection`, `preset`, `audio`, and `agent` params are read; canonical URLs are written back from typed route state. | `src/js/frontend/url-state.ts` |
+| Engine seam | The React shell talks to the MilkDrop engine only through the adapter contract. | `src/js/frontend/engine/milkdrop-engine-adapter.ts` |
+| Preset runtime | MilkDrop compiler, runtime, overlay, editor, and inspector remain live behind the adapter. | `src/js/milkdrop/runtime.ts`, `src/js/milkdrop/overlay.ts` |
+| Audio inputs | Demo, microphone, tab capture, and YouTube-backed capture are available from the workspace launch surface. | `src/js/frontend/App.tsx`, `src/js/ui/audio-advanced-sources.ts`, `src/js/ui/youtube-controller.ts` |
+| Quality + fallback | WebGPU is preferred, WebGL fallback is supported, and users can tune quality, render scale, pixel ratio, and compatibility mode. | `src/js/core/renderer-capabilities.ts`, `src/js/core/settings-panel.ts`, `src/js/core/state/render-preference-store.ts` |
+| Automation + QA | Agent mode, canonical route testing, and browser-backed smoke coverage are live on the root route. | `src/js/core/agent-api.ts`, `tests/agent-integration.test.ts` |
 
 ## Root workspace (`/`)
 
@@ -93,15 +93,15 @@ This document describes the shipped React workspace frontend and the preserved M
 
 The following modules still exist for compatibility coverage and lower-level tests, but they are not the root frontend architecture anymore:
 
-- `assets/js/loader.ts`
-- `assets/js/router.ts`
-- `assets/js/toy-view.ts`
-- `assets/js/library-view.js`
-- `assets/js/library-view/*`
-- `assets/js/bootstrap/*`
+- `src/js/loader.ts`
+- `src/js/router.ts`
+- `src/js/toy-view.ts`
+- `src/js/library-view.js`
+- `src/js/library-view/*`
+- `src/js/bootstrap/*`
 
 Current product-facing frontend work should prefer:
 
-- `assets/js/app.ts`
-- `assets/js/frontend/*`
-- `assets/js/frontend/engine/milkdrop-engine-adapter.ts`
+- `src/js/app.ts`
+- `src/js/frontend/*`
+- `src/js/frontend/engine/milkdrop-engine-adapter.ts`

--- a/docs/FRONTEND_PERFORMANCE_BOTTLENECKS.md
+++ b/docs/FRONTEND_PERFORMANCE_BOTTLENECKS.md
@@ -102,8 +102,8 @@ The adapter frequently uses `group.children.slice(...)` and similar array-copy p
 
 ## Evidence reviewed
 
-- `assets/js/milkdrop/runtime.ts`
-- `assets/js/milkdrop/vm.ts`
-- `assets/js/milkdrop/overlay.ts`
-- `assets/js/milkdrop/renderer-adapter.ts`
-- `assets/js/core/web-toy.ts`
+- `src/js/milkdrop/runtime.ts`
+- `src/js/milkdrop/vm.ts`
+- `src/js/milkdrop/overlay.ts`
+- `src/js/milkdrop/renderer-adapter.ts`
+- `src/js/core/web-toy.ts`

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -37,7 +37,7 @@ This document is the consolidated source for implementation progress across road
 - [x] **Milestone C:** Broad toy migration with hardened drift checks.
   - [x] Added `bun run check:architecture` and wired it into the full `bun run check` quality gate.
   - [x] Promoted additional runtime-critical helpers (`audio-handler`, `unified-input`, `webgl-check`, `webgl-renderer`, `party-mode`, `shared-initializer`, and library back-navigation) out of `utils/` and into `core/`.
-  - [x] Turned `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md` into deterministic generated artifacts from `assets/data/toys.json`.
+  - [x] Turned `docs/TOY_SCRIPT_INDEX.md` and `docs/toys.md` into deterministic generated artifacts from `src/data/toys.json`.
   - [x] Wired `bun run check:toys` and `bun run check:seo` into the main quality gate so metadata/docs and shipped SEO surfaces fail fast when they drift.
 - [x] **Milestone D:** Performance/reliability pass complete.
   - [x] Reduced per-frame signal override allocation churn in the MilkDrop input-response path.
@@ -54,12 +54,12 @@ This document is the consolidated source for implementation progress across road
 - [x] 2) Shared runtime boundary extraction.
   - [x] MilkDrop runtime orchestration now delegates startup selection, backend failover, interaction shaping, and frame lifecycle decisions to dedicated modules.
   - [x] Runtime ownership boundaries are now documented in `docs/ARCHITECTURE.md`.
-  - [x] Runtime-critical boundary helpers now live under `assets/js/core/*` instead of `assets/js/utils/*`.
+  - [x] Runtime-critical boundary helpers now live under `src/js/core/*` instead of `src/js/utils/*`.
 - [x] 3) Toy module normalization.
   - [x] MilkDrop pilot slice now uses `core/` starter/quality helpers instead of `utils/` runtime helpers.
 - [x] 4) Data and metadata consistency hardening.
   - [x] Architecture boundary enforcement now runs in CI-local parity through `bun run check:architecture`.
-  - [x] Toy manifest docs are generated from `assets/data/toys.json` and validated by `bun run check:toys`.
+  - [x] Toy manifest docs are generated from `src/data/toys.json` and validated by `bun run check:toys`.
   - [x] SEO surface validation now runs alongside the main quality gate through `bun run check:seo`.
 - [x] 5) Incremental performance and reliability pass.
   - [x] Catalog refresh scheduling now coalesces to the latest requested overlay state during rapid preset/backend churn.

--- a/docs/MANUAL_SMOKE_BASELINE.md
+++ b/docs/MANUAL_SMOKE_BASELINE.md
@@ -31,27 +31,27 @@ Milestone A baseline evidence is the combination of:
   ```
 
 - The checked-in behavior snapshot sources:
-  - `assets/data/milkdrop-parity/visual-baselines.json` for deterministic VM/frame-shape expectations.
-  - `assets/data/milkdrop-parity/certification-corpus.json` for the representative preset set used during parity-oriented validation.
-  - `assets/data/milkdrop-parity/visual-reference-manifest.json` plus `tests/fixtures/milkdrop/projectm-reference/` for image-level comparison fixtures.
+  - `src/data/milkdrop-parity/visual-baselines.json` for deterministic VM/frame-shape expectations.
+  - `src/data/milkdrop-parity/certification-corpus.json` for the representative preset set used during parity-oriented validation.
+  - `src/data/milkdrop-parity/visual-reference-manifest.json` plus `tests/fixtures/milkdrop/projectm-reference/` for image-level comparison fixtures.
 
 ## When to run this baseline
 
 Run the full baseline when a change touches any of these areas:
 
 - `index.html` or `milkdrop/index.html`
-- `assets/js/app.ts` or `assets/js/frontend/*`
-- `assets/js/frontend/engine/*` or launch/session UI
-- `assets/js/core/*` startup, renderer, or audio wiring
-- `assets/js/milkdrop/runtime.ts`
+- `src/js/app.ts` or `src/js/frontend/*`
+- `src/js/frontend/engine/*` or launch/session UI
+- `src/js/core/*` startup, renderer, or audio wiring
+- `src/js/milkdrop/runtime.ts`
 - preset boot, overlay, or renderer-fallback behavior
 
 Run the compatibility-only legacy suite instead when a change is limited to:
 
-- `assets/js/loader.ts`, `assets/js/router.ts`, or `assets/js/loader/*`
-- `assets/js/toy-view.ts`
-- `assets/js/library-view.js` or `assets/js/library-view/*`
-- `assets/js/bootstrap/*`
+- `src/js/loader.ts`, `src/js/router.ts`, or `src/js/loader/*`
+- `src/js/toy-view.ts`
+- `src/js/library-view.js` or `src/js/library-view/*`
+- `src/js/bootstrap/*`
 
 For narrowly scoped docs-only changes, this baseline is not required.
 

--- a/docs/MILKDROP_PRESET_RUNTIME.md
+++ b/docs/MILKDROP_PRESET_RUNTIME.md
@@ -46,9 +46,9 @@ Both camelCase and snake_case aliases are exposed so preset equations can stay r
 
 ## Metadata sync workflow
 
-`assets/data/toys.json` remains the checked-in manifest source for the shipped experience. `bun run generate:toys` rewrites the derived artifacts:
+`src/data/toys.json` remains the checked-in manifest source for the shipped experience. `bun run generate:toys` rewrites the derived artifacts:
 
-- `assets/js/data/toy-manifest.ts`
+- `src/js/data/toy-manifest.ts`
 - `public/toys.json`
 - `docs/TOY_SCRIPT_INDEX.md`
 - `docs/toys.md`
@@ -71,13 +71,13 @@ The MilkDrop runtime can now gate each WebGPU descriptor optimization independen
 
 When any flag is disabled and the runtime still starts on WebGPU, the overlay status includes a short `WebGPU rollout flags active: ...` message so test runs and manual QA can confirm which descriptor paths remain guarded.
 
-`assets/js/milkdrop/renderer-execution-plan.ts` is the runtime decision point for applying these flags to a compiled descriptor plan. The same plan result drives backend fallback checks, the effective descriptor plan stored by the renderer core, and the WebGPU adapter feedback-manager mode. The plan also exposes `disabledFeatures`, `statusLabels`, and structured fallback reasons such as `descriptor-feedback` so overlays, tests, and telemetry can report the same decision.
+`src/js/milkdrop/renderer-execution-plan.ts` is the runtime decision point for applying these flags to a compiled descriptor plan. The same plan result drives backend fallback checks, the effective descriptor plan stored by the renderer core, and the WebGPU adapter feedback-manager mode. The plan also exposes `disabledFeatures`, `statusLabels`, and structured fallback reasons such as `descriptor-feedback` so overlays, tests, and telemetry can report the same decision.
 
 Current WebGPU feedback mode is `none` on both safe and full paths until native feedback parity is stable. Native feedback has an explicit planner opt-in (`nativeWebGpuFeedbackEnabled`) for future rollout tests, but no production caller enables it yet.
 
 ## Shader execution classification
 
-Direct shader payloads keep a separate execution classification in `assets/js/milkdrop/compiler/shader-execution-classification.ts`. Runtime consumers should use this helper instead of checking `supportedBackends`, `rawGlsl`, and `requiresControlFallback` directly. The current categories are:
+Direct shader payloads keep a separate execution classification in `src/js/milkdrop/compiler/shader-execution-classification.ts`. Runtime consumers should use this helper instead of checking `supportedBackends`, `rawGlsl`, and `requiresControlFallback` directly. The current categories are:
 
 - `backend-executable`
 - `backend-executable-with-control-fallback`

--- a/docs/MILKDROP_PROJECTM_PARITY_BACKLOG.md
+++ b/docs/MILKDROP_PROJECTM_PARITY_BACKLOG.md
@@ -38,7 +38,7 @@ Bundled shipped preset lane:
   - import the matching `projectM` reference,
   - promote the reference into `tests/fixtures/milkdrop/projectm-reference/`,
   - run `bun run parity:suite`,
-  - promote the suite result into `assets/data/milkdrop-parity/measured-results.json`,
+  - promote the suite result into `src/data/milkdrop-parity/measured-results.json`,
   - sync `public/milkdrop-presets/catalog.json`.
   - The current report intentionally classifies one as WebGL-only and three as uncertified because the latest captures do not pass the required native WebGPU lane. They must not be described as WebGPU-certified.
 
@@ -91,7 +91,7 @@ Goal:
 - Replace ad hoc visual inspection with a small, versioned, certified preset/reference corpus.
 
 Files to add or change:
-- `assets/data/milkdrop-parity/visual-reference-manifest.json`
+- `src/data/milkdrop-parity/visual-reference-manifest.json`
 - `tests/fixtures/milkdrop/projectm-reference/`
 - `scripts/visual-reference-manifest.ts`
 - `scripts/promote-projectm-reference.ts`
@@ -159,10 +159,10 @@ Goal:
 - Stop inferring fidelity from compiler optimism and make measured visual results authoritative.
 
 Primary files to change:
-- [`assets/js/milkdrop/compiler/core.ts`](../assets/js/milkdrop/compiler/core.ts)
-- [`assets/js/milkdrop/compiler/ir.ts`](../assets/js/milkdrop/compiler/ir.ts)
-- [`assets/js/milkdrop/compiler/compatibility.ts`](../assets/js/milkdrop/compiler/compatibility.ts)
-- [`assets/js/milkdrop/catalog-store-analysis.ts`](../assets/js/milkdrop/catalog-store-analysis.ts)
+- [`src/js/milkdrop/compiler/core.ts`](../src/js/milkdrop/compiler/core.ts)
+- [`src/js/milkdrop/compiler/ir.ts`](../src/js/milkdrop/compiler/ir.ts)
+- [`src/js/milkdrop/compiler/compatibility.ts`](../src/js/milkdrop/compiler/compatibility.ts)
+- [`src/js/milkdrop/catalog-store-analysis.ts`](../src/js/milkdrop/catalog-store-analysis.ts)
 - [`public/milkdrop-presets/catalog.json`](../public/milkdrop-presets/catalog.json)
 
 Implementation tasks:
@@ -185,10 +185,10 @@ Goal:
 - Eliminate the largest visible drift source first.
 
 Primary files to change:
-- [`assets/js/milkdrop/renderer-helpers/feedback-composite.ts`](../assets/js/milkdrop/renderer-helpers/feedback-composite.ts)
-- [`assets/js/milkdrop/feedback-manager-shared.ts`](../assets/js/milkdrop/feedback-manager-shared.ts)
-- [`assets/js/milkdrop/feedback-manager-webgpu.ts`](../assets/js/milkdrop/feedback-manager-webgpu.ts)
-- [`assets/js/milkdrop/compiler/gpu-descriptor-plan.ts`](../assets/js/milkdrop/compiler/gpu-descriptor-plan.ts)
+- [`src/js/milkdrop/renderer-helpers/feedback-composite.ts`](../src/js/milkdrop/renderer-helpers/feedback-composite.ts)
+- [`src/js/milkdrop/feedback-manager-shared.ts`](../src/js/milkdrop/feedback-manager-shared.ts)
+- [`src/js/milkdrop/feedback-manager-webgpu.ts`](../src/js/milkdrop/feedback-manager-webgpu.ts)
+- [`src/js/milkdrop/compiler/gpu-descriptor-plan.ts`](../src/js/milkdrop/compiler/gpu-descriptor-plan.ts)
 - [`tests/milkdrop-renderer-adapter.test.ts`](../tests/milkdrop-renderer-adapter.test.ts)
 
 Implementation tasks:
@@ -216,9 +216,9 @@ Goal:
 - Shrink the gap between translated controls and actual projectM shader behavior.
 
 Primary files to change:
-- [`assets/js/milkdrop/compiler/shader-analysis.ts`](../assets/js/milkdrop/compiler/shader-analysis.ts)
-- [`assets/js/milkdrop/compiler/ir.ts`](../assets/js/milkdrop/compiler/ir.ts)
-- [`assets/js/milkdrop/compiler/parity.ts`](../assets/js/milkdrop/compiler/parity.ts)
+- [`src/js/milkdrop/compiler/shader-analysis.ts`](../src/js/milkdrop/compiler/shader-analysis.ts)
+- [`src/js/milkdrop/compiler/ir.ts`](../src/js/milkdrop/compiler/ir.ts)
+- [`src/js/milkdrop/compiler/parity.ts`](../src/js/milkdrop/compiler/parity.ts)
 - [`tests/milkdrop-compiler-shader-analysis.test.ts`](../tests/milkdrop-compiler-shader-analysis.test.ts)
 - [`tests/milkdrop-projectm-compat.test.ts`](../tests/milkdrop-projectm-compat.test.ts)
 
@@ -246,9 +246,9 @@ Goal:
 - Remove known sampler approximations that visibly change output.
 
 Primary files to change:
-- [`assets/js/milkdrop/compiler/shader-analysis.ts`](../assets/js/milkdrop/compiler/shader-analysis.ts)
-- [`assets/js/milkdrop/feedback-manager-shared.ts`](../assets/js/milkdrop/feedback-manager-shared.ts)
-- [`assets/js/milkdrop/feedback-manager-webgpu.ts`](../assets/js/milkdrop/feedback-manager-webgpu.ts)
+- [`src/js/milkdrop/compiler/shader-analysis.ts`](../src/js/milkdrop/compiler/shader-analysis.ts)
+- [`src/js/milkdrop/feedback-manager-shared.ts`](../src/js/milkdrop/feedback-manager-shared.ts)
+- [`src/js/milkdrop/feedback-manager-webgpu.ts`](../src/js/milkdrop/feedback-manager-webgpu.ts)
 - [`tests/milkdrop-shader-sampler-aliases.test.ts`](../tests/milkdrop-shader-sampler-aliases.test.ts)
 
 Implementation tasks:
@@ -274,11 +274,11 @@ Goal:
 - Match what projectM actually draws, not just how many primitives Stims emits.
 
 Primary files to change:
-- [`assets/js/milkdrop/renderer-helpers/wave-renderer.ts`](../assets/js/milkdrop/renderer-helpers/wave-renderer.ts)
-- [`assets/js/milkdrop/renderer-helpers/procedural-wave-renderer.ts`](../assets/js/milkdrop/renderer-helpers/procedural-wave-renderer.ts)
-- [`assets/js/milkdrop/renderer-helpers/shape-renderer.ts`](../assets/js/milkdrop/renderer-helpers/shape-renderer.ts)
-- [`assets/js/milkdrop/renderer-helpers/border-renderer.ts`](../assets/js/milkdrop/renderer-helpers/border-renderer.ts)
-- [`assets/js/milkdrop/renderer-helpers/mesh-renderer.ts`](../assets/js/milkdrop/renderer-helpers/mesh-renderer.ts)
+- [`src/js/milkdrop/renderer-helpers/wave-renderer.ts`](../src/js/milkdrop/renderer-helpers/wave-renderer.ts)
+- [`src/js/milkdrop/renderer-helpers/procedural-wave-renderer.ts`](../src/js/milkdrop/renderer-helpers/procedural-wave-renderer.ts)
+- [`src/js/milkdrop/renderer-helpers/shape-renderer.ts`](../src/js/milkdrop/renderer-helpers/shape-renderer.ts)
+- [`src/js/milkdrop/renderer-helpers/border-renderer.ts`](../src/js/milkdrop/renderer-helpers/border-renderer.ts)
+- [`src/js/milkdrop/renderer-helpers/mesh-renderer.ts`](../src/js/milkdrop/renderer-helpers/mesh-renderer.ts)
 - [`tests/milkdrop-renderer-adapter.test.ts`](../tests/milkdrop-renderer-adapter.test.ts)
 
 Implementation tasks:
@@ -315,9 +315,9 @@ Goal:
 - Prevent WebGPU from claiming parity before it has earned it.
 
 Primary files to change:
-- [`assets/js/milkdrop/renderer-adapter-webgpu.ts`](../assets/js/milkdrop/renderer-adapter-webgpu.ts)
-- [`assets/js/milkdrop/renderer-adapter-webgl.ts`](../assets/js/milkdrop/renderer-adapter-webgl.ts)
-- [`assets/js/milkdrop/webgpu-optimization-flags.ts`](../assets/js/milkdrop/webgpu-optimization-flags.ts)
+- [`src/js/milkdrop/renderer-adapter-webgpu.ts`](../src/js/milkdrop/renderer-adapter-webgpu.ts)
+- [`src/js/milkdrop/renderer-adapter-webgl.ts`](../src/js/milkdrop/renderer-adapter-webgl.ts)
+- [`src/js/milkdrop/webgpu-optimization-flags.ts`](../src/js/milkdrop/webgpu-optimization-flags.ts)
 - [`tests/milkdrop-webgpu-rollout.test.ts`](../tests/milkdrop-webgpu-rollout.test.ts)
 
 Implementation tasks:
@@ -345,11 +345,11 @@ Goal:
 - Make the product surface tell the truth about what is measured and what is inferred.
 
 Primary files to change:
-- [`assets/js/milkdrop/overlay.ts`](../assets/js/milkdrop/overlay.ts)
-- [`assets/js/milkdrop/overlay/inspector-panel.ts`](../assets/js/milkdrop/overlay/inspector-panel.ts)
-- [`assets/js/milkdrop/overlay/preset-row.ts`](../assets/js/milkdrop/overlay/preset-row.ts)
-- [`assets/js/milkdrop/catalog-store-analysis.ts`](../assets/js/milkdrop/catalog-store-analysis.ts)
-- [`assets/js/milkdrop/common-types.ts`](../assets/js/milkdrop/common-types.ts)
+- [`src/js/milkdrop/overlay.ts`](../src/js/milkdrop/overlay.ts)
+- [`src/js/milkdrop/overlay/inspector-panel.ts`](../src/js/milkdrop/overlay/inspector-panel.ts)
+- [`src/js/milkdrop/overlay/preset-row.ts`](../src/js/milkdrop/overlay/preset-row.ts)
+- [`src/js/milkdrop/catalog-store-analysis.ts`](../src/js/milkdrop/catalog-store-analysis.ts)
+- [`src/js/milkdrop/common-types.ts`](../src/js/milkdrop/common-types.ts)
 - [`docs/MILKDROP_PRESET_RUNTIME.md`](./MILKDROP_PRESET_RUNTIME.md)
 
 Implementation tasks:

--- a/docs/MILKDROP_PROJECTM_PARITY_PLAN.md
+++ b/docs/MILKDROP_PROJECTM_PARITY_PLAN.md
@@ -82,8 +82,8 @@ bun run parity:promote-reference -- \
   --strata feedback,shader-supported
 ```
 
-That flow copies the selected projectM artifact into `tests/fixtures/milkdrop/projectm-reference/` and updates `assets/data/milkdrop-parity/visual-reference-manifest.json`, which becomes the source of truth for certified visual references.
-The bounded preset universe for that work is tracked separately in `assets/data/milkdrop-parity/certification-corpus.json`, so reference images and measured results stay scoped to an explicit WebGPU certification corpus instead of open-ended imports.
+That flow copies the selected projectM artifact into `tests/fixtures/milkdrop/projectm-reference/` and updates `src/data/milkdrop-parity/visual-reference-manifest.json`, which becomes the source of truth for certified visual references.
+The bounded preset universe for that work is tracked separately in `src/data/milkdrop-parity/certification-corpus.json`, so reference images and measured results stay scoped to an explicit WebGPU certification corpus instead of open-ended imports.
 
 For the bundled shipped presets, repeat the same capture/import/promote sequence one preset at a time and do not move to `measured-results.json` until the corresponding `projectM` reference is checked in for that same preset id.
 
@@ -105,7 +105,7 @@ bun run parity:promote-result -- \
   --preset eos-glowsticks-v2-03-music
 ```
 
-That step writes to `assets/data/milkdrop-parity/measured-results.json`, which is the first manifest used by runtime/catalog analysis to prefer measured visual fidelity over compiler-only inference.
+That step writes to `src/data/milkdrop-parity/measured-results.json`, which is the first manifest used by runtime/catalog analysis to prefer measured visual fidelity over compiler-only inference.
 
 Sync the shipped bundled catalog metadata from that measured-results manifest:
 

--- a/docs/MILKDROP_SUCCESSOR_WORKSTREAMS.md
+++ b/docs/MILKDROP_SUCCESSOR_WORKSTREAMS.md
@@ -17,10 +17,10 @@ Primary requirement:
 
 Primary files:
 
-- `assets/js/milkdrop/compiler/*`
-- `assets/js/milkdrop/vm/*`
-- `assets/js/milkdrop/renderer-helpers/*`
-- `assets/data/milkdrop-parity/*`
+- `src/js/milkdrop/compiler/*`
+- `src/js/milkdrop/vm/*`
+- `src/js/milkdrop/renderer-helpers/*`
+- `src/data/milkdrop-parity/*`
 - `tests/milkdrop-parity.test.ts`
 - `tests/milkdrop-projectm-compat.test.ts`
 
@@ -45,11 +45,11 @@ Own the hot path where frame time and GC pressure matter most.
 
 Primary files:
 
-- `assets/js/milkdrop/runtime.ts`
-- `assets/js/milkdrop/vm.ts`
-- `assets/js/milkdrop/vm/frame-generation.ts`
-- `assets/js/milkdrop/vm/wave-builder.ts`
-- `assets/js/milkdrop/renderer-adapter*.ts`
+- `src/js/milkdrop/runtime.ts`
+- `src/js/milkdrop/vm.ts`
+- `src/js/milkdrop/vm/frame-generation.ts`
+- `src/js/milkdrop/vm/wave-builder.ts`
+- `src/js/milkdrop/renderer-adapter*.ts`
 
 Exit signal:
 
@@ -62,8 +62,8 @@ Own the React shell, route state, and overlay UX that make Stims feel better tha
 
 Primary files:
 
-- `assets/js/frontend/*`
-- `assets/js/milkdrop/overlay/*`
+- `src/js/frontend/*`
+- `src/js/milkdrop/overlay/*`
 - `public/milkdrop-presets/catalog.json`
 
 Exit signal:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -106,21 +106,21 @@ Integration tests run on **every PR** — not just on push to main. This is inte
 
 ## Per-change checklists
 
-### Touching `assets/js/milkdrop/feedback-manager-*` or `renderer-adapter*`
+### Touching `src/js/milkdrop/feedback-manager-*` or `renderer-adapter*`
 
 - [ ] `bun run test:compat` passes against the reference preset set
 - [ ] WebGL and WebGPU paths both exercised (check `tests/milkdrop-renderer-adapter.test.ts`)
 - [ ] No hardcoded resolution scales or target sizes without a comment explaining the reason
 - [ ] Blend alpha order verified against projectM baseline
 
-### Touching `assets/js/core/renderer-setup.ts`, `renderer-capabilities.ts`, `render-service.ts`, `backend-fallback.ts`
+### Touching `src/js/core/renderer-setup.ts`, `renderer-capabilities.ts`, `render-service.ts`, `backend-fallback.ts`
 
 - [ ] Fallback chain tested with WebGPU disabled (see `tests/renderer-capabilities.test.js`)
 - [ ] `renderScale` propagation verified end-to-end (capability probe → renderer plan → query override → pooled renderers)
 - [ ] Audio worklet initialization validated on the fallback path
 - [ ] `bun run test:integration` passes locally if the shell or audio bridge was touched
 
-### Touching `assets/js/milkdrop/compiler/**`
+### Touching `src/js/milkdrop/compiler/**`
 
 - [ ] `bun run test:compat` passes
 - [ ] Any new compiler behavior has a focused test in `tests/milkdrop-compiler-seams.test.ts` or `tests/milkdrop-compiler-shader-analysis.test.ts`
@@ -132,7 +132,7 @@ Integration tests run on **every PR** — not just on push to main. This is inte
 - [ ] No new uses of `importFresh()` — prefer factory functions with injected dependencies
 - [ ] Integration harness startup contract in `tests/agent-integration.test.ts` unchanged unless intentionally versioned
 
-### Touching shell or routing (`assets/js/frontend/App.tsx`, `url-state.ts`, `workspace-hooks.ts`)
+### Touching shell or routing (`src/js/frontend/App.tsx`, `url-state.ts`, `workspace-hooks.ts`)
 
 - [ ] `tests/app-shell.test.js` and `tests/frontend-url-state.test.ts` pass
 - [ ] `bun run test:integration` passes (integration harness exercises the full boot sequence)

--- a/docs/VERIFICATION_MATRIX.md
+++ b/docs/VERIFICATION_MATRIX.md
@@ -8,7 +8,7 @@ those workflows change.
 
 | Path | Use for | Notes |
 | --- | --- | --- |
-| `Three.js` / imperative MilkDrop runtime | The actual visualizer engine, preset compilation/execution, renderer backends, audio response, and overlay/editor composition. | This is the product-critical path under `assets/js/milkdrop/*` and `assets/js/core/*`. |
+| `Three.js` / imperative MilkDrop runtime | The actual visualizer engine, preset compilation/execution, renderer backends, audio response, and overlay/editor composition. | This is the product-critical path under `src/js/milkdrop/*` and `src/js/core/*`. |
 | Three.js decorative scenes | Small imperative Three.js scene pieces used by the workspace shell for decorative or staging visuals. | Keep this layer small and isolated; it should not become a second visualizer runtime. |
 | WebGL | Baseline rendering path. | Use this as the default compatibility target for visual verification. |
 | WebGPU | Optional enhancement path. | Treat it as an additive path that must not break WebGL behavior. |

--- a/docs/WEBGPU_ARCHITECTURAL_REVAMP.md
+++ b/docs/WEBGPU_ARCHITECTURAL_REVAMP.md
@@ -25,11 +25,11 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Route `setRenderTarget` calls through the renderer, not hardcoded WebGL assumptions
 
 **Files**:
-- `assets/js/milkdrop/renderer-execution-plan.ts`
-- `assets/js/milkdrop/feedback-render-targets.ts`
-- `assets/js/milkdrop/feedback-manager-shared.ts`
-- `assets/js/milkdrop/feedback-manager-webgpu-tsl.ts`  
-- `assets/js/milkdrop/renderer-adapter-core.ts`
+- `src/js/milkdrop/renderer-execution-plan.ts`
+- `src/js/milkdrop/feedback-render-targets.ts`
+- `src/js/milkdrop/feedback-manager-shared.ts`
+- `src/js/milkdrop/feedback-manager-webgpu-tsl.ts`  
+- `src/js/milkdrop/renderer-adapter-core.ts`
 
 ### 2) Consolidate Composite Shader Source of Truth
 
@@ -41,9 +41,9 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Explore using TSL for both backends (TSL can emit GLSL)
 
 **Files**:
-- New: `assets/js/milkdrop/feedback-composite-ir.ts`
-- `assets/js/milkdrop/feedback-manager-shared.ts`
-- `assets/js/milkdrop/feedback-manager-webgpu-tsl.ts`
+- New: `src/js/milkdrop/feedback-composite-ir.ts`
+- `src/js/milkdrop/feedback-manager-shared.ts`
+- `src/js/milkdrop/feedback-manager-webgpu-tsl.ts`
 
 ### 3) Add WebGL Fallback to Worker Renderer
 
@@ -55,9 +55,9 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Keep worker WebGL path simple (no feedback/batching)
 
 **Files**:
-- `assets/js/core/renderer-worker.ts`
-- `assets/js/core/renderer-worker-protocol.ts`
-- `assets/js/core/renderer-setup.ts`
+- `src/js/core/renderer-worker.ts`
+- `src/js/core/renderer-worker-protocol.ts`
+- `src/js/core/renderer-setup.ts`
 
 ### 4) Vectorize WGSL Code Generation
 
@@ -69,8 +69,8 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Fuse adjacent scalar assignments into vector assignments
 
 **Files**:
-- `assets/js/milkdrop/compiler/wgsl-generator.ts`
-- `assets/js/milkdrop/vm-gpu.ts`
+- `src/js/milkdrop/compiler/wgsl-generator.ts`
+- `src/js/milkdrop/vm-gpu.ts`
 
 ### 5) Implement RenderBundle for Static Draw Calls
 
@@ -82,8 +82,8 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Execute bundles in render pass
 
 **Files**:
-- New: `assets/js/milkdrop/renderer-bundles.ts`
-- `assets/js/milkdrop/renderer-adapter-core.ts`
+- New: `src/js/milkdrop/renderer-bundles.ts`
+- `src/js/milkdrop/renderer-adapter-core.ts`
 
 ### 6) Gradual WebGPU Enablement
 
@@ -94,7 +94,7 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Track engagement/error/fallback rates via telemetry
 
 **Files**:
-- `assets/js/core/renderer-query-override.ts`
+- `src/js/core/renderer-query-override.ts`
 
 ### 7) Split Compiler Execution Contracts
 
@@ -106,9 +106,9 @@ This plan addresses structural issues in the dual-backend rendering pipeline ide
 - Move descriptor-plan assembly inputs into a typed compiler output object so renderer planning does not re-derive compiler intent
 
 **Files**:
-- `assets/js/milkdrop/compiler/ir.ts`
-- `assets/js/milkdrop/compiler/shader-execution-classification.ts`
-- New follow-up: `assets/js/milkdrop/compiler/compatibility-report.ts`
+- `src/js/milkdrop/compiler/ir.ts`
+- `src/js/milkdrop/compiler/shader-execution-classification.ts`
+- New follow-up: `src/js/milkdrop/compiler/compatibility-report.ts`
 
 ## Sequencing
 

--- a/docs/architecture/fallback-state-machine.md
+++ b/docs/architecture/fallback-state-machine.md
@@ -248,34 +248,34 @@ The changes below are ordered by dependency; each builds on the previous.
 
 | Order | File | Change |
 |-------|------|--------|
-| 1 | `assets/js/core/renderer-fsm.ts` (NEW) | Define the explicit state machine: `RendererSetupState` enum, `RendererSetupEvent` discriminated union, `transition(state, event): RendererSetupState` pure function. Include all states and transitions from §2.2. |
-| 2 | `assets/js/core/renderer-fsm.test.ts` (NEW) | Test every valid transition and assert every invalid transition throws. |
-| 3 | `assets/js/core/renderer-setup.ts` | Replace the inline fallback branches with calls to the FSM. `initRenderer` becomes a state-machine executor: poll current state, dispatch events, react to next state. |
-| 4 | `assets/js/core/renderer-capabilities.ts` | Extract the `probeRendererCapabilities` 9-return-path cascade into a `probeCapabilityTier()` function that returns an event (`AdapterFound`, `AdapterFallback`, `DeviceTimeout`, etc.) rather than a complex result object. |
+| 1 | `src/js/core/renderer-fsm.ts` (NEW) | Define the explicit state machine: `RendererSetupState` enum, `RendererSetupEvent` discriminated union, `transition(state, event): RendererSetupState` pure function. Include all states and transitions from §2.2. |
+| 2 | `src/js/core/renderer-fsm.test.ts` (NEW) | Test every valid transition and assert every invalid transition throws. |
+| 3 | `src/js/core/renderer-setup.ts` | Replace the inline fallback branches with calls to the FSM. `initRenderer` becomes a state-machine executor: poll current state, dispatch events, react to next state. |
+| 4 | `src/js/core/renderer-capabilities.ts` | Extract the `probeRendererCapabilities` 9-return-path cascade into a `probeCapabilityTier()` function that returns an event (`AdapterFound`, `AdapterFallback`, `DeviceTimeout`, etc.) rather than a complex result object. |
 
 ### Phase 2: renderScale Typing
 
 | Order | File | Change |
 |-------|------|--------|
-| 5 | `assets/js/core/renderer-settings.ts` | Add `RenderScaleUser` (input), `RenderScaleComputed` (after multiplier chain), and `RenderScaleEffective` (final pixel ratio) branded types. Split `resolveRendererSettings` into `resolveUserScale` and `computeEffectiveScale` — separate concerns. |
-| 6 | `assets/js/core/renderer-setup.ts` | Accept typed `RenderScaleUser` in `RendererInitConfig`, produce typed `RenderScaleEffective` in `RendererInitResult`. Remove in-place mutation of `info.renderScale` from `applyRendererSettings`. |
-| 7 | `assets/js/core/services/render-service.ts` | Update `getRenderDefaults()` to use typed scale composition. |
+| 5 | `src/js/core/renderer-settings.ts` | Add `RenderScaleUser` (input), `RenderScaleComputed` (after multiplier chain), and `RenderScaleEffective` (final pixel ratio) branded types. Split `resolveRendererSettings` into `resolveUserScale` and `computeEffectiveScale` — separate concerns. |
+| 6 | `src/js/core/renderer-setup.ts` | Accept typed `RenderScaleUser` in `RendererInitConfig`, produce typed `RenderScaleEffective` in `RendererInitResult`. Remove in-place mutation of `info.renderScale` from `applyRendererSettings`. |
+| 7 | `src/js/core/services/render-service.ts` | Update `getRenderDefaults()` to use typed scale composition. |
 
 ### Phase 3: Timeout & Cleanup Hardening
 
 | Order | File | Change |
 |-------|------|--------|
-| 8 | `assets/js/core/renderer-init-timeout.ts` | Add `AbortController` support. Return a `{ result, didTimeout }` wrapper instead of racing and discarding. |
-| 9 | `assets/js/core/renderer-setup.ts` | Replace fire-and-forget `void initPromise.then(disposeTimedOutRenderer)` with a cancellable cleanup token. Track the init promise's lifecycle through the FSM. |
-| 10 | `assets/js/core/services/render-service.ts` | Add retry backoff with max attempts for `queueWebGpuRecovery`. Track recovery attempts in the FSM state. |
+| 8 | `src/js/core/renderer-init-timeout.ts` | Add `AbortController` support. Return a `{ result, didTimeout }` wrapper instead of racing and discarding. |
+| 9 | `src/js/core/renderer-setup.ts` | Replace fire-and-forget `void initPromise.then(disposeTimedOutRenderer)` with a cancellable cleanup token. Track the init promise's lifecycle through the FSM. |
+| 10 | `src/js/core/services/render-service.ts` | Add retry backoff with max attempts for `queueWebGpuRecovery`. Track recovery attempts in the FSM state. |
 
 ### Phase 4: Audio-Renderer Coupling
 
 | Order | File | Change |
 |-------|------|--------|
-| 11 | `assets/js/core/audio-handler.ts` | Add `AudioPipelineMode` enum (`worklet` | `analyser-node`). Expose on `FrequencyAnalyser`. Add `AudioInitEvent` union for FSM integration. |
-| 12 | `assets/js/core/animation-loop.ts` | Guard `initAudio` call with FSM state check: only proceed if state is `renderer-ready` or `renderer-degraded`. |
-| 13 | `assets/js/core/renderer-fsm.ts` | Expand FSM to include audio states and cross-cutting transitions (audio failure while rendering, device loss during audio playback). |
+| 11 | `src/js/core/audio-handler.ts` | Add `AudioPipelineMode` enum (`worklet` | `analyser-node`). Expose on `FrequencyAnalyser`. Add `AudioInitEvent` union for FSM integration. |
+| 12 | `src/js/core/animation-loop.ts` | Guard `initAudio` call with FSM state check: only proceed if state is `renderer-ready` or `renderer-degraded`. |
+| 13 | `src/js/core/renderer-fsm.ts` | Expand FSM to include audio states and cross-cutting transitions (audio failure while rendering, device loss during audio playback). |
 
 ### Files NOT Changed
 

--- a/docs/architecture/shader-support-inventory.md
+++ b/docs/architecture/shader-support-inventory.md
@@ -1,6 +1,6 @@
 # Shader Support Inventory — MilkDrop Compiler
 
-Analysis date: 2026-07-18. Based on the current audit of `assets/js/milkdrop/compiler/**`, `assets/js/milkdrop/shader-ast.ts`, `assets/js/milkdrop/shader-samplers.ts`, and the test suite (`tests/milkdrop-compiler*.test.ts`).
+Analysis date: 2026-07-18. Based on the current audit of `src/js/milkdrop/compiler/**`, `src/js/milkdrop/shader-ast.ts`, `src/js/milkdrop/shader-samplers.ts`, and the test suite (`tests/milkdrop-compiler*.test.ts`).
 
 ## Scope
 

--- a/docs/evidence/RECURRING_FIX_PATTERNS_AUDIT_2026-05.md
+++ b/docs/evidence/RECURRING_FIX_PATTERNS_AUDIT_2026-05.md
@@ -26,23 +26,23 @@ Files appearing most often in the 300 fix-captioned commits:
 |---|---|---|---|---|
 | 1 | `tests/milkdrop-renderer-adapter.test.ts` | 10 | 58 | 17.2% |
 | 2 | `assets/css/base.css` | 9 | 22 | 40.9% |
-| 3 | `assets/js/milkdrop/feedback-manager-shared.ts` | 8 | 21 | 38.1% |
-| 4 | `assets/js/milkdrop/feedback-manager-webgpu.ts` | 7 | 20 | 35.0% |
-| 5 | `assets/js/frontend/workspace-hooks.ts` | 7 | 19 | 36.8% |
-| 6 | `assets/js/frontend/App.tsx` | 7 | 39 | 17.9% |
-| 7 | `assets/js/core/renderer-setup.ts` | 7 | 9 | 77.8% |
+| 3 | `src/js/milkdrop/feedback-manager-shared.ts` | 8 | 21 | 38.1% |
+| 4 | `src/js/milkdrop/feedback-manager-webgpu.ts` | 7 | 20 | 35.0% |
+| 5 | `src/js/frontend/workspace-hooks.ts` | 7 | 19 | 36.8% |
+| 6 | `src/js/frontend/App.tsx` | 7 | 39 | 17.9% |
+| 7 | `src/js/core/renderer-setup.ts` | 7 | 9 | 77.8% |
 | 8 | `assets/css/index.css` | 7 | 31 | 22.6% |
 | 9 | `tests/milkdrop-compiler.test.ts` | 6 | 30 | 20.0% |
 | 10 | `tests/loader.test.js` | 6 | 20 | 30.0% |
 | 11 | `index.html` | 6 | 32 | 18.8% |
-| 12 | `assets/js/ui/audio-controls.ts` | 6 | 16 | 37.5% |
-| 13 | `assets/js/milkdrop/renderer-adapter.ts` | 6 | 33 | 18.2% |
+| 12 | `src/js/ui/audio-controls.ts` | 6 | 16 | 37.5% |
+| 13 | `src/js/milkdrop/renderer-adapter.ts` | 6 | 33 | 18.2% |
 | 14 | `tests/setup.ts` | 5 | 15 | 33.3% |
-| 15 | `assets/js/ui/nav.ts` | 5 | 19 | 26.3% |
-| 16 | `assets/js/toy-view.ts` | 5 | 12 | 41.7% |
-| 17 | `assets/js/milkdrop/compiler.ts` | 5 | 25 | 20.0% |
-| 18 | `assets/js/library-view.js` | 5 | 16 | 31.3% |
-| 19 | `assets/js/core/capability-preflight.ts` | 5 | 15 | 33.3% |
+| 15 | `src/js/ui/nav.ts` | 5 | 19 | 26.3% |
+| 16 | `src/js/toy-view.ts` | 5 | 12 | 41.7% |
+| 17 | `src/js/milkdrop/compiler.ts` | 5 | 25 | 20.0% |
+| 18 | `src/js/library-view.js` | 5 | 16 | 31.3% |
+| 19 | `src/js/core/capability-preflight.ts` | 5 | 15 | 33.3% |
 | 20 | `toys/symph.html` | 4 | 10 | 40.0% |
 
 \* File removed in Jun 2026 refactor — capability probe logic folded into `engine-context.tsx`.
@@ -52,14 +52,14 @@ Files appearing most often in the 300 fix-captioned commits:
 Files that are both high-churn (top 20 in all-commit frequency) AND high-fix-density (≥25% fix rate):
 
 ### Feedback manager (parity core)
-- **`assets/js/milkdrop/feedback-manager-shared.ts`** — 8/21 = 38.1% fix rate
-- **`assets/js/milkdrop/feedback-manager-webgpu.ts`** — 7/20 = 35.0% fix rate
+- **`src/js/milkdrop/feedback-manager-shared.ts`** — 8/21 = 38.1% fix rate
+- **`src/js/milkdrop/feedback-manager-webgpu.ts`** — 7/20 = 35.0% fix rate
 - Root cause: Shared logic drifts when WebGPU path diverges; parity changes don't always get cross-backend regression tests.
 
 ### UI state surface
-- **`assets/js/frontend/workspace-hooks.ts`** — 7/19 = 36.8% fix rate
-- **`assets/js/ui/audio-controls.ts`** — 6/16 = 37.5% fix rate
-- **`assets/js/ui/nav.ts`** — 5/19 = 26.3% fix rate
+- **`src/js/frontend/workspace-hooks.ts`** — 7/19 = 36.8% fix rate
+- **`src/js/ui/audio-controls.ts`** — 6/16 = 37.5% fix rate
+- **`src/js/ui/nav.ts`** — 5/19 = 26.3% fix rate
 - Root cause: Stale closures in React hooks, async engine-state races, toggle double-fire.
 
 ### CSS regressions
@@ -68,13 +68,13 @@ Files that are both high-churn (top 20 in all-commit frequency) AND high-fix-den
 - Root cause: Shared CSS base has cascading effects; layout fixes aren't verified at responsive breakpoints.
 
 ### Toy/module boundary
-- **`assets/js/toy-view.ts`** — 5/12 = 41.7% fix rate
-- **`assets/js/library-view.js`** — 5/16 = 31.3% fix rate
+- **`src/js/toy-view.ts`** — 5/12 = 41.7% fix rate
+- **`src/js/library-view.js`** — 5/16 = 31.3% fix rate
 - **`toys/symph.html`** — 4/10 = 40.0% fix rate
 - Root cause: Standalone toy HTML pages and their loader bridge share no contract or test; each toy breaks independently.
 
 ### Renderer setup (fallback)
-- **`assets/js/core/renderer-setup.ts`** — 7/9 = 77.8% fix rate
+- **`src/js/core/renderer-setup.ts`** — 7/9 = 77.8% fix rate
 - Root cause: Nearly every change to this file is a fix. The fallback/initialization state machine is fragile despite low overall churn.
 
 ## 4. New patterns
@@ -82,7 +82,7 @@ Files that are both high-churn (top 20 in all-commit frequency) AND high-fix-den
 ### Module loading & bootstrap (11.2% of fixes)
 This category covers: toy module loading failures, manifest resolution, library boot regressions, gamepad polling, iframe loading, demo autostart, and route loader resolution. These are distinct from deploy/tooling (build pipeline, wrangler config) and distinct from fallback fragility (renderer backends).
 
-**Typical files:** `assets/js/bootstrap/*`, `assets/js/loader.ts`, `assets/js/library-view.js`, `assets/js/toy-view.ts`, `assets/js/milkdrop/catalog-store*.ts`
+**Typical files:** `src/js/bootstrap/*`, `src/js/loader.ts`, `src/js/library-view.js`, `src/js/toy-view.ts`, `src/js/milkdrop/catalog-store*.ts`
 
 **Why it's new:** These commits did not exist when the five-theme taxonomy was created. The repo has grown a complex module-loading layer (bundled toys, catalog, manifest) that lacks a dedicated review skill.
 
@@ -108,7 +108,7 @@ This category covers: standalone toy HTML files (`toys/*.html`, `multi.html`, `d
 ### review-test-harness
 - **Update:** The "~20%" claim is close (15.2%).
 - **Add checklist item:** `tests/milkdrop-renderer-adapter.test.ts` appears in 10 fix commits (most of any file). Any test expectation change in this file must reference a specific parity regression commit SHA.
-- **Add checklist item:** `tests/loader.test.js` (30% fix rate) — loader test stubs must mock consistently with `assets/js/loader.ts` module resolution semantics.
+- **Add checklist item:** `tests/loader.test.js` (30% fix rate) — loader test stubs must mock consistently with `src/js/loader.ts` module resolution semantics.
 
 ### review-workspace-ui-state
 - **Update:** The "~10%" claim needs correction to 18.4%.
@@ -117,11 +117,11 @@ This category covers: standalone toy HTML files (`toys/*.html`, `multi.html`, `d
 - **Add checklist item:** `nav.ts` (26.3% fix rate) — verify that back-button, search-launch, and route-change paths have regression tests covering rapid sequential invocations.
 
 ### New skill: review-module-loading (recommended)
-- **Files to gate:** `assets/js/bootstrap/*`, `assets/js/loader.ts`, `assets/js/library-view.js`, `assets/js/toy-view.ts`, `assets/js/milkdrop/catalog-store*.ts`, `index.html`
+- **Files to gate:** `src/js/bootstrap/*`, `src/js/loader.ts`, `src/js/library-view.js`, `src/js/toy-view.ts`, `src/js/milkdrop/catalog-store*.ts`, `index.html`
 - **Why:** 11.2% of fixes cluster in module loading, manifest resolution, and library boot. No skill exists.
 - **Checklist items:**
   - Toy module paths must be validated against the bundled manifest
-  - Loader resolution must handle both dev (`/assets/js/...`) and prod (hashed) paths
+  - Loader resolution must handle both dev (`/src/js/...`) and prod (hashed) paths
   - Library boot must guard against null DOM cache reads
   - Gamepad polling must survive startup before `navigator.getGamepads` is available
   - `index.html` changes must be verified across all route entry points (`/`, `/?tool=`, `/?preset=`)
@@ -148,7 +148,7 @@ Created to cover the deploy/tooling category (16.0%, #3). Gating files: `.github
 
 ### review-module-loading (2026-05-16)
 
-Created to cover the module loading & bootstrap category (11.2%, #5). Gating files: `assets/js/bootstrap/*`, `assets/js/loader.ts`, `assets/js/library-view.js`, `assets/js/toy-view.ts`, `assets/js/milkdrop/catalog-store*.ts`, `assets/data/toys.json`, `index.html`, gamepad polling code. See `.agent/skills/review-module-loading/SKILL.md`.
+Created to cover the module loading & bootstrap category (11.2%, #5). Gating files: `src/js/bootstrap/*`, `src/js/loader.ts`, `src/js/library-view.js`, `src/js/toy-view.ts`, `src/js/milkdrop/catalog-store*.ts`, `src/data/toys.json`, `index.html`, gamepad polling code. See `.agent/skills/review-module-loading/SKILL.md`.
 
 Both skills are registered in `scripts/mcp-shared.ts`, `docs/agents/custom-capabilities.md`, and `docs/agents/visualizer-workflows.md`.
 

--- a/docs/evidence/RELEASE_EVIDENCE_LEDGER_2026-05.md
+++ b/docs/evidence/RELEASE_EVIDENCE_LEDGER_2026-05.md
@@ -50,7 +50,7 @@ Volume samplers are semantically routed on both backends. WebGPU uses native 3D 
 
 Source artifacts:
 
-- `assets/data/milkdrop-parity/webgpu-certification-report.json`
-- `assets/data/milkdrop-parity/visual-reference-manifest.json`
-- `assets/data/milkdrop-parity/measured-results.json`
+- `src/data/milkdrop-parity/webgpu-certification-report.json`
+- `src/data/milkdrop-parity/visual-reference-manifest.json`
+- `src/data/milkdrop-parity/measured-results.json`
 - `tests/fixtures/milkdrop/projectm-reference/`

--- a/docs/evidence/public-claim-audit.md
+++ b/docs/evidence/public-claim-audit.md
@@ -13,8 +13,8 @@
 | 3 | `index.html` | 84–91 | LD+JSON schema `"name": "MilkDrop Visualizer"` | Structured-data markup claims "MilkDrop Visualizer" as the application name. Schema consumers (search engines, assistants) will treat this as the canonical product name. | **Critical** |
 | 4 | `index.html` | 99 | `"Loading MilkDrop visualizer"` (loading-screen text) | Same unqualified naming in user-facing loading copy. | **Critical** |
 | 5 | `docs/LINEAGE_AND_CREDITS.md` | 11 | "Compatible with parts of the broader MilkDrop/projectM preset ecosystem." | "Compatible" implies functional equivalence. Only 4 of 23 corpus presets have measured visual evidence against any reference. 19 have no measured comparison — including 7 projectM-upstream fixtures and all 10 parity-corpus presets. "Parts of" softens the claim but does not quantify which parts or how many. | **High** |
-| 6 | `assets/data/milkdrop-parity/certification-corpus.json` | 3,5 | `"parityTarget": "projectm-webgpu-certification-v1"`, `"presetCount": 23` | The file name (`certification-corpus`) and its top-level fields present all 23 presets as part of a "certification" target. Only 4 have certified results in `measured-results.json`. The other 19 are uncertified with no measured visual evidence. | **High** |
-| 7 | `docs/DEVELOPMENT.md` | 111–114 | "To capture the certification corpus directly from `assets/data/milkdrop-parity/certification-corpus.json` … use: `bun run parity:capture:corpus -- --group bundled-shipped`" | Refers to the full 23-preset file as a "certification corpus" without distinguishing which presets are certified (4) from which are targets for future certification (19). The command scopes correctly to `bundled-shipped` but the surrounding prose does not. | **High** |
+| 6 | `src/data/milkdrop-parity/certification-corpus.json` | 3,5 | `"parityTarget": "projectm-webgpu-certification-v1"`, `"presetCount": 23` | The file name (`certification-corpus`) and its top-level fields present all 23 presets as part of a "certification" target. Only 4 have certified results in `measured-results.json`. The other 19 are uncertified with no measured visual evidence. | **High** |
+| 7 | `docs/DEVELOPMENT.md` | 111–114 | "To capture the certification corpus directly from `src/data/milkdrop-parity/certification-corpus.json` … use: `bun run parity:capture:corpus -- --group bundled-shipped`" | Refers to the full 23-preset file as a "certification corpus" without distinguishing which presets are certified (4) from which are targets for future certification (19). The command scopes correctly to `bundled-shipped` but the surrounding prose does not. | **High** |
 | 8 | `docs/DEVELOPMENT.md` | 155,161 | "To run the certified parity suite … each certified preset" | Calls presets in the corpus "certified" when only 4 have certification evidence. A reader scanning this section would assume all suite presets have been through the full measurement pipeline. | **High** |
 | 9 | `docs/MILKDROP_PROJECTM_PARITY_BACKLOG.md` | 1 | `# MilkDrop projectM parity backlog` | Title implies Stims is tracking toward "MilkDrop projectM parity" — a framing that suggests parity is an achievable next step rather than an open research question. The body correctly qualifies this but the title is absolute. | **Medium** |
 | 10 | `docs/MILKDROP_SUCCESSOR_WORKSTREAMS.md` | 1 | `# MilkDrop successor workstreams` | Title uses "successor" without qualification. The body on line 5 adds aspirational language ("to become the strongest credible successor candidate"), but the unqualified title reads as a claim of successor status. | **Medium** |
@@ -88,7 +88,7 @@ Imprecise language that a skeptical reader would challenge, or titles/headings t
 + "Able to load and render presets from the MilkDrop/projectM ecosystem. Visual fidelity varies: 4 of 23 certification-corpus presets have measured near-exact results; the remaining presets are at the compiler/runtime compatibility stage and have not yet been measured against projectM references."
 ```
 
-**Finding #6 — `assets/data/milkdrop-parity/certification-corpus.json:3`**
+**Finding #6 — `src/data/milkdrop-parity/certification-corpus.json:3`**
 This is a data file, not prose. Add a top-level note field:
 ```json
 "parityTarget": "projectm-webgpu-certification-v1",
@@ -98,7 +98,7 @@ This is a data file, not prose. Add a top-level note field:
 
 **Finding #7 — `docs/DEVELOPMENT.md:111–114`**
 ```
-  To capture the certification corpus directly from `assets/data/milkdrop-parity/certification-corpus.json`
+  To capture the certification corpus directly from `src/data/milkdrop-parity/certification-corpus.json`
   instead of the checked-in visual-reference manifest, use:
 + (Note: only 4 of the 23 corpus presets have measured results. The corpus represents certification targets,
 + not completed certifications.)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "check:architecture": "node --max-old-space-size=4096 ./node_modules/dependency-cruiser/bin/dependency-cruise.mjs --config .dependency-cruiser.mjs src/js scripts tests",
     "check:toys": "bun run scripts/check-toys.ts",
     "check:seo": "bun run scripts/check-seo.ts",
+    "check:css-tokens": "bun run scripts/check-css-tokens.ts",
+    "check:stale-paths": "bun run scripts/check-stale-paths.ts",
     "build": "bun scripts/build.mjs || node scripts/build.mjs",
     "build:reuse": "bun run build -- --reuse",
     "generate:toys": "bun run scripts/generate-toy-manifest.ts",

--- a/scripts/check-css-tokens.ts
+++ b/scripts/check-css-tokens.ts
@@ -1,0 +1,100 @@
+/**
+ * Fail on `var(--token)` references that resolve to nothing.
+ *
+ * CSS treats an undefined custom property as invalid at computed-value time:
+ * the declaration is dropped and the property falls back to its inherited or
+ * initial value, silently. `body, html { font-family: var(--display-font) }`
+ * referenced a property that was never defined, so the entire app rendered in
+ * the UA serif — in production, past CI, past 1200 tests, unnoticed.
+ *
+ * A usage is considered safe when the property is defined anywhere in the CSS,
+ * set from JS via setProperty, or the `var()` supplies a fallback.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+const CSS_ROOTS = ['src/css'];
+const JS_ROOTS = ['src/js'];
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist']);
+
+function walk(dir: string, exts: string[], out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) walk(full, exts, out);
+    else if (exts.includes(extname(full))) out.push(full);
+  }
+  return out;
+}
+
+const cssFiles = CSS_ROOTS.flatMap((r) => walk(r, ['.css']));
+const jsFiles = JS_ROOTS.flatMap((r) => walk(r, ['.ts', '.tsx', '.js']));
+
+/** Properties declared in CSS: `--name:` */
+const defined = new Set<string>();
+for (const file of cssFiles) {
+  const text = readFileSync(file, 'utf8');
+  for (const m of text.matchAll(/(--[A-Za-z0-9_-]+)\s*:/g)) {
+    defined.add(m[1]);
+  }
+}
+
+/** Properties written from JS: setProperty('--name', …) */
+for (const file of jsFiles) {
+  const text = readFileSync(file, 'utf8');
+  if (!text.includes('setProperty')) continue;
+  for (const m of text.matchAll(
+    /setProperty\(\s*['"`](--[A-Za-z0-9_-]+)['"`]/g,
+  )) {
+    defined.add(m[1]);
+  }
+}
+
+type Offence = { file: string; line: number; token: string; text: string };
+const offences: Offence[] = [];
+
+/** Blank out comments while preserving line numbers. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+for (const file of cssFiles) {
+  const lines = stripComments(readFileSync(file, 'utf8')).split('\n');
+  lines.forEach((line, i) => {
+    // Capture the token and whatever follows, to detect a fallback argument.
+    for (const m of line.matchAll(/var\(\s*(--[A-Za-z0-9_-]+)\s*([,)])/g)) {
+      const token = m[1];
+      const hasFallback = m[2] === ',';
+      if (hasFallback || defined.has(token)) continue;
+      offences.push({
+        file,
+        line: i + 1,
+        token,
+        text: line.trim().slice(0, 120),
+      });
+    }
+  });
+}
+
+if (offences.length > 0) {
+  console.error(
+    `Found ${offences.length} var() reference(s) to undefined custom properties.\n` +
+      `An undefined var() with no fallback drops the whole declaration silently.\n` +
+      `Define the token, or give the var() a fallback value.\n`,
+  );
+  for (const o of offences) {
+    console.error(`  ${o.file}:${o.line}  ${o.token}\n      ${o.text}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `✔ all var() references resolve (${defined.size} tokens defined, ${cssFiles.length} stylesheets)`,
+);

--- a/scripts/check-stale-paths.ts
+++ b/scripts/check-stale-paths.ts
@@ -7,8 +7,10 @@
  * `.claude/CLAUDE.md` straight into them — and CODEOWNERS globs that match
  * nothing silently disable review requirements.
  *
- * `docs/archive/` is exempt: archived material is a record of what was true
- * at the time, not a live instruction.
+ * Historical records are exempt: `docs/archive/`, plus dated audits, critiques
+ * and assessments. Those describe what a file tree looked like when someone
+ * examined it, so rewriting their paths would misrepresent the record. The
+ * guard covers material that is meant to be acted on today.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -23,6 +25,18 @@ const SKIP_DIRS = new Set([
   'screenshots',
 ]);
 const STALE = /\bassets\/(js|data)\b/;
+
+/**
+ * Point-in-time findings rather than live instruction. These get archived
+ * rather than maintained, so their paths are left as they were recorded.
+ */
+const HISTORICAL_RECORD =
+  /(AUDIT|CRITIQUE|ANTI_PATTERNS|RESEARCH|_REPORT_|assessment)/i;
+
+function isHistoricalRecord(file: string): boolean {
+  const name = file.split('/').pop() ?? '';
+  return file.startsWith('docs/') && HISTORICAL_RECORD.test(name);
+}
 
 function walk(dir: string, out: string[] = []): string[] {
   let entries: string[];
@@ -49,6 +63,7 @@ function walk(dir: string, out: string[] = []): string[] {
 const offenders: Array<{ file: string; line: number; text: string }> = [];
 
 for (const file of [...ROOTS.flatMap((r) => walk(r)), ...EXTRA_FILES]) {
+  if (isHistoricalRecord(file)) continue;
   let text: string;
   try {
     text = readFileSync(file, 'utf8');

--- a/scripts/check-stale-paths.ts
+++ b/scripts/check-stale-paths.ts
@@ -1,0 +1,77 @@
+/**
+ * Guard against references to the pre-`src/` tree.
+ *
+ * The move from `assets/**` to `src/**` left 353 dangling references across
+ * docs, agent skills, CODEOWNERS, and the labeler config. Docs that lie are
+ * worse than missing docs — agents follow the routing tables in
+ * `.claude/CLAUDE.md` straight into them — and CODEOWNERS globs that match
+ * nothing silently disable review requirements.
+ *
+ * `docs/archive/` is exempt: archived material is a record of what was true
+ * at the time, not a live instruction.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = ['.agent', 'docs', '.github', 'src', 'scripts', 'tests'];
+const EXTRA_FILES = ['AGENTS.md', 'README.md'];
+const SKIP_DIRS = new Set([
+  'archive',
+  'node_modules',
+  '.git',
+  'dist',
+  'screenshots',
+]);
+const STALE = /\bassets\/(js|data)\b/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+const offenders: Array<{ file: string; line: number; text: string }> = [];
+
+for (const file of [...ROOTS.flatMap((r) => walk(r)), ...EXTRA_FILES]) {
+  let text: string;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+  if (!STALE.test(text)) continue;
+  text.split('\n').forEach((line, i) => {
+    if (STALE.test(line)) {
+      offenders.push({ file, line: i + 1, text: line.trim().slice(0, 120) });
+    }
+  });
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `Found ${offenders.length} reference(s) to the removed assets/ tree.\n` +
+      `The source lives under src/js/** and src/data/** now.\n`,
+  );
+  for (const o of offenders) {
+    console.error(`  ${o.file}:${o.line}  ${o.text}`);
+  }
+  process.exit(1);
+}
+
+console.log('✔ no references to the removed assets/ tree');

--- a/scripts/run-quality-gate.ts
+++ b/scripts/run-quality-gate.ts
@@ -81,6 +81,14 @@ export function buildGatePlan(
         cmd: ['bun', 'run', 'check:seo'],
       },
       {
+        label: 'CSS token resolution',
+        cmd: ['bun', 'run', 'check:css-tokens'],
+      },
+      {
+        label: 'Stale assets/ path check',
+        cmd: ['bun', 'run', 'check:stale-paths'],
+      },
+      {
         label: 'Architecture boundary check',
         cmd: ['bun', 'run', 'check:architecture'],
       },

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1515,7 +1515,7 @@ html.light .search-meta__note {
   border: 1px dashed var(--surface-border);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
-  background: var(--surface-strong);
+  background: var(--panel-solid);
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -1535,7 +1535,7 @@ html.light .search-meta__note {
   text-align: left;
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-border);
-  background: color-mix(in srgb, var(--surface-strong) 78%, transparent);
+  background: color-mix(in srgb, var(--panel-solid) 78%, transparent);
   padding: 0.35rem 0.55rem 0.6rem;
 }
 
@@ -2721,7 +2721,7 @@ body.tv-mode .content {
   border-radius: 10px;
   border: 1px solid var(--interactive-border);
   background: color-mix(in srgb, var(--card-bg) 90%, transparent);
-  color: var(--text-primary);
+  color: var(--text-color);
   min-height: 44px;
   padding: 0.5rem 0.65rem;
 }
@@ -2776,7 +2776,7 @@ body.tv-mode .content {
   align-self: start;
   border-radius: var(--radius-pill);
   border: 1px solid var(--interactive-border);
-  color: var(--text-primary);
+  color: var(--text-color);
   text-decoration: none;
   padding: 0.4rem 0.8rem;
   min-height: 40px;

--- a/src/js/core/device-profile.ts
+++ b/src/js/core/device-profile.ts
@@ -138,9 +138,9 @@ export function getAdaptiveMaxPixelRatio(maxPixelRatio: number) {
  */
 export const DEVICE_TIER_QUALITY_PRESET_IDS: Record<DeviceTier, string> = {
   low: 'performance',
-  mid: 'tv',
-  high: 'balanced',
-  ultra: 'hi-fi',
+  mid: 'balanced',
+  high: 'hi-fi',
+  ultra: 'ultra',
 };
 
 /** Used whenever tier detection is unavailable or maps to an unknown preset. */

--- a/src/js/core/device-profile.ts
+++ b/src/js/core/device-profile.ts
@@ -138,9 +138,9 @@ export function getAdaptiveMaxPixelRatio(maxPixelRatio: number) {
  */
 export const DEVICE_TIER_QUALITY_PRESET_IDS: Record<DeviceTier, string> = {
   low: 'performance',
-  mid: 'balanced',
-  high: 'hi-fi',
-  ultra: 'ultra',
+  mid: 'tv',
+  high: 'balanced',
+  ultra: 'hi-fi',
 };
 
 /** Used whenever tier detection is unavailable or maps to an unknown preset. */

--- a/tests/e2e/chrome-visual-contract.test.ts
+++ b/tests/e2e/chrome-visual-contract.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Rendered-invariant checks for the workspace chrome.
+ *
+ * Deliberately not pixel snapshots: baselines captured on macOS drift against
+ * Linux CI on font rasterisation alone, and this repo already has enough tests
+ * that fail for reasons unrelated to the defect they claim to guard.
+ *
+ * Instead this asserts properties of the *computed* result, which are stable
+ * across platforms. Each check corresponds to a defect that actually shipped:
+ *
+ *   - `var(--display-font)` was undefined, so every page fell back to the UA
+ *     serif. Nothing caught it.
+ *   - A blanket `input { min-height: 44px }` stretched checkboxes to 18x44.
+ *   - The collection chips overflowed their row and clipped at both edges.
+ *   - The side panel was hard-coded dark, so light mode failed WCAG AA.
+ */
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import { type Browser, chromium, type Page } from 'playwright';
+import { type DevServerHandle, startDevServer } from './dev-server.ts';
+
+const TEST_PORT = 5183;
+const hasChromium = fs.existsSync(chromium.executablePath());
+const chromeTest = hasChromium ? test : test.skip;
+
+let server: DevServerHandle | null = null;
+let browser: Browser | null = null;
+
+beforeAll(async () => {
+  if (!hasChromium) return;
+  server = await startDevServer({ port: TEST_PORT });
+  browser = await chromium.launch({ headless: true });
+}, 90000);
+
+afterAll(async () => {
+  await browser?.close();
+  const s = server;
+  server = null;
+  await s?.stop();
+});
+
+async function openPanel(panel: string, theme: 'dark' | 'light' = 'dark') {
+  const page = await (browser as Browser).newPage({
+    viewport: { width: 1280, height: 900 },
+  });
+  // Seed the stored preference before boot. Toggling the class afterwards is
+  // not enough: the app applies its own theme on mount and overwrites it,
+  // which silently turned the light-mode assertions into a second dark run.
+  await page.addInitScript((t) => {
+    try {
+      localStorage.setItem('stims:theme', t as string);
+    } catch {}
+  }, theme);
+  await page.goto(`${server?.url}/?agent=true&panel=${panel}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.waitForSelector('.ctl-section, .ctl-browse-filters', {
+    timeout: 30000,
+  });
+
+  // Fail loudly if the theme did not take, rather than measuring the wrong one.
+  const applied = await page.evaluate(() =>
+    document.documentElement.classList.contains('light') ? 'light' : 'dark',
+  );
+  if (applied !== theme) {
+    throw new Error(
+      `Expected ${theme} theme but the document resolved to ${applied}; the contrast assertions would have measured the wrong palette.`,
+    );
+  }
+  return page;
+}
+
+/** WCAG relative-luminance contrast between two rendered colours. */
+const CONTRAST_FN = `(fg, bg) => {
+  const parse = (c) => c.match(/[\\d.]+/g).map(Number);
+  const lin = (v) => { v /= 255; return v <= 0.03928 ? v/12.92 : ((v+0.055)/1.055) ** 2.4; };
+  const lum = ([r,g,b]) => 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b);
+  const f = parse(fg), b = parse(bg);
+  const a = f.length > 3 && f[3] < 1
+    ? [0,1,2].map(i => f[3]*f[i] + (1-f[3])*b[i])
+    : f.slice(0,3);
+  const L1 = lum(a), L2 = lum(b.slice(0,3));
+  return (Math.max(L1,L2) + 0.05) / (Math.min(L1,L2) + 0.05);
+}`;
+
+chromeTest(
+  'body text does not fall back to the UA serif',
+  async () => {
+    const page = await openPanel('settings');
+    try {
+      const family = await page.evaluate(
+        () => getComputedStyle(document.body).fontFamily,
+      );
+      // The exact stack may change; falling back to a UA serif never should.
+      expect(family.toLowerCase()).not.toMatch(/^(times|serif|"times)/);
+      expect(family).toMatch(/Grotesk|Inter|system-ui|sans-serif/i);
+    } finally {
+      await page.close();
+    }
+  },
+  60000,
+);
+
+chromeTest(
+  'switches render as switches, not stretched bars',
+  async () => {
+    const page = await openPanel('settings');
+    try {
+      const boxes = await page.$$eval('.ctl-switch', (els) =>
+        els.map((el) => {
+          const r = el.getBoundingClientRect();
+          return { w: Math.round(r.width), h: Math.round(r.height) };
+        }),
+      );
+      expect(boxes.length).toBeGreaterThan(0);
+      for (const box of boxes) {
+        // A control forced to a 44px touch target while keeping its 18px width
+        // is the exact failure this guards; a switch is wider than it is tall.
+        expect(box.h).toBeLessThanOrEqual(32);
+        expect(box.w).toBeGreaterThan(box.h);
+      }
+    } finally {
+      await page.close();
+    }
+  },
+  60000,
+);
+
+chromeTest(
+  'browse filter chips stay reachable rather than clipping',
+  async () => {
+    const page = await openPanel('browse');
+    try {
+      const scroller = await page.evaluate(() => {
+        const el = document.querySelector('.ctl-scroller');
+        if (!el) return null;
+        const cs = getComputedStyle(el);
+        return {
+          overflowX: cs.overflowX,
+          masked:
+            cs.maskImage !== 'none' ||
+            (cs as unknown as { webkitMaskImage?: string }).webkitMaskImage !==
+              'none',
+          overflows: el.scrollWidth > el.clientWidth,
+        };
+      });
+      expect(scroller).not.toBeNull();
+      // Content wider than the rail is expected; being unable to reach it is not.
+      if (scroller?.overflows) {
+        expect(scroller.overflowX).toBe('auto');
+        expect(scroller.masked).toBe(true);
+      }
+    } finally {
+      await page.close();
+    }
+  },
+  60000,
+);
+
+for (const theme of ['dark', 'light'] as const) {
+  chromeTest(
+    `panel text meets WCAG AA in ${theme} mode`,
+    async () => {
+      const page = await openPanel('browse', theme);
+      try {
+        const results = await page.evaluate(
+          ([contrastSrc]) => {
+            const contrast = eval(contrastSrc as string) as (
+              fg: string,
+              bg: string,
+            ) => number;
+            const panel = document.querySelector('[class*="_panel_"]');
+            if (!panel) return [];
+            const bg = getComputedStyle(panel).backgroundColor;
+            const targets = [
+              '.ctl-preset__title',
+              '.ctl-preset__meta',
+              '.ctl-readout',
+              '.ctl-field',
+            ];
+            return targets.flatMap((sel) => {
+              const el = document.querySelector(sel);
+              if (!el) return [];
+              const cs = getComputedStyle(el);
+              return [
+                {
+                  sel,
+                  px: parseFloat(cs.fontSize),
+                  ratio: contrast(cs.color, bg),
+                },
+              ];
+            });
+          },
+          [CONTRAST_FN],
+        );
+
+        expect(results.length).toBeGreaterThan(0);
+        for (const r of results) {
+          const needed = r.px >= 24 ? 3 : 4.5;
+          if (r.ratio < needed) {
+            throw new Error(
+              `${r.sel} at ${r.px}px has contrast ${r.ratio.toFixed(2)}:1 in ${theme} mode, needs ${needed}:1`,
+            );
+          }
+        }
+      } finally {
+        await page.close();
+      }
+    },
+    60000,
+  );
+}

--- a/tests/e2e/chrome-visual-contract.test.ts
+++ b/tests/e2e/chrome-visual-contract.test.ts
@@ -57,6 +57,7 @@ async function openPanel(panel: string, theme: 'dark' | 'light' = 'dark') {
   await page.waitForSelector('.ctl-section, .ctl-browse-filters', {
     timeout: 30000,
   });
+  await settle(page, '[class*="_panel_"]');
 
   // Fail loudly if the theme did not take, rather than measuring the wrong one.
   const applied = await page.evaluate(() =>
@@ -68,6 +69,23 @@ async function openPanel(panel: string, theme: 'dark' | 'light' = 'dark') {
     );
   }
   return page;
+}
+
+/**
+ * Wait for entrance animations to settle. The panel slides up over 300ms, so
+ * measuring geometry immediately after it appears reads a partially
+ * transformed box and fails intermittently.
+ */
+async function settle(page: Page, selector: string) {
+  await page.waitForFunction(
+    (sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return false;
+      return el.getAnimations().every((a) => a.playState !== 'running');
+    },
+    selector,
+    { timeout: 10000 },
+  );
 }
 
 /** WCAG relative-luminance contrast between two rendered colours. */
@@ -150,6 +168,87 @@ chromeTest(
         expect(scroller.overflowX).toBe('auto');
         expect(scroller.masked).toBe(true);
       }
+    } finally {
+      await page.close();
+    }
+  },
+  60000,
+);
+
+chromeTest(
+  'mobile layout scrolls and never overflows sideways',
+  async () => {
+    const page = await (browser as Browser).newPage({
+      viewport: { width: 375, height: 812 },
+      deviceScaleFactor: 2,
+      isMobile: true,
+      hasTouch: true,
+    });
+    try {
+      await page.goto(`${server?.url}/?agent=true`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.waitForSelector('.stims-shell__stage-frame', {
+        timeout: 30000,
+      });
+
+      const layout = await page.evaluate(() => {
+        const doc = document.documentElement;
+        const frame = document.querySelector('.stims-shell__stage-frame');
+        return {
+          // A horizontal scrollbar on a phone is always a layout bug. The 2px
+          // slack absorbs sub-pixel rounding on fractional device ratios.
+          horizontalOverflow: doc.scrollWidth - doc.clientWidth,
+          // The home stage must be reachable by scrolling rather than clipped.
+          verticallyScrollable: doc.scrollHeight > doc.clientHeight,
+          frameWidth: frame ? frame.getBoundingClientRect().width : 0,
+          viewportWidth: doc.clientWidth,
+        };
+      });
+
+      expect(layout.horizontalOverflow).toBeLessThanOrEqual(2);
+      // The stage must actually occupy the viewport, not collapse to a sliver.
+      expect(layout.frameWidth).toBeGreaterThan(layout.viewportWidth * 0.8);
+    } finally {
+      await page.close();
+    }
+  },
+  60000,
+);
+
+chromeTest(
+  'panel becomes a full-width sheet on mobile',
+  async () => {
+    const page = await (browser as Browser).newPage({
+      viewport: { width: 375, height: 812 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    try {
+      await page.goto(`${server?.url}/?agent=true&panel=browse`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.waitForSelector('.ctl-browse-filters', { timeout: 30000 });
+      await settle(page, '[class*="_panel_"]');
+
+      const panel = await page.evaluate(() => {
+        const el = document.querySelector('[class*="_panel_"]');
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return {
+          width: Math.round(r.width),
+          viewport: document.documentElement.clientWidth,
+          bottom: Math.round(r.bottom),
+          viewportHeight: window.innerHeight,
+        };
+      });
+
+      expect(panel).not.toBeNull();
+      // Bottom sheet: spans the viewport width and is anchored to the bottom.
+      expect(panel?.width).toBe(panel?.viewport as number);
+      expect(
+        Math.abs((panel?.bottom ?? 0) - (panel?.viewportHeight ?? 0)),
+      ).toBeLessThanOrEqual(2);
     } finally {
       await page.close();
     }

--- a/tests/e2e/chrome-visual-contract.test.ts
+++ b/tests/e2e/chrome-visual-contract.test.ts
@@ -88,19 +88,6 @@ async function settle(page: Page, selector: string) {
   );
 }
 
-/** WCAG relative-luminance contrast between two rendered colours. */
-const CONTRAST_FN = `(fg, bg) => {
-  const parse = (c) => c.match(/[\\d.]+/g).map(Number);
-  const lin = (v) => { v /= 255; return v <= 0.03928 ? v/12.92 : ((v+0.055)/1.055) ** 2.4; };
-  const lum = ([r,g,b]) => 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b);
-  const f = parse(fg), b = parse(bg);
-  const a = f.length > 3 && f[3] < 1
-    ? [0,1,2].map(i => f[3]*f[i] + (1-f[3])*b[i])
-    : f.slice(0,3);
-  const L1 = lum(a), L2 = lum(b.slice(0,3));
-  return (Math.max(L1,L2) + 0.05) / (Math.min(L1,L2) + 0.05);
-}`;
-
 chromeTest(
   'body text does not fall back to the UA serif',
   async () => {
@@ -262,36 +249,51 @@ for (const theme of ['dark', 'light'] as const) {
     async () => {
       const page = await openPanel('browse', theme);
       try {
-        const results = await page.evaluate(
-          ([contrastSrc]) => {
-            const contrast = eval(contrastSrc as string) as (
-              fg: string,
-              bg: string,
-            ) => number;
-            const panel = document.querySelector('[class*="_panel_"]');
-            if (!panel) return [];
-            const bg = getComputedStyle(panel).backgroundColor;
-            const targets = [
-              '.ctl-preset__title',
-              '.ctl-preset__meta',
-              '.ctl-readout',
-              '.ctl-field',
+        const results = await page.evaluate(() => {
+          // Inlined rather than passed in: page.evaluate cannot serialise a
+          // closure, and eval() of a stringified helper is both a lint
+          // violation and needless indirection.
+          const parse = (c: string) => (c.match(/[\d.]+/g) ?? []).map(Number);
+          const lin = (v: number) => {
+            const n = v / 255;
+            return n <= 0.03928 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+          };
+          const lum = (rgb: number[]) =>
+            0.2126 * lin(rgb[0]) + 0.7152 * lin(rgb[1]) + 0.0722 * lin(rgb[2]);
+          const contrast = (fg: string, bg: string) => {
+            const f = parse(fg);
+            const b = parse(bg);
+            // Flatten a translucent foreground onto its backdrop first.
+            const front =
+              f.length > 3 && f[3] < 1
+                ? [0, 1, 2].map((i) => f[3] * f[i] + (1 - f[3]) * b[i])
+                : f.slice(0, 3);
+            const L1 = lum(front);
+            const L2 = lum(b.slice(0, 3));
+            return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+          };
+          const panel = document.querySelector('[class*="_panel_"]');
+          if (!panel) return [];
+          const bg = getComputedStyle(panel).backgroundColor;
+          const targets = [
+            '.ctl-preset__title',
+            '.ctl-preset__meta',
+            '.ctl-readout',
+            '.ctl-field',
+          ];
+          return targets.flatMap((sel) => {
+            const el = document.querySelector(sel);
+            if (!el) return [];
+            const cs = getComputedStyle(el);
+            return [
+              {
+                sel,
+                px: parseFloat(cs.fontSize),
+                ratio: contrast(cs.color, bg),
+              },
             ];
-            return targets.flatMap((sel) => {
-              const el = document.querySelector(sel);
-              if (!el) return [];
-              const cs = getComputedStyle(el);
-              return [
-                {
-                  sel,
-                  px: parseFloat(cs.fontSize),
-                  ratio: contrast(cs.color, bg),
-                },
-              ];
-            });
-          },
-          [CONTRAST_FN],
-        );
+          });
+        });
 
         expect(results.length).toBeGreaterThan(0);
         for (const r of results) {

--- a/tests/e2e/dev-server.ts
+++ b/tests/e2e/dev-server.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared dev-server harness for the browser end-to-end tests.
+ *
+ * Both e2e suites used to spawn vite themselves with `stdio: 'ignore'`, which
+ * made a failed start indistinguishable from a slow one: the poll loop simply
+ * timed out and every test then failed with ERR_CONNECTION_REFUSED and no
+ * explanation. This helper fixes the three ways that went wrong:
+ *
+ *   1. stderr is captured, so a start failure reports why instead of vanishing.
+ *   2. `--strictPort` makes vite fail loudly on a busy port. Without it vite
+ *      silently moves to the next free port and the tests poll an address
+ *      nothing is listening on.
+ *   3. The child is spawned detached and killed by process group. `bun run dev`
+ *      spawns vite as a grandchild, so signalling only the wrapper orphaned
+ *      vite and left it holding the port for the rest of the run.
+ */
+import { spawn } from 'node:child_process';
+
+export type DevServerHandle = {
+  readonly port: number;
+  readonly url: string;
+  stop: () => Promise<void>;
+};
+
+/** Any HTTP response proves the server is listening; a 404 counts. */
+async function isListening(url: string): Promise<boolean> {
+  try {
+    await fetch(url, { signal: AbortSignal.timeout(2000) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function startDevServer({
+  port,
+  startupTimeoutMs = 60000,
+}: {
+  port: number;
+  startupTimeoutMs?: number;
+}): Promise<DevServerHandle> {
+  const url = `http://127.0.0.1:${port}`;
+
+  const child = spawn(
+    'bun',
+    [
+      'run',
+      'vite',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--strictPort',
+    ],
+    {
+      cwd: process.cwd(),
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, BROWSER: 'none' },
+    },
+  );
+
+  let output = '';
+  const record = (chunk: Buffer) => {
+    // Keep only the tail; vite is chatty and the whole log is never useful.
+    output = `${output}${chunk.toString()}`.slice(-4000);
+  };
+  child.stdout?.on('data', record);
+  child.stderr?.on('data', record);
+
+  let exited: { code: number | null; signal: string | null } | null = null;
+  child.once('exit', (code, signal) => {
+    exited = { code, signal };
+  });
+
+  const stop = async () => {
+    if (exited || child.pid === undefined) return;
+    // Negative pid signals the whole group, so vite dies with the wrapper.
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      try {
+        child.kill('SIGTERM');
+      } catch {}
+    }
+    await Promise.race([
+      new Promise<void>((resolve) => child.once('exit', () => resolve())),
+      new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+    ]);
+    if (!exited && child.pid !== undefined) {
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {}
+    }
+  };
+
+  const deadline = Date.now() + startupTimeoutMs;
+  while (Date.now() < deadline) {
+    if (exited) {
+      const { code, signal } = exited as {
+        code: number | null;
+        signal: string | null;
+      };
+      throw new Error(
+        `Dev server exited before it started listening (code=${code}, signal=${signal}) on port ${port}.\n` +
+          `--- server output ---\n${output.trim() || '(no output)'}`,
+      );
+    }
+    if (await isListening(url)) {
+      return { port, url, stop };
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  await stop();
+  throw new Error(
+    `Dev server did not listen on ${url} within ${startupTimeoutMs}ms.\n` +
+      `--- server output ---\n${output.trim() || '(no output)'}`,
+  );
+}

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -3,12 +3,12 @@
  * Uses headed Chromium for real GPU rendering on macOS.
  */
 import { afterAll, beforeAll, expect, test } from 'bun:test';
-import { type ChildProcess, spawn } from 'node:child_process';
 import { chromium, devices } from 'playwright';
+import { type DevServerHandle, startDevServer } from './dev-server.ts';
 
 const TEST_PORT = 5181;
 const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
-let devServer: ChildProcess | null = null;
+let devServer: DevServerHandle | null = null;
 
 async function waitForMountedStage(page: import('playwright').Page) {
   await page.waitForFunction(
@@ -33,27 +33,13 @@ async function waitForActivePreset(
 }
 
 async function startServer() {
-  devServer = spawn('bun', ['run', 'dev', '--port', String(TEST_PORT)], {
-    stdio: 'ignore',
-    env: { ...process.env, BROWSER: 'none' },
-  });
-
-  const deadline = Date.now() + 45000;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(SERVER_URL);
-      if (res.ok) return;
-    } catch {}
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  throw new Error('Dev server failed to start');
+  devServer = await startDevServer({ port: TEST_PORT });
 }
 
 async function stopServer() {
-  if (devServer) {
-    devServer.kill('SIGTERM');
-    devServer = null;
-  }
+  const server = devServer;
+  devServer = null;
+  await server?.stop();
 }
 
 beforeAll(() => startServer(), { timeout: 60000 });

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -10,6 +10,32 @@ const TEST_PORT = 5181;
 const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
 let devServer: DevServerHandle | null = null;
 
+/**
+ * CI runs headed Chromium under xvfb with no real GPU. Without an explicit
+ * software renderer the browser crashes mid-test, and the failure surfaces as
+ * "Target page, context or browser has been closed" from the cleanup block
+ * rather than as the crash it actually is. These are the same flags the
+ * agent-integration suite already uses to stay green on CI.
+ */
+const RENDERER_ARGS = [
+  '--use-angle=swiftshader',
+  '--use-gl=angle',
+  '--enable-webgl',
+  '--enable-unsafe-swiftshader',
+  '--ignore-gpu-blocklist',
+];
+
+/** Never let teardown mask the assertion failure that got us here. */
+async function closeQuietly(
+  ...closeables: Array<{ close: () => Promise<unknown> }>
+) {
+  for (const c of closeables) {
+    try {
+      await c.close();
+    } catch {}
+  }
+}
+
 async function waitForMountedStage(page: import('playwright').Page) {
   await page.waitForFunction(
     () =>
@@ -48,7 +74,10 @@ afterAll(() => stopServer());
 test(
   'mounts engine, loads preset, and renders a silent preview frame',
   async () => {
-    const browser = await chromium.launch({ headless: false });
+    const browser = await chromium.launch({
+      headless: false,
+      args: RENDERER_ARGS,
+    });
     const ctx = await browser.newContext({
       viewport: { width: 1280, height: 720 },
       deviceScaleFactor: 2,
@@ -97,8 +126,7 @@ test(
       expect(info.height).toBeGreaterThan(0);
       expect(info.hasContent).toBe(true);
     } finally {
-      await ctx.close();
-      await browser.close();
+      await closeQuietly(ctx, browser);
     }
   },
   { timeout: 120000 },
@@ -107,7 +135,10 @@ test(
 test(
   'switches preset and canvas content changes',
   async () => {
-    const browser = await chromium.launch({ headless: false });
+    const browser = await chromium.launch({
+      headless: false,
+      args: RENDERER_ARGS,
+    });
     const ctx = await browser.newContext({
       viewport: { width: 1280, height: 720 },
       deviceScaleFactor: 2,
@@ -162,8 +193,7 @@ test(
       expect(hash1).toBeGreaterThan(1000);
       expect(hash2).toBeGreaterThan(1000);
     } finally {
-      await ctx.close();
-      await browser.close();
+      await closeQuietly(ctx, browser);
     }
   },
   { timeout: 120000 },
@@ -175,6 +205,7 @@ test.skipIf(!!process.env.CI)(
     const browser = await chromium.launch({
       headless: false,
       args: [
+        ...RENDERER_ARGS,
         '--use-fake-device-for-media-stream',
         '--use-fake-ui-for-media-stream',
       ],
@@ -254,8 +285,7 @@ test.skipIf(!!process.env.CI)(
 
       expect(info.route).toContain('audio=microphone');
     } finally {
-      await ctx.close();
-      await browser.close();
+      await closeQuietly(ctx, browser);
     }
   },
   { timeout: 120000 },

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -11,6 +11,15 @@ const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
 let devServer: DevServerHandle | null = null;
 
 /**
+ * Headed Chromium is what exercises a real GPU locally, which is the point of
+ * this suite on a developer machine. CI has no GPU: it runs under xvfb, and a
+ * headed browser there dies partway through the first test. Headless plus a
+ * software renderer is stable there and still produces real canvas content,
+ * which is all these assertions read.
+ */
+const HEADLESS = !!process.env.CI;
+
+/**
  * CI runs headed Chromium under xvfb with no real GPU. Without an explicit
  * software renderer the browser crashes mid-test, and the failure surfaces as
  * "Target page, context or browser has been closed" from the cleanup block
@@ -75,7 +84,7 @@ test(
   'mounts engine, loads preset, and renders a silent preview frame',
   async () => {
     const browser = await chromium.launch({
-      headless: false,
+      headless: HEADLESS,
       args: RENDERER_ARGS,
     });
     const ctx = await browser.newContext({
@@ -136,7 +145,7 @@ test(
   'switches preset and canvas content changes',
   async () => {
     const browser = await chromium.launch({
-      headless: false,
+      headless: HEADLESS,
       args: RENDERER_ARGS,
     });
     const ctx = await browser.newContext({
@@ -203,7 +212,7 @@ test.skipIf(!!process.env.CI)(
   'starts microphone audio on a mobile browser with one permission request',
   async () => {
     const browser = await chromium.launch({
-      headless: false,
+      headless: HEADLESS,
       args: [
         ...RENDERER_ARGS,
         '--use-fake-device-for-media-stream',

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -3,8 +3,17 @@
  * Uses headed Chromium for real GPU rendering on macOS.
  */
 import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
 import { chromium, devices } from 'playwright';
 import { type DevServerHandle, startDevServer } from './dev-server.ts';
+
+/**
+ * Not every workflow installs Playwright browsers — upgrade-guardrails runs
+ * `bun run test` without them, where chromium.launch() fails in milliseconds
+ * and reads as a product regression. Skip instead, matching agent-integration.
+ */
+const hasChromium = fs.existsSync(chromium.executablePath());
+const browserTest = hasChromium ? test : test.skip;
 
 const TEST_PORT = 5181;
 const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
@@ -68,6 +77,7 @@ async function waitForActivePreset(
 }
 
 async function startServer() {
+  if (!hasChromium) return;
   devServer = await startDevServer({ port: TEST_PORT });
 }
 
@@ -80,7 +90,7 @@ async function stopServer() {
 beforeAll(() => startServer(), { timeout: 60000 });
 afterAll(() => stopServer());
 
-test(
+browserTest(
   'mounts engine, loads preset, and renders a silent preview frame',
   async () => {
     const browser = await chromium.launch({
@@ -141,7 +151,7 @@ test(
   { timeout: 120000 },
 );
 
-test(
+browserTest(
   'switches preset and canvas content changes',
   async () => {
     const browser = await chromium.launch({
@@ -208,7 +218,7 @@ test(
   { timeout: 120000 },
 );
 
-test.skipIf(!!process.env.CI)(
+(hasChromium ? test.skipIf(!!process.env.CI) : test.skip)(
   'starts microphone audio on a mobile browser with one permission request',
   async () => {
     const browser = await chromium.launch({

--- a/tests/fixtures/milkdrop/projectm-reference/README.md
+++ b/tests/fixtures/milkdrop/projectm-reference/README.md
@@ -4,7 +4,7 @@ This directory stores checked-in reference renders captured from `projectM` for 
 
 The source of truth for this fixture set is:
 
-- [`assets/data/milkdrop-parity/visual-reference-manifest.json`](../../../assets/data/milkdrop-parity/visual-reference-manifest.json)
+- [`src/data/milkdrop-parity/visual-reference-manifest.json`](../../../src/data/milkdrop-parity/visual-reference-manifest.json)
 
 Each promoted native projectM preset must include:
 

--- a/tests/unit/adaptive-quality-controller.test.ts
+++ b/tests/unit/adaptive-quality-controller.test.ts
@@ -12,7 +12,28 @@ const originalNavigator = globalThis.navigator;
  * CI for exactly that reason. Individual tests still override as needed.
  */
 beforeEach(() => {
+  // Navigator first, and never behind a `window` guard: the starting quality
+  // step is gated on isMobileDevice()/isInAppBrowser(), which read userAgent,
+  // platform and maxTouchPoints. An earlier version of this hook returned
+  // early when window was undefined and silently skipped all of it.
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      ...originalNavigator,
+      // A plain desktop browser: not mobile, not an in-app webview.
+      userAgent:
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      platform: 'Linux x86_64',
+      userAgentData: undefined,
+      maxTouchPoints: 0,
+      // getDevicePerformanceProfile treats <=3 cores or <=3GB as low power.
+      hardwareConcurrency: 8,
+      deviceMemory: 8,
+    },
+  });
+
   if (typeof globalThis.window === 'undefined') return;
+
   // Nothing matches: no coarse pointer, no reduced motion, and no
   // `(update: fast)`, which pins getDisplayRefreshRate to its 60Hz baseline.
   // The expected quality steps in this suite are written against 60Hz; a
@@ -34,23 +55,6 @@ beforeEach(() => {
   if (typeof screen !== 'undefined' && 'refreshRate' in screen) {
     delete (screen as unknown as { refreshRate?: number }).refreshRate;
   }
-  Object.defineProperty(navigator, 'maxTouchPoints', {
-    configurable: true,
-    value: 0,
-  });
-
-  // The controller derives its starting step from the device performance
-  // profile, which treats <=3 cores or <=3GB as low power. CI runners report
-  // very different values from developer machines, so these are pinned to a
-  // comfortably unconstrained desktop rather than left to the host.
-  Object.defineProperty(navigator, 'hardwareConcurrency', {
-    configurable: true,
-    value: 8,
-  });
-  Object.defineProperty(navigator, 'deviceMemory', {
-    configurable: true,
-    value: 8,
-  });
 
   // renderer-capabilities stamps this on window at runtime and most suites
   // never clear it; a leaked "high-end" value promotes every device to ultra.

--- a/tests/unit/adaptive-quality-controller.test.ts
+++ b/tests/unit/adaptive-quality-controller.test.ts
@@ -1,5 +1,44 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createAdaptiveQualityController } from '../../src/js/core/services/adaptive-quality-controller.ts';
+
+const originalMatchMedia = globalThis.window?.matchMedia;
+const originalMaxTouchPoints = globalThis.navigator?.maxTouchPoints;
+
+/**
+ * The controller reads pointer/reduced-motion media queries and touch points
+ * when choosing a starting quality step. Other suites replace matchMedia
+ * globally, so without a deterministic baseline these assertions depend on
+ * which test file ran first — they passed on developer machines and failed on
+ * CI for exactly that reason. Individual tests still override as needed.
+ */
+beforeEach(() => {
+  if (typeof globalThis.window === 'undefined') return;
+  globalThis.window.matchMedia = ((query: string) =>
+    ({
+      media: query,
+      matches: false,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: 0,
+  });
+});
+
+afterEach(() => {
+  if (typeof globalThis.window !== 'undefined' && originalMatchMedia) {
+    globalThis.window.matchMedia = originalMatchMedia;
+  }
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: originalMaxTouchPoints ?? 0,
+  });
+});
 
 describe('createAdaptiveQualityController', () => {
   test('starts from capability heuristics for baseline webgpu devices', () => {

--- a/tests/unit/adaptive-quality-controller.test.ts
+++ b/tests/unit/adaptive-quality-controller.test.ts
@@ -13,6 +13,10 @@ const originalNavigator = globalThis.navigator;
  */
 beforeEach(() => {
   if (typeof globalThis.window === 'undefined') return;
+  // Nothing matches: no coarse pointer, no reduced motion, and no
+  // `(update: fast)`, which pins getDisplayRefreshRate to its 60Hz baseline.
+  // The expected quality steps in this suite are written against 60Hz; a
+  // 120Hz budget starts the controller several steps more aggressive.
   globalThis.window.matchMedia = ((query: string) =>
     ({
       media: query,
@@ -24,6 +28,12 @@ beforeEach(() => {
       removeEventListener: () => {},
       dispatchEvent: () => false,
     }) as MediaQueryList) as typeof window.matchMedia;
+
+  // happy-dom exposes screen.refreshRate on some hosts and not others, and it
+  // short-circuits the refresh-rate probe before matchMedia is consulted.
+  if (typeof screen !== 'undefined' && 'refreshRate' in screen) {
+    delete (screen as unknown as { refreshRate?: number }).refreshRate;
+  }
   Object.defineProperty(navigator, 'maxTouchPoints', {
     configurable: true,
     value: 0,

--- a/tests/unit/adaptive-quality-controller.test.ts
+++ b/tests/unit/adaptive-quality-controller.test.ts
@@ -28,6 +28,14 @@ beforeEach(() => {
     configurable: true,
     value: 0,
   });
+
+  // renderer-capabilities stamps this on window at runtime and most suites
+  // never clear it; a leaked "high-end" value promotes every device to ultra.
+  delete (
+    globalThis.window as unknown as {
+      __stims_webgpu_performance_tier?: string;
+    }
+  ).__stims_webgpu_performance_tier;
 });
 
 afterEach(() => {

--- a/tests/unit/adaptive-quality-controller.test.ts
+++ b/tests/unit/adaptive-quality-controller.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createAdaptiveQualityController } from '../../src/js/core/services/adaptive-quality-controller.ts';
 
 const originalMatchMedia = globalThis.window?.matchMedia;
-const originalMaxTouchPoints = globalThis.navigator?.maxTouchPoints;
+const originalNavigator = globalThis.navigator;
 
 /**
  * The controller reads pointer/reduced-motion media queries and touch points
@@ -29,6 +29,19 @@ beforeEach(() => {
     value: 0,
   });
 
+  // The controller derives its starting step from the device performance
+  // profile, which treats <=3 cores or <=3GB as low power. CI runners report
+  // very different values from developer machines, so these are pinned to a
+  // comfortably unconstrained desktop rather than left to the host.
+  Object.defineProperty(navigator, 'hardwareConcurrency', {
+    configurable: true,
+    value: 8,
+  });
+  Object.defineProperty(navigator, 'deviceMemory', {
+    configurable: true,
+    value: 8,
+  });
+
   // renderer-capabilities stamps this on window at runtime and most suites
   // never clear it; a leaked "high-end" value promotes every device to ultra.
   delete (
@@ -42,9 +55,9 @@ afterEach(() => {
   if (typeof globalThis.window !== 'undefined' && originalMatchMedia) {
     globalThis.window.matchMedia = originalMatchMedia;
   }
-  Object.defineProperty(navigator, 'maxTouchPoints', {
+  Object.defineProperty(globalThis, 'navigator', {
     configurable: true,
-    value: originalMaxTouchPoints ?? 0,
+    value: originalNavigator,
   });
 });
 

--- a/tests/unit/app-shell-mobile-layout.test.ts
+++ b/tests/unit/app-shell-mobile-layout.test.ts
@@ -30,9 +30,9 @@ function hasRuleInQuery(
   selector: string,
   declaration: string,
 ) {
-  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const quote = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(
-    `${escape(query)}[\\s\\S]*?${escape(selector)}[^{]*\\{[^}]*?${escape(declaration)}`,
+    `${quote(query)}[\\s\\S]*?${quote(selector)}[^{]*\\{[^}]*?${quote(declaration)}`,
     'u',
   );
   return re.test(css);

--- a/tests/unit/app-shell-mobile-layout.test.ts
+++ b/tests/unit/app-shell-mobile-layout.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Structural guards for the mobile shell layout.
+ *
+ * These used to pin exact declarations — `padding: 112px 10px 18px`,
+ * `clamp(3rem, 7vw, 5rem)`, `repeat(2, minmax(0, 1fr))` — which broke on any
+ * restyle while never verifying that the layout actually worked. The cosmetic
+ * values are gone; what remains asserts the structural decisions that carry
+ * meaning (a breakpoint exists, a rail collapses, a fallback is present).
+ *
+ * The behaviour itself — no sideways overflow, the stage filling the viewport,
+ * the panel docking as a bottom sheet — is verified against a real browser in
+ * tests/e2e/chrome-visual-contract.test.ts, which catches the layout being
+ * broken rather than merely being written differently.
+ */
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -9,25 +23,41 @@ function readAppShellCss() {
   );
 }
 
+/** Does `declaration` appear inside a block for `selector` under `query`? */
+function hasRuleInQuery(
+  css: string,
+  query: string,
+  selector: string,
+  declaration: string,
+) {
+  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `${escape(query)}[\\s\\S]*?${escape(selector)}[^{]*\\{[^}]*?${escape(declaration)}`,
+    'u',
+  );
+  return re.test(css);
+}
+
 describe('Workspace shell mobile layout regression', () => {
-  test('turns the home state into a stage-first hero on phones', () => {
+  test('lets the home page scroll instead of trapping it at viewport height', () => {
     const css = readAppShellCss();
 
+    // The workspace document must be allowed to grow; a fixed-height body is
+    // what clipped the home content on phones.
     expect(css).toMatch(
-      /\.stims-shell__workspace\[data-mode="home"\]\s*\{[\s\S]*?padding:\s*0;/u,
+      /body\[data-page="workspace"\]\s*\{[\s\S]*?height:\s*auto;/u,
     );
-    expect(css).toMatch(
-      /html:has\(body\[data-page="workspace"\]\),\s*body\[data-page="workspace"\]\s*\{[\s\S]*?height:\s*auto;[\s\S]*?overflow-y:\s*auto;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__stage-frame\[data-mode="home"\]\s*\{[\s\S]*?min-height:\s*auto;[\s\S]*?overflow:\s*visible;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__stage-frame\[data-mode="home"\] \.stims-shell__stage-hero\s*\{[\s\S]*?position:\s*relative;[\s\S]*?inset:\s*auto;[\s\S]*?padding:\s*112px 10px 18px;/u,
-    );
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-width: 720px)',
+        '.stims-shell__stage-frame[data-mode="home"]',
+        'overflow: visible',
+      ),
+    ).toBe(true);
   });
 
-  test('sizes the mounted visualizer canvas to the stage frame instead of the viewport', () => {
+  test('sizes the mounted visualizer canvas to the stage frame, not the viewport', () => {
     const css = readAppShellCss();
 
     expect(css).toMatch(
@@ -38,57 +68,62 @@ describe('Workspace shell mobile layout regression', () => {
     );
   });
 
-  test('keeps supporting cards compact and secondary actions side-by-side on phones', () => {
+  test('collapses the launch layout to a single column on narrow viewports', () => {
     const css = readAppShellCss();
 
-    expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__launch-actions\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/u,
-    );
-    expect(css).not.toContain('.stims-shell__launch-actions > :first-child');
-    expect(css).toMatch(
-      /@media \(max-width: 480px\)[\s\S]*?\.stims-shell__launch-recommendation\s*\{[\s\S]*?display:\s*none;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__launch-panel\s*\{[\s\S]*?width:\s*min\(100%, calc\(100vw - 20px\)\);/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-layout\s*\{[\s\S]*?display:\s*flex;[\s\S]*?flex-direction:\s*column;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-rail\s*\{[\s\S]*?display:\s*contents;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-copy,[\s\S]*?\.stims-shell__launch-layout > \.stims-shell__launch-source-dock,[\s\S]*?width:\s*100%;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-copy h1\s*\{[\s\S]*?font-size:\s*clamp\(3rem, 7vw, 5rem\);[\s\S]*?line-height:\s*0\.92;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 720px\)[\s\S]*?\.stims-shell__browse-toolbar\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/u,
-    );
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-width: 1120px)',
+        '.stims-shell__launch-layout',
+        'flex-direction: column',
+      ),
+    ).toBe(true);
+    // The rail dissolves into the parent flow rather than becoming a column.
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-width: 1120px)',
+        '.stims-shell__launch-rail',
+        'display: contents',
+      ),
+    ).toBe(true);
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-width: 1120px)',
+        '.stims-shell__launch-hero',
+        'grid-template-columns: 1fr',
+      ),
+    ).toBe(true);
+    // The recommendation card is optional chrome; it goes on the smallest screens.
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-width: 480px)',
+        '.stims-shell__launch-recommendation',
+        'display: none',
+      ),
+    ).toBe(true);
   });
 
-  test('keeps the launch panel usable on short desktop and landscape viewports', () => {
+  test('keeps the stage usable on short landscape viewports', () => {
     const css = readAppShellCss();
 
-    expect(css).toMatch(
-      /@media \(max-height: 720px\)[\s\S]*?\.stims-shell__stage-frame,\s*\.stims-shell__stage-frame\[data-mode="home"\]\s*\{[\s\S]*?min-height:\s*calc\(100vh - 28px\);/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-height: 720px\)[\s\S]*?\.stims-shell__stage-hero\s*\{[\s\S]*?overflow-y:\s*auto;[\s\S]*?overscroll-behavior:\s*contain;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-height: 480px\)[\s\S]*?\.stims-shell__stage-frame,\s*\.stims-shell__stage-frame\[data-mode="home"\]\s*\{[\s\S]*?min-height:\s*calc\(100vh - 20px\);/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-hero\s*\{[\s\S]*?grid-template-columns:\s*1fr;/u,
-    );
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\)[\s\S]*?\.stims-shell__launch-recommendation\s*\{[\s\S]*?min-height:\s*0;/u,
-    );
+    // Height-based breakpoints exist so landscape phones do not get a stage
+    // taller than the screen with no way to scroll the hero.
+    expect(css).toMatch(/@media \(max-height: 720px\)/u);
+    expect(
+      hasRuleInQuery(
+        css,
+        '@media (max-height: 720px)',
+        '.stims-shell__stage-hero',
+        'overflow-y: auto',
+      ),
+    ).toBe(true);
   });
 
-  test('adds compatibility fallbacks for older mobile browser CSS support', () => {
+  test('keeps a fallback for browsers without color-mix', () => {
     const css = readAppShellCss();
 
     expect(css).toMatch(

--- a/tests/unit/device-profile.test.ts
+++ b/tests/unit/device-profile.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   getAdaptiveMaxPixelRatio,
   getDevicePerformanceProfile,
@@ -7,12 +7,38 @@ import {
 import { getRendererBackendMaxPixelRatioCap } from '../../src/js/core/renderer-settings.ts';
 
 const originalNavigator = globalThis.navigator;
+const originalMatchMedia = globalThis.window?.matchMedia;
+
+/**
+ * getDevicePerformanceProfile() folds `prefers-reduced-motion` into lowPower,
+ * so leaving matchMedia to whatever a previously-run test file left behind
+ * makes these assertions depend on file execution order. Several other suites
+ * replace window.matchMedia globally, which is exactly how these tests came to
+ * pass locally and fail on CI.
+ */
+beforeEach(() => {
+  if (typeof globalThis.window === 'undefined') return;
+  globalThis.window.matchMedia = ((query: string) =>
+    ({
+      media: query,
+      matches: false,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+});
 
 afterEach(() => {
   Object.defineProperty(globalThis, 'navigator', {
     configurable: true,
     value: originalNavigator,
   });
+  if (typeof globalThis.window !== 'undefined' && originalMatchMedia) {
+    globalThis.window.matchMedia = originalMatchMedia;
+  }
 });
 
 describe('device-profile flagship mobile optimizations', () => {

--- a/tests/unit/device-profile.test.ts
+++ b/tests/unit/device-profile.test.ts
@@ -29,6 +29,14 @@ beforeEach(() => {
       removeEventListener: () => {},
       dispatchEvent: () => false,
     }) as MediaQueryList) as typeof window.matchMedia;
+
+  // renderer-capabilities stamps this on window at runtime and most suites
+  // never clear it; a leaked "high-end" value promotes every device to ultra.
+  delete (
+    globalThis.window as unknown as {
+      __stims_webgpu_performance_tier?: string;
+    }
+  ).__stims_webgpu_performance_tier;
 });
 
 afterEach(() => {

--- a/tests/unit/run-quality-gate.test.ts
+++ b/tests/unit/run-quality-gate.test.ts
@@ -17,15 +17,20 @@ test('quick gate plan keeps tests out of the concurrent lane', () => {
   const plan = buildGatePlan('quick', 'parallel');
 
   expect(plan.preflight).toHaveLength(1);
-  expect(plan.concurrent.map((step) => step.label)).toEqual([
-    'Biome check',
-    'Bundled catalog fidelity',
-    'Bundled catalog integrity',
-    'Toy manifest and docs drift',
-    'SEO surface check',
-    'Architecture boundary check',
-    'TypeScript typecheck',
-  ]);
+
+  // The invariant is that nothing in the concurrent lane runs tests, not that
+  // the lane holds one particular list. Pinning the list meant every new check
+  // failed this test for no reason.
+  for (const step of plan.concurrent) {
+    expect(step.cmd.some((arg) => /^test(:|$)/.test(arg))).toBe(false);
+  }
+
+  // The lane is still expected to carry the checks the gate exists for.
+  const labels = plan.concurrent.map((step) => step.label);
+  expect(labels).toContain('Biome check');
+  expect(labels).toContain('TypeScript typecheck');
+  expect(plan.concurrent.length).toBeGreaterThanOrEqual(7);
+
   expect(plan.postflight).toHaveLength(0);
 });
 


### PR DESCRIPTION
## Summary

`main` has had a red quality gate and a red e2e job for weeks. This makes both green and adds guards for the specific ways breakage kept reaching production undetected.

**E2E was unfixable because it was undiagnosable.** The engine-mount suite spawned vite with `stdio: 'ignore'` and no strict port, then polled until timeout. When the server failed to start, CI reported only `ERR_CONNECTION_REFUSED` with no explanation. The new shared harness (`tests/e2e/dev-server.ts`) captures server output and reports it on failure, passes `--strictPort` so vite fails loudly instead of silently drifting to the next free port, and spawns detached so the whole process group is killed — signalling only the `bun run` wrapper orphaned vite and left it holding the port for the rest of the run.

**353 references to the removed `assets/**` tree.** Not cosmetic: `CODEOWNERS` globs that match nothing silently disable review requirements, and `.claude/CLAUDE.md` routes agents straight into the affected docs. `check:stale-paths` now fails on any reference to the old tree. Dated audits and critiques are exempt — they describe what a tree looked like when someone examined it, so rewriting their paths would misrepresent the record.

**`var(--undefined)` is dropped silently.** This is what rendered the entire app in the UA serif via `var(--display-font)` — in production, past CI, past 1200 tests. `check:css-tokens` resolves every `var()` against defined tokens (including those set from JS via `setProperty`) and fails on any with no definition and no fallback. It immediately found four more live instances: `--surface-strong` was dropping two backgrounds and `--text-primary` two text colours.

**The labeler was applying almost nothing.** Its `toys` rule pointed at three deleted paths and no rule matched `src/` at all, so source changes went unlabelled. Adds `frontend`/`renderer`/`styles` rules and fixes the missing `pull-requests: write` permission that made the check fail outright.

### Rendered invariants instead of pixel snapshots

`tests/e2e/chrome-visual-contract.test.ts` guards the defect class that keeps shipping: CSS that is syntactically fine, passes every unit test, and renders wrong. Not pixel baselines — those drift between macOS and Linux CI on font rasterisation alone, and this repo already has enough tests that fail for reasons unrelated to what they guard.

Each check maps to a defect that reached production, and **every one was verified by reintroducing the original defect**: the serif check reports `times`, the switch check reports `44` against a 32px ceiling, and the contrast check reports the same `3.03:1` the light-mode palette measured before it was fixed.

### Tests that blocked refactoring without catching bugs

`app-shell-mobile-layout` asserted exact declarations by regex — `padding: 112px 10px 18px`, `clamp(3rem, 7vw, 5rem)`. Those break on any restyle while never checking the layout works: they would pass just as happily with the page rendering as a single unusable column. The cosmetic pins are gone; what remains asserts structural decisions. The behaviour is now checked in a real browser at 375px.

`run-quality-gate.test.ts` is named "keeps tests out of the concurrent lane" but asserted the full step list, so adding either new check failed it. It now asserts the invariant its name describes.

## Testing

Validated in a clean worktree at this branch's HEAD, so it matches exactly what CI sees rather than my working tree:

- `bun run check` → **exit 0**, 1165 pass / 0 fail
- `bun run test:e2e` → **13 pass / 0 fail** across all three e2e files
- `tests/e2e/chrome-visual-contract.test.ts` run three consecutive times → 7/7 each

The new visual checks initially failed intermittently because they read geometry while the 300ms panel slide-up was still running — the sheet measured 70px short of the viewport bottom. They now wait for animations to settle. The light-mode contrast case also seeds `stims:theme` before boot rather than toggling the class afterwards; the app applies its own theme on mount, so the naive version silently ran the dark palette twice and passed against a known-bad value. It now fails loudly if the theme does not take.

## Docs touched

None. The `assets/**` → `src/**` rewrite touches doc *content* across 30 files, but is a mechanical path correction rather than a documentation change.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown) — the harness change is entirely process lifecycle: startup polling, group teardown, and the orphaned-child case
- [x] Existing shared helper/module checked before introducing duplicate logic — one harness now serves the engine-mount and visual-contract suites. `agent-integration` deliberately keeps its own: it passes in CI today and has extra restart logic, so migrating it is a follow-up rather than a risk taken here.
- [x] New visual literals use existing design tokens (or include a new named token) — the two undefined tokens were repointed at existing ones (`--panel-solid`, `--text-color`)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [ ] `bun run build` — not run; no build output changed (test harness, CI config, and two CSS token references)