### PR TITLE
fix: bound preset preview cache

### DIFF
--- a/src/js/frontend/hooks/use-preset-previews.ts
+++ b/src/js/frontend/hooks/use-preset-previews.ts
@@ -71,6 +71,17 @@ export function usePresetPreviews({
               [preview.presetId]: preview,
             }));
           },
+          onPreviewEvicted: (presetId) => {
+            requestedIdsRef.current.delete(presetId);
+            setPresetPreviews((current) => {
+              if (!(presetId in current)) {
+                return current;
+              }
+              const next = { ...current };
+              delete next[presetId];
+              return next;
+            });
+          },
         });
 
         return service;

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -607,6 +607,7 @@ export function createMilkdropExperience({
     previewService = createMilkdropPresetPreviewService({
       capturePreview: capturePresetPreview,
       onPreviewChanged: () => {},
+      onPreviewEvicted: () => {},
     });
   }
 

--- a/src/js/milkdrop/runtime/preset-preview-service.ts
+++ b/src/js/milkdrop/runtime/preset-preview-service.ts
@@ -5,21 +5,53 @@ import {
 
 type CaptureResult = Omit<MilkdropPresetRenderPreview, 'presetId' | 'status'>;
 
+// Keeps enough snapshots for the visible catalog rows plus a generous
+// near-visible overscan without retaining every preset a user scrolls past.
+export const MAX_PRESET_PREVIEW_CACHE_SIZE = 48;
+
 export function createMilkdropPresetPreviewService({
   capturePreview,
   onPreviewChanged,
+  onPreviewEvicted,
 }: {
   capturePreview: (presetId: string) => Promise<CaptureResult>;
   onPreviewChanged: (preview: MilkdropPresetRenderPreview) => void;
+  onPreviewEvicted: (presetId: string) => void;
 }) {
   const previews = new Map<string, MilkdropPresetRenderPreview>();
   let queue: string[] = [];
   let currentPresetId: string | null = null;
   let disposed = false;
 
+  const touch = (presetId: string) => {
+    const preview = previews.get(presetId);
+    if (!preview) {
+      return;
+    }
+    previews.delete(presetId);
+    previews.set(presetId, preview);
+  };
+
+  const evictSettledPreviews = () => {
+    while (previews.size > MAX_PRESET_PREVIEW_CACHE_SIZE) {
+      const evictionCandidate = [...previews].find(
+        ([, preview]) =>
+          preview.status === 'ready' || preview.status === 'failed',
+      );
+      if (!evictionCandidate) {
+        return;
+      }
+      const [presetId] = evictionCandidate;
+      previews.delete(presetId);
+      onPreviewEvicted(presetId);
+    }
+  };
+
   const emit = (preview: MilkdropPresetRenderPreview) => {
     previews.set(preview.presetId, preview);
+    touch(preview.presetId);
     onPreviewChanged(preview);
+    evictSettledPreviews();
   };
 
   const ensureQueuedPreview = (presetId: string) => {
@@ -133,7 +165,11 @@ export function createMilkdropPresetPreviewService({
     },
 
     getPreview(presetId: string) {
-      return previews.get(presetId) ?? null;
+      const preview = previews.get(presetId) ?? null;
+      if (preview) {
+        touch(presetId);
+      }
+      return preview;
     },
 
     dispose() {

--- a/tests/unit/memory-leak-prevention.test.ts
+++ b/tests/unit/memory-leak-prevention.test.ts
@@ -30,6 +30,7 @@ describe('memory leak prevention', () => {
     const service = createMilkdropPresetPreviewService({
       capturePreview,
       onPreviewChanged,
+      onPreviewEvicted: () => {},
     });
 
     service.requestPreviews(['p1', 'p2', 'p3']);

--- a/tests/unit/milkdrop-preset-preview-service.test.ts
+++ b/tests/unit/milkdrop-preset-preview-service.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { createMilkdropPresetPreviewService } from '../../src/js/milkdrop/runtime/preset-preview-service.ts';
+import {
+  createMilkdropPresetPreviewService,
+  MAX_PRESET_PREVIEW_CACHE_SIZE,
+} from '../../src/js/milkdrop/runtime/preset-preview-service.ts';
 
 describe('milkdrop preset preview service', () => {
   test('queues captures once and prioritizes the latest visible preset order', async () => {
@@ -31,6 +34,7 @@ describe('milkdrop preset preview service', () => {
       onPreviewChanged: (preview) => {
         previewStates.push(`${preview.presetId}:${preview.status}`);
       },
+      onPreviewEvicted: () => {},
     });
 
     service.requestPreviews(['signal-bloom', 'aurora-drift']);
@@ -64,6 +68,7 @@ describe('milkdrop preset preview service', () => {
     const service = createMilkdropPresetPreviewService({
       capturePreview,
       onPreviewChanged: () => {},
+      onPreviewEvicted: () => {},
     });
 
     service.requestPreviews(['signal-bloom']);
@@ -79,5 +84,102 @@ describe('milkdrop preset preview service', () => {
     expect(capturePreview).toHaveBeenCalledTimes(2);
 
     service.dispose();
+  });
+
+  test('bounds settled previews by LRU recency and recaptures evicted entries', async () => {
+    const capturePreview = mock(async (presetId: string) => ({
+      imageUrl: `data:${presetId}`,
+      actualBackend: 'webgl' as const,
+      updatedAt: Date.now(),
+      error: null,
+      source: 'runtime-snapshot' as const,
+    }));
+    const evictedIds: string[] = [];
+    const service = createMilkdropPresetPreviewService({
+      capturePreview,
+      onPreviewChanged: () => {},
+      onPreviewEvicted: (presetId) => evictedIds.push(presetId),
+    });
+    const presetIds = Array.from(
+      { length: MAX_PRESET_PREVIEW_CACHE_SIZE * 3 },
+      (_, index) => `preset-${index}`,
+    );
+
+    service.requestPreviews(presetIds);
+    for (let index = 0; index < presetIds.length * 3; index += 1) {
+      await Promise.resolve();
+    }
+
+    const retainedIds = presetIds.filter(
+      (presetId) => service.getPreview(presetId) !== null,
+    );
+    expect(retainedIds).toHaveLength(MAX_PRESET_PREVIEW_CACHE_SIZE);
+    expect(evictedIds).toHaveLength(
+      presetIds.length - MAX_PRESET_PREVIEW_CACHE_SIZE,
+    );
+    expect(service.getPreview('preset-0')).toBeNull();
+
+    // Reading the oldest retained entry makes it more recent than its neighbor.
+    expect(
+      service.getPreview(`preset-${MAX_PRESET_PREVIEW_CACHE_SIZE * 2}`),
+    ).not.toBeNull();
+    service.requestPreviews(['preset-0']);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturePreview).toHaveBeenCalledTimes(presetIds.length + 1);
+    expect(service.getPreview('preset-0')?.status).toBe('ready');
+    expect(
+      service.getPreview(`preset-${MAX_PRESET_PREVIEW_CACHE_SIZE * 2}`),
+    ).not.toBeNull();
+    expect(
+      service.getPreview(`preset-${MAX_PRESET_PREVIEW_CACHE_SIZE * 2 + 1}`),
+    ).toBeNull();
+    expect(
+      presetIds.filter((presetId) => service.getPreview(presetId) !== null),
+    ).toHaveLength(MAX_PRESET_PREVIEW_CACHE_SIZE);
+    service.dispose();
+  });
+
+  test('disposes safely while a capture is active', async () => {
+    let finishCapture: (() => void) | undefined;
+    const capturePreview = mock(
+      (presetId: string) =>
+        new Promise<{
+          imageUrl: string;
+          actualBackend: 'webgl';
+          updatedAt: number;
+          error: null;
+          source: 'runtime-snapshot';
+        }>((resolve) => {
+          finishCapture = () =>
+            resolve({
+              imageUrl: `data:${presetId}`,
+              actualBackend: 'webgl',
+              updatedAt: Date.now(),
+              error: null,
+              source: 'runtime-snapshot',
+            });
+        }),
+    );
+    const changed = mock(() => {});
+    const evicted = mock(() => {});
+    const service = createMilkdropPresetPreviewService({
+      capturePreview,
+      onPreviewChanged: changed,
+      onPreviewEvicted: evicted,
+    });
+
+    service.requestPreviews(['active', 'queued']);
+    expect(service.getPreview('active')?.status).toBe('capturing');
+    service.dispose();
+    finishCapture?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(service.getPreview('active')).toBeNull();
+    expect(capturePreview).toHaveBeenCalledTimes(1);
+    expect(changed).toHaveBeenCalledTimes(3);
+    expect(evicted).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent unbounded growth of in-memory preset previews when users scroll through the catalog by capping retained previews to a size tuned for visible and near-visible tiles.
- Ensure recency is refreshed on access and successful capture so frequently viewed previews stay cached.
- Evict only settled previews (`ready` or `failed`) to avoid disrupting queued or actively capturing entries.
- Avoid leaving a secondary unbounded collection in the React layer by removing evicted records from the hook state and requested-id tracking.

### Description

- Added a bounded LRU-style cache to the preview service with `MAX_PRESET_PREVIEW_CACHE_SIZE = 48` and a `touch` mechanism to refresh recency on `getPreview` and on every `emit` of a successful/queued/failed preview in `src/js/milkdrop/runtime/preset-preview-service.ts`.
- Implemented `evictSettledPreviews` to evict old `ready` or `failed` entries until the cache is within the configured limit and added an `onPreviewEvicted` callback to notify consumers of evictions.
- Extended the service contract to accept `onPreviewEvicted` and updated `src/js/frontend/hooks/use-preset-previews.ts` to remove evicted entries from both `presetPreviews` and `requestedIdsRef` so React-held state stays bounded.
- Added unit tests in `tests/unit/milkdrop-preset-preview-service.test.ts` to verify bounded retention, LRU recency behavior, recapture after eviction, and safe disposal during an active capture, and updated `tests/unit/memory-leak-prevention.test.ts` to wire the new callback.

### Testing

- Ran the targeted unit tests with `bun run test tests/unit/milkdrop-preset-preview-service.test.ts tests/unit/memory-leak-prevention.test.ts` and all tests passed (6 pass, 0 fail).
- Ran the quick and full quality gates with `bun run check:quick` and `bun run check`, both of which completed successfully. 
- The changes are covered by the new tests that simulate requesting many previews (3× cache size), verifying eviction and recapture, and a disposal while capture is active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80887e423c8332b0aed30b5de4b3c1)