### PR TITLE
test(e2e): stop the failure dump swallowing the real error

### DIFF
--- a/tests/e2e/agent-api.ts
+++ b/tests/e2e/agent-api.ts
@@ -255,13 +255,46 @@ export interface FailureArtifactResult {
  * when nothing could be captured (e.g. the page never got far enough to
  * install `window.__stims_agent` — that case is expected pre-boot and is
  * not itself an error, so this silently no-ops rather than throwing).
+ *
+ * "Wrapped" has to mean time-bounded, not just `.catch()`. Both page probes
+ * below are `page.evaluate` calls, and a `catch` does nothing for an evaluate
+ * that never settles — which is exactly the state a page is in when a test
+ * failed because the page wedged. The dump then hangs in the `catch` block,
+ * the original (informative) error never propagates, and the suite dies on its
+ * outer test timeout with no message at all. That is the worst possible
+ * outcome for a diagnostic: it destroys the diagnosis it exists to provide.
  */
+/** Upper bound for any single page probe inside the dump. */
+const FAILURE_ARTIFACT_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolves to `fallback` if `work` has not settled in time. The dump is
+ * diagnostics, never a gate, so a wedged page costs a fallback value rather
+ * than the whole test's error message.
+ */
+async function withProbeTimeout<T>(work: Promise<T>, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work.catch(() => fallback),
+      new Promise<T>((resolve) => {
+        timer = setTimeout(
+          () => resolve(fallback),
+          FAILURE_ARTIFACT_PROBE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export async function writeAgentFailureArtifact(
   page: Page,
   testName: string,
 ): Promise<FailureArtifactResult | null> {
   try {
-    const installed = await hasAgentGlobal(page).catch(() => false);
+    const installed = await withProbeTimeout(hasAgentGlobal(page), false);
     if (!installed) {
       // Pre-boot failure (e.g. the page never reached App mount) — nothing
       // agent-shaped to dump. Skip silently rather than writing an
@@ -275,16 +308,14 @@ export async function writeAgentFailureArtifact(
     );
     fs.mkdirSync(dir, { recursive: true });
 
-    const diagnostics: AgentDiagnostics = await dumpAgentDiagnostics(
-      page,
-    ).catch(
-      () =>
-        ({
-          state: null,
-          events: [],
-          stats: null,
-          installed: true,
-        }) satisfies AgentDiagnostics,
+    const diagnostics: AgentDiagnostics = await withProbeTimeout(
+      dumpAgentDiagnostics(page),
+      {
+        state: null,
+        events: [],
+        stats: null,
+        installed: true,
+      } satisfies AgentDiagnostics,
     );
 
     const diagnosticsPath = path.join(dir, 'diagnostics.json');

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -588,34 +588,51 @@ browserTest(
       console.log(`[VT SWAP TEST CONSOLE] ${msg.type()}: ${msg.text()}`);
     });
 
+    // This test only reproduces on CI, where the page produces no console
+    // output beyond React's mount message — so the log cannot show which wait
+    // is the one that stalls. Name each step as it starts; the last line
+    // printed is the step that did not finish.
+    const step = (name: string) => {
+      console.log(`[VT SWAP STEP] ${name}`);
+    };
+
     try {
+      step('goto');
       await page.goto(`${SERVER_URL}/?agent=true&renderer=webgl`, {
         waitUntil: 'domcontentloaded',
       });
+      step('await #stims-main');
       await page.waitForSelector('#stims-main', { timeout: 30000 });
+      step('await stage-frame[data-mode=home]');
       await page.waitForSelector(
         '.stims-shell__stage-frame[data-mode="home"]',
         { timeout: 30000 },
       );
+      step('await stage-hero');
       await page.waitForSelector('.stims-shell__stage-hero', {
         timeout: 30000,
       });
 
       // Demo audio needs no mic permission. Click() auto-waits for engineReady.
+      step('open audio disclosure');
       await openAudioSourceDisclosure(page);
+      step('click demo-audio');
       await page
         .locator('.stims-shell__source-card[data-demo-audio-btn]')
         .click();
 
+      step('await audioActive=true');
       await page.waitForFunction(
         () => document.body.dataset.audioActive === 'true',
         undefined,
         { timeout: 60000 },
       );
+      step('await stage-frame[data-mode=live]');
       await page.waitForSelector(
         '.stims-shell__stage-frame[data-mode="live"]',
         { timeout: 30000 },
       );
+      step('await live canvas');
       await page.waitForSelector('.stims-shell__stage-frame canvas', {
         timeout: 30000,
       });
@@ -628,6 +645,9 @@ browserTest(
       // transition is active runViewTransition skips the next one (correct
       // reentrancy behavior), which would make the home-side flip below
       // update directly instead of running its own transition.
+      // Unbounded by nature: it awaits the browser's own transition.finished.
+      // Named so a stall here is distinguishable from one in a timed wait.
+      step('await __stimsVTDone()');
       await page.evaluate(() =>
         (
           window as typeof window & {
@@ -645,11 +665,13 @@ browserTest(
         window.history.pushState(null, '', nextUrl);
         window.dispatchEvent(new PopStateEvent('popstate'));
       });
+      step('await audioActive!=true');
       await page.waitForFunction(
         () => document.body.dataset.audioActive !== 'true',
         undefined,
         { timeout: 60000 },
       );
+      step('await stage-frame[data-mode=home] (return)');
       await page.waitForSelector(
         '.stims-shell__stage-frame[data-mode="home"]',
         { timeout: 30000 },


### PR DESCRIPTION
## Summary

`e2e-engine-mount > home-to-live flip` fails on CI as a bare **240s timeout with no message**, and only on CI. It passes locally headed (3.6s) and headless with `CI=1` and SwiftShader args (12.4s). The CI log gives nothing: the page emits three lines — vite connect, vite connected, React's mount message — and then silence.

**I have not fixed the stall.** I could not reproduce it. What I found instead is why it has stayed undiagnosed, and that turns out to be a real bug of its own.

### The failure dump destroys the diagnosis it exists to provide

Every wait inside the test has its own timeout (15s–60s). An inner failure should surface long before 240s, with a useful Playwright error naming the selector. It never does.

The reason is the `catch` block. It calls `writeAgentFailureArtifact`, whose first two steps are bare `page.evaluate` calls:

```ts
const installed = await hasAgentGlobal(page).catch(() => false);
const diagnostics = await dumpAgentDiagnostics(page).catch(() => …);
```

A `.catch()` does nothing for an evaluate that never *settles* — and never settling is exactly what a wedged page does, which is the state the page is in whenever this dump is reached. So the dump hangs in the catch, the original error never propagates, and the suite dies on its outer timeout.

The function's own docblock claims "every step is wrapped so a dump failure can never mask or replace the original test failure." Wrapping in `.catch()` isn't enough; it has to be time-bounded. Both probes are now bounded at 10s and fall back rather than hang, so the triggering error always wins. (The screenshot step already had Playwright's own timeout.)

This affects every e2e suite that uses the helper, not just this test.

### Step tracing

With no console output from the page on CI there is no way to tell *which* wait stalls. The test now names each step as it starts, so the last `[VT SWAP STEP]` line printed is the step that did not finish:

```
[VT SWAP STEP] goto
[VT SWAP STEP] await #stims-main
[VT SWAP STEP] await stage-frame[data-mode=home]
…
[VT SWAP STEP] await __stimsVTDone()
```

`__stimsVTDone()` is called out explicitly because it is the one genuinely unbounded await in the test body — it waits on the browser's own `transition.finished` — so a stall there is worth distinguishing from one in a timed wait.

## Testing

- `bun run check` — pass, 2346 tests.
- `CI=1 bun test tests/e2e/e2e-engine-mount.test.ts -t "home-to-live flip"` — passes, all 12 steps traced in order.
- Locally the stall does not reproduce in either mode, so the value of this PR is what the **next CI run** prints, not what it fixes.

## Docs touched

None. The reasoning is in docblocks at both changes.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: test-infrastructure only, no production code. The async item is the substance — an unbounded `await` in a `catch`.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
