### PR TITLE
feat(agents): pre-install dependencies on Claude Code web session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# SessionStart hook for Claude Code on the web: pre-install dependencies so
+# tests, linters, and the quality gate work from the first command. The
+# container snapshot is cached after this completes, so subsequent sessions
+# resume with node_modules already warm and the install is skipped entirely
+# (scripts/codex-setup.sh fingerprints package.json/bun.lock and no-ops when
+# they match).
+#
+# Local sessions manage their own setup (`bun run setup:codex`) — only run
+# remotely.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# --frozen-lockfile keeps the worktree clean at session start (a lockfile
+# drift is a real signal, not something to silently rewrite). Checks are
+# skipped for startup speed — sessions run `bun run check:quick` on demand.
+# Playwright browsers are NOT installed here: the remote environment ships
+# Chromium pre-installed via PLAYWRIGHT_BROWSERS_PATH.
+bash scripts/codex-setup.sh --frozen-lockfile --skip-check

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Claude Code on the web sessions start from a bare fresh clone, so the first real command in every session paid the full `bun install` (plus the resvg wasm postinstall) before any test or linter could run.

This adds a `SessionStart` hook (`.claude/hooks/session-start.sh`, registered in `.claude/settings.json`) that pre-installs dependencies when a cloud session's container is created:

- Runs `scripts/codex-setup.sh --frozen-lockfile --skip-check` — reusing the existing fingerprint-cached setup script, so a resumed/cached container where `node_modules` already matches `package.json`/`bun.lock` no-ops in ~40 ms.
- Remote-only: guarded on `CLAUDE_CODE_REMOTE=true`, so local sessions and other tooling are untouched.
- `--frozen-lockfile` keeps the worktree clean at session start (lockfile drift fails loudly instead of being silently rewritten).
- Deliberately excluded: quality checks (sessions run `bun run check:quick` on demand) and Playwright browser installs (the remote environment ships Chromium pre-installed via `PLAYWRIGHT_BROWSERS_PATH`).

The hook runs synchronously, guaranteeing dependencies exist before the session's first command. Once merged to `main`, all future cloud sessions pick it up automatically.

## Testing

- Cold path: `rm -rf node_modules .codex/setup && CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` — installs 334 packages and completes
- Warm path: immediate re-run — fingerprint match, install skipped, ~40 ms total
- Local guard: `env -u CLAUDE_CODE_REMOTE ./.claude/hooks/session-start.sh` — exits 0 with no output
- Post-hook linter: `bunx biome check scripts/deploy-cloudflare.mjs` — pass
- Post-hook test: `bun run test tests/unit/adaptive-quality-controller.test.ts` — 8 pass, 0 fail
- `bun run check:quick` — pass

## Docs touched

- None (behavior documented via comments in the hook script)

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic (`${CLAUDE_CODE_REMOTE:-}` guard handles unset)
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown) — n/a, no runtime code
- [x] Existing shared helper/module checked before introducing duplicate logic (reuses `scripts/codex-setup.sh` rather than a new install path)
- [x] New visual literals use existing design tokens (or include a new named token) — n/a
- [x] Behavior change is covered by tests (or reason provided) — shell hook exercised directly in all three paths above; no test harness exists for session hooks

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` — not run for this change: no JS/TS touched (shell + JSON config only); `check:quick` covers Biome/config checks
- [ ] `bun run build` (if build/runtime output changed) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1d38qtMDZW4wNBSyaXpJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1d38qtMDZW4wNBSyaXpJ5)_