### PR TITLE
refactor(webgpu): bounded LRU caches for procedural material signatures and teardown clearing

### DIFF
--- a/src/js/core/services/render-service.ts
+++ b/src/js/core/services/render-service.ts
@@ -88,6 +88,23 @@ export type RendererLifecycleEvent = {
 const rendererLifecycleSubscribers = new Set<
   (event: RendererLifecycleEvent) => void
 >();
+const rendererTeardownCallbacks = new Set<() => void>();
+
+/** Register cleanup for module-level GPU resources tied to pooled renderers. */
+export function registerRendererTeardownCallback(callback: () => void) {
+  rendererTeardownCallbacks.add(callback);
+  return () => rendererTeardownCallbacks.delete(callback);
+}
+
+function notifyRendererTeardown() {
+  rendererTeardownCallbacks.forEach((callback) => {
+    try {
+      callback();
+    } catch (error) {
+      console.warn('Renderer teardown callback failed.', error);
+    }
+  });
+}
 
 export function subscribeToRendererLifecycle(
   subscriber: (event: RendererLifecycleEvent) => void,
@@ -596,6 +613,7 @@ async function createRendererHandle(
         if (observedRevision !== observedWebGpuDeviceRevision) {
           return;
         }
+        notifyRendererTeardown();
         const message = describeWebGpuDeviceLoss(info);
         console.warn(message);
         recordWebGpuDeviceLost(info);
@@ -913,6 +931,7 @@ export function resetRendererPool({
     }
   });
   if (dispose) {
+    notifyRendererTeardown();
     rendererPool.splice(0, rendererPool.length);
   }
   activeQuality = getActiveQualityPreset();

--- a/src/js/milkdrop/renderer-adapter-webgpu-batching.ts
+++ b/src/js/milkdrop/renderer-adapter-webgpu-batching.ts
@@ -24,6 +24,7 @@ import {
   getUnitPolygonVertices,
   normalizeMilkdropPolygonSides,
 } from './renderer-adapter-shared';
+import { clearWebGpuProceduralMaterialCaches } from './renderer-backends/webgpu-procedural-materials';
 import {
   getMilkdropSegmentWidth,
   MILKDROP_CUSTOM_WAVE_Z,
@@ -1873,6 +1874,7 @@ class WebGPUBatchingLayer implements MilkdropRendererBatcher {
     this.dispose();
     clearStaticGeometryCaches();
     clearBufferPool();
+    clearWebGpuProceduralMaterialCaches();
   }
 }
 

--- a/src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts
+++ b/src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts
@@ -1,6 +1,7 @@
 import { Color } from 'three';
 // @ts-expect-error - 'three/webgpu' is available at runtime but not under the repo's current moduleResolution.
 import { NodeMaterial, TSL } from 'three/webgpu';
+import { registerRendererTeardownCallback } from '../../core/services/render-service';
 import {
   MILKDROP_CUSTOM_WAVE_Z,
   MILKDROP_WAVE_Z,
@@ -61,6 +62,40 @@ type TslNode = {
 type TslVertexFn = (inputs: object) => TslNode;
 
 type TslUniformNodes<T> = { [K in keyof T]: TslNode };
+
+const WEBGPU_PROCEDURAL_CACHE_LIMIT = 64;
+
+class BoundedLruCache<T> {
+  readonly entries = new Map<string, T>();
+
+  constructor(readonly limit: number) {}
+
+  get(key: string) {
+    const value = this.entries.get(key);
+    if (value !== undefined) {
+      this.entries.delete(key);
+      this.entries.set(key, value);
+    }
+    return value;
+  }
+
+  set(key: string, value: T) {
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    if (this.entries.size > this.limit) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey !== undefined) this.entries.delete(oldestKey);
+    }
+  }
+
+  clear() {
+    this.entries.clear();
+  }
+
+  get size() {
+    return this.entries.size;
+  }
+}
 
 // The per-preset field programs arrive as expression ASTs and historically
 // compiled to GLSL. On WebGPU they must compile to WGSL instead; the
@@ -490,7 +525,9 @@ const WGSL_APPLY_INTERACTION = `
     );
 `;
 
-const transformIncludeCache = new Map<string, unknown>();
+const transformIncludeCache = new BoundedLruCache<unknown>(
+  WEBGPU_PROCEDURAL_CACHE_LIMIT,
+);
 
 function getTransformInclude(
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,
@@ -584,7 +621,9 @@ ${WGSL_APPLY_INTERACTION}
   }
 `;
 
-const meshVertexFnCache = new Map<string, TslVertexFn>();
+const meshVertexFnCache = new BoundedLruCache<TslVertexFn>(
+  WEBGPU_PROCEDURAL_CACHE_LIMIT,
+);
 
 function getProceduralMeshVertexFn(
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,
@@ -728,7 +767,9 @@ ${WGSL_APPLY_INTERACTION}
   }
 `;
 
-const motionVectorVertexFnCache = new Map<string, TslVertexFn>();
+const motionVectorVertexFnCache = new BoundedLruCache<TslVertexFn>(
+  WEBGPU_PROCEDURAL_CACHE_LIMIT,
+);
 
 function getProceduralMotionVectorVertexFn(
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,
@@ -972,7 +1013,28 @@ ${WGSL_APPLY_INTERACTION}
   }`;
 }
 
-const customWaveVertexFnCache = new Map<string, TslVertexFn>();
+const customWaveVertexFnCache = new BoundedLruCache<TslVertexFn>(
+  WEBGPU_PROCEDURAL_CACHE_LIMIT,
+);
+
+export function clearWebGpuProceduralMaterialCaches() {
+  transformIncludeCache.clear();
+  meshVertexFnCache.clear();
+  motionVectorVertexFnCache.clear();
+  customWaveVertexFnCache.clear();
+}
+
+export function getWebGpuProceduralMaterialCacheDiagnostics() {
+  return {
+    limit: WEBGPU_PROCEDURAL_CACHE_LIMIT,
+    transformIncludes: transformIncludeCache.size,
+    meshVertexFns: meshVertexFnCache.size,
+    motionVectorVertexFns: motionVectorVertexFnCache.size,
+    customWaveVertexFns: customWaveVertexFnCache.size,
+  } as const;
+}
+
+registerRendererTeardownCallback(clearWebGpuProceduralMaterialCaches);
 
 function getProceduralCustomWaveVertexFn(
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,

--- a/tests/unit/milkdrop-renderer-adapter.test.ts
+++ b/tests/unit/milkdrop-renderer-adapter.test.ts
@@ -32,6 +32,11 @@ import { createMilkdropRendererAdapter } from '../../src/js/milkdrop/renderer-ad
 import { createWebGPUBatchingLayer } from '../../src/js/milkdrop/renderer-adapter-webgpu-batching.ts';
 import {
   buildMilkdropTransformWgslCode,
+  clearWebGpuProceduralMaterialCaches,
+  createProceduralCustomWaveMaterial,
+  createProceduralMeshMaterial,
+  createProceduralMotionVectorMaterial,
+  getWebGpuProceduralMaterialCacheDiagnostics,
   MILKDROP_FIELD_WGSL_HELPERS_SOURCE,
 } from '../../src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts';
 import { buildFeedbackCompositeState } from '../../src/js/milkdrop/renderer-helpers/feedback-composite.ts';
@@ -1729,6 +1734,55 @@ per_pixel_3=sx=2;
     expect(transformWgsl).toContain(
       '(rendererFieldY - normalizedCenterY) * fieldScaleY',
     );
+  });
+
+  test('bounds and clears WebGPU procedural material signature caches', () => {
+    clearWebGpuProceduralMaterialCaches();
+    const { limit } = getWebGpuProceduralMaterialCacheDiagnostics();
+
+    for (let index = 0; index < limit + 12; index += 1) {
+      const program = {
+        kind: 'gpu-field-program' as const,
+        statements: [
+          {
+            target: 'x',
+            expression: { type: 'literal' as const, value: index },
+          },
+        ],
+        temporaries: [],
+        signature: `editor-signature-${index}`,
+      };
+      createProceduralMeshMaterial(program).dispose();
+      createProceduralMotionVectorMaterial(program).dispose();
+      createProceduralCustomWaveMaterial(program).dispose();
+    }
+
+    const populated = getWebGpuProceduralMaterialCacheDiagnostics();
+    expect(populated.transformIncludes).toBe(limit);
+    expect(populated.meshVertexFns).toBe(limit);
+    expect(populated.motionVectorVertexFns).toBe(limit);
+    expect(populated.customWaveVertexFns).toBe(limit);
+
+    clearWebGpuProceduralMaterialCaches();
+    expect(getWebGpuProceduralMaterialCacheDiagnostics()).toEqual({
+      limit,
+      transformIncludes: 0,
+      meshVertexFns: 0,
+      motionVectorVertexFns: 0,
+      customWaveVertexFns: 0,
+    });
+
+    createProceduralMeshMaterial({
+      kind: 'gpu-field-program',
+      statements: [],
+      temporaries: [],
+      signature: 'teardown-signature',
+    }).dispose();
+    const batcher = createWebGPUBatchingLayer();
+    batcher.disposeWithCaches?.();
+    expect(
+      getWebGpuProceduralMaterialCacheDiagnostics().transformIncludes,
+    ).toBe(0);
   });
 
   test('renders motion vectors directly on webgpu when per-pixel VM work is absent', async () => {


### PR DESCRIPTION
### Motivation

- Prevent unbounded growth of WGSL/Tsl caches keyed by field-program signatures so editor-generated signatures cannot exhaust memory or retain stale shader objects.
- Ensure module-level procedural-material caches are cleared when a renderer or underlying WebGPU device is lost or when the renderer pool is fully disposed.

### Description

- Introduced a small `BoundedLruCache<T>` abstraction and a `WEBGPU_PROCEDURAL_CACHE_LIMIT = 64` sizing constant used to bound caches keyed by `MilkdropGpuFieldProgramDescriptor.signature`.
- Replaced the previous `Map` caches with the bounded LRU for `transformIncludeCache`, `meshVertexFnCache`, `motionVectorVertexFnCache`, and `customWaveVertexFnCache` in `src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts`.
- Exported `clearWebGpuProceduralMaterialCaches()` and `getWebGpuProceduralMaterialCacheDiagnostics()` for diagnostics and explicit clearing, and registered the clear function with a new renderer teardown callback mechanism (`registerRendererTeardownCallback`) in `src/js/core/services/render-service.ts`.
- Invoked teardown callbacks when a WebGPU device is lost and during full `resetRendererPool({ dispose: true })` to ensure module-level caches are cleaned when the renderer or device is gone, and wired `disposeWithCaches()` in the WebGPU batching layer to also clear the procedural caches.
- Added a test that compiles more distinct signatures than the configured limit and asserts each procedural cache stays bounded and can be cleared during teardown (`tests/unit/milkdrop-renderer-adapter.test.ts`).

### Testing

- Ran the focused unit tests for the renderer adapter: `bun run test tests/unit/milkdrop-renderer-adapter.test.ts` and the suite passed (77 tests, 0 failures). 
- Ran repository quality and checks: `bunx biome check` (auto-fixed imports/format where needed) and `bun run check` (full quality gate) which completed successfully. 
- The new unit test confirms that inserting `limit + 12` distinct signatures results in each cache reaching the configured `limit` and that `clearWebGpuProceduralMaterialCaches()` and `disposeWithCaches()` properly reset cache sizes to zero.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8088813f6c8332b2c58a38734a6a3c)