### PR TITLE
fix: optimize preset stage transitions

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -210,23 +210,27 @@ body {
 .active-toy-container[data-transition-state="running"] .active-toy-stage {
   transition:
     opacity 320ms ease,
-    filter 320ms ease,
     transform 320ms ease;
-  will-change: opacity, filter, transform;
+  will-change: opacity, transform;
 }
 
 .active-toy-container[data-transition-state="running"]
   .active-toy-stage[data-stage-state="incoming"] {
   opacity: 1;
-  filter: blur(0);
   transform: scale(1);
 }
 
 .active-toy-container[data-transition-state="running"]
   .active-toy-stage[data-stage-state="outgoing"] {
   opacity: 0;
-  filter: blur(12px);
   transform: scale(1.015);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .active-toy-container[data-transition-state="running"] .active-toy-stage {
+    transition: none;
+    will-change: auto;
+  }
 }
 
 .active-toy-status {

--- a/tests/unit/preset-stage-transition-css.test.ts
+++ b/tests/unit/preset-stage-transition-css.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const css = readFileSync(
+  join(import.meta.dir, '..', '..', 'src', 'css', 'base.css'),
+  'utf8',
+);
+
+const runningStageRule = css.match(
+  /\.active-toy-container\[data-transition-state="running"\] \.active-toy-stage \{([^}]*)\}/,
+)?.[1];
+
+describe('preset stage transition visual contract', () => {
+  test('promotes only compositor-friendly properties while running', () => {
+    expect(runningStageRule).toBeDefined();
+    expect(runningStageRule).toContain('opacity 320ms ease');
+    expect(runningStageRule).toContain('transform 320ms ease');
+    expect(runningStageRule).toContain('will-change: opacity, transform');
+    expect(runningStageRule).not.toContain('filter');
+  });
+
+  test('does not filter the incoming or outgoing live WebGL stage', () => {
+    const stageTransitionRules = css.slice(
+      css.indexOf(
+        '.active-toy-container[data-transition-state="loading"] .active-toy-stage',
+      ),
+      css.indexOf('.active-toy-status'),
+    );
+
+    expect(stageTransitionRules).not.toContain('filter:');
+    expect(stageTransitionRules).not.toContain('blur(');
+  });
+
+  test('releases the layer hint when reduced motion disables the transition', () => {
+    expect(css).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{\s*\.active-toy-container\[data-transition-state="running"\] \.active-toy-stage \{\s*transition: none;\s*will-change: auto;/,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent expensive layer promotions and GPU-heavy `filter` effects from animating the live WebGL stage by limiting transitions to compositor-friendly properties.
- Ensure reduced-motion respects the preference by disabling transitions and releasing `will-change` during that mode.
- Add a small automated guard to catch regressions where the live stage might be filtered or promoted incorrectly.

### Description
- Updated `src/css/base.css` to remove `filter` from the `.active-toy-container[data-transition-state="running"] .active-toy-stage` transition and to drop the outgoing `blur(12px)` on the outgoing stage, leaving only `opacity` and `transform` to animate.
- Scoped `will-change` to `opacity, transform` instead of promoting `filter`, and added a `@media (prefers-reduced-motion: reduce)` rule that disables the transition and sets `will-change: auto` to release the layer hint.
- Removed the incoming `filter: blur(0)` and the outgoing blur so the live WebGL canvas is not filtered during preset changes.
- Added `tests/unit/preset-stage-transition-css.test.ts` which asserts that the running-stage rule only promotes compositor-friendly properties, that no `filter`/`blur(...)` appear in the stage transition slice, and that reduced-motion releases the layer hint.

### Testing
- Ran the new unit test: `bun run test tests/unit/preset-stage-transition-css.test.ts` — passed.
- Ran the fast quality gate: `bun run check:quick` — passed.
- Ran the full quality gate: `bun run check` — all suites passed (1,833 tests across the repo in this run).
- Executed a scripted rapid-transition verification (`/tmp/verify-preset-transition.mjs`) that exercises rapid preset retargets on desktop, a constrained mobile/low-device-tier profile, and `prefers-reduced-motion: reduce`, which confirmed `filter: none`, active-only `will-change`, and immediate reduced-motion settling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8086be5b948332863ba42e4dd068ff)