### PR TITLE
refactor: pause shader identicon animation when not visible

### DIFF
--- a/src/js/frontend/ShaderIdenticon.tsx
+++ b/src/js/frontend/ShaderIdenticon.tsx
@@ -27,7 +27,35 @@ export function ShaderIdenticon({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<ShaderIdenticonRenderer | null>(null);
   const animFrameRef = useRef<number | null>(null);
-  const startTimeRef = useRef<number>(performance.now());
+  const startTimeRef = useRef(performance.now());
+  const visibleRef = useRef(false);
+  const documentVisibleRef = useRef(!document.hidden);
+  const reducedMotionRef = useRef(false);
+  const smallIconRef = useRef(size <= 32);
+  const lastAnimatedRenderRef = useRef<number | null>(null);
+  const renderStateRef = useRef({
+    seed,
+    mode,
+    audioPeak,
+    bass: multiBand?.bass,
+    mid: multiBand?.mid,
+    treble: multiBand?.treble,
+  });
+
+  renderStateRef.current = {
+    seed,
+    mode,
+    audioPeak,
+    bass: multiBand?.bass,
+    mid: multiBand?.mid,
+    treble: multiBand?.treble,
+  };
+  smallIconRef.current = size <= 32;
+
+  const controlsRef = useRef({
+    render: (_now: number) => {},
+    reconcile: () => {},
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -35,28 +63,109 @@ export function ShaderIdenticon({
 
     const renderer = new ShaderIdenticonRenderer(canvas);
     rendererRef.current = renderer;
+    const motionQuery = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    reducedMotionRef.current = motionQuery?.matches ?? false;
 
-    const animate = (now: number) => {
-      const timeSec = (now - startTimeRef.current) / 1000;
+    const render = (now: number) => {
+      const state = renderStateRef.current;
       renderer.render({
-        seed,
-        mode,
-        audioPeak,
-        multiBand,
-        timeSec,
+        seed: state.seed,
+        mode: state.mode,
+        audioPeak: state.audioPeak,
+        multiBand: {
+          bass: state.bass,
+          mid: state.mid,
+          treble: state.treble,
+        },
+        timeSec: (now - startTimeRef.current) / 1000,
       });
+    };
+    const isPlaying = () =>
+      visibleRef.current &&
+      documentVisibleRef.current &&
+      !reducedMotionRef.current;
+    const animate = (now: number) => {
+      animFrameRef.current = null;
+      if (!isPlaying()) {
+        render(now);
+        return;
+      }
+      // Source-card icons are numerous and too small to benefit from a full
+      // display-rate update. Keep them on one RAF chain, but draw at ~10fps.
+      const lastRender = lastAnimatedRenderRef.current;
+      if (
+        !smallIconRef.current ||
+        lastRender === null ||
+        now - lastRender >= 100
+      ) {
+        render(now);
+        lastAnimatedRenderRef.current = now;
+      }
       animFrameRef.current = requestAnimationFrame(animate);
     };
+    const reconcile = () => {
+      if (isPlaying()) {
+        if (animFrameRef.current === null) {
+          animFrameRef.current = requestAnimationFrame(animate);
+        }
+      } else {
+        if (animFrameRef.current !== null) {
+          cancelAnimationFrame(animFrameRef.current);
+          animFrameRef.current = null;
+        }
+        render(performance.now());
+      }
+    };
+    controlsRef.current = { render, reconcile };
 
-    animFrameRef.current = requestAnimationFrame(animate);
+    const observer =
+      typeof IntersectionObserver === 'undefined'
+        ? null
+        : new IntersectionObserver((entries) => {
+            visibleRef.current = entries.some(
+              (entry) => entry.target === canvas && entry.isIntersecting,
+            );
+            reconcile();
+          });
+    if (observer) {
+      observer.observe(canvas);
+    } else {
+      // Older browsers and lightweight DOM test environments have no
+      // observer; preserve the previous animated behavior there.
+      visibleRef.current = true;
+      reconcile();
+    }
+
+    const onVisibilityChange = () => {
+      documentVisibleRef.current = !document.hidden;
+      reconcile();
+    };
+    const onMotionChange = (event: MediaQueryListEvent) => {
+      reducedMotionRef.current = event.matches;
+      reconcile();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    motionQuery?.addEventListener('change', onMotionChange);
+    render(performance.now());
 
     return () => {
+      observer?.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      motionQuery?.removeEventListener('change', onMotionChange);
       if (animFrameRef.current !== null) {
         cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
       }
       renderer.destroy();
+      rendererRef.current = null;
     };
-  }, [seed, mode, audioPeak, multiBand]);
+  }, []);
+
+  useEffect(() => {
+    if (rendererRef.current && animFrameRef.current === null) {
+      controlsRef.current.render(performance.now());
+    }
+  });
 
   return (
     <span

--- a/tests/unit/shader-identicon-component.test.tsx
+++ b/tests/unit/shader-identicon-component.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { act, createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import type { ShaderIdenticonRenderState } from '../../src/js/ui/shader-identicon.ts';
+import { createToyContainer } from '../toy-test-helpers.ts';
+
+class RendererMock {
+  static instances: RendererMock[] = [];
+  renders: ShaderIdenticonRenderState[] = [];
+  destroyed = false;
+
+  constructor(_canvas: HTMLCanvasElement) {
+    RendererMock.instances.push(this);
+  }
+
+  render(state: ShaderIdenticonRenderState) {
+    this.renders.push(state);
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+mock.module('../../src/js/ui/shader-identicon.ts', () => ({
+  ShaderIdenticonRenderer: RendererMock,
+}));
+
+const { ShaderIdenticon } = await import(
+  '../../src/js/frontend/ShaderIdenticon.tsx'
+);
+
+type ObserverCallback = IntersectionObserverCallback;
+let observerCallback: ObserverCallback;
+let observedCanvas: Element;
+let callbacks: Map<number, FrameRequestCallback>;
+let nextFrameId: number;
+let reducedMotion = false;
+let root: Root;
+let disposeContainer: () => void;
+let container: HTMLElement;
+
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    value: hidden,
+  });
+};
+
+const intersect = (isIntersecting: boolean) => {
+  act(() => {
+    observerCallback(
+      [{ target: observedCanvas, isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  });
+};
+
+const runFrame = (now = 100) => {
+  const [id, callback] = callbacks.entries().next().value ?? [];
+  if (id === undefined || !callback) throw new Error('No frame scheduled');
+  callbacks.delete(id);
+  act(() => callback(now));
+};
+
+describe('ShaderIdenticon component animation lifecycle', () => {
+  beforeEach(() => {
+    RendererMock.instances = [];
+    callbacks = new Map();
+    nextFrameId = 1;
+    reducedMotion = false;
+    setDocumentHidden(false);
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      const id = nextFrameId++;
+      callbacks.set(id, callback);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+    window.matchMedia = (() => ({
+      matches: reducedMotion,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => true,
+    })) as typeof window.matchMedia;
+    globalThis.IntersectionObserver = class {
+      constructor(callback: ObserverCallback) {
+        observerCallback = callback;
+      }
+      observe(target: Element) {
+        observedCanvas = target;
+      }
+      disconnect() {}
+      unobserve() {}
+      takeRecords() {
+        return [];
+      }
+      root = null;
+      rootMargin = '';
+      scrollMargin = '';
+      thresholds = [];
+    } as typeof IntersectionObserver;
+
+    const toy = createToyContainer('shader-identicon-component');
+    container = toy.container;
+    disposeContainer = toy.dispose;
+    root = createRoot(container);
+    flushSync(() => {
+      root.render(createElement(ShaderIdenticon, { seed: 'first' }));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    disposeContainer();
+  });
+
+  test('animates only while intersecting and leaves a static offscreen frame', () => {
+    const renderer = RendererMock.instances[0];
+    expect(callbacks.size).toBe(0);
+    expect(renderer.renders.length).toBeGreaterThan(0);
+
+    intersect(true);
+    expect(callbacks.size).toBe(1);
+    runFrame();
+    expect(callbacks.size).toBe(1);
+
+    intersect(false);
+    expect(callbacks.size).toBe(0);
+    expect(renderer.renders.at(-1)?.seed).toBe('first');
+  });
+
+  test('pauses while the document is hidden and resumes when shown', () => {
+    intersect(true);
+    setDocumentHidden(true);
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    expect(callbacks.size).toBe(0);
+
+    setDocumentHidden(false);
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    expect(callbacks.size).toBe(1);
+  });
+
+  test('uses updated render props without replacing the renderer', () => {
+    intersect(true);
+    flushSync(() => {
+      root.render(
+        createElement(ShaderIdenticon, {
+          seed: 'updated',
+          mode: '3d-polyhedron',
+          audioPeak: 0.8,
+          multiBand: { bass: 0.1, mid: 0.2, treble: 0.3 },
+        }),
+      );
+    });
+    runFrame();
+
+    expect(RendererMock.instances).toHaveLength(1);
+    expect(RendererMock.instances[0].renders.at(-1)).toMatchObject({
+      seed: 'updated',
+      mode: '3d-polyhedron',
+      audioPeak: 0.8,
+      multiBand: { bass: 0.1, mid: 0.2, treble: 0.3 },
+    });
+  });
+
+  test('renders statically when reduced motion is preferred', () => {
+    act(() => root.unmount());
+    reducedMotion = true;
+    root = createRoot(container);
+    flushSync(() => {
+      root.render(createElement(ShaderIdenticon, { seed: 'reduced' }));
+    });
+    intersect(true);
+
+    expect(callbacks.size).toBe(0);
+    expect(RendererMock.instances.at(-1)?.renders.at(-1)?.seed).toBe('reduced');
+  });
+
+  test('cancels its frame and destroys its renderer on unmount', () => {
+    intersect(true);
+    const renderer = RendererMock.instances[0];
+    act(() => root.unmount());
+
+    expect(callbacks.size).toBe(0);
+    expect(renderer.destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce unnecessary RAF work and power/CPU usage by stopping identicon animation when the canvas is not visible or the document is hidden. 
- Preserve a single static frame while paused and respect `prefers-reduced-motion` to improve accessibility. 
- Avoid re-creating the heavy `ShaderIdenticonRenderer` when render-state props change to prevent churn and leaks. 

### Description
- Create/destroy `ShaderIdenticonRenderer` only for the canvas lifecycle and retain latest `seed`, `mode`, `audioPeak`, and band values in refs so the animation callback reads them without replacing the renderer. 
- Use `IntersectionObserver` + `document.visibilitychange` + `prefers-reduced-motion` to start/stop a single scheduled RAF cleanly and render one static frame while paused, with cleanup disconnecting observers, listeners, and cancelling RAF. 
- Reduce cadence for small source-card icons by coalescing draws to ~10 FPS for small sizes to limit many tiny icons driving full display-rate updates. 
- Add component tests that mock `requestAnimationFrame` and `IntersectionObserver` to cover visible/offscreen transitions, document hidden/visible, prop updates without renderer replacement, reduced-motion static rendering, and unmount teardown. 

### Testing
- Ran the new component unit tests with `bun run test tests/unit/shader-identicon-component.test.tsx` and all tests passed. 
- Ran the targeted test set `bun run test tests/unit/shader-identicon-component.test.tsx tests/unit/accessibility-regression.test.tsx tests/unit/app-shell-user-journeys.test.tsx` and those tests passed. 
- Ran the quick quality gate with `bun run check:quick` which passed (lint/type quick checks). 
- Ran the repository-wide `bun run check`; the run exercised the full test/quality gate (1,800+ tests) and the change did not introduce regressions in the targeted areas, though the full suite reported a small number of unrelated/flaky failures (four existing/timeouts) observed in parallel CI during the run and were not caused by the identicon changes; an affected accessibility expectation passed on the targeted rerun.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8086b69f7c83328217b4fa13e54cc9)