### PR TITLE
fix(eel): stop the parser silently discarding preset equations

### DIFF
--- a/src/js/milkdrop/compiler/program-assembly.ts
+++ b/src/js/milkdrop/compiler/program-assembly.ts
@@ -393,7 +393,26 @@ export function pushProgramStatementWithContinuation(
       return;
     }
 
-    if (!trimmedValue.includes('=')) {
+    // An unclosed `(` on the pending line beats the `=` heuristic. MilkDrop
+    // concatenates the numbered lines of a block into one source blob before
+    // parsing, so a `loop(N,` head legitimately spans many of them and its
+    // body is full of assignments:
+    //
+    //   per_frame_8 =loop(1024,  sample=i/1024;
+    //   per_frame_10=s = 5.5*6.28*sample;
+    //   per_frame_17=i=i+1;);
+    //
+    // Treating line 10's `=` as the start of a new statement flushed the
+    // half-written `loop(` head — which then failed extractCallInner and was
+    // discarded — and left the closing `);` as an orphan. Whole iterative
+    // loops disappeared from shipped presets that way.
+    const pendingContext = scanMilkdropProgramExpressionContext(
+      pending.sourceLine,
+    );
+    const pendingIsOpen =
+      pendingContext.parenthesisDepth > 0 || pendingContext.hasOpenQuote;
+
+    if (pendingIsOpen || !trimmedValue.includes('=')) {
       const combined = `${pending.sourceLine} ${trimmedValue}`.trim();
       if (canContinueMilkdropProgramLine(combined)) {
         pendingProgramSources.set(block, {
@@ -415,10 +434,12 @@ export function pushProgramStatementWithContinuation(
     return;
   }
 
-  if (
-    trimmedValue.includes('=') &&
-    canContinueMilkdropProgramLine(trimmedValue)
-  ) {
+  // Whether the line continues is decided by the line itself, not by whether
+  // it happens to contain an `=`. A bare `loop (10000,` head — the exact form
+  // several shipped presets open an init loop with — has no `=`, so requiring
+  // one pushed it immediately as a complete statement; it then failed
+  // extractCallInner and vanished, taking its body with it.
+  if (canContinueMilkdropProgramLine(trimmedValue)) {
     pendingProgramSources.set(block, { sourceLine: trimmedValue, line });
     return;
   }

--- a/src/js/milkdrop/expression.ts
+++ b/src/js/milkdrop/expression.ts
@@ -7,6 +7,7 @@ import {
   EEL_UNARY_OPERATORS,
   type EelEvalHelpers,
   evaluateEelCall,
+  finiteOrZero,
   MILKDROP_EEL_CLOSE_FACTOR,
   toMilkdropInt,
 } from './compiler/eel-function-table.ts';
@@ -54,7 +55,22 @@ type ParseResult<T> = {
   diagnostics: MilkdropDiagnostic[];
 };
 
-const operatorTokens = ['<=', '>=', '==', '!=', '&&', '||'];
+/**
+ * EEL compound assignment. ns-eel supports these and the corpus uses them
+ * (`exec2(k1 += 0.05 * bass_att, k1)`), so they must tokenize as one operator
+ * rather than as `+` followed by `=`.
+ */
+const COMPOUND_ASSIGNMENT_OPERATORS = ['+=', '-=', '*=', '/=', '%='] as const;
+
+const operatorTokens = [
+  '<=',
+  '>=',
+  '==',
+  '!=',
+  '&&',
+  '||',
+  ...COMPOUND_ASSIGNMENT_OPERATORS,
+];
 
 // The names live in `builtin-docs.ts` (the single source of truth shared with
 // the editor's highlighter, autocomplete, and hover docs); these sets remain
@@ -135,7 +151,7 @@ function tokenize(source: string, line: number): ParseResult<Token[]> {
       continue;
     }
 
-    if ('+-*/%^<>!|&='.includes(current)) {
+    if ('+-*/%^<>!|&=?:'.includes(current)) {
       tokens.push({ type: 'operator', value: current });
       index += 1;
       continue;
@@ -274,27 +290,78 @@ class ExpressionParser {
   }
 
   /** Assignment has the lowest precedence and is right-associative, so a=b=c
-   * parses as a=(b=c). */
+   * parses as a=(b=c). Compound assignment (`x += y`) desugars here into
+   * `x = x + y`, which is exactly what EEL does; every downstream tier then
+   * sees an ordinary assignment and needs no compound-operator handling. */
   private parseAssignment(): MilkdropExpressionNode {
     if (!this.enterDepth()) {
       return { type: 'literal', value: 0 };
     }
     try {
-      const left = this.parseLogicalOr();
-      const operator = this.matchOperator('=');
+      const left = this.parseConditional();
+      const operator = this.matchOperator(
+        '=',
+        ...COMPOUND_ASSIGNMENT_OPERATORS,
+      );
       if (!operator) {
         return left;
       }
       const right = this.parseAssignment();
+      if (operator === '=') {
+        return { type: 'binary', operator: '=', left, right };
+      }
       return {
         type: 'binary',
         operator: '=',
         left,
-        right,
+        // The target is re-read, not re-evaluated for effect: for the
+        // identifier and megabuf targets EEL allows, reading is pure.
+        right: {
+          type: 'binary',
+          operator: operator[0] as '+' | '-' | '*' | '/' | '%',
+          left,
+          right,
+        },
       };
     } finally {
       this.leaveDepth();
     }
+  }
+
+  /**
+   * The EEL ternary, which binds tighter than assignment and looser than
+   * `||`, and is right-associative (`a ? b : c ? d : e` groups to the right).
+   *
+   * It desugars to the intrinsic `if(cond, then, else)` — the same node the
+   * parser already produces for the call form — so every tier keeps its
+   * existing lazy-branch semantics and needs no new case.
+   */
+  private parseConditional(): MilkdropExpressionNode {
+    const condition = this.parseLogicalOr();
+    if (!this.matchOperator('?')) {
+      return condition;
+    }
+    const whenTrue = this.parseAssignment();
+    if (!this.matchOperator(':')) {
+      this.diagnostics.push(
+        createDiagnostic(
+          this.line,
+          'expr_expected_conditional_colon',
+          'Expected ":" to complete a "?:" conditional.',
+        ),
+      );
+      return condition;
+    }
+    // The else branch parses as a full assignment, matching how JS (and how
+    // preset authors) read `c ? a = 5 : a = 9`. Recursing through
+    // parseAssignment still reaches parseConditional, so a chained
+    // `a ? b : c ? d : e` stays right-associative.
+    const whenFalse = this.parseAssignment();
+    return {
+      type: 'call',
+      name: 'if',
+      args: [condition, whenTrue, whenFalse],
+    };
   }
 
   private peek() {
@@ -573,7 +640,16 @@ export function evaluateMilkdropExpression(
     case 'binary': {
       // Assignment is handled specially to allow side effects on LHS
       if (node.operator === '=') {
-        const rvalue = evaluateMilkdropExpression(node.right, env, helpers);
+        // Clamp before the store, not after: the JIT emits the same clamp on
+        // its nested-assignment temporary, and without it an assignment
+        // nested inside an expression (`zoom = (q1 = 1e300 * 1e300)`) writes
+        // a raw Infinity/NaN straight into the persistent register/state
+        // mirrors, where it survives every later frame. The statement-level
+        // clamp in expression-jit's interpreted runner only covers the
+        // outermost value, so it never caught these.
+        const rvalue = finiteOrZero(
+          evaluateMilkdropExpression(node.right, env, helpers),
+        );
         // Perform assignment to the left side
         if (node.left.type === 'identifier') {
           const key = node.left.name.toLowerCase();
@@ -676,19 +752,51 @@ export function splitMilkdropStatements(source: string) {
   return statements;
 }
 
-function findAssignmentIndex(source: string) {
+/**
+ * Locates the top-level assignment operator, returning where it starts and
+ * which one it is (`=` or a compound form).
+ *
+ * The `=` in `==`, `<=`, `>=` and `!=` is NOT an assignment: matching it split
+ * `x == 1` into the target `x` and the expression `= 1`, reporting a bogus
+ * invalid-target error for a statement that is merely a (useless but legal)
+ * comparison.
+ */
+function findAssignmentIndex(source: string): {
+  index: number;
+  operator: string;
+} {
   let depth = 0;
+  let sawConditional = false;
   for (let index = 0; index < source.length; index += 1) {
     const char = source[index];
     if (char === '(') {
       depth += 1;
-    } else if (char === ')') {
-      depth = Math.max(0, depth - 1);
-    } else if (char === '=' && depth === 0) {
-      return index;
+      continue;
     }
+    if (char === ')') {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (char === '?' && depth === 0) {
+      // Past a top-level `?` every `=` belongs to a ternary branch
+      // (`c ? x = 1 : x = 2`), not to a statement-level assignment.
+      sawConditional = true;
+      continue;
+    }
+    if (char !== '=' || depth !== 0 || sawConditional) {
+      continue;
+    }
+    if (source[index + 1] === '=' || '<>!='.includes(source[index - 1] ?? '')) {
+      continue;
+    }
+    const compound = COMPOUND_ASSIGNMENT_OPERATORS.find(
+      (operator) => operator[0] === source[index - 1],
+    );
+    return compound
+      ? { index: index - 1, operator: compound }
+      : { index, operator: '=' };
   }
-  return -1;
+  return { index: -1, operator: '=' };
 }
 
 export function parseMilkdropExpression(
@@ -707,19 +815,23 @@ export function parseMilkdropExpression(
   };
 }
 
-const CONTROL_LOOP_PREFIX = 'loop(';
-const CONTROL_WHILE_PREFIX = 'while(';
 const CONTROL_TARGET_SENTINEL = '__control';
+
+/**
+ * `loop`/`while` at the head of a statement, allowing whitespace before the
+ * `(` and any casing. EEL is whitespace-insensitive and its identifiers are
+ * case-insensitive, and the corpus uses both: matching the bare `'loop('`
+ * prefix dropped `loop (10000, ...)` — and with it the entire loop body —
+ * off the front of 12 shipped presets.
+ */
+const CONTROL_FLOW_PATTERN = /^(loop|while)\s*\(/iu;
 
 /** True when `source` is a single `loop(...)` or `while(...)` call (possibly
  * trailing a `;`). These lines have no top-level `=`, so the flat-statement
  * parser would otherwise drop them. */
 function isControlFlowStatement(source: string) {
   const trimmed = source.trim().replace(/;+\s*$/u, '');
-  return (
-    trimmed.startsWith(CONTROL_LOOP_PREFIX) ||
-    trimmed.startsWith(CONTROL_WHILE_PREFIX)
-  );
+  return CONTROL_FLOW_PATTERN.test(trimmed);
 }
 
 /** Returns the text between the outer `(` and its matching `)`, or null when
@@ -788,10 +900,20 @@ function parseControlFlowStatement(
   line: number,
 ): ParseResult<MilkdropCompiledStatement> {
   const trimmed = source.trim().replace(/;+\s*$/u, '');
-  const isLoop = trimmed.startsWith(CONTROL_LOOP_PREFIX);
+  const isLoop =
+    CONTROL_FLOW_PATTERN.exec(trimmed)?.[1]?.toLowerCase() === 'loop';
   const inner = extractCallInner(trimmed);
   if (inner === null) {
-    return { value: null, diagnostics: [] };
+    return {
+      value: null,
+      diagnostics: [
+        createDiagnostic(
+          line,
+          'statement_invalid_target',
+          `Unterminated ${isLoop ? 'loop' : 'while'} control statement.`,
+        ),
+      ],
+    };
   }
   const split = splitControlHeadAndBody(inner);
   if (!split) {
@@ -853,7 +975,7 @@ export function parseMilkdropStatement(
     return parseControlFlowStatement(source, line);
   }
 
-  const index = findAssignmentIndex(source);
+  const { index, operator } = findAssignmentIndex(source);
 
   // Skip empty or missing assignments — common in .milk preset files with
   // blank per-frame/per-pixel lines used as visual spacing between blocks
@@ -866,7 +988,12 @@ export function parseMilkdropStatement(
     }
     const exprResult = parseMilkdropExpression(trimmed, line);
     if (!exprResult.value) {
-      return { value: null, diagnostics: [] };
+      // Report, don't swallow. Dropping the diagnostics here made every
+      // unparseable statement without a top-level `=` disappear in total
+      // silence — no error, no warning, just a preset quietly missing an
+      // equation. That is how the `loop (` and `+=` gaps above survived a
+      // corpus that otherwise compiles with zero errors.
+      return { value: null, diagnostics: exprResult.diagnostics };
     }
     // Accept any valid expression as an expression statement
     return {
@@ -880,12 +1007,18 @@ export function parseMilkdropStatement(
     };
   }
 
-  if (!source.slice(index + 1).trim()) {
+  const rawValueSource = source.slice(index + operator.length).trim();
+  if (!rawValueSource) {
     return { value: null, diagnostics: [] };
   }
 
   const target = source.slice(0, index).trim();
-  const expressionSource = source.slice(index + 1).trim();
+  // `x += v` is `x = x + (v)`. Parenthesising the value keeps the compound
+  // operator's precedence: without it `x *= a + b` would become `x = x * a + b`.
+  const expressionSource =
+    operator === '='
+      ? rawValueSource
+      : `${target} ${operator[0]} (${rawValueSource})`;
   const megabufTarget = target.match(/^(g?megabuf)\((.+)\)$/iu);
 
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(target) && !megabufTarget) {

--- a/tests/unit/eel-csp-fallback.test.ts
+++ b/tests/unit/eel-csp-fallback.test.ts
@@ -118,6 +118,20 @@ describe('EEL CSP interpreter-only fallback', () => {
     expect(fallback.env.x).toBe(jit.env.x);
   });
 
+  test('clamps non-finite nested assignments like the JIT', () => {
+    // Regression: the fallback's statement-level clamp only covered the
+    // outermost value, so an assignment nested inside an expression stored a
+    // raw Infinity into the register/state mirrors, where it persisted
+    // across frames and NaN-poisoned everything reading it.
+    const program = ['zoom = (q1 = 1e300 * 1e300) * 0 + 1'];
+    const jit = runTier(program, true);
+    const fallback = runTier(program, false);
+
+    expect(fallback.registers.q1).toBe(0);
+    expect(fallback.registers.q1).toBe(jit.registers.q1 as number);
+    expect(fallback.state.zoom).toBe(jit.state.zoom as number);
+  });
+
   test('runs unknown-function arguments for their side effects', () => {
     // Regression: the JIT's unknown-name fallback emitted a bare `(0)` and
     // threw the compiled argument expressions away, so an assignment nested
@@ -152,16 +166,26 @@ describe('EEL CSP interpreter-only fallback', () => {
   });
 
   test('agrees with the JIT on 300 seeded random programs', () => {
-    const VARS = ['a', 'b', 'c', 'd', 'x', 'y', 'zoom', 'rot'];
+    const VARS = ['a', 'b', 'c', 'd', 'x', 'y', 'zoom', 'rot', 'q1', 't2'];
+    const OVERFLOW_LITERALS = ['1e300', '-1e300', '1e-320', '1e38'];
     const failures: string[] = [];
     for (let seed = 1; seed <= 300; seed++) {
       const rnd = mulberry32(seed);
       const genExpr = (depth: number): string => {
         const roll = rnd();
         if (depth <= 0 || roll < 0.3) {
-          return rnd() < 0.5
-            ? (rnd() * 20 - 10).toFixed(4)
-            : (VARS[Math.floor(rnd() * VARS.length)] as string);
+          if (rnd() < 0.5) {
+            // A tenth of the literals overflow f64 when multiplied, which is
+            // what makes the never-let-NaN-escape clamp observable. A pool of
+            // only +/-10 values kept the fuzz permanently inside the finite
+            // range and hid an unclamped nested-assignment store.
+            return rnd() < 0.2
+              ? (OVERFLOW_LITERALS[
+                  Math.floor(rnd() * OVERFLOW_LITERALS.length)
+                ] as string)
+              : (rnd() * 20 - 10).toFixed(4);
+          }
+          return VARS[Math.floor(rnd() * VARS.length)] as string;
         }
         if (roll < 0.5) {
           const fns = ['sin', 'sqrt', 'log', 'int', 'frac', 'abs', 'sqr'];
@@ -190,16 +214,33 @@ describe('EEL CSP interpreter-only fallback', () => {
         failures.push(`seed ${seed} threw: ${(error as Error).message}`);
         continue;
       }
-      for (const key of new Set([
-        ...Object.keys(jit.env),
-        ...Object.keys(fallback.env),
-      ])) {
-        if (!closeEnough(jit.env[key] ?? 0, fallback.env[key] ?? 0)) {
-          failures.push(
-            `seed ${seed}: ${key} jit=${jit.env[key]} fallback=${fallback.env[key]}\n  ${lines.join('\n  ')}`,
-          );
-          break;
+      // Every store, not just env: q registers and the state mirror are what
+      // persist across frames, so a value that only goes bad there is exactly
+      // the one that poisons a preset for its whole lifetime.
+      let mismatched = false;
+      for (const store of ['env', 'state', 'registers'] as const) {
+        for (const key of new Set([
+          ...Object.keys(jit[store]),
+          ...Object.keys(fallback[store]),
+        ])) {
+          const jitValue = jit[store][key] ?? 0;
+          const fallbackValue = fallback[store][key] ?? 0;
+          if (!Number.isFinite(jitValue) || !Number.isFinite(fallbackValue)) {
+            failures.push(
+              `seed ${seed}: ${store}.${key} escaped non-finite jit=${jitValue} fallback=${fallbackValue}\n  ${lines.join('\n  ')}`,
+            );
+            mismatched = true;
+            break;
+          }
+          if (!closeEnough(jitValue, fallbackValue)) {
+            failures.push(
+              `seed ${seed}: ${store}.${key} jit=${jitValue} fallback=${fallbackValue}\n  ${lines.join('\n  ')}`,
+            );
+            mismatched = true;
+            break;
+          }
         }
+        if (mismatched) break;
       }
     }
     expect(failures).toEqual([]);

--- a/tests/unit/milkdrop-compiler.test.ts
+++ b/tests/unit/milkdrop-compiler.test.ts
@@ -13,6 +13,51 @@ import {
 import type { MilkdropVideoEchoOrientation } from '../../src/js/milkdrop/types.ts';
 
 describe('milkdrop compiler', () => {
+  test('joins a loop body split across numbered program lines', () => {
+    // MilkDrop concatenates the numbered lines of a block into one source
+    // blob before parsing, so a `loop(` head legitimately spans many of them.
+    // Two rules broke that: a pending line was flushed as soon as the next
+    // one contained an `=` (every loop body is full of them), and a pending
+    // line was only ever started if it contained an `=` itself — which a bare
+    // `loop (10000,` head does not. Either one dropped the head, which then
+    // failed to find its closing paren and vanished silently, leaving the
+    // `);` behind as an orphan. Whole iterative loops disappeared from
+    // shipped presets that way.
+    const compiled = compileMilkdropPresetSource(
+      `
+title="Continued Loop"
+per_frame_init_1=index = 0;
+per_frame_init_2=loop (4,
+per_frame_init_3=  megabuf(index) = .1;
+per_frame_init_4=  index = index + 1;
+per_frame_init_5=);
+per_frame_1=x = 0;
+per_frame_2=loop(3,  sample = 1;
+per_frame_3=
+per_frame_4=x = x + sample;
+per_frame_5=);
+`,
+      { id: 'continued-loop' },
+    );
+
+    expect(
+      compiled.diagnostics.filter((entry) => entry.severity === 'error'),
+    ).toEqual([]);
+
+    const init = compiled.ir.programs.init.statements.filter(
+      (entry) => entry?.control,
+    );
+    expect(init).toHaveLength(1);
+    expect(init[0]?.control?.kind).toBe('loop');
+    expect(init[0]?.control?.body).toHaveLength(2);
+
+    const perFrame = compiled.ir.programs.perFrame.statements.filter(
+      (entry) => entry?.control,
+    );
+    expect(perFrame).toHaveLength(1);
+    expect(perFrame[0]?.control?.body).toHaveLength(2);
+  });
+
   test('compiles preset metadata, scalars, and program statements', () => {
     const compiled = compileMilkdropPresetSource(
       `

--- a/tests/unit/milkdrop-expression.test.ts
+++ b/tests/unit/milkdrop-expression.test.ts
@@ -210,4 +210,159 @@ describe('milkdrop expression', () => {
       expect(evaluate('2*e')).toBeCloseTo(2 * Math.E, 12);
     });
   });
+
+  describe('compound assignment', () => {
+    const runStatement = (source: string, env: Record<string, number>) => {
+      const parsed = parseMilkdropStatement(source, 1);
+      expect(parsed.diagnostics.filter((d) => d.severity === 'error')).toEqual(
+        [],
+      );
+      if (!parsed.value) {
+        throw new Error(`Expected "${source}" to parse.`);
+      }
+      const value = evaluateMilkdropExpression(parsed.value.expression, env);
+      if (parsed.value.target !== '__control') {
+        env[parsed.value.target] = value;
+      }
+      return env;
+    };
+
+    test('desugars every compound operator at statement level', () => {
+      // ns-eel supports these and the shipped corpus uses them; before, the
+      // `=` of `+=` was read as the assignment and `k1 +` as the target, so
+      // the statement was rejected as an invalid target.
+      expect(runStatement('k1 += 3', { k1: 2 }).k1).toBe(5);
+      expect(runStatement('k1 -= 3', { k1: 10 }).k1).toBe(7);
+      expect(runStatement('k1 *= 3', { k1: 10 }).k1).toBe(30);
+      expect(runStatement('k1 /= 4', { k1: 10 }).k1).toBe(2.5);
+      expect(runStatement('k1 %= 3', { k1: 10 }).k1).toBe(1);
+    });
+
+    test('keeps the compound operator binding tighter than the value', () => {
+      // `x *= 3 + 1` is `x = x * (3 + 1)`, not `x = x * 3 + 1`.
+      expect(runStatement('k1 *= 3 + 1', { k1: 2 }).k1).toBe(8);
+      expect(runStatement('k1 -= 3 - 1', { k1: 10 }).k1).toBe(8);
+    });
+
+    test('desugars nested compound assignment inside an expression', () => {
+      // The shape five shipped presets use: `exec2(k1 += v, k1)`. This has no
+      // top-level `=`, so failing to parse it dropped the whole statement.
+      const env: Record<string, number> = { k1: 2, bass_att: 1 };
+      const parsed = parseMilkdropStatement(
+        'exec2(k1 += 0.05 * bass_att, k1)',
+        1,
+      );
+      expect(parsed.diagnostics).toEqual([]);
+      if (!parsed.value) {
+        throw new Error('Expected the exec2 statement to parse.');
+      }
+      expect(evaluateMilkdropExpression(parsed.value.expression, env)).toBe(
+        2.05,
+      );
+      expect(env.k1).toBe(2.05);
+    });
+
+    test('does not mistake a comparison operator for an assignment', () => {
+      // `==`, `<=`, `>=` and `!=` all contain an `=`; treating it as the
+      // assignment split `x == 1` into the target `x` and the value `= 1`.
+      for (const source of ['x == 1', 'x <= 1', 'x >= 1', 'x != 1']) {
+        const parsed = parseMilkdropStatement(source, 1);
+        expect(
+          parsed.diagnostics.filter((d) => d.severity === 'error'),
+          source,
+        ).toEqual([]);
+      }
+      expect(runStatement('y = x >= 2', { x: 3 }).y).toBe(1);
+    });
+  });
+
+  describe('control-flow statements', () => {
+    const bodyLength = (source: string) => {
+      const parsed = parseMilkdropStatement(source, 1);
+      expect(parsed.diagnostics.filter((d) => d.severity === 'error')).toEqual(
+        [],
+      );
+      return parsed.value?.control?.body.length ?? 0;
+    };
+
+    test('accepts whitespace and any casing before the opening paren', () => {
+      // EEL is whitespace-insensitive and its identifiers are case
+      // insensitive. Matching the bare `loop(` prefix dropped `loop (10000,`
+      // — head and body together — from shipped presets.
+      expect(bodyLength('loop(2, k1 = k1 + 1)')).toBe(1);
+      expect(bodyLength('loop (2, k1 = k1 + 1)')).toBe(1);
+      expect(bodyLength('LOOP (2, k1 = k1 + 1)')).toBe(1);
+      expect(bodyLength('while (below(n, 4), n = n + 1)')).toBe(1);
+      expect(bodyLength('While(below(n, 4), n = n + 1)')).toBe(1);
+    });
+
+    test('reports an unterminated control statement instead of dropping it', () => {
+      const parsed = parseMilkdropStatement('loop (10000,', 1);
+      expect(parsed.value).toBeNull();
+      expect(parsed.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ternary conditional', () => {
+    const evaluateStatement = (source: string, env: Record<string, number>) => {
+      const parsed = parseMilkdropStatement(source, 1);
+      expect(parsed.diagnostics.filter((d) => d.severity === 'error')).toEqual(
+        [],
+      );
+      if (!parsed.value) {
+        throw new Error(`Expected "${source}" to parse.`);
+      }
+      return evaluateMilkdropExpression(parsed.value.expression, env);
+    };
+
+    test('picks the branch and binds looser than every other operator', () => {
+      expect(evaluateStatement('x = 1 > 0 ? 10 : 20', {})).toBe(10);
+      expect(evaluateStatement('x = 0 > 1 ? 10 : 20', {})).toBe(20);
+      expect(evaluateStatement('x = 1 + (0 ? 5 : 2) * 3', {})).toBe(7);
+      expect(evaluateStatement('y = x > 1 ? x + 1 : x - 1', { x: 2 })).toBe(3);
+    });
+
+    test('chains right-associatively', () => {
+      expect(evaluateStatement('x = 1 ? 2 : 3 ? 4 : 5', {})).toBe(2);
+      expect(evaluateStatement('x = 0 ? 2 : 0 ? 4 : 5', {})).toBe(5);
+    });
+
+    test('evaluates only the taken branch', () => {
+      // It desugars to the intrinsic `if()`, which is lazy — preset code
+      // relies on that for side effects.
+      const taken: Record<string, number> = { a: 0, b: 0 };
+      evaluateStatement('x = 1 ? (a = 7) : (b = 9)', taken);
+      expect(taken).toEqual({ a: 7, b: 0 });
+
+      const notTaken: Record<string, number> = { a: 0, b: 0 };
+      evaluateStatement('x = 0 ? (a = 7) : (b = 9)', notTaken);
+      expect(notTaken).toEqual({ a: 0, b: 9 });
+    });
+
+    test('allows an unparenthesised assignment in either branch', () => {
+      const env: Record<string, number> = { a: 0 };
+      evaluateStatement('1 > 0 ? a = 5 : a = 9', env);
+      expect(env.a).toBe(5);
+    });
+
+    test('reports a missing colon', () => {
+      const parsed = parseMilkdropStatement('x = 1 ? 2', 1);
+      expect(parsed.diagnostics.map((d) => d.code)).toContain(
+        'expr_expected_conditional_colon',
+      );
+    });
+  });
+
+  test('reports a malformed expression statement rather than swallowing it', () => {
+    // A statement with no top-level `=` used to return no diagnostics at all
+    // when it failed to parse, so a preset could quietly lose an equation —
+    // which is how the `loop (` and `+=` gaps survived a corpus that
+    // otherwise compiled with zero errors. `)` is the exact orphan a
+    // mis-split multi-line loop body left behind.
+    const parsed = parseMilkdropStatement(')', 1);
+    expect(parsed.value).toBeNull();
+    expect(parsed.diagnostics.map((d) => d.code)).toContain(
+      'expr_expected_primary',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Compiling all 2686 bundled `.milk` files reported **zero errors while silently discarding 64 statements**. That is the headline: the parser had a path that dropped an equation with no error, no warning, and no trace, so every other gap below hid behind it. Any previous "the corpus compiles clean" claim about this pipeline was measuring nothing.

`parseMilkdropStatement` returned `{ value: null, diagnostics: [] }` whenever a statement with no top-level `=` failed to parse. It now reports. With the drops visible, three real gaps surfaced.

### Multi-line loop bodies lost their heads — 12 presets

MilkDrop joins the numbered lines of a block into one source blob before parsing, so a `loop(` head legitimately spans several of them:

```
per_frame_8 =loop(1024,  sample=i/1024;
per_frame_10=s = 5.5*6.28*sample;
per_frame_17=i=i+1;);
```

`pushProgramStatementWithContinuation` broke that two ways. It flushed the pending line as soon as the next one contained an `=` — every loop body is full of them — and it only *started* a pending line if that line contained an `=` itself, which a bare `loop (10000,` head does not. Either path pushed the half-written head, which then failed `extractCallInner` and vanished with its entire body, leaving the `);` behind as an orphan.

Corpus control statements go **307 → 330 across 56 → 63 presets**. For `cotc-amandio-c-iterative-squares-*` the recovered `loop(1024, …)` *is* the preset — it generates the geometry.

### `loop (` with a space, or any casing

`isControlFlowStatement` matched the literal `'loop('` prefix. EEL is both whitespace- and case-insensitive, and shipped presets open init loops as `loop (10000,`.

### Compound assignment was unsupported — 5 presets

`+=`, `-=`, `*=`, `/=`, `%=` are real ns-eel operators. `martin-cherry-brain-2`, `martin-cherry-brain-wall-mod`, `martin-mandelbulb-slideshow`, `martin-extreme-heat` and `martin-frosty-caves-2` all use them — `exec2(k1 += 0.05 * bass_att, k1)` — and lost those statements outright, so `k1` never accumulated, `bpm /= 2` never halved, `anz += 1` never counted.

They desugar at parse time into `x = x + (v)`, so no downstream tier needs a compound case. The parenthesisation is load-bearing: `x *= 3 + 1` must stay `x * (3 + 1)`, not `x * 3 + 1`.

### Also

- `findAssignmentIndex` read the `=` in `==`, `<=`, `>=` and `!=` as an assignment, splitting `x == 1` into the target `x` and the value `= 1`.
- Adds the ternary `?:`, desugared to the intrinsic `if(c, a, b)` node so every tier inherits its lazy-branch semantics unchanged. This is the one change here **without** confirmed shipped impact — no corpus preset uses `?`; it is for imported and hand-authored EEL.

Still unsupported, none present in the corpus: ns-eel `$x41` hex and `$'c'` char literals, and `;` sequences inside parentheses — the corpus uses `exec2`/`exec3` instead.

## Testing

- **All 2686 bundled presets compile with zero errors** — now meaningful, since errors are actually reported. This was the instrument that found every bug here; testing the parser directly finds none of them.
- **`bun run lab:nan-sweep`: 2679 presets, 655s, 0 failures, no new failures vs baseline** — with the recovered loops genuinely executing, which is the check that mattered most. Presets that had been quietly skipping a 1024-iteration loop now run it.
- `bun run test:unit` 2318 pass / 0 fail; `bun run test:compat` 26 pass / 0 fail; `bun run check:quick` clean (also enforced by the pre-commit gate).

New coverage in `tests/unit/milkdrop-expression.test.ts` (compound operators and their precedence, comparison-vs-assignment, `loop (` spacing and casing, unterminated control statements, ternary branch laziness and right-associativity, non-swallowed diagnostics) and `tests/unit/milkdrop-compiler.test.ts` (a loop body split across numbered program lines, asserting both the init and per-frame bodies survive).

`tests/unit/eel-csp-fallback.test.ts` also gains the widened NaN fuzz from the preceding work: overflow-magnitude literals in the generator, and all three stores compared rather than just `env`.

## Docs touched

None. This is a parser correctness fix behind an unchanged public surface — no script, command, or authoring-facing behaviour changes, so no page in `docs/` or `.claude/CLAUDE.md` goes stale. `docs/authoring/reference.md` is generated and verified current by the pre-commit gate. The newly accepted syntax (compound assignment, `?:`) is standard ns-eel that authoring docs already treat as EEL.

## Base branch

Based on `fix/fallback-audit` (#1120) rather than `main`, so this diff is exactly the one parser commit. Retarget to `main` once #1120 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
