### PR TITLE
test(vm): give the golden-trace portability cases room to run

### DIFF
--- a/tests/unit/vm-golden-traces.test.ts
+++ b/tests/unit/vm-golden-traces.test.ts
@@ -112,6 +112,17 @@ describe('VM golden traces', () => {
       };
     });
 
+    /**
+     * Both cases below replay every witness (4 presets x 120 frames) with each
+     * transcendental wrapped in a JS shim, which is far slower than the plain
+     * replay above. That took ~6s on CI runners and tripped Bun's 5s default,
+     * failing as a timeout rather than on anything it measured. The work is
+     * inherent to what these tests check, so they get room instead of being
+     * thinned out — a portability guard that only runs on fast hardware is the
+     * failure mode this whole describe block exists to prevent.
+     */
+    const SLOW_REPLAY_TIMEOUT_MS = 30_000;
+
     const divergedUnder = (patch: (original: typeof originalMath) => void) => {
       try {
         patch({ ...originalMath });
@@ -141,13 +152,13 @@ describe('VM golden traces', () => {
           Math.atan2 = (a, b) => nextUp(original.atan2(a, b));
         }),
       ).toEqual([]);
-    });
+    }, SLOW_REPLAY_TIMEOUT_MS);
 
     test('still catches a 0.1% semantics change in every witness', () => {
       const diverged = divergedUnder((original) => {
         Math.sin = (x) => original.sin(x) * 1.001;
       });
       expect(diverged.sort()).toEqual([...traceFiles].sort());
-    });
+    }, SLOW_REPLAY_TIMEOUT_MS);
   });
 });

--- a/tests/unit/vm-golden-traces.test.ts
+++ b/tests/unit/vm-golden-traces.test.ts
@@ -140,25 +140,33 @@ describe('VM golden traces', () => {
       }
     };
 
-    test('replays clean under a foreign libm (1-ULP transcendentals)', () => {
-      expect(
-        divergedUnder((original) => {
-          Math.sin = (x) => nextUp(original.sin(x));
-          Math.cos = (x) => nextUp(original.cos(x));
-          Math.exp = (x) => nextUp(original.exp(x));
-          Math.log = (x) => nextUp(original.log(x));
-          Math.tan = (x) => nextUp(original.tan(x));
-          Math.pow = (a, b) => nextUp(original.pow(a, b));
-          Math.atan2 = (a, b) => nextUp(original.atan2(a, b));
-        }),
-      ).toEqual([]);
-    }, SLOW_REPLAY_TIMEOUT_MS);
+    test(
+      'replays clean under a foreign libm (1-ULP transcendentals)',
+      () => {
+        expect(
+          divergedUnder((original) => {
+            Math.sin = (x) => nextUp(original.sin(x));
+            Math.cos = (x) => nextUp(original.cos(x));
+            Math.exp = (x) => nextUp(original.exp(x));
+            Math.log = (x) => nextUp(original.log(x));
+            Math.tan = (x) => nextUp(original.tan(x));
+            Math.pow = (a, b) => nextUp(original.pow(a, b));
+            Math.atan2 = (a, b) => nextUp(original.atan2(a, b));
+          }),
+        ).toEqual([]);
+      },
+      SLOW_REPLAY_TIMEOUT_MS,
+    );
 
-    test('still catches a 0.1% semantics change in every witness', () => {
-      const diverged = divergedUnder((original) => {
-        Math.sin = (x) => original.sin(x) * 1.001;
-      });
-      expect(diverged.sort()).toEqual([...traceFiles].sort());
-    }, SLOW_REPLAY_TIMEOUT_MS);
+    test(
+      'still catches a 0.1% semantics change in every witness',
+      () => {
+        const diverged = divergedUnder((original) => {
+          Math.sin = (x) => original.sin(x) * 1.001;
+        });
+        expect(diverged.sort()).toEqual([...traceFiles].sort());
+      },
+      SLOW_REPLAY_TIMEOUT_MS,
+    );
   });
 });


### PR DESCRIPTION
## Summary

> **Stacked on #1127** — base is `fix/bun-lockfile-sync`, not `main`. It has to be: on `main` this branch dies at `bun install --frozen-lockfile` like everything else and can never demonstrate green. Merge #1127 first; GitHub will retarget this to `main` automatically.

The two cases in `VM golden traces > stays portable without going blind` fail on CI as **timeouts**, not on anything they measure:

```
(fail) replays clean under a foreign libm (1-ULP transcendentals) [6021.08ms]
  ^ this test timed out after 5000ms.
(fail) still catches a 0.1% semantics change in every witness [6066.73ms]
```

Each replays every witness (4 presets × 120 frames) with each transcendental wrapped in a JS shim — far slower than the plain bit-for-bit replay above it. ~6s on CI runners against Bun's 5s default. They pass locally only because dev hardware is faster, which is the same machine-dependence this block exists to catch.

The cost is inherent to what these tests check, so they get a 30s budget rather than being thinned out. A portability guard that only runs on fast machines is exactly the failure mode being guarded against.

Only visible at all because #1127 lets CI reach the test step.

## Testing

- `bun test tests/unit/vm-golden-traces.test.ts` in a clean worktree — 7 pass, 0 fail.
- Confirmed from CI logs that both failures were timeouts (6021ms / 6066ms vs the 5000ms default), not assertion failures. No assertion was altered or relaxed — only the time budget.

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: test-only change, no production code.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` — passes on the stacked base
- [ ] `bun run build` (if build/runtime output changed) — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
