### PR TITLE
fix(webgl): declare texsize on the warp material

### DIFF
--- a/src/js/milkdrop/feedback-manager-shared.ts
+++ b/src/js/milkdrop/feedback-manager-shared.ts
@@ -1656,6 +1656,17 @@ class SharedMilkdropFeedbackManager
         blur2Tex: { value: this.blurTargets[1].texture },
         blur3Tex: { value: this.blurTargets[2].texture },
         texelSize: { value: new Vector2(1, 1) },
+        // MilkDrop's texsize builtin, declared for every custom shader body by
+        // MILKDROP_SHADER_BUILTIN_DECLARATIONS — so the warp shader can read
+        // it, and two paths here write it every frame (swap() and
+        // applyCompositeState). It was never actually created on this
+        // material, so the first of those writes threw
+        // "Cannot read properties of undefined (reading 'value')" inside the
+        // adapter's try/catch: every frame logged "render failed (potentially
+        // during fallback/transition)" and returned false, so nothing drew at
+        // all. Placeholder dimensions; both writers overwrite it with the
+        // feedback target's real size before it is sampled.
+        texsize: { value: new Vector4(1, 1, 1, 1) },
         noiseTex: { value: this.auxTextures.noise },
         simplexTex: { value: this.auxTextures.simplex },
         voronoiTex: { value: this.auxTextures.voronoi },

--- a/tests/unit/milkdrop-feedback-composite-profile.test.ts
+++ b/tests/unit/milkdrop-feedback-composite-profile.test.ts
@@ -237,3 +237,46 @@ test('applies comp-stage color controls and overlay work before legacy post effe
     manager.dispose();
   }
 });
+
+test('every material written each frame declares the texsize builtin', () => {
+  // Regression: MILKDROP_SHADER_BUILTIN_DECLARATIONS declares `uniform vec4
+  // texsize` for every custom shader body, and two paths write it every frame
+  // (swap() and applyCompositeState). The warp material never actually created
+  // the uniform, so the first write threw "Cannot read properties of undefined
+  // (reading 'value')" inside the adapter's try/catch — every frame logged
+  // "render failed (potentially during fallback/transition)" and returned
+  // false, so nothing drew at all. The catch turned a crash into a silent
+  // stall, and the e2e waiting for canvas content timed out instead.
+  const manager = createSharedMilkdropFeedbackManager(
+    320,
+    180,
+    WEBGL_MILKDROP_BACKEND_BEHAVIOR,
+  ) as {
+    warpMaterial: { uniforms: Record<string, { value: unknown } | undefined> };
+    compositeMaterial: {
+      uniforms: Record<string, { value: unknown } | undefined>;
+    };
+    feedbackBlendMaterial: {
+      uniforms: Record<string, { value: unknown } | undefined>;
+    };
+    dispose: () => void;
+  };
+
+  try {
+    for (const [label, material] of [
+      ['warp', manager.warpMaterial],
+      ['composite', manager.compositeMaterial],
+      ['feedbackBlend', manager.feedbackBlendMaterial],
+    ] as const) {
+      const texsize = material.uniforms.texsize;
+      expect(`${label}: ${texsize ? 'declared' : 'MISSING'}`).toBe(
+        `${label}: declared`,
+      );
+      // vec4 (width, height, 1/width, 1/height) — a Vector2 here would compile
+      // but silently truncate the .zw one-texel offset neighbour taps read.
+      expect(texsize?.value).toHaveProperty('w');
+    }
+  } finally {
+    manager.dispose();
+  }
+});


### PR DESCRIPTION
## Summary

This is the last failure on `main` — `e2e-engine-mount`'s `home-to-live flip` test, timing out at 240s.

It is not a test problem. The WebGL adapter was logging this **every single frame**, and drawing nothing:

```
ThreeMilkdropAdapter: render failed (potentially during fallback/transition)
TypeError: Cannot read properties of undefined (reading 'value')
  at SharedMilkdropFeedbackManager.applyCompositeState
```

`MILKDROP_SHADER_BUILTIN_DECLARATIONS` declares `uniform vec4 texsize` for every custom shader body, and two paths write it every frame — `swap()` and `applyCompositeState`. **The warp material never created the uniform**, so the first of those writes threw.

The adapter wraps `render()` in a `try/catch` that warns and returns `false`. That turned a hard crash into a silent stall: the canvas simply never updated, and the e2e waiting on canvas content sat there until its timeout. A crash would have been easier to find than the warning.

The composite and feedback-blend materials both declared `texsize` already — only warp was missing. So warp shaders reading `texsize.zw` for their one-texel neighbour offset were getting nothing either.

## Testing

- `bun run check` — pass, 2349 tests.
- `bun test tests/e2e/e2e-engine-mount.test.ts -t "home-to-live flip"` — **passes, with zero `render failed` warnings** (previously one per frame).
- New regression test asserts all three materials declare `texsize`, and that the value is a vec4 — a `Vector2` would compile but silently truncate the `.zw` offset the neighbour taps depend on. **Verified failing against the unfixed source** with `warp: MISSING`.

### Not fixed here

`requests default microphone access for a first-time smartphone user` fails in this file locally, but it fails identically on unmodified `main` — I checked before attributing it. It is a local mic-permission environment issue; CI does not report it among this suite's tests.

## Docs touched

None. The rationale is in a docblock at the new uniform and in the regression test.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: the null/undefined item *is* the bug. No visual literals or CSS involved.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — no build output change; a uniform declaration, covered by `check` and the e2e above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
