### PR TITLE
fix(replay): make the golden-trace escalation actually work off-Linux

### DIFF
--- a/scripts/preset-lab-replay.ts
+++ b/scripts/preset-lab-replay.ts
@@ -162,15 +162,29 @@ function diffFields(
 ): string[] {
   const [leftLabel, rightLabel] = labels;
   const details: string[] = [];
-  const keys = new Set([
-    ...Object.keys(left.variables ?? {}),
-    ...Object.keys(right.variables ?? {}),
-  ]);
-  for (const key of [...keys].sort()) {
-    const a = left.variables?.[key];
-    const b = right.variables?.[key];
-    if (!equals(a, b)) {
-      details.push(`  variables.${key}: ${leftLabel}=${a} ${rightLabel}=${b}`);
+  // Only diff variables when BOTH sides carry them. A compact trace stores
+  // variables on checkpoint frames only, so on every other frame the union of
+  // keys pitted the replay's real values against `undefined` — which the
+  // tolerance comparators read as 0 — and reported every variable in the
+  // preset as moved. That made the digest-mismatch escalation below unusable
+  // on exactly the frames it exists for: a machine whose libm differs from
+  // the recorder's fails the digest, escalates, and is told that all ~2000
+  // variables changed. The gate could therefore only ever pass on the machine
+  // that recorded the traces, which is the very thing the tolerances were
+  // added to fix.
+  if (left.variables && right.variables) {
+    const keys = new Set([
+      ...Object.keys(left.variables),
+      ...Object.keys(right.variables),
+    ]);
+    for (const key of [...keys].sort()) {
+      const a = left.variables[key];
+      const b = right.variables[key];
+      if (!equals(a, b)) {
+        details.push(
+          `  variables.${key}: ${leftLabel}=${a} ${rightLabel}=${b}`,
+        );
+      }
     }
   }
   for (const field of ['mainWave', 'customWaves', 'shapes'] as const) {

--- a/tests/unit/replay-compare-escalation.test.ts
+++ b/tests/unit/replay-compare-escalation.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit cover for compareReplay's digest-mismatch escalation.
+ *
+ * A compact golden trace stores variables on checkpoint frames only, but the
+ * live replay always captures them. When the digests disagree — which is what
+ * a machine with a different libm produces — the comparison escalates to a
+ * field diff, and that diff used to pit the replay's real values against the
+ * `undefined` the compact frame never stored, reading it as 0 and reporting
+ * every variable in the preset as moved.
+ *
+ * That made the escalation unusable on precisely the frames it exists for, so
+ * the gate stayed pinned to whichever machine recorded the traces even after
+ * tolerances were added. These cases are cheap and VM-free, so the property
+ * is pinned independently of the witness presets.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  compareReplay,
+  type TraceFile,
+} from '../../scripts/preset-lab-replay.ts';
+
+const geometry = { mainWave: 1.5, customWaves: 2.5, shapes: 3.5 };
+
+function traceOf(frames: unknown[]): TraceFile {
+  return {
+    version: 1,
+    presetId: 'test-preset',
+    capturedAt: '',
+    fps: 60,
+    scenario: 'full-mix',
+    frames,
+  } as unknown as TraceFile;
+}
+
+describe('compareReplay digest-mismatch escalation', () => {
+  test('ignores variables the compact frame never recorded', () => {
+    const trace = traceOf([{ digest: 'aaaaaaaa', geometry }]);
+    const replayed = [
+      {
+        digest: 'bbbbbbbb', // differing libm: the digest cannot match
+        variables: { zoom: 1.05, rot: 0.02 },
+        geometry,
+      },
+    ] as never;
+
+    expect(compareReplay(trace, replayed)).toBeNull();
+  });
+
+  test('still reports geometry that actually moved on such a frame', () => {
+    const trace = traceOf([{ digest: 'aaaaaaaa', geometry }]);
+    const replayed = [
+      {
+        digest: 'bbbbbbbb',
+        variables: { zoom: 1.05 },
+        geometry: { ...geometry, shapes: 99 },
+      },
+    ] as never;
+
+    const divergence = compareReplay(trace, replayed);
+    expect(divergence?.frame).toBe(0);
+    expect(divergence?.details.join('\n')).toContain('geometry.shapes');
+  });
+
+  test('still compares variables on checkpoint frames', () => {
+    const trace = traceOf([
+      { digest: 'aaaaaaaa', variables: { zoom: 1.05 }, geometry },
+    ]);
+    const replayed = [
+      { digest: 'bbbbbbbb', variables: { zoom: 1.25 }, geometry },
+    ] as never;
+
+    const divergence = compareReplay(trace, replayed);
+    expect(divergence?.details.join('\n')).toContain('variables.zoom');
+  });
+
+  test('absorbs ULP-scale noise on a checkpoint frame', () => {
+    const trace = traceOf([
+      {
+        digest: 'aaaaaaaa',
+        variables: { zoom: 0.07056442000143237 },
+        geometry,
+      },
+    ]);
+    const replayed = [
+      {
+        digest: 'bbbbbbbb',
+        variables: { zoom: 0.07056442000143243 }, // 4 ULP, the measured delta
+        geometry,
+      },
+    ] as never;
+
+    expect(compareReplay(trace, replayed)).toBeNull();
+  });
+});

--- a/tests/unit/vm-golden-traces.test.ts
+++ b/tests/unit/vm-golden-traces.test.ts
@@ -53,4 +53,101 @@ describe('VM golden traces', () => {
       ).toBe(true);
     });
   }
+
+  /**
+   * The gate's own regression guard.
+   *
+   * Both halves of the bargain, because each without the other is worthless.
+   *
+   * Portability: preset state is computed with `Math.sin`/`cos`/`exp`/`pow`,
+   * which ECMA-262 permits to be implementation-defined approximations and
+   * which differ by a few ULP across engine, platform libm and CPU
+   * architecture. Perturbing every transcendental by 1 ULP is what a foreign
+   * libm looks like from here. This gate has twice been pinned to whichever
+   * machine recorded the traces — first bit-for-bit, then via a
+   * digest-mismatch escalation that compared the replay's variables against
+   * the `undefined` a compact frame does not store, and so reported every
+   * variable as moved. Both times it was green for its author and red for
+   * everyone else.
+   *
+   * Sensitivity: a tolerance is only legitimate while the gate still bites,
+   * so a deliberate 0.1% semantics change must still be caught in every
+   * witness.
+   */
+  describe('stays portable without going blind', () => {
+    const originalMath = {
+      sin: Math.sin,
+      cos: Math.cos,
+      exp: Math.exp,
+      pow: Math.pow,
+      log: Math.log,
+      tan: Math.tan,
+      atan2: Math.atan2,
+    };
+    const scratch = new ArrayBuffer(8);
+    const asFloat = new Float64Array(scratch);
+    const asBits = new BigUint64Array(scratch);
+    /** The next representable double away from zero: a 1-ULP perturbation. */
+    const nextUp = (value: number) => {
+      if (!Number.isFinite(value) || value === 0) {
+        return value;
+      }
+      asFloat[0] = value;
+      asBits[0] += 1n;
+      return asFloat[0];
+    };
+
+    // Built BEFORE Math is patched: buildScenarioInputs synthesises the
+    // spectrum with Math.sin, so patching first would perturb the stimulus
+    // rather than the VM — a different and much larger test.
+    const cases = traceFiles.map((name) => {
+      const trace = JSON.parse(
+        readFileSync(join(tracesDir, name), 'utf8'),
+      ) as TraceFile;
+      return {
+        name,
+        trace,
+        raw: loadPresetSource(repoRoot, { presetId: trace.presetId }).raw,
+        inputs: traceInputs(trace),
+      };
+    });
+
+    const divergedUnder = (patch: (original: typeof originalMath) => void) => {
+      try {
+        patch({ ...originalMath });
+        return cases
+          .filter(
+            (entry) =>
+              compareReplay(
+                entry.trace,
+                runTrace(entry.raw, entry.trace.presetId, entry.inputs),
+              ) !== null,
+          )
+          .map((entry) => entry.name);
+      } finally {
+        Object.assign(Math, originalMath);
+      }
+    };
+
+    test('replays clean under a foreign libm (1-ULP transcendentals)', () => {
+      expect(
+        divergedUnder((original) => {
+          Math.sin = (x) => nextUp(original.sin(x));
+          Math.cos = (x) => nextUp(original.cos(x));
+          Math.exp = (x) => nextUp(original.exp(x));
+          Math.log = (x) => nextUp(original.log(x));
+          Math.tan = (x) => nextUp(original.tan(x));
+          Math.pow = (a, b) => nextUp(original.pow(a, b));
+          Math.atan2 = (a, b) => nextUp(original.atan2(a, b));
+        }),
+      ).toEqual([]);
+    });
+
+    test('still catches a 0.1% semantics change in every witness', () => {
+      const diverged = divergedUnder((original) => {
+        Math.sin = (x) => original.sin(x) * 1.001;
+      });
+      expect(diverged.sort()).toEqual([...traceFiles].sort());
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The golden-trace gate is green on CI and red on every developer's Mac. It is the same defect as before, one layer down.

Preset state is computed with `Math.sin`/`cos`/`exp`/`pow`, which ECMA-262 permits to be implementation-defined approximations. They differ by a few ULP across engine, platform libm and CPU architecture — measured on identical hardware, `Math.exp(1.7)` is `4015e552770df8a7` under JSC and `...a6` under V8. So `compareReplay`'s digest can only ever match on the machine that recorded the trace, and a digest mismatch is meant to **escalate** to a tolerance-based field diff. That escalation is the thing that makes the gate portable.

**The escalation never worked.** A compact trace stores variables on checkpoint frames only, but the live replay always captures them, and `diffFields` unioned the two sides' keys. On every non-checkpoint frame it compared the replay's real values against the `undefined` that was never stored — which the tolerance comparators read as `0` — and reported all ~2000 variables as moved:

```
diverged at frame 1:
  variables.attributes: recorded=undefined replayed=32
  variables.b: recorded=undefined replayed=2
  ... (~2000 more)
```

The frames the escalation exists for were exactly the frames it could not survive.

So the tolerances added in #1119 were dead code on those frames, and re-recording only moved *which* machine the gate passes on: green-on-macOS/red-on-Linux became green-on-Linux/red-on-macOS. `diffFields` now skips variables unless both sides carry them, and compares the geometry that compact frames *do* store on every frame. With that, the Linux-recorded traces replay clean on macOS — no re-recording, no tolerance change.

## Testing

- `bun run check` — pass (2342 tests). Before this change, `bun run test tests/unit/vm-golden-traces.test.ts` fails on macOS at frame 1 on a clean checkout of `main`.
- Measured, by perturbing every transcendental by 1 ULP and replaying all four witnesses: worst relative variable divergence **4.4e-15** across 120 frames, geometry checksums **bit-identical**. These presets are contractive, so the noise does not amplify and the existing 1e-9 tolerance has ample headroom.

New guards, because this gate has now been pinned to one machine twice:

- `tests/unit/vm-golden-traces.test.ts` — replays every witness with all transcendentals perturbed by 1 ULP (what a foreign libm looks like from here) and asserts none diverge. Its other half asserts a deliberate 0.1% semantics change is still caught in **every** witness, since a tolerance is only legitimate while the gate still bites. Both fail against the unfixed code.
- `tests/unit/replay-compare-escalation.test.ts` — covers the escalation directly and VM-free, so the property does not depend on the witness presets. Includes the real 4-ULP `shape4_x` delta from the original CI failure.

One subtlety worth recording: the inputs must be built *before* `Math` is patched. `buildScenarioInputs` synthesises the spectrum with `Math.sin`, so patching first perturbs the stimulus rather than the VM — a different and much larger test that produces false divergences.

## Docs touched

None. The module docblocks in `scripts/preset-lab-replay.ts` and the header of `tests/unit/vm-golden-traces.test.ts` are updated in place to describe the escalation contract.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: the change *is* a null/undefined path fix. No visual literals or lifecycle code involved — this is the replay comparator and its tests.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — not applicable, no runtime output changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
