### PR TITLE
fix(deps): unbreak CI — sync bun.lock, revert typescript to 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "@playwright/test": "1.62.1",
         "@types/bun": "^1.3.14",
-        "@types/node": "^22.0.0",
+        "@types/node": "^26.2.0",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@types/three": "^0.185.4",
@@ -387,7 +387,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -829,7 +829,7 @@
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
@@ -911,7 +911,15 @@
 
     "@tonaljs/scale/@tonaljs/chord-type": ["@tonaljs/chord-type@5.1.1", "", { "dependencies": { "@tonaljs/pcset": "4.10.1" } }, "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw=="],
 
+    "@types/ws/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "buffer-image-size/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "bun-types/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "happy-dom/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
@@ -944,6 +952,14 @@
     "@tonaljs/progression/@tonaljs/chord/@tonaljs/interval": ["@tonaljs/interval@5.1.0", "", { "dependencies": { "@tonaljs/pitch": "^5.0.2", "@tonaljs/pitch-distance": "^5.0.4", "@tonaljs/pitch-interval": "^6.0.0" } }, "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg=="],
 
     "@tonaljs/progression/@tonaljs/pitch-interval/@tonaljs/pitch": ["@tonaljs/pitch@5.0.2", "", {}, "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "buffer-image-size/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "stream-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "pixelmatch": "^7.2.0",
     "playwright": "1.62.1",
     "sharp": "^0.35.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vite": "8.0.16",
     "wrangler": "^4.123.0",
     "zod": "4.4.3"


### PR DESCRIPTION
## Summary

**CI is red on `main` and on every open branch, and has been since the last dependabot merges.** Every job dies before running a single check:

```
error: lockfile had changes, but lockfile is frozen
```

`#1072` and `#1115` landed `package.json` bumps whose resolutions never made it into `bun.lock`. Because `bun install --frozen-lockfile` is the first step of every job, the failure surfaces as whatever job reports it — Quality gate, Production build, Workers Builds, the e2e suites — rather than as a dependency problem. A clean checkout of `origin/main` reproduces it.

**Regenerating the lockfile is only half of it.** Doing that alone moves the failure from install to typecheck, because `#1072` was a major TypeScript upgrade that CI never got far enough to validate:

```
tsconfig.json(5,25): error TS5108: Option 'moduleResolution=node10' has been
removed. Please remove it from your configuration.
```

Switching to `moduleResolution: "bundler"` — the right successor for a Bun + Vite project importing with explicit `.ts` extensions — clears that, but then surfaces **117 type errors**, 60 of them `TS2769` overload mismatches in the three.js TSL node types:

| code | count |
|---|---|
| TS2769 overload mismatch (TSL nodes) | 60 |
| TS2352 unsafe cast | 23 |
| TS2339 property missing | 15 |
| TS2578 unused `@ts-expect-error` | 9 |
| TS2322 / TS2345 | 10 |

That is a migration, not a lockfile fix.

So this PR pins `typescript` back to `^6.0.3` and syncs the lockfile against it. The `@types/node` bump from `#1115` is **kept** — it is fine on its own, and the full gate passes with 26.2.0.

The TypeScript 7 upgrade is worth doing deliberately, with the `tsconfig` change and the TSL typings addressed together. Happy to open an issue for it.

## Testing

All run in a clean worktree checked out from `origin/main`, so nothing is masked by a warm local `node_modules`:

- `bun install --frozen-lockfile` — **now passes** (this is the check that is currently failing everywhere).
- `bun run check` — pass, 2342 tests.
- Verified the failure reproduces on unmodified `origin/main` before changing anything.
- Verified the lockfile-only fix is insufficient (moves the failure to TS5108), and measured the 117-error cost of pushing through to TS 7, before deciding to revert.

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: no application code changes — this is `package.json` + `bun.lock` only. The behaviour covered is the build itself, which the full gate exercises.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — no runtime output change; `check` covers typecheck and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
