### PR TITLE
test(e2e): bound teardown, probe why the stage hero never shows

### DIFF
--- a/tests/e2e/agent-boot-smoke.test.ts
+++ b/tests/e2e/agent-boot-smoke.test.ts
@@ -21,6 +21,7 @@ import {
   localOnlyBrowserTest,
   requiredBrowserTest,
 } from './browser-availability.ts';
+import { closeQuietly } from './browser-teardown.ts';
 import { type DevServerHandle, startDevServer } from './dev-server.ts';
 import {
   HEADLESS,
@@ -67,16 +68,6 @@ type AgentWindow = typeof window & {
     } | null;
   };
 };
-
-async function closeQuietly(
-  ...closeables: Array<{ close: () => Promise<unknown> }>
-) {
-  for (const c of closeables) {
-    try {
-      await c.close();
-    } catch {}
-  }
-}
 
 beforeAll(
   async () => {

--- a/tests/e2e/browser-teardown.ts
+++ b/tests/e2e/browser-teardown.ts
@@ -1,0 +1,36 @@
+/**
+ * Bounded teardown for Playwright browsers and contexts.
+ *
+ * Two suites had their own `closeQuietly`, each awaiting `close()` under a
+ * bare try/catch. A `catch` does nothing for a close that never *settles*, and
+ * a wedged browser is exactly what a suite has on its hands when teardown runs
+ * after a failure — so the `finally` block hung, the error that triggered it
+ * never propagated, and the suite died on its outer test timeout with no
+ * message. That is how `home-to-live flip` reported a bare 240s timeout while
+ * its real failure was a 30s selector timeout it had already hit.
+ *
+ * Teardown is never a gate: a close that does not finish in time is abandoned
+ * and the process reaps the child, which costs nothing next to losing the
+ * failure that mattered.
+ */
+const CLOSE_TIMEOUT_MS = 15_000;
+
+export async function closeQuietly(
+  ...closeables: Array<{ close: () => Promise<unknown> }>
+): Promise<void> {
+  for (const closeable of closeables) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        closeable.close().catch(() => undefined),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, CLOSE_TIMEOUT_MS);
+        }),
+      ]);
+    } catch {
+      // Teardown is best-effort by definition.
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -10,6 +10,7 @@ import {
   localOnlyBrowserTest,
   requiredBrowserTest,
 } from './browser-availability.ts';
+import { closeQuietly } from './browser-teardown.ts';
 import {
   type DevServerHandle,
   isResponsive,
@@ -48,15 +49,6 @@ let devServer: DevServerHandle | null = null;
 const GPU_PROBE_TIMEOUT_MS = 120000;
 
 /** Never let teardown mask the assertion failure that got us here. */
-async function closeQuietly(
-  ...closeables: Array<{ close: () => Promise<unknown> }>
-) {
-  for (const c of closeables) {
-    try {
-      await c.close();
-    } catch {}
-  }
-}
 
 /**
  * Waits for the GPU to produce non-zero output anywhere on the stage canvas.
@@ -609,9 +601,49 @@ browserTest(
         { timeout: 30000 },
       );
       step('await stage-hero');
-      await page.waitForSelector('.stims-shell__stage-hero', {
-        timeout: 30000,
-      });
+      try {
+        await page.waitForSelector('.stims-shell__stage-hero', {
+          timeout: 30000,
+        });
+      } catch (heroError) {
+        // This is the step that stalls on CI. waitForSelector defaults to
+        // state:'visible', so "not found" and "in the DOM but zero-sized or
+        // hidden" are the same failure here and need very different fixes:
+        // the first points at the lazy home chunk never resolving, the second
+        // at a CSS rule (this viewport is exactly 1280x720, which sits on the
+        // boundary of both a max-width:1280px and a max-height:720px query).
+        const probe = await page
+          .evaluate(() => {
+            const el = document.querySelector('.stims-shell__stage-hero');
+            const frame = document.querySelector('.stims-shell__stage-frame');
+            if (!el) {
+              return {
+                attached: false,
+                frameMode: frame?.getAttribute('data-mode') ?? null,
+                frameChildCount: frame?.childElementCount ?? 0,
+                bodyHtmlLength: document.body.innerHTML.length,
+              };
+            }
+            const rect = el.getBoundingClientRect();
+            const style = getComputedStyle(el);
+            return {
+              attached: true,
+              width: rect.width,
+              height: rect.height,
+              display: style.display,
+              visibility: style.visibility,
+              opacity: style.opacity,
+              childCount: el.childElementCount,
+              frameMode: frame?.getAttribute('data-mode') ?? null,
+              viewport: `${window.innerWidth}x${window.innerHeight}`,
+            };
+          })
+          .catch((probeError: unknown) => ({
+            probeFailed: String(probeError),
+          }));
+        console.log(`[VT SWAP HERO PROBE] ${JSON.stringify(probe)}`);
+        throw heroError;
+      }
 
       // Demo audio needs no mic permission. Click() auto-waits for engineReady.
       step('open audio disclosure');


### PR DESCRIPTION
## Summary

The step trace merged in #1132 did its job. CI now says exactly where the home-to-live stall is:

```
[VT SWAP STEP] goto
[VT SWAP STEP] await #stims-main
[VT SWAP STEP] await stage-frame[data-mode=home]
[VT SWAP STEP] await stage-hero          ← never completes
```

Everything before it passes — including `stage-frame[data-mode=home]` — so the home surface **does** render, and only `.stims-shell__stage-hero` does not.

### A second masker

That wait has a 30s timeout, yet the test still burns the full 240s. So a second unbounded `await` is swallowing the rejection: `closeQuietly` in the `finally`. It awaits `close()` under a bare try/catch, and a catch does nothing for a close that never *settles* — which is what a wedged browser does. Same defect as the failure dump in #1132, one block later.

It is now bounded (15s per close) and shared, instead of copy-pasted into two suites — which is how the two copies drifted apart unnoticed. With this, the hero timeout should finally surface as itself, at 30s, naming the selector.

### Why the hero is missing — narrowing it

`waitForSelector` defaults to `state: 'visible'`, so it cannot distinguish two very different causes:

- **never rendered** → the lazy home chunk (`NewHomePage`) never resolved;
- **rendered but zero-sized/hidden** → CSS. This test's viewport is exactly **1280×720**, which sits on the boundary of *both* a `max-width: 1280px` and a `max-height: 720px` query.

The hero step now probes on failure and reports attachment, box size, computed `display`/`visibility`/`opacity`, child count and viewport, so the next run distinguishes them.

**This is still not a fix.** It should make the next CI run say which of the two it is.

## Testing

- `bun run check` — pass, 2350 tests.
- `CI=1 bun test tests/e2e/e2e-engine-mount.test.ts -t "home-to-live flip"` — passes locally, all 12 steps traced, probe not triggered (the stall does not reproduce here in either mode).
- `closeQuietly` behaviour is unchanged on the success path; only the hang is bounded.

## Docs touched

None. Reasoning is in the docblock of the new shared module and at the probe.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Notes: test-infrastructure only. The teardown item is the substance — an unbounded `await` in a `finally`. The dedupe is the "existing shared helper" item: two copies of `closeQuietly` became one.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
