### PR TITLE
perf(deploy): stop re-uploading unchanged assets and un-gate previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,26 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # The loop-preset visual sweep in tests/corpus/ launches headless
-      # Chromium, so the corpus is no longer browser-free.
+      # Chromium, so the corpus is no longer browser-free. On an exact cache
+      # hit only the apt-installed system libraries are missing (the runner
+      # image doesn't guarantee them and they can't be cached), so skip the
+      # ~150 MB browser download and install just the deps.
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: Run compat + parity corpus
         run: bun run test:compat
@@ -236,13 +247,25 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
+      # On an exact cache hit only the apt-installed system libraries are
+      # missing (the runner image doesn't guarantee them and they can't be
+      # cached), so skip the ~150 MB browser download and install just the
+      # deps.
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       # engine-mount launches a headed browser for real canvas rendering, so
       # it needs a virtual display; xvfb ships with Playwright's --with-deps
@@ -253,11 +276,12 @@ jobs:
   deploy_preview:
     name: Deploy Pages preview
     runs-on: ubuntu-latest
+    # Previews only need the built artifact — they exist for humans to look
+    # at, and the test jobs still report (and gate merging) independently.
+    # Gating on `build` alone shaves the whole Playwright/e2e tail off
+    # time-to-preview-URL. Production deploys below keep the full gate.
     needs:
-      - check
-      - parity
       - build
-      - integration
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -284,8 +308,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      # The install only exists to provide wrangler — the build step reuses
+      # the downloaded artifact, and the committed functions/api/resvg.wasm
+      # already matches what postinstall would sync — so skip scripts.
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Download Pages artifact
         uses: actions/download-artifact@v4
@@ -337,8 +364,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      # The install only exists to provide wrangler — the build step reuses
+      # the downloaded artifact, and the committed functions/api/resvg.wasm
+      # already matches what postinstall would sync — so skip scripts.
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Download Pages artifact
         uses: actions/download-artifact@v4

--- a/scripts/deploy-cloudflare.mjs
+++ b/scripts/deploy-cloudflare.mjs
@@ -105,6 +105,12 @@ if (!usesDefaultPagesConfig) {
   process.exit(1);
 }
 
+// Wrangler's upload cache dedupes unchanged files (the ~2k static preset
+// assets) across deploys. Only bypass it when the Pages asset-cache API
+// itself misbehaves.
+const skipUploadCache =
+  hasFlag('--skip-caching') || process.env.STIMS_WRANGLER_SKIP_CACHING === '1';
+
 const wranglerArgs = [
   'wrangler',
   'pages',
@@ -112,8 +118,11 @@ const wranglerArgs = [
   directory,
   '--project-name',
   projectName,
-  '--skip-caching',
 ];
+
+if (skipUploadCache) {
+  wranglerArgs.push('--skip-caching');
+}
 
 if (preview) {
   wranglerArgs.push('--branch', branch);
@@ -138,6 +147,7 @@ console.log(
     preview ? `[deploy-cloudflare] Branch: ${branch}` : null,
     commitHash ? `[deploy-cloudflare] Commit: ${commitHash}` : null,
     `[deploy-cloudflare] Dirty workspace: ${dirtyWorkspace ? 'yes' : 'no'}`,
+    `[deploy-cloudflare] Upload cache: ${skipUploadCache ? 'off (--skip-caching)' : 'on'}`,
   ]
     .filter(Boolean)
     .join('\n'),


### PR DESCRIPTION
## Summary

Makes Cloudflare Pages deploys faster on two fronts — how much gets uploaded, and how long the deploy waits to start:

- **Stop forcing full re-uploads.** `scripts/deploy-cloudflare.mjs` hardcoded `--skip-caching`, disabling wrangler's upload-side hash dedupe, so every deploy re-uploaded all ~2,100 files (~26 MB) in `dist` — almost all of them the static `.milk` preset corpus and preview PNGs that never change. The flag is removed from the default path; wrangler now only uploads files the Pages project hasn't seen. It stays reachable as an escape hatch via `--skip-caching` or `STIMS_WRANGLER_SKIP_CACHING=1`, and the deploy summary logs which mode ran.
- **Preview deploys gate on `build` only.** `deploy_preview` previously waited on `check`, `parity`, `build`, and the 3-leg `integration` matrix even though `dist` is ready when `build` finishes. Previews exist for humans to look at, and the test jobs still report (and gate merging) independently, so time-to-preview-URL drops from `max(all four jobs) + deploy` to `build + deploy`. **Production keeps the full gate.**
- **Slimmer deploy jobs.** Their `bun install` exists only to provide wrangler (the build step reuses the downloaded artifact), and the postinstall wasm sync is redundant because `functions/api/resvg.wasm` is committed — so install with `--ignore-scripts`.
- **Playwright caching fixed in the gate jobs.** The browser cache in `parity`/`integration` had no `restore-keys` (any lockfile bump was a full cold miss) and the ~150 MB browser download ran unconditionally even on a cache hit. Now: `restore-keys` added, and on an exact hit only the uncacheable apt system deps are installed. This cost was paid 4× per run (parity + 3 e2e legs), all upstream of the production deploy.

Note: the first deploy after merge still uploads everything (seeds wrangler's server-side cache); the win shows from the second deploy on. Likewise the Playwright cache-hit path kicks in from the second CI run.

## Testing

- `bun run check:quick` — pass
- `bun run check` — pass (full quality gate incl. `check:ci-config` workflow-consistency guard; 570 tests, 0 fail)
- Local dry-run of arg construction: `node scripts/deploy-cloudflare.mjs --preview --branch test` against a stub `dist` prints `Upload cache: on` with no `--skip-caching` in the wrangler args; with `STIMS_WRANGLER_SKIP_CACHING=1` it prints `Upload cache: off (--skip-caching)` and re-adds the flag
- On this PR's CI run: `deploy_preview` should start as soon as `build` is green while `parity`/`integration` are still running, and its logs should show no postinstall/`sync-resvg-wasm` output

## Docs touched

- None (behavior documented via comments in `ci.yml` and `deploy-cloudflare.mjs`)

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic (env var/flag checks only; `skipUploadCache` is a plain boolean)
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown) — n/a, no runtime code touched
- [x] Existing shared helper/module checked before introducing duplicate logic (reuses existing `hasFlag` helper)
- [x] New visual literals use existing design tokens (or include a new named token) — n/a
- [ ] Behavior change is covered by tests (or reason provided) — no existing coverage of deploy args or workflow `needs:`; `check:ci-config` still guards script references. Verified via local dry-run + this PR's own CI run.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — build inputs unchanged; `build` job on this PR covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1d38qtMDZW4wNBSyaXpJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1d38qtMDZW4wNBSyaXpJ5)_