### PR TITLE
refactor: bound source diff working memory

### DIFF
--- a/src/js/milkdrop/overlay/source-diff.ts
+++ b/src/js/milkdrop/overlay/source-diff.ts
@@ -6,71 +6,224 @@ export type SourceDiffLine = {
   text: string;
 };
 
-// Preset sources are a few hundred lines; beyond this the quadratic LCS is
-// not worth it and the preview degrades to a whole-file replacement notice.
+export type SourceDiffStats = {
+  oldLineCount: number;
+  newLineCount: number;
+  /** Largest pair of LCS rows allocated at once, measured in Uint32 cells. */
+  maxWorkingCells: number;
+  usedCoarseFallback: boolean;
+};
+
+export type SourceDiffOptions = {
+  /** Test/diagnostic hook; it does not retain any of the diff's working data. */
+  onStats?: (stats: SourceDiffStats) => void;
+};
+
+// Bound both CPU work and input storage. Above these limits a detailed preview
+// is less useful than a prompt whole-document replacement warning.
 const MAX_DIFF_LINES = 2000;
+const MAX_DIFF_CHARACTERS = 2_000_000;
 const CONTEXT_LINES = 2;
+
+type Match = { oldIndex: number; newIndex: number };
 
 export function computeSourceDiff(
   before: string,
   after: string,
+  options: SourceDiffOptions = {},
 ): SourceDiffLine[] {
-  if (before === after) {
-    return [];
-  }
   const a = before.split('\n');
   const b = after.split('\n');
-  if (a.length > MAX_DIFF_LINES || b.length > MAX_DIFF_LINES) {
-    return [
+  const stats: SourceDiffStats = {
+    oldLineCount: a.length,
+    newLineCount: b.length,
+    maxWorkingCells: 0,
+    usedCoarseFallback: false,
+  };
+  const finish = (diff: SourceDiffLine[]) => {
+    options.onStats?.(stats);
+    return diff;
+  };
+
+  if (before === after) {
+    return finish([]);
+  }
+  if (
+    a.length > MAX_DIFF_LINES ||
+    b.length > MAX_DIFF_LINES ||
+    before.length + after.length > MAX_DIFF_CHARACTERS
+  ) {
+    stats.usedCoarseFallback = true;
+    return finish([
       {
         kind: 'gap',
         text: `Replaces all ${a.length} lines with ${b.length} new lines`,
       },
-    ];
+    ]);
   }
 
-  // Longest-common-subsequence table over lines.
-  const rows = a.length;
-  const cols = b.length;
-  const lcs: Uint32Array[] = [];
-  for (let i = 0; i <= rows; i += 1) {
-    lcs.push(new Uint32Array(cols + 1));
-  }
-  for (let i = rows - 1; i >= 0; i -= 1) {
-    for (let j = cols - 1; j >= 0; j -= 1) {
-      lcs[i][j] =
-        a[i] === b[j]
-          ? lcs[i + 1][j + 1] + 1
-          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
-    }
+  // Hirschberg reconstruction retains only two LCS rows. Put the shorter
+  // document on the row width so auxiliary memory is O(min(old, new)), rather
+  // than retaining the previous oldLineCount * newLineCount matrix.
+  let matches: Match[];
+  if (b.length <= a.length) {
+    matches = findLcsMatches(a, b, stats).map(([oldIndex, newIndex]) => ({
+      oldIndex,
+      newIndex,
+    }));
+  } else {
+    matches = findLcsMatches(b, a, stats).map(([newIndex, oldIndex]) => ({
+      oldIndex,
+      newIndex,
+    }));
   }
 
   const raw: SourceDiffLine[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < rows && j < cols) {
-    if (a[i] === b[j]) {
-      raw.push({ kind: 'context', text: a[i] });
-      i += 1;
-      j += 1;
-    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
-      raw.push({ kind: 'del', text: a[i] });
-      i += 1;
-    } else {
-      raw.push({ kind: 'add', text: b[j] });
-      j += 1;
+  let oldIndex = 0;
+  let newIndex = 0;
+  for (const match of matches) {
+    while (oldIndex < match.oldIndex) {
+      raw.push({ kind: 'del', text: a[oldIndex++] });
     }
+    while (newIndex < match.newIndex) {
+      raw.push({ kind: 'add', text: b[newIndex++] });
+    }
+    raw.push({ kind: 'context', text: a[oldIndex] });
+    oldIndex += 1;
+    newIndex += 1;
   }
-  while (i < rows) {
-    raw.push({ kind: 'del', text: a[i] });
-    i += 1;
+  while (oldIndex < a.length) {
+    raw.push({ kind: 'del', text: a[oldIndex++] });
   }
-  while (j < cols) {
-    raw.push({ kind: 'add', text: b[j] });
-    j += 1;
+  while (newIndex < b.length) {
+    raw.push({ kind: 'add', text: b[newIndex++] });
   }
 
-  return collapseContext(raw);
+  return finish(collapseContext(raw));
+}
+
+/** Returns ordered matching indexes using linear-space LCS reconstruction. */
+function findLcsMatches(
+  rows: string[],
+  columns: string[],
+  stats: SourceDiffStats,
+  rowStart = 0,
+  rowEnd = rows.length,
+  columnStart = 0,
+  columnEnd = columns.length,
+): Array<[number, number]> {
+  if (rowStart === rowEnd || columnStart === columnEnd) {
+    return [];
+  }
+  if (rowEnd - rowStart === 1) {
+    for (let column = columnStart; column < columnEnd; column += 1) {
+      if (rows[rowStart] === columns[column]) {
+        return [[rowStart, column]];
+      }
+    }
+    return [];
+  }
+
+  const rowMiddle = Math.floor((rowStart + rowEnd) / 2);
+  const columnMiddle = findSplitColumn(
+    rows,
+    columns,
+    rowStart,
+    rowMiddle,
+    rowEnd,
+    columnStart,
+    columnEnd,
+    stats,
+  );
+  return [
+    ...findLcsMatches(
+      rows,
+      columns,
+      stats,
+      rowStart,
+      rowMiddle,
+      columnStart,
+      columnMiddle,
+    ),
+    ...findLcsMatches(
+      rows,
+      columns,
+      stats,
+      rowMiddle,
+      rowEnd,
+      columnMiddle,
+      columnEnd,
+    ),
+  ];
+}
+
+function findSplitColumn(
+  rows: string[],
+  columns: string[],
+  rowStart: number,
+  rowMiddle: number,
+  rowEnd: number,
+  columnStart: number,
+  columnEnd: number,
+  stats: SourceDiffStats,
+): number {
+  const width = columnEnd - columnStart;
+  stats.maxWorkingCells = Math.max(stats.maxWorkingCells, 2 * (width + 1));
+  const forward = lcsLengths(
+    rows,
+    columns,
+    rowStart,
+    rowMiddle,
+    columnStart,
+    columnEnd,
+    false,
+  );
+  const backward = lcsLengths(
+    rows,
+    columns,
+    rowMiddle,
+    rowEnd,
+    columnStart,
+    columnEnd,
+    true,
+  );
+  let split = 0;
+  let best = -1;
+  for (let offset = 0; offset <= width; offset += 1) {
+    const length = forward[offset] + backward[width - offset];
+    if (length > best) {
+      best = length;
+      split = offset;
+    }
+  }
+  return columnStart + split;
+}
+
+function lcsLengths(
+  rows: string[],
+  columns: string[],
+  rowStart: number,
+  rowEnd: number,
+  columnStart: number,
+  columnEnd: number,
+  reverse: boolean,
+): Uint32Array {
+  const width = columnEnd - columnStart;
+  const lengths = new Uint32Array(width + 1);
+  for (let rowOffset = 0; rowOffset < rowEnd - rowStart; rowOffset += 1) {
+    const row = reverse ? rowEnd - rowOffset - 1 : rowStart + rowOffset;
+    let diagonal = 0;
+    for (let offset = 1; offset <= width; offset += 1) {
+      const column = reverse ? columnEnd - offset : columnStart + offset - 1;
+      const previousRowLength = lengths[offset];
+      lengths[offset] =
+        rows[row] === columns[column]
+          ? diagonal + 1
+          : Math.max(previousRowLength, lengths[offset - 1]);
+      diagonal = previousRowLength;
+    }
+  }
+  return lengths;
 }
 
 // Keep CONTEXT_LINES of unchanged code around each change; fold longer

--- a/tests/unit/assisted-edit-gate.test.ts
+++ b/tests/unit/assisted-edit-gate.test.ts
@@ -22,6 +22,82 @@ describe('source diff for assisted edits', () => {
     ]);
   });
 
+  test('handles insertions and deletions without changing surrounding lines', () => {
+    expect(computeSourceDiff('a\nc', 'a\nb\nc')).toEqual([
+      { kind: 'context', text: 'a' },
+      { kind: 'add', text: 'b' },
+      { kind: 'context', text: 'c' },
+    ]);
+    expect(computeSourceDiff('a\nb\nc', 'a\nc')).toEqual([
+      { kind: 'context', text: 'a' },
+      { kind: 'del', text: 'b' },
+      { kind: 'context', text: 'c' },
+    ]);
+  });
+
+  test('finds a stable alignment when lines repeat', () => {
+    expect(
+      computeSourceDiff(
+        'start\nrepeat\nold\nrepeat\nend',
+        'start\nrepeat\nrepeat\nend',
+      ),
+    ).toEqual([
+      { kind: 'context', text: 'start' },
+      { kind: 'context', text: 'repeat' },
+      { kind: 'del', text: 'old' },
+      { kind: 'context', text: 'repeat' },
+      { kind: 'context', text: 'end' },
+    ]);
+  });
+
+  test('uses linear working rows for large synthetic documents', () => {
+    const beforeLines = Array.from({ length: 800 }, (_, i) => `line-${i}`);
+    const afterLines = [...beforeLines];
+    afterLines[400] = 'replacement';
+    let maxWorkingCells = Number.POSITIVE_INFINITY;
+
+    const diff = computeSourceDiff(
+      beforeLines.join('\n'),
+      afterLines.join('\n'),
+      {
+        onStats: (stats) => {
+          maxWorkingCells = stats.maxWorkingCells;
+          expect(stats.usedCoarseFallback).toBe(false);
+        },
+      },
+    );
+
+    expect(diff).toContainEqual({ kind: 'del', text: 'line-400' });
+    expect(diff).toContainEqual({ kind: 'add', text: 'replacement' });
+    // Two rows of the shorter input, not an 800 * 800 LCS matrix.
+    expect(maxWorkingCells).toBeLessThanOrEqual(2 * (beforeLines.length + 1));
+    expect(maxWorkingCells).toBeLessThan(
+      beforeLines.length * afterLines.length,
+    );
+  });
+
+  test('falls back to a coarse replacement for exceptionally large sources', () => {
+    const before = Array.from({ length: 2001 }, (_, i) => `old-${i}`).join(
+      '\n',
+    );
+    const after = Array.from({ length: 2001 }, (_, i) => `new-${i}`).join('\n');
+    let usedCoarseFallback = false;
+
+    expect(
+      computeSourceDiff(before, after, {
+        onStats: (stats) => {
+          usedCoarseFallback = stats.usedCoarseFallback;
+        },
+      }),
+    ).toEqual([
+      {
+        kind: 'gap',
+        text: 'Replaces all 2001 lines with 2001 new lines',
+      },
+    ]);
+    expect(usedCoarseFallback).toBe(true);
+  });
+
   test('folds long unchanged runs into a gap marker', () => {
     const before = Array.from({ length: 30 }, (_, i) => `line${i}`).join('\n');
     const after = `${before}\nnew-tail`;


### PR DESCRIPTION
### Motivation

- Reduce the quadratic memory usage of the existing full LCS matrix used for line diffs so editor previews remain responsive for larger sources. 
- Preserve the existing `SourceDiffLine` shape and context-folding behavior so callers (the editor UI) need no changes. 
- Add defensive limits and a coarse whole-document fallback for exceptionally large inputs to avoid excessive CPU/memory use. 

### Description

- Replaced the quadratic-memory LCS implementation with a linear-space reconstruction (Hirschberg-style) implemented in `src/js/milkdrop/overlay/source-diff.ts` via `findLcsMatches`, `findSplitColumn`, and `lcsLengths`. 
- Added `SourceDiffStats` and `SourceDiffOptions` plus an `onStats` hook to report `oldLineCount`, `newLineCount`, `maxWorkingCells`, and `usedCoarseFallback` for diagnostics without retaining working data. 
- Introduced defensive guards `MAX_DIFF_LINES` and `MAX_DIFF_CHARACTERS` and return the existing gap-style whole-document replacement (`kind: 'gap'`) when inputs exceed these limits. 
- Kept the original `SourceDiffLine` output and the `collapseContext` behavior so context lines, additions, deletions, and gap markers are unchanged for consumers. 

### Testing

- Ran unit tests with `bun run test tests/unit/assisted-edit-gate.test.ts` and all tests passed (new tests added cover insertions, deletions, repeated lines, large synthetic documents, and coarse-fallback behavior). 
- Ran quick and full quality gates with `bun run check:quick` and `bun run check` and they completed successfully. 
- Added an instrumentation assertion in the test `uses linear working rows for large synthetic documents` that examines `stats.maxWorkingCells` and asserts it is bounded by the linear-row working set (`<= 2 * (minLines + 1)`) and strictly less than the prior `oldLineCount * newLineCount` product. 
- Added a fallback test that creates >2000-line inputs and asserts the function returns a single gap entry and sets `stats.usedCoarseFallback` to `true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8088832cfc8332b076d43c26772dc4)