### PR TITLE
test(e2e): make the browser suites name the step they stop on

### DIFF
--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -236,26 +236,47 @@ integrationTest(
     const mobile = await createMobilePage();
 
     try {
+      // The canonical route, not the /milkdrop/ alias. The alias is a
+      // client-side redirect, so going through it costs a second document
+      // load before the shell even starts booting — on CI's 2-core
+      // SwiftShader runner that hop was pure overhead against this test's
+      // budget, and the alias has its own coverage in the SEO guard.
       await mobile.page.goto(
-        `http://127.0.0.1:${TEST_PORT}/milkdrop/?agent=true&experience=non-existent-toy-slug&renderer=webgl`,
-        { waitUntil: 'domcontentloaded' },
+        `http://127.0.0.1:${TEST_PORT}/?agent=true&experience=non-existent-toy-slug&renderer=webgl`,
+        { waitUntil: 'domcontentloaded', timeout: 30000 },
       );
-      // The agent-facing failure signal is the error status the shell
-      // renders for a slug no toy exists under. This used to go through
-      // playToy, whose preflight probes (each `page.evaluate` defaulting to
-      // a 30s Playwright timeout) piled up against the full app boot on
-      // CI's 2-core SwiftShader runner and blew the 180s budget without
-      // ever asserting. Navigate straight to the route and assert the error
-      // DOM instead: same contract, a fraction of the work.
-      await mobile.page.waitForSelector('.active-toy-status.is-error', {
-        timeout: 60000,
-      });
-      const message = await mobile.page.evaluate(
-        () =>
-          document
-            .querySelector('.active-toy-status.is-error p')
-            ?.textContent?.trim() ?? '',
-      );
+
+      // Two waits, not one, because they fail for different reasons and the
+      // difference is the whole diagnosis. The error status is plain
+      // URL-derived React state with no engine involvement, so if the shell
+      // has mounted and the status is still missing, routing is broken; if
+      // the shell itself never mounts, the app did not boot. Collapsed into
+      // a single 60s wait, both looked identical — and when the boot ran
+      // long, the wait outlived the test's own budget, so the suite reported
+      // a bare "timed out" naming neither.
+      await mobile.page.waitForSelector('#stims-main', { timeout: 30000 });
+      const message = await mobile.page
+        .waitForSelector('.active-toy-status.is-error p', { timeout: 20000 })
+        .then((handle) => handle.textContent())
+        .then((text) => text?.trim() ?? '')
+        .catch(async (error) => {
+          // Name what the page actually showed instead. Without this the
+          // only artifact of a failure here is the selector string.
+          const shellState = await mobile.page.evaluate(() => ({
+            url: window.location.href,
+            readyState: document.readyState,
+            hasShell: Boolean(document.getElementById('stims-main')),
+            statusText:
+              document
+                .querySelector('.active-toy-status')
+                ?.textContent?.trim() ?? null,
+          }));
+          throw new Error(
+            `Error status never rendered: ${JSON.stringify(shellState)} (${
+              (error as Error).message
+            })`,
+          );
+        });
       expect(message).toContain('non-existent-toy-slug');
     } finally {
       await mobile.close();

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -550,8 +550,18 @@ const VT_COUNT_INIT_SCRIPT = `
   const win = window;
   win.__stimsVTCount = 0;
   win.__stimsVTs = [];
-  win.__stimsVTDone = () =>
-    Promise.all(win.__stimsVTs.map((p) => p.catch(() => {}))).then(() => true);
+  // Bounded on the page side: page.evaluate has no timeout of its own, so a
+  // view transition whose finished promise never settles - which is what a
+  // stalled compositor under software rendering looks like - hangs the
+  // evaluate until the whole test's budget runs out, reporting a bare
+  // "timed out" against a test that never named the step it stopped on.
+  win.__stimsVTDone = (timeoutMs = 15000) =>
+    Promise.race([
+      Promise.all(win.__stimsVTs.map((p) => p.catch(() => {}))).then(
+        () => true,
+      ),
+      new Promise((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ]);
   const original = document.startViewTransition?.bind(document);
   if (original) {
     document.startViewTransition = (callback) => {
@@ -628,13 +638,14 @@ browserTest(
       // transition is active runViewTransition skips the next one (correct
       // reentrancy behavior), which would make the home-side flip below
       // update directly instead of running its own transition.
-      await page.evaluate(() =>
+      const transitionsSettled = await page.evaluate(() =>
         (
           window as typeof window & {
-            __stimsVTDone: () => Promise<boolean>;
+            __stimsVTDone: (timeoutMs?: number) => Promise<boolean>;
           }
         ).__stimsVTDone(),
       );
+      expect(transitionsSettled).toBe(true);
 
       // Flip back to home through the app's own route plumbing: dropping the
       // audio param stops audio, which re-crosses the audioActive edge and


### PR DESCRIPTION
## Summary

Both browser e2e suites have been failing on `main` as bare timeouts — `timed out after 90000ms` against a test that logged nothing — and which test draws the short straw moves between runs, which is what made it read as flakiness rather than a fixed defect. Neither reproduces locally, headed or under `CI=1` (headless + SwiftShader). So the first job is to stop losing the diagnosis.

**`agents can detect failing toy`** (90s timeout; failed on `2bad26d8`, `802c3f36`, and a rerun of #1130): the 60s selector wait sat behind a `goto` inside a 90s test budget, so a slow boot ran the *test* out of time before the selector's own timeout could report anything — 30s of navigation plus 60s of waiting is the budget exactly. It now waits for the shell root and the error status separately, with room for both: those fail for different reasons — app never booted, versus routing never produced the status — and that distinction is the diagnosis. The error status is plain URL-derived React state with no engine involvement, so "shell mounted but no status" and "no shell" are genuinely different bugs. When the status is missing, the failure now carries the URL, `readyState`, and whatever the status element does say.

It also navigates to the canonical route instead of the `/milkdrop/` alias. The alias is a client-side redirect, so the old path paid for a second document load before the shell began booting; the alias itself is already covered by the SEO guard.

**`home-to-live flip runs a view transition and mounts the live canvas`** (240s timeout; failed on `2bad26d8`, `4d6d01ac`, #1130, #1131): `__stimsVTDone()` awaited every transition's `finished` promise inside `page.evaluate`, which has no timeout of its own. A view transition that never settles — what a stalled compositor under software rendering looks like — hung until the test's whole 240s budget expired. The race is now bounded on the page side and its result asserted, so a stalled transition fails in 15s saying so.

This is deliberately not a claimed fix for an unreproducible hang. If the timeouts persist, the next run will name the step instead of the budget.

## Testing

- `CI=1 bun test tests/e2e/agent-integration.test.ts` — 4 pass, 1 skip, 36s (headless + SwiftShader, matching CI's renderer path)
- `CI=1 bun test tests/e2e/e2e-engine-mount.test.ts` — 4 pass, 2 skip, 51s
- `bun run check` — pass

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided) — this change *is* test-only

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — no runtime files touched

## Reviewer notes

- Test-only diff; no `src/` changes.
- The per-frame `TypeError: Cannot read properties of undefined (reading 'value')` that flooded these logs was a separate defect, fixed by #1131 — I confirmed it is gone from the local run on current `main`. The timeouts outlived it, which is what prompted this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
