### PR TITLE
fix: bound idle renderer pool retention

### DIFF
--- a/src/js/core/services/render-service.ts
+++ b/src/js/core/services/render-service.ts
@@ -62,6 +62,7 @@ export type RendererHandle = {
 type RendererPoolEntry = {
   handle: RendererHandle;
   inUse: boolean;
+  lastReleasedAt: number;
 };
 
 type RendererPoolLifecycle = {
@@ -71,6 +72,39 @@ type RendererPoolLifecycle = {
 
 const rendererPool: RendererPoolEntry[] = [];
 const rendererLifecycles = new WeakMap<RendererHandle, RendererPoolLifecycle>();
+export const DEFAULT_MAX_IDLE_RENDERERS = 2;
+let maxIdleRenderers = DEFAULT_MAX_IDLE_RENDERERS;
+
+function disposeRendererPoolEntry(entry: RendererPoolEntry) {
+  entry.handle.renderer.setAnimationLoop?.(null);
+  rendererLifecycles.get(entry.handle)?.release();
+  entry.handle.renderer.dispose?.();
+  detachCanvas(entry.handle.canvas);
+  const entryIndex = rendererPool.indexOf(entry);
+  if (entryIndex !== -1) {
+    rendererPool.splice(entryIndex, 1);
+  }
+}
+
+function trimIdleRendererPool() {
+  const idleEntries = rendererPool
+    .filter((entry) => !entry.inUse)
+    .sort((left, right) => left.lastReleasedAt - right.lastReleasedAt);
+  const excessIdleCount = idleEntries.length - maxIdleRenderers;
+  for (let index = 0; index < excessIdleCount; index += 1) {
+    disposeRendererPoolEntry(idleEntries[index]);
+  }
+}
+
+export function setMaxIdleRenderers(maximum: number) {
+  if (!Number.isInteger(maximum) || maximum < 0) {
+    throw new RangeError(
+      'Maximum idle renderer count must be a non-negative integer.',
+    );
+  }
+  maxIdleRenderers = maximum;
+  trimIdleRendererPool();
+}
 
 /**
  * Emitted whenever a pooled renderer stops being the same live GPU renderer
@@ -838,10 +872,14 @@ export async function requestRenderer({
   const poolEntry: RendererPoolEntry = {
     handle,
     inUse: true,
+    lastReleasedAt: 0,
   };
 
   const releaseHandle = handle.release;
   handle.release = () => {
+    if (!poolEntry.inUse) {
+      return;
+    }
     releaseHandle();
     // Stop rendering and park the canvas, but keep the renderer itself
     // alive — the whole point of the pool is to let the next toy reuse it
@@ -852,7 +890,9 @@ export async function requestRenderer({
     // via resetRendererPool({ dispose: true }).
     handle.renderer.setAnimationLoop?.(null);
     poolEntry.inUse = false;
+    poolEntry.lastReleasedAt = performance.now();
     detachCanvas(handle.canvas);
+    trimIdleRendererPool();
   };
 
   rendererPool.push(poolEntry);
@@ -900,21 +940,22 @@ export async function prewarmRendererCapabilities() {
 
 export function resetRendererPool({
   dispose = false,
+  maxIdle = DEFAULT_MAX_IDLE_RENDERERS,
 }: {
   dispose?: boolean;
+  maxIdle?: number;
 } = {}) {
-  rendererPool.forEach((entry) => {
+  setMaxIdleRenderers(maxIdle);
+  for (const entry of [...rendererPool]) {
     entry.inUse = false;
-    rendererLifecycles.get(entry.handle)?.release();
+    entry.lastReleasedAt = performance.now();
     if (dispose) {
-      entry.handle.renderer.setAnimationLoop?.(null);
-      entry.handle.renderer.dispose?.();
-      detachCanvas(entry.handle.canvas);
+      disposeRendererPoolEntry(entry);
+    } else {
+      rendererLifecycles.get(entry.handle)?.release();
     }
-  });
-  if (dispose) {
-    rendererPool.splice(0, rendererPool.length);
   }
+  trimIdleRendererPool();
   activeQuality = getActiveQualityPreset();
   _activeRenderPreferences = getActiveRenderPreferences();
   resetRendererRuntimeControls();

--- a/tests/unit/services-pool.test.ts
+++ b/tests/unit/services-pool.test.ts
@@ -20,6 +20,7 @@ import type {
   requestRenderer as requestType,
   resetRendererPool as resetPoolType,
   setRendererRuntimeControls as setControlsType,
+  setMaxIdleRenderers as setMaxIdleRenderersType,
   subscribeToRendererRuntimeControls as subscribeType,
 } from '../../src/js/core/services/render-service.ts';
 import { resetSettingsPanelState } from '../../src/js/core/settings-panel.ts';
@@ -30,6 +31,7 @@ import { flushTasks, importFresh } from '../test-helpers.ts';
 let getRendererRuntimeControls: typeof getControlsType;
 let requestRenderer: typeof requestType;
 let resetRendererPool: typeof resetPoolType;
+let setMaxIdleRenderers: typeof setMaxIdleRenderersType;
 let setRendererRuntimeControls: typeof setControlsType;
 let subscribeToRendererRuntimeControls: typeof subscribeType;
 
@@ -58,6 +60,7 @@ describe('render-service pooling', () => {
     getRendererRuntimeControls = renderService.getRendererRuntimeControls;
     requestRenderer = renderService.requestRenderer;
     resetRendererPool = renderService.resetRendererPool;
+    setMaxIdleRenderers = renderService.setMaxIdleRenderers;
     setRendererRuntimeControls = renderService.setRendererRuntimeControls;
     subscribeToRendererRuntimeControls =
       renderService.subscribeToRendererRuntimeControls;
@@ -128,6 +131,74 @@ describe('render-service pooling', () => {
     expect(first.canvas).toBe(second.canvas);
     expect(host.contains(second.canvas)).toBe(true);
     expect(initRendererImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('bounds idle renderers across repeated concurrent acquire and release cycles', async () => {
+    setMaxIdleRenderers(2);
+    const renderers: Array<{
+      setAnimationLoop: ReturnType<typeof mock>;
+      dispose: ReturnType<typeof mock>;
+    }> = [];
+    const initRendererImpl = mock(async () => {
+      const renderer = {
+        setPixelRatio: mock(),
+        setSize: mock(),
+        setAnimationLoop: mock(),
+        dispose: mock(),
+        toneMappingExposure: 1,
+      };
+      renderers.push(renderer);
+      return {
+        renderer: renderer as unknown as WebGLRenderer,
+        backend: 'webgl' as const,
+        adapter: null,
+        device: null,
+        maxPixelRatio: 2,
+        renderScale: 1,
+        adaptiveMaxPixelRatioMultiplier: 1,
+        adaptiveRenderScaleMultiplier: 1,
+        adaptiveDensityMultiplier: 1,
+        exposure: 1,
+      };
+    });
+
+    const firstCycle = await Promise.all(
+      Array.from({ length: 5 }, () => requestRenderer({ initRendererImpl })),
+    );
+    firstCycle[0].release();
+    firstCycle[1].release();
+    firstCycle[2].release();
+
+    expect(renderers[0].dispose).toHaveBeenCalledTimes(1);
+    expect(renderers[1].dispose).toHaveBeenCalledTimes(0);
+    expect(renderers[2].dispose).toHaveBeenCalledTimes(0);
+    // Renderers that remain checked out must never be candidates for eviction.
+    expect(renderers[3].dispose).toHaveBeenCalledTimes(0);
+    expect(renderers[4].dispose).toHaveBeenCalledTimes(0);
+
+    firstCycle[3].release();
+    firstCycle[4].release();
+    expect(
+      renderers.filter((renderer) => renderer.dispose.mock.calls.length === 0),
+    ).toHaveLength(2);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const handles = await Promise.all(
+        Array.from({ length: 4 }, () => requestRenderer({ initRendererImpl })),
+      );
+      handles.forEach((handle) => handle.release());
+      expect(
+        renderers.filter(
+          (renderer) => renderer.dispose.mock.calls.length === 0,
+        ),
+      ).toHaveLength(2);
+    }
+
+    for (const renderer of renderers.filter(
+      (candidate) => candidate.dispose.mock.calls.length > 0,
+    )) {
+      expect(renderer.setAnimationLoop).toHaveBeenCalledWith(null);
+    }
   });
 
   test('shares runtime optimization controls through the render service', async () => {


### PR DESCRIPTION
### Motivation

- Prevent the renderer pool from retaining every historically-created session indefinitely and growing unbounded under peak concurrency.  
- Ensure idle renderers are evicted in LRU order and fully torn down so animation loops, lifecycle observers, GPU resources, and canvases are not leaked.

### Description

- Track last-release time by adding `lastReleasedAt` to `RendererPoolEntry` and expose a configurable `setMaxIdleRenderers()` with `DEFAULT_MAX_IDLE_RENDERERS = 2`.  
- Add `disposeRendererPoolEntry()` that stops the animation loop, releases lifecycle state, calls `renderer.dispose()`, detaches the canvas, and removes the entry from `rendererPool`.  
- Add `trimIdleRendererPool()` to evict least-recently released idle entries when idle count exceeds the configured limit and call it after releases and on pool reset.  
- Update `requestRenderer`'s overridden `handle.release` to record `lastReleasedAt`, guard against double-release, detach the canvas, and trigger trimming; update `resetRendererPool` to accept `maxIdle` and to dispose or mark entries for release accordingly.

### Testing

- ✅ Ran unit file: `bun run test tests/unit/services-pool.test.ts` and the new pooling tests passed.  
- ✅ Ran quick quality gate: `bun run check:quick` which completed without failures.  
- ✅ Verified a potentially flaky timing test in isolation with: `bun run test tests/unit/live-modulation.test.ts` which passed when run separately.  
- ⚠️ Ran full quality gate: `bun run check` (fast suite), which reported the large test run with the usual passing tests; one timing-sensitive test failed during a parallel fast run but passed in isolation, so this appears unrelated to the pool change and is marked as a warning for CI flakiness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80887a2420833286e3c5afac9668f0)