### PR TITLE
fix: bound compiled preset cache warmup

### DIFF
--- a/src/js/milkdrop/compiler.ts
+++ b/src/js/milkdrop/compiler.ts
@@ -21,8 +21,28 @@ export {
 const MAX_COMPILED_PRESET_CACHE = 50;
 const compiledPresetCache = new Map<string, MilkdropCompiledPreset>();
 
+function insertCompiledPresetCacheEntry(
+  raw: string,
+  compiled: MilkdropCompiledPreset,
+) {
+  compiledPresetCache.delete(raw);
+  compiledPresetCache.set(raw, compiled);
+
+  while (compiledPresetCache.size > MAX_COMPILED_PRESET_CACHE) {
+    const oldestKey = compiledPresetCache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    compiledPresetCache.delete(oldestKey);
+  }
+}
+
 export function clearCompiledPresetCache() {
   compiledPresetCache.clear();
+}
+
+export function getCompiledPresetCacheSize() {
+  return compiledPresetCache.size;
 }
 
 export function compileMilkdropPresetSource(
@@ -38,8 +58,7 @@ export function compileMilkdropPresetSource(
   if (isSimpleCall) {
     const cached = compiledPresetCache.get(raw);
     if (cached) {
-      compiledPresetCache.delete(raw);
-      compiledPresetCache.set(raw, cached);
+      insertCompiledPresetCacheEntry(raw, cached);
       return cached;
     }
   }
@@ -62,22 +81,16 @@ export function compileMilkdropPresetSource(
   compiled.formattedSource = formatMilkdropPreset(compiled);
 
   if (isSimpleCall) {
-    if (compiledPresetCache.size >= MAX_COMPILED_PRESET_CACHE) {
-      const oldestKey = compiledPresetCache.keys().next().value;
-      if (oldestKey !== undefined) {
-        compiledPresetCache.delete(oldestKey);
-      }
-    }
-    compiledPresetCache.set(raw, compiled);
+    insertCompiledPresetCacheEntry(raw, compiled);
   }
 
   return compiled;
 }
 
 export function warmupCompiledPresetCache(presets: MilkdropCompiledPreset[]) {
-  presets.forEach((compiled) => {
+  presets.slice(-MAX_COMPILED_PRESET_CACHE).forEach((compiled) => {
     if (compiled.source?.raw) {
-      compiledPresetCache.set(compiled.source.raw, compiled);
+      insertCompiledPresetCacheEntry(compiled.source.raw, compiled);
     }
   });
 }

--- a/tests/unit/milkdrop-compiler-cache.test.ts
+++ b/tests/unit/milkdrop-compiler-cache.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  clearCompiledPresetCache,
+  compileMilkdropPresetSource,
+  getCompiledPresetCacheSize,
+  warmupCompiledPresetCache,
+} from '../../src/js/milkdrop/compiler.ts';
+
+describe('milkdrop compiled preset cache', () => {
+  afterEach(() => {
+    clearCompiledPresetCache();
+  });
+
+  test('warm-up retains only the 50 most recent unique presets', () => {
+    const presets = Array.from({ length: 55 }, (_, index) => {
+      const raw = `title=Cache Preset ${index}\nwave_r=${index}`;
+      return compileMilkdropPresetSource(raw, {
+        id: `cache-preset-${index}`,
+        title: `Cache Preset ${index}`,
+      });
+    });
+
+    warmupCompiledPresetCache(presets);
+
+    expect(getCompiledPresetCacheSize()).toBe(50);
+
+    for (const preset of presets.slice(5).reverse()) {
+      expect(compileMilkdropPresetSource(preset.source.raw)).toBe(preset);
+    }
+
+    expect(compileMilkdropPresetSource(presets[4].source.raw)).not.toBe(
+      presets[4],
+    );
+    expect(getCompiledPresetCacheSize()).toBe(50);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent warm-up from overflowing the compiled preset cache and make warm-up behave identically to normal compilation by applying the same bounded LRU insertion semantics. 
- Centralize cache insertion/update logic to avoid duplication and ensure hits refresh LRU order.

### Description

- Add a private helper `insertCompiledPresetCacheEntry(raw, compiled)` that refreshes LRU order, inserts the entry, and evicts oldest entries until `MAX_COMPILED_PRESET_CACHE` is satisfied. 
- Use the new helper for cache hits and normal compilation paths inside `compileMilkdropPresetSource` so both paths refresh and insert through the same bounded logic. 
- Change `warmupCompiledPresetCache` to only consider the most relevant slice via `presets.slice(-MAX_COMPILED_PRESET_CACHE)` and insert through the same helper so warm-up cannot exceed the cache limit. 
- Add `getCompiledPresetCacheSize()` for observability and a unit test `tests/unit/milkdrop-compiler-cache.test.ts` that warms with 55 unique presets and asserts the cache size is capped at 50 and that the most-recent entries are retained.

### Testing

- ✅ Ran `bun run test tests/unit/milkdrop-compiler-cache.test.ts` and the new cache test passed. 
- ✅ Ran `bun run check:quick` and the quick quality gate passed. 
- ✅ Ran `bun run check` (full quality gate) and the project checks and test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a808882c6288332a208a564ae5ab9e3)