### PR TITLE
fix: coalesce stage control activity

### DIFF
--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -171,18 +171,25 @@ export function StageControls({
   }, [transition.phase, signalActivity]);
 
   useEffect(() => {
+    let activityFrame: number | null = null;
+    const handlePointerMove = () => {
+      if (activityFrame !== null) return;
+      activityFrame = requestAnimationFrame(() => {
+        activityFrame = null;
+        signalActivity();
+      });
+    };
     const handleActivity = () => signalActivity();
-    document.addEventListener('mousemove', handleActivity, { passive: true });
-    document.addEventListener('pointerdown', handleActivity, { passive: true });
-    document.addEventListener('pointermove', handleActivity, {
+    document.addEventListener('pointermove', handlePointerMove, {
       passive: true,
     });
+    document.addEventListener('pointerdown', handleActivity, { passive: true });
     document.addEventListener('wheel', handleActivity, { passive: true });
     document.addEventListener('keydown', handleActivity);
     return () => {
-      document.removeEventListener('mousemove', handleActivity);
+      if (activityFrame !== null) cancelAnimationFrame(activityFrame);
+      document.removeEventListener('pointermove', handlePointerMove);
       document.removeEventListener('pointerdown', handleActivity);
-      document.removeEventListener('pointermove', handleActivity);
       document.removeEventListener('wheel', handleActivity);
       document.removeEventListener('keydown', handleActivity);
     };

--- a/src/js/frontend/hooks/useAutoHideActivity.ts
+++ b/src/js/frontend/hooks/useAutoHideActivity.ts
@@ -9,26 +9,45 @@ export function useAutoHideActivity(
 } {
   const [visible, setVisible] = useState(initiallyVisible);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastActivityRef = useRef(Date.now());
 
   const clearTimer = useCallback(() => {
-    if (timerRef.current) {
+    if (timerRef.current !== null) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
   }, []);
 
+  const scheduleHide = useCallback(() => {
+    const hideAfterInactivity = () => {
+      const remainingMs = delayMs - (Date.now() - lastActivityRef.current);
+      if (remainingMs > 0) {
+        timerRef.current = setTimeout(hideAfterInactivity, remainingMs);
+        return;
+      }
+
+      timerRef.current = null;
+      setVisible(false);
+    };
+    timerRef.current = setTimeout(hideAfterInactivity, delayMs);
+  }, [delayMs]);
+
   const signalActivity = useCallback(() => {
+    lastActivityRef.current = Date.now();
     setVisible(true);
-    clearTimer();
-    timerRef.current = setTimeout(() => setVisible(false), delayMs);
-  }, [delayMs, clearTimer]);
+    // Keep the existing deadline during an activity burst. When it arrives,
+    // the callback above moves it forward once from the most recent activity
+    // instead of allocating a fresh timeout for every pointer event.
+    if (timerRef.current === null) scheduleHide();
+  }, [scheduleHide]);
 
   useEffect(() => {
     if (initiallyVisible) {
-      timerRef.current = setTimeout(() => setVisible(false), delayMs);
+      lastActivityRef.current = Date.now();
+      scheduleHide();
     }
     return clearTimer;
-  }, [delayMs, initiallyVisible, clearTimer]);
+  }, [initiallyVisible, clearTimer, scheduleHide]);
 
   return { visible, signalActivity };
 }

--- a/tests/unit/use-auto-hide-activity.test.tsx
+++ b/tests/unit/use-auto-hide-activity.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, jest, test } from 'bun:test';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useAutoHideActivity } from '../../src/js/frontend/hooks/useAutoHideActivity.ts';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  jest.useRealTimers();
+  document.body.replaceChildren();
+});
+
+function ActivityHarness({ delayMs }: { delayMs: number }) {
+  const { visible, signalActivity } = useAutoHideActivity(delayMs, false);
+
+  return createElement(
+    'button',
+    {
+      type: 'button',
+      'data-visible': visible,
+      onPointerMove: signalActivity,
+    },
+    'activity target',
+  );
+}
+
+describe('useAutoHideActivity', () => {
+  test('coalesces a pointer-event burst into one active timeout', () => {
+    jest.useFakeTimers();
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => root.render(createElement(ActivityHarness, { delayMs: 1000 })));
+    const button = container.querySelector('button');
+
+    act(() => {
+      for (let index = 0; index < 50; index += 1) {
+        button?.dispatchEvent(new Event('pointermove', { bubbles: true }));
+      }
+    });
+
+    expect(button?.getAttribute('data-visible')).toBe('true');
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    setTimeoutSpy.mockRestore();
+    act(() => root.unmount());
+  });
+
+  test('hides after inactivity measured from the latest event', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => root.render(createElement(ActivityHarness, { delayMs: 1000 })));
+    const button = container.querySelector('button');
+    act(() => {
+      button?.dispatchEvent(new Event('pointermove', { bubbles: true }));
+      jest.advanceTimersByTime(800);
+      button?.dispatchEvent(new Event('pointermove', { bubbles: true }));
+      jest.advanceTimersByTime(999);
+    });
+    expect(button?.getAttribute('data-visible')).toBe('true');
+
+    act(() => jest.advanceTimersByTime(1));
+    expect(button?.getAttribute('data-visible')).toBe('false');
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent an unbounded timeout being created per pointer event while preserving immediate visibility when the user interacts with the stage controls.
- Keep discrete interactions (`pointerdown`, `wheel`, `keydown`) responsive while reducing CPU/timer churn from high-frequency pointer movement.

### Description

- Replaced duplicate `mousemove`/`pointermove` handling in `StageControls.tsx` with a single `pointermove` listener that coalesces notifications using `requestAnimationFrame`, while keeping `pointerdown`, `wheel`, and `keydown` handlers immediate and cancelling pending frames on cleanup.
- Reworked `useAutoHideActivity` so `signalActivity` records the most recent activity timestamp and only schedules a single hide deadline that is advanced from the latest activity instead of clearing/creating a new timeout per event.
- Added focused unit tests in `tests/unit/use-auto-hide-activity.test.tsx` that use fake timers to assert that a burst of pointer events creates only one initial timeout and that controls hide after inactivity measured from the last event.
- Applied small robustness fixes (null checks and button `type`) needed by the tests and linter.

### Testing

- Ran the targeted unit test: `bun run test tests/unit/use-auto-hide-activity.test.tsx`, which passed.
- Ran the repository quality gate checks with `bun run check`/`bun run check:quick`, which completed without failures.
- The fast test profile executed as part of the quality gate completed successfully (the test run reported 1830 passing tests and 0 failures for the fast profile run used by the checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8086d0d9fc833297f034a9300461ea)