### PR TITLE
fix(og): put the actual preset in the preset social card

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -9,6 +9,7 @@
 //      social share collapsed onto `/`.
 
 import { isAllowedDiscoverSlug } from './discover-slugs.ts';
+import { presentTitle } from './shared/preset-title.ts';
 
 interface EventContext {
   request: Request;
@@ -216,10 +217,13 @@ export async function onRequest(context: EventContext): Promise<Response> {
     return response;
   }
 
-  const [title, author] = entry;
+  const [rawTitle, author] = entry;
+  // preset-meta titles carry the author as a prefix ("Rovastar - Parallel
+  // Universe"), so using them raw next to a byline printed the name twice.
+  const title = presentTitle(rawTitle, author);
   const authorCredit = author ? ` by ${author}` : '';
-  const fullTitle = `▶ Play ${title}${authorCredit} — Stims Visualizer`;
-  const description = `Tap to launch "${title}" live in 60FPS WebGPU. Reacts to your mic or audio in the browser — zero install required.`;
+  const fullTitle = `${title}${authorCredit} — MilkDrop preset on Stims`;
+  const description = `${title}${authorCredit} is a MilkDrop preset running live in your browser on Stims. It reacts to the demo track, your microphone, or audio from another tab.`;
 
   // Crawlers require absolute image URLs; /api/og-preset rasterizes the
   // per-preset card to PNG via resvg-wasm (SVG is refused by every major

--- a/functions/api/og-preset.ts
+++ b/functions/api/og-preset.ts
@@ -5,6 +5,7 @@
 // Discord, and iMessage all refuse SVG in link previews. `?format=svg`
 // returns the source SVG for debugging the template.
 import { initWasm, Resvg } from '@resvg/resvg-wasm';
+import { presentTitle } from '../shared/preset-title.ts';
 import resvgWasm from './resvg.wasm';
 
 const escapeXml = (value: string) =>
@@ -25,79 +26,70 @@ export type OgPresetOptions = {
   previewImageUri?: string;
 };
 
-// A row of VU-meter bars, echoing the app's own level meter — a real
-// instrument reading, not a decorative logo mark. Heights are fixed (not
-// randomized) so output is reproducible.
-type OgPalette = {
-  primary: string;
-  secondary: string;
-  glow: string;
-  badgeBg: string;
-};
+// The card is preview-forward: the preset's own rendered frame fills the
+// canvas and everything else is a caption over it. Earlier revisions boxed a
+// 506x430 thumbnail inside invented HUD chrome (play button, "LIVE 60FPS"
+// pill, decorative waveform), which spent most of a 1200x630 unfurl on
+// ornament and showed a hard-cropped sliver of the actual product.
 
-function getPresetPalette(id: string): OgPalette {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash << 5) - hash + id.charCodeAt(i);
-    hash |= 0;
+// Preset previews are 16:9 (480x270); the card is 1.90:1, so a slice crop
+// loses ~7% of the frame height and nothing horizontally.
+const CARD_W = 1200;
+const CARD_H = 630;
+const MARGIN = 64;
+
+const INK = '#f7f4eb';
+const CORAL = '#f47a54';
+const GROUND = '#070a0e';
+
+// Space Grotesk Bold measures ~0.55em per character across mixed-case Latin.
+// Good enough to pick a size and wrap point without shaping the text.
+const TITLE_CHAR_RATIO = 0.55;
+const TITLE_MAX_WIDTH = CARD_W - MARGIN * 2;
+
+function wrapWords(text: string, maxChars: number): string[] {
+  const lines: string[] = [];
+  let line = '';
+  for (const word of text.split(/\s+/).filter(Boolean)) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (candidate.length <= maxChars || !line) {
+      line = candidate;
+    } else {
+      lines.push(line);
+      line = word;
+    }
   }
-  const index = Math.abs(hash) % 5;
-  const palettes: OgPalette[] = [
-    {
-      primary: '#77c9ff',
-      secondary: '#f47a54',
-      glow: 'rgba(119, 201, 255, 0.28)',
-      badgeBg: 'rgba(119, 201, 255, 0.12)',
-    },
-    {
-      primary: '#c084fc',
-      secondary: '#f472b6',
-      glow: 'rgba(192, 132, 252, 0.28)',
-      badgeBg: 'rgba(192, 132, 252, 0.12)',
-    },
-    {
-      primary: '#34d399',
-      secondary: '#38bdf8',
-      glow: 'rgba(52, 211, 153, 0.28)',
-      badgeBg: 'rgba(52, 211, 153, 0.12)',
-    },
-    {
-      primary: '#fbbf24',
-      secondary: '#fb7185',
-      glow: 'rgba(251, 191, 36, 0.28)',
-      badgeBg: 'rgba(251, 191, 36, 0.12)',
-    },
-    {
-      primary: '#60a5fa',
-      secondary: '#e879f9',
-      glow: 'rgba(96, 165, 250, 0.28)',
-      badgeBg: 'rgba(96, 165, 250, 0.12)',
-    },
-  ];
-  return palettes[index];
+  if (line) lines.push(line);
+  return lines;
 }
 
-const SPECTRUM_HEIGHTS = [24, 48, 82, 56, 92, 70, 44, 88, 36, 64, 84, 50, 96, 54, 32];
-function buildSpectrumAnalyzer(
-  x: number,
-  y: number,
-  primaryColor: string,
-  secondaryColor: string,
-): string {
-  const barWidth = 8;
-  const gap = 5;
-  const bars = SPECTRUM_HEIGHTS.map((h, i) => {
-    const bx = i * (barWidth + gap);
-    const color = i % 3 === 0 ? secondaryColor : primaryColor;
-    return `<rect x="${bx}" y="${-h}" width="${barWidth}" height="${h}" rx="2" fill="${color}" opacity="${
-      0.55 + (i % 4) * 0.12
-    }" /><rect x="${bx}" y="${-h - 5}" width="${barWidth}" height="2" rx="1" fill="${secondaryColor}" opacity="0.95" />`;
-  }).join('');
-  return `<g transform="translate(${x},${y})">${bars}</g>`;
+// Long preset names get two lines before they get small — shrinking a 60-char
+// title to fit one line makes it unreadable at feed thumbnail size.
+export function fitTitle(title: string): { size: number; lines: string[] } {
+  for (const size of [68, 60, 52, 46, 40]) {
+    const maxChars = Math.floor(TITLE_MAX_WIDTH / (size * TITLE_CHAR_RATIO));
+    const lines = wrapWords(title, maxChars);
+    if (lines.length <= 2 && lines.every((l) => l.length <= maxChars)) {
+      return { size, lines };
+    }
+  }
+  const size = 40;
+  const maxChars = Math.floor(TITLE_MAX_WIDTH / (size * TITLE_CHAR_RATIO));
+  const lines = wrapWords(title, maxChars).slice(0, 2);
+  if (lines.length === 2 && lines[1].length > maxChars - 1) {
+    lines[1] = `${lines[1].slice(0, maxChars - 1)}…`;
+  }
+  return { size, lines };
 }
 
-const WAVEFORM_TRACE_PATH =
-  'M0,320 Q50,260 100,320 T200,322 T300,282 T400,342 T500,300 T600,358 T700,290 T800,332 T900,278 T1000,320 T1100,285 T1200,320';
+function eyebrowLabel(tags: string[], tweak?: string): string {
+  if (tweak) return `EDITED · ${tweak.slice(0, 24)}`;
+  const collection = tags
+    .find((t) => t.startsWith('collection:'))
+    ?.replace('collection:', '')
+    .replace(/-/g, ' ');
+  return collection ? collection : 'MilkDrop preset';
+}
 
 export function buildPresetOgSvg({
   id = DEFAULT_PRESET_ID,
@@ -107,146 +99,62 @@ export function buildPresetOgSvg({
   tweak,
   previewImageUri,
 }: OgPresetOptions): string {
-  const palette = getPresetPalette(id);
-  const truncatedTitle = title.length > 55 ? `${title.slice(0, 52)}...` : title;
-  const safeTitle = escapeXml(truncatedTitle);
-  const titleFontSize =
-    truncatedTitle.length > 28
-      ? Math.max(34, Math.round(52 * (28 / truncatedTitle.length)))
-      : 52;
+  void id;
+  const display = presentTitle(title, author);
+  const { size: titleSize, lines } = fitTitle(display);
+  const safeLines = lines.map(escapeXml);
   const safeAuthor = author ? escapeXml(author.trim()) : null;
-  const safeTweak = tweak ? escapeXml(tweak.slice(0, 30)) : null;
+  const label = escapeXml(eyebrowLabel(tags, tweak).toUpperCase());
 
-  const collectionTag = tags
-    .find((t) => t.startsWith('collection:'))
-    ?.replace('collection:', '')
-    .replace(/-/g, ' ');
-  const badgeLabel = safeTweak
-    ? `TWEAK: ${safeTweak.toUpperCase()}`
-    : collectionTag
-      ? collectionTag.toUpperCase()
-      : 'BEAT REACTIVE';
+  // The caption block is bottom-anchored so a two-line title grows upward and
+  // the byline stays on the same baseline for every preset.
+  const authorBaseline = 552;
+  const titleBaseline = safeAuthor ? 498 : 528;
+  const lineHeight = Math.round(titleSize * 1.1);
+  const firstBaseline = titleBaseline - (safeLines.length - 1) * lineHeight;
+  const labelBaseline = firstBaseline - titleSize - 22;
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${safeTitle}">
+  // Every MilkDrop frame is a different image — the corpus runs from
+  // near-black to near-white. A flat overlay would grey out the bright ones,
+  // so all chrome lives in one bottom caption band with its own scrim and the
+  // top two-thirds of the frame is shown untouched.
+  const backdrop = previewImageUri
+    ? `<image href="${previewImageUri}" x="0" y="0" width="${CARD_W}" height="${CARD_H}" preserveAspectRatio="xMidYMid slice"/>
+  <rect x="0" y="230" width="${CARD_W}" height="400" fill="url(#caption-scrim)"/>`
+    : `<rect width="${CARD_W}" height="${CARD_H}" fill="url(#empty-cool)"/>
+  <rect width="${CARD_W}" height="${CARD_H}" fill="url(#empty-warm)"/>`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${CARD_W}" height="${CARD_H}" viewBox="0 0 ${CARD_W} ${CARD_H}" role="img" aria-label="${escapeXml(display)}${safeAuthor ? ` by ${safeAuthor}` : ''} — a MilkDrop preset running on Stims">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0c1118"/>
-      <stop offset="50%" stop-color="#111823"/>
-      <stop offset="100%" stop-color="#070a0e"/>
+    <linearGradient id="caption-scrim" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="${GROUND}" stop-opacity="0"/>
+      <stop offset="42%" stop-color="${GROUND}" stop-opacity="0.72"/>
+      <stop offset="100%" stop-color="${GROUND}" stop-opacity="0.97"/>
     </linearGradient>
-    <radialGradient id="glow-left" cx="20%" cy="25%" r="60%">
-      <stop offset="0%" stop-color="${palette.glow}"/>
-      <stop offset="100%" stop-color="rgba(0,0,0,0)"/>
+    <radialGradient id="empty-cool" cx="18%" cy="12%" r="85%">
+      <stop offset="0%" stop-color="#16202c"/>
+      <stop offset="100%" stop-color="${GROUND}"/>
     </radialGradient>
-    <radialGradient id="glow-right" cx="80%" cy="70%" r="55%">
-      <stop offset="0%" stop-color="${safeTweak ? 'rgba(244, 122, 84, 0.35)' : 'rgba(244, 122, 84, 0.2)'}"/>
-      <stop offset="100%" stop-color="rgba(0,0,0,0)"/>
+    <radialGradient id="empty-warm" cx="88%" cy="96%" r="60%">
+      <stop offset="0%" stop-color="${CORAL}" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="${CORAL}" stop-opacity="0"/>
     </radialGradient>
-    <linearGradient id="card-border" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="${palette.primary}" stop-opacity="0.4"/>
-      <stop offset="100%" stop-color="${palette.secondary}" stop-opacity="0.1"/>
-    </linearGradient>
-    <clipPath id="preview-clip">
-      <rect x="0" y="0" width="506" height="430" rx="16"/>
-    </clipPath>
-    <style>
-      @keyframes pulseDot {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.3; }
-      }
-      .live-pulse-dot {
-        animation: pulseDot 1.4s ease-in-out infinite;
-      }
-      @keyframes waveFlow {
-        0% { stroke-dashoffset: 0; }
-        100% { stroke-dashoffset: -120; }
-      }
-      .wave-trace {
-        stroke-dasharray: 10, 5;
-        animation: waveFlow 4s linear infinite;
-      }
-    </style>
   </defs>
 
-  <!-- Background Layer -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#glow-left)"/>
-  <rect width="1200" height="630" fill="url(#glow-right)"/>
+  ${backdrop}
 
-  <!-- Subtle Audio Waveform Layer -->
-  <path d="${WAVEFORM_TRACE_PATH}" fill="none" stroke="${palette.secondary}" stroke-opacity="0.18" stroke-width="2" transform="translate(0, -20)"/>
-  <path d="${WAVEFORM_TRACE_PATH}" fill="none" stroke="${palette.primary}" stroke-opacity="0.3" stroke-width="3"/>
+  <text x="${MARGIN}" y="${labelBaseline}" font-size="14" font-weight="700" fill="rgba(247,244,235,0.62)" font-family="Space Mono, monospace" letter-spacing="2.8">${label}</text>
 
-  <!-- Left Content Panel -->
-  <g transform="translate(64, 60)">
-    <!-- Header Badge -->
-    <circle cx="10" cy="14" r="5" fill="${palette.secondary}"/>
-    <text x="24" y="19" font-size="14" font-weight="700" fill="${palette.primary}" font-family="Space Mono, monospace" letter-spacing="2.5">STIMS • SOUND REACTIVE VISUALIZER</text>
+  ${safeLines
+    .map(
+      (line, i) =>
+        `<text x="${MARGIN}" y="${firstBaseline + i * lineHeight}" font-size="${titleSize}" font-weight="700" fill="${INK}" font-family="Space Grotesk, system-ui, sans-serif" letter-spacing="-1">${line}</text>`,
+    )
+    .join('\n  ')}
 
-    <!-- Title -->
-    <text x="0" y="${safeAuthor ? '145' : '165'}" font-size="${titleFontSize}" font-weight="700" fill="#f7f4eb" font-family="Space Grotesk, system-ui, sans-serif" letter-spacing="-0.5">${safeTitle}</text>
+  ${safeAuthor ? `<text x="${MARGIN}" y="${authorBaseline}" font-size="25" font-weight="500" fill="rgba(247,244,235,0.74)" font-family="Space Grotesk, system-ui, sans-serif">by ${safeAuthor}</text>` : ''}
 
-    <!-- Author Byline -->
-    ${safeAuthor ? `<text x="0" y="195" font-size="24" font-weight="500" fill="rgba(247,244,235,0.72)" font-family="Space Grotesk, system-ui, sans-serif">by <tspan fill="#f7f4eb" font-weight="700">${safeAuthor}</tspan></text>` : ''}
-
-    <!-- Badges Row -->
-    <g transform="translate(0, ${safeAuthor ? 235 : 215})">
-      <rect x="0" y="0" width="${safeTweak ? 240 : 170}" height="36" rx="6" fill="${palette.badgeBg}" stroke="${palette.primary}" stroke-opacity="0.4"/>
-      <text x="14" y="23" font-size="13" font-weight="700" fill="${palette.primary}" font-family="Space Mono, monospace">${escapeXml(badgeLabel)}</text>
-
-      <rect x="${safeTweak ? 252 : 182}" y="0" width="150" height="36" rx="6" fill="rgba(244, 122, 84, 0.14)" stroke="rgba(244, 122, 84, 0.4)"/>
-      <text x="${safeTweak ? 266 : 196}" y="23" font-size="13" font-weight="700" fill="#f47a54" font-family="Space Mono, monospace">WEBGPU • 60 FPS</text>
-    </g>
-  </g>
-
-  <!-- Right Visualizer Preview HUD Canvas Card -->
-  <g transform="translate(630, 65)">
-    ${
-      previewImageUri
-        ? `<!-- Real Preset Preview Image Snapshot -->
-    <image href="${previewImageUri}" x="0" y="0" width="506" height="430" preserveAspectRatio="xMidYMid slice" clip-path="url(#preview-clip)" opacity="0.92"/>
-    <rect width="506" height="430" rx="16" fill="none" stroke="url(#card-border)" stroke-width="1.5"/>`
-        : `<!-- Fallback HUD Frame -->
-    <rect width="506" height="430" rx="16" fill="#0f1722" stroke="url(#card-border)" stroke-width="1.5"/>
-    <circle cx="253" cy="215" r="130" fill="none" stroke="${palette.primary}" stroke-opacity="0.15" stroke-width="1" stroke-dasharray="6,6"/>
-    <circle cx="253" cy="215" r="95" fill="none" stroke="${palette.secondary}" stroke-opacity="0.25" stroke-width="1.5"/>
-    <circle cx="253" cy="215" r="60" fill="none" stroke="${palette.primary}" stroke-opacity="0.4" stroke-width="2"/>
-    <circle cx="253" cy="215" r="25" fill="${palette.secondary}" fill-opacity="0.6"/>
-    <line x1="123" y1="85" x2="228" y2="190" stroke="${palette.primary}" stroke-opacity="0.3" stroke-width="1.5"/>
-    <line x1="383" y1="85" x2="278" y2="190" stroke="${palette.primary}" stroke-opacity="0.3" stroke-width="1.5"/>
-    <line x1="123" y1="345" x2="228" y2="240" stroke="${palette.primary}" stroke-opacity="0.3" stroke-width="1.5"/>
-    <line x1="383" y1="345" x2="278" y2="240" stroke="${palette.primary}" stroke-opacity="0.3" stroke-width="1.5"/>`
-    }
-
-    <!-- HUD Grid Ticks -->
-    <line x1="20" y1="20" x2="40" y2="20" stroke="${palette.primary}" stroke-opacity="0.6" stroke-width="2"/>
-    <line x1="20" y1="20" x2="20" y2="40" stroke="${palette.primary}" stroke-opacity="0.6" stroke-width="2"/>
-    <line x1="486" y1="20" x2="466" y2="20" stroke="${palette.primary}" stroke-opacity="0.6" stroke-width="2"/>
-    <line x1="486" y1="20" x2="486" y2="40" stroke="${palette.primary}" stroke-opacity="0.6" stroke-width="2"/>
-
-    <!-- High-CTR Play CTA Overlay -->
-    <g transform="translate(253, 200)">
-      <circle r="42" fill="#0c1118" stroke="${palette.primary}" stroke-width="2.5"/>
-      <polygon points="-11,-18 18,0 -11,18" fill="${palette.secondary}"/>
-    </g>
-    <g transform="translate(253, 275)">
-      <rect x="-100" y="-16" width="200" height="32" rx="16" fill="${palette.secondary}"/>
-      <text x="0" y="5" font-size="12" font-weight="700" fill="#0c1118" font-family="Space Mono, monospace" text-anchor="middle">LAUNCH VISUALIZER ▶</text>
-    </g>
-
-    <!-- Live Status Pill -->
-    <rect x="366" y="24" width="116" height="28" rx="14" fill="rgba(16, 185, 129, 0.2)" stroke="rgba(16, 185, 129, 0.5)"/>
-    <circle cx="382" cy="38" r="4" fill="#10b981" class="live-pulse-dot"/>
-    <text x="394" y="43" font-size="12" font-weight="700" fill="#10b981" font-family="Space Mono, monospace">LIVE 60FPS</text>
-  </g>
-
-  <!-- Bottom Spectrum Analyzer & Branding Bar -->
-  ${buildSpectrumAnalyzer(650, 565, palette.primary, palette.secondary)}
-
-  <g transform="translate(64, 560)">
-    <text x="0" y="20" font-size="22" font-weight="700" fill="#f47a54" font-family="Space Mono, monospace">toil.fyi</text>
-    <text x="110" y="20" font-size="16" font-weight="500" fill="rgba(247,244,235,0.7)" font-family="Space Grotesk, system-ui, sans-serif">• Instant audio-reactive visualizer in your browser</text>
-  </g>
+  <text x="${CARD_W - MARGIN}" y="${authorBaseline}" text-anchor="end" font-size="19" font-weight="700" font-family="Space Mono, monospace"><tspan fill="${CORAL}" letter-spacing="2">STIMS</tspan><tspan fill="rgba(247,244,235,0.45)"> · toil.fyi</tspan></text>
 </svg>`;
 }
 
@@ -334,9 +242,21 @@ type StaticAssetFetcher = {
   fetch: (input: Request | URL | string) => Promise<Response>;
 };
 
+// Preview PNGs are 135MB across ~3,600 files and are excluded from the deploy
+// bundle (see wrangler.site.jsonc); functions/milkdrop-presets/previews serves
+// them out of the stims-static R2 bucket. Reading them back through ASSETS —
+// as this function used to — never hits a preview in production: the binding
+// answers unknown paths with the SPA shell, so every shared preset card
+// rendered the "no preview" branch.
+type PreviewBucket = {
+  get: (
+    key: string,
+  ) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> } | null>;
+};
+
 type OgPresetContext = {
   request: Request;
-  env?: { ASSETS?: StaticAssetFetcher };
+  env?: { ASSETS?: StaticAssetFetcher; STATIC_R2?: PreviewBucket };
   waitUntil?: (promise: Promise<unknown>) => void;
   // Test seam: bypasses the .wasm module import and ASSETS font loading.
   renderAssets?: RenderAssets;
@@ -420,38 +340,81 @@ async function fallbackPngResponse(
   return Response.redirect(new URL('/og/milkdrop.png', origin), 302);
 }
 
+function toDataUri(buffer: ArrayBuffer): string {
+  let b64: string;
+  if (typeof Buffer !== 'undefined') {
+    b64 = Buffer.from(buffer).toString('base64');
+  } else {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+    }
+    b64 = btoa(binary);
+  }
+  return `data:image/png;base64,${b64}`;
+}
+
 async function loadPresetPreviewDataUri(
-  assetsBinding: StaticAssetFetcher | undefined,
+  env: OgPresetContext['env'],
   origin: string,
   presetId: string,
 ): Promise<string | undefined> {
-  if (!assetsBinding) return undefined;
-  try {
-    const previewUrl = new URL(
-      `/milkdrop-presets/previews/${encodeURIComponent(presetId)}.png`,
-      origin,
-    );
-    const response = await assetsBinding.fetch(previewUrl);
-    if (response.ok) {
-      const buffer = await response.arrayBuffer();
-      let b64: string;
-      if (typeof Buffer !== 'undefined') {
-        b64 = Buffer.from(buffer).toString('base64');
-      } else {
-        const bytes = new Uint8Array(buffer);
-        let binary = '';
-        const chunkSize = 0x8000;
-        for (let i = 0; i < bytes.length; i += chunkSize) {
-          binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
-        }
-        b64 = btoa(binary);
-      }
-      return `data:image/png;base64,${b64}`;
+  const relative = `milkdrop-presets/previews/${presetId}.png`;
+
+  if (env?.STATIC_R2) {
+    try {
+      const object = await env.STATIC_R2.get(relative);
+      if (object) return toDataUri(await object.arrayBuffer());
+    } catch {
+      // fall through to the assets binding
     }
-  } catch {
-    // preview unavailable
+  }
+
+  // Local dev and preview builds still keep previews under public/. The
+  // content-type check matters: ASSETS answers a miss with the SPA HTML at
+  // status 200, which would otherwise be embedded as a bogus PNG data URI.
+  if (env?.ASSETS) {
+    try {
+      const response = await env.ASSETS.fetch(new URL(`/${relative}`, origin));
+      if (
+        response.ok &&
+        response.headers.get('content-type')?.startsWith('image/')
+      ) {
+        return toDataUri(await response.arrayBuffer());
+      }
+    } catch {
+      // preview unavailable
+    }
   }
   return undefined;
+}
+
+// preset-meta.json is the same table the OG middleware reads for <title> and
+// og:description, so the card and the unfurl text name the preset identically.
+// Without it the card can only guess from the slug ("Eo.S. + Phat" becomes
+// "Eos").
+type PresetMetaTable = Record<string, [string, string]>;
+let presetMetaPromise: Promise<PresetMetaTable | null> | null = null;
+
+async function loadPresetMeta(
+  env: OgPresetContext['env'],
+  origin: string,
+): Promise<PresetMetaTable | null> {
+  const assets = env?.ASSETS;
+  if (!assets) return null;
+  presetMetaPromise ??= (async () => {
+    try {
+      const response = await assets.fetch(new URL('/preset-meta.json', origin));
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      return (await response.json()) as PresetMetaTable;
+    } catch {
+      presetMetaPromise = null;
+      return null;
+    }
+  })();
+  return presetMetaPromise;
 }
 
 export async function onRequest(context: OgPresetContext): Promise<Response> {
@@ -464,13 +427,21 @@ export async function onRequest(context: OgPresetContext): Promise<Response> {
   const tweak = url.searchParams.get('tweak') || undefined;
   const format = url.searchParams.get('format') === 'svg' ? 'svg' : 'png';
 
-  const { title, author } = humanizePresetId(presetId);
-  const previewImageUri = await loadPresetPreviewDataUri(
-    context.env?.ASSETS,
-    url.origin,
-    presetId,
-  );
-  const svg = buildPresetOgSvg({ id: presetId, title, author, tweak, previewImageUri });
+  const [meta, previewImageUri] = await Promise.all([
+    loadPresetMeta(context.env, url.origin),
+    loadPresetPreviewDataUri(context.env, url.origin, presetId),
+  ]);
+  const entry = meta?.[presetId];
+  const { title, author } = entry
+    ? { title: entry[0], author: entry[1] || undefined }
+    : humanizePresetId(presetId);
+  const svg = buildPresetOgSvg({
+    id: presetId,
+    title,
+    author,
+    tweak,
+    previewImageUri,
+  });
 
   if (format === 'svg') {
     return new Response(svg, {

--- a/functions/api/og-preset.ts
+++ b/functions/api/og-preset.ts
@@ -47,19 +47,58 @@ const GROUND = '#070a0e';
 const TITLE_CHAR_RATIO = 0.55;
 const TITLE_MAX_WIDTH = CARD_W - MARGIN * 2;
 
+// The brand lockup is right-aligned on the byline's own baseline, so the
+// byline has to stop before it. Space Mono is monospaced at 0.6em, which makes
+// the lockup's width exact rather than estimated. Collaboration credits in the
+// corpus run to 94 characters ("The NG + Stahlregen & Boz + EoS + Geiss + ..."),
+// and 60 of them exceed 40, so an unconstrained byline runs straight through
+// the branding and off the card.
+const BRAND_TEXT = 'STIMS · toil.fyi';
+const BRAND_FONT_SIZE = 19;
+const BRAND_WIDTH = BRAND_TEXT.length * BRAND_FONT_SIZE * 0.6;
+const BYLINE_GAP = 40;
+const BYLINE_FONT_SIZE = 25;
+const BYLINE_CHAR_RATIO = 0.52;
+const BYLINE_PREFIX = 'by ';
+
+export function fitByline(author: string): string {
+  const available = CARD_W - MARGIN * 2 - BRAND_WIDTH - BYLINE_GAP;
+  const maxChars =
+    Math.floor(available / (BYLINE_FONT_SIZE * BYLINE_CHAR_RATIO)) -
+    BYLINE_PREFIX.length;
+  if (author.length <= maxChars) return author;
+  return `${author.slice(0, Math.max(1, maxChars - 1)).trimEnd()}…`;
+}
+
 function wrapWords(text: string, maxChars: number): string[] {
   const lines: string[] = [];
   let line = '';
+  const flush = () => {
+    if (line) {
+      lines.push(line);
+      line = '';
+    }
+  };
   for (const word of text.split(/\s+/).filter(Boolean)) {
-    const candidate = line ? `${line} ${word}` : word;
+    // Preset names are full of underscore- and paren-delimited runs carrying
+    // no spaces at all ("triptrap_(getting_concrete_visions_through_a_..."),
+    // which no amount of word wrapping can fit. Break them at the measured
+    // limit rather than letting one word run off the right edge.
+    let rest = word;
+    while (rest.length > maxChars) {
+      flush();
+      lines.push(rest.slice(0, maxChars));
+      rest = rest.slice(maxChars);
+    }
+    const candidate = line ? `${line} ${rest}` : rest;
     if (candidate.length <= maxChars || !line) {
       line = candidate;
     } else {
-      lines.push(line);
-      line = word;
+      flush();
+      line = rest;
     }
   }
-  if (line) lines.push(line);
+  flush();
   return lines;
 }
 
@@ -75,9 +114,12 @@ export function fitTitle(title: string): { size: number; lines: string[] } {
   }
   const size = 40;
   const maxChars = Math.floor(TITLE_MAX_WIDTH / (size * TITLE_CHAR_RATIO));
-  const lines = wrapWords(title, maxChars).slice(0, 2);
-  if (lines.length === 2 && lines[1].length > maxChars - 1) {
-    lines[1] = `${lines[1].slice(0, maxChars - 1)}…`;
+  const wrapped = wrapWords(title, maxChars);
+  const lines = wrapped.slice(0, 2);
+  // Something was dropped, so the last visible line has to say so.
+  if (wrapped.length > lines.length && lines.length > 0) {
+    const last = lines[lines.length - 1];
+    lines[lines.length - 1] = `${last.slice(0, maxChars - 1).trimEnd()}…`;
   }
   return { size, lines };
 }
@@ -103,7 +145,7 @@ export function buildPresetOgSvg({
   const display = presentTitle(title, author);
   const { size: titleSize, lines } = fitTitle(display);
   const safeLines = lines.map(escapeXml);
-  const safeAuthor = author ? escapeXml(author.trim()) : null;
+  const safeAuthor = author ? escapeXml(fitByline(author.trim())) : null;
   const label = escapeXml(eyebrowLabel(tags, tweak).toUpperCase());
 
   // The caption block is bottom-anchored so a two-line title grows upward and
@@ -152,9 +194,9 @@ export function buildPresetOgSvg({
     )
     .join('\n  ')}
 
-  ${safeAuthor ? `<text x="${MARGIN}" y="${authorBaseline}" font-size="25" font-weight="500" fill="rgba(247,244,235,0.74)" font-family="Space Grotesk, system-ui, sans-serif">by ${safeAuthor}</text>` : ''}
+  ${safeAuthor ? `<text x="${MARGIN}" y="${authorBaseline}" font-size="${BYLINE_FONT_SIZE}" font-weight="500" fill="rgba(247,244,235,0.74)" font-family="Space Grotesk, system-ui, sans-serif">by ${safeAuthor}</text>` : ''}
 
-  <text x="${CARD_W - MARGIN}" y="${authorBaseline}" text-anchor="end" font-size="19" font-weight="700" font-family="Space Mono, monospace"><tspan fill="${CORAL}" letter-spacing="2">STIMS</tspan><tspan fill="rgba(247,244,235,0.45)"> · toil.fyi</tspan></text>
+  <text x="${CARD_W - MARGIN}" y="${authorBaseline}" text-anchor="end" font-size="${BRAND_FONT_SIZE}" font-weight="700" font-family="Space Mono, monospace"><tspan fill="${CORAL}" letter-spacing="2">STIMS</tspan><tspan fill="rgba(247,244,235,0.45)"> · toil.fyi</tspan></text>
 </svg>`;
 }
 

--- a/functions/shared/preset-title.ts
+++ b/functions/shared/preset-title.ts
@@ -1,0 +1,25 @@
+// Display formatting for preset names, shared by the OG middleware (which
+// writes <title>/og:description) and the OG card renderer, so a shared link's
+// text and its image name the preset the same way.
+
+// preset-meta stores titles as they appear in the corpus, which is mostly
+// "Author - Name". Repeating the author in a byline underneath reads as a data
+// leak, so strip the prefix when the byline will carry it. Slug-derived titles
+// additionally arrive as "Eos - Ether - Posession - Phat - Edit"; collapse
+// those runs so the result reads as a name rather than a delimiter chain.
+export function presentTitle(title: string, author?: string): string {
+  let display = title.trim();
+  if (author) {
+    const prefix = author.trim().toLowerCase();
+    const lower = display.toLowerCase();
+    for (const sep of [' - ', ' – ', ' — ', ': ']) {
+      if (lower.startsWith(prefix + sep)) {
+        display = display.slice(prefix.length + sep.length).trim();
+        break;
+      }
+    }
+  }
+  const parts = display.split(' - ');
+  if (parts.length > 2) display = parts.join(' ');
+  return display || title.trim();
+}

--- a/public/milkdrop-presets/preview-failures.json
+++ b/public/milkdrop-presets/preview-failures.json
@@ -8,195 +8,15 @@
     "reason": "black frame (mean=1.4, max=25)"
   },
   {
-    "presetId": "27-super-goats-orbus-maximus",
-    "reason": "flat frame (mean=253.5, std=2.1)"
-  },
-  {
     "presetId": "300-beatdetect-bassmidtreb",
     "reason": "black frame (mean=0.3, max=19)"
-  },
-  {
-    "presetId": "a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual",
-    "reason": "black frame (mean=0.1, max=50)"
-  },
-  {
-    "presetId": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7",
-    "reason": "flat frame (mean=149.7, std=0.0)"
-  },
-  {
-    "presetId": "aderrasi-causeway-of-dreams-point-mix",
-    "reason": "black frame (mean=1.9, max=27)"
-  },
-  {
-    "presetId": "aderrasi-chromatic-abyss-refined-abyss-mix",
-    "reason": "black frame (mean=1.8, max=29)"
-  },
-  {
-    "presetId": "aderrasi-ghast-entity",
-    "reason": "flat frame (mean=0.9, std=2.0)"
-  },
-  {
-    "presetId": "aderrasi-horvath-s-holistic-abyss",
-    "reason": "black frame (mean=1.6, max=23)"
-  },
-  {
-    "presetId": "aderrasi-madness-teaches-us-to-fly",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "aderrasi-roaming-star-himalaya-brach-office-mash0000-creaming-the-summit",
-    "reason": "black frame (mean=3.2, max=23)"
-  },
-  {
-    "presetId": "aderrasi-songflower-moss-posy",
-    "reason": "black frame (mean=0.5, max=1)"
-  },
-  {
-    "presetId": "aderrasi-variants-of-eternity",
-    "reason": "black frame (mean=1.0, max=20)"
-  },
-  {
-    "presetId": "amandio-c-flashy-thing",
-    "reason": "black frame (mean=0.1, max=5)"
-  },
-  {
-    "presetId": "amandio-c-fume",
-    "reason": "black frame (mean=0.1, max=3)"
-  },
-  {
-    "presetId": "amandio-c-odd-star",
-    "reason": "black frame (mean=0.3, max=4)"
-  },
-  {
-    "presetId": "amandio-c-salty-beats-spiral",
-    "reason": "black frame (mean=2.2, max=16)"
-  },
-  {
-    "presetId": "bdrv-al-aderrasi-oracle-bdrv-et-al-rmx-a",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "bdrv-al-eo-s-phat-intergalactic-conquest-flag2b",
-    "reason": "black frame (mean=0.4, max=16)"
-  },
-  {
-    "presetId": "bdrv-al-eo-s-phat-intergalactic-fuzzball",
-    "reason": "black frame (mean=0.3, max=22)"
-  },
-  {
-    "presetId": "bdrv-al-phat-and-eo-s-shapes-are-cool-slow-colour-melting-edit-bdrv-et-al-rmxmix32",
-    "reason": "flat frame (mean=254.9, std=0.3)"
-  },
-  {
-    "presetId": "bdrv-al-telek-spirality",
-    "reason": "flat frame (mean=253.8, std=2.1)"
-  },
-  {
-    "presetId": "bdrv-al-zylot-pinwheelw",
-    "reason": "black frame (mean=0.5, max=14)"
-  },
-  {
-    "presetId": "best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-23",
-    "reason": "flat frame (mean=255.0, std=0.2)"
-  },
-  {
-    "presetId": "beta106i-songflower-orchid-field-mash0000-too-drunk-and-high-at-club",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "bmelgren-krash-rainbow-orb-peacock-lonely-signal-gone-mad-mix",
-    "reason": "black frame (mean=2.7, max=19)"
-  },
-  {
-    "presetId": "brainstain-blackwidow",
-    "reason": "black frame (mean=0.4, max=12)"
-  },
-  {
-    "presetId": "brainstain-boiling-mix2-redi-jedi-full-carb-mix",
-    "reason": "flat frame (mean=220.0, std=0.0)"
-  },
-  {
-    "presetId": "brainstain-re-entry",
-    "reason": "black frame (mean=0.4, max=28)"
-  },
-  {
-    "presetId": "che-terracarbon-stream",
-    "reason": "black frame (mean=2.5, max=32)"
-  },
-  {
-    "presetId": "cope-27-super-goats-orbus-maximus-breach-the-egg-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cope-ferrofluid",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "cope-flexi-mother-of-whirl-no-fnords-were-hurt",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cope-martin-mother-of-pearl",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "cope-the-drain-to-heaven",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "cotc-101",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-102",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-103",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-13",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-14",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-141",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-146",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-16",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-170",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-174",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-19",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-22",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-220",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -208,71 +28,11 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-307",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-308",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-310",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-312",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-313",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-314",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-315",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-316",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-317",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-318",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-338",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-34",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-345",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-367",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-368",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-370",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-372",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -284,19 +44,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -309,34 +57,6 @@
   },
   {
     "presetId": "cotc-455",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-99",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-bit-storm-effected-by-adamfx-2-shadowharlequin-bit-storm-ft-dancing-petals",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-hexocollie-flexi-adamfx-",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -364,28 +84,8 @@
     "reason": "black frame (mean=0.0, max=3)"
   },
   {
-    "presetId": "cotc-amandio-c-sierpinsky-s-triangle",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-amandio-c-water-ripples-2d",
     "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-bdrv-aderrasi-true-subject-star-pure-medium-bdrv-etal",
-    "reason": "flat frame (mean=1.0, std=2.2)"
-  },
-  {
-    "presetId": "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-bdrv-etal-nighthawk-dark-crystal",
@@ -396,23 +96,7 @@
     "reason": "black frame (mean=2.4, max=16)"
   },
   {
-    "presetId": "cotc-beta106i-old-myths-and-fairytales",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-beta106i-songflower-ice-flower",
-    "reason": "black frame (mean=1.0, max=1)"
-  },
-  {
-    "presetId": "cotc-bleeding-like-a-horsey",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-bleeding-like-a-horsey-roams-i-just-got-through-watching-planet-bboy-and-boy-do-i-feel-emba",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -432,14 +116,6 @@
     "reason": "black frame (mean=2.6, max=19)"
   },
   {
-    "presetId": "cotc-cope-flexi-julia-set-strange-days-bdrv2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-dbleja-horizontology-blue-mix",
     "reason": "flat frame (mean=255.0, std=0.1)"
   },
@@ -454,14 +130,6 @@
   {
     "presetId": "cotc-drugsincombat-reactive-molecule-v-05a",
     "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-eos-3d",
-    "reason": "black frame (mean=0.6, max=17)"
-  },
-  {
-    "presetId": "cotc-eos-apocalypse-b",
-    "reason": "black frame (mean=2.2, max=30)"
   },
   {
     "presetId": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-flexi-s-reflections-phat-s-r",
@@ -484,24 +152,12 @@
     "reason": "black frame (mean=1.4, max=31)"
   },
   {
-    "presetId": "cotc-eos-magnetosphere-06-birthegg",
-    "reason": "black frame (mean=1.1, max=25)"
-  },
-  {
-    "presetId": "cotc-eos-multisphere-01-b-phat-ra-mix-nexus-roams-falling-through-9-time",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-eos-phat-i-v2-gradients",
     "reason": "black frame (mean=3.0, max=25)"
   },
   {
     "presetId": "cotc-eos-phat-i-v2-gradients-rot",
     "reason": "black frame (mean=1.5, max=30)"
-  },
-  {
-    "presetId": "cotc-eos-phat-linear-clouds-solarized-points-of-light",
-    "reason": "flat frame (mean=255.0, std=0.0)"
   },
   {
     "presetId": "cotc-eos-phat-linear-clouds-solarized-points-of-light-v2",
@@ -548,14 +204,6 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-evet-flexi-geiss-tokamak-fractal-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-evet-jewelsmoke",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-evet-waterrgate",
     "reason": "black frame (mean=0.0, max=0)"
   },
@@ -566,22 +214,6 @@
   {
     "presetId": "cotc-eviljim-ice-drops",
     "reason": "black frame (mean=0.8, max=7)"
-  },
-  {
-    "presetId": "cotc-fishbrain-betelguese3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-fishbrain-betelguese3-aa",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-fishbrain-david-bowie-cpe",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-fishbrain-evolution-3d-phat-edit-v2",
-    "reason": "flat frame (mean=0.5, std=1.7)"
   },
   {
     "presetId": "cotc-fishbrain-flexi-stitchcraft-n",
@@ -597,10 +229,6 @@
   },
   {
     "presetId": "cotc-fishbrain-geiss-witchcraft-glow-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-fishbrain-submarine-exp-ame-med",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -648,19 +276,11 @@
     "reason": "black frame (mean=0.3, max=18)"
   },
   {
-    "presetId": "cotc-fishbrain-witchcraft-neuromancer-remix",
-    "reason": "flat frame (mean=0.5, std=1.1)"
-  },
-  {
     "presetId": "cotc-fishbrain-witchcraft-sorcery-remix",
     "reason": "black frame (mean=0.1, max=21)"
   },
   {
     "presetId": "cotc-fleekus-flokus-violent-and-insane-homicidal-air-molecules-beat-code-experiment2-gss",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -704,10 +324,6 @@
     "reason": "black frame (mean=0.2, max=6)"
   },
   {
-    "presetId": "cotc-flexi-fishbrain-geiss-unchained-others-plaidcraft",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
     "reason": "black frame (mean=0.0, max=0)"
   },
@@ -721,10 +337,6 @@
   },
   {
     "presetId": "cotc-flexi-identity-killing-petting-colon-gonad-type9",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-flexi-leaving-colors-crazy-cogitations-centrifuge-collapsing-cosmos-creation-oh-thats-still",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -748,31 +360,11 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-geiss-cosmic-dust-2-laplacian-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-geiss-cosmic-dust-2-laplacian-mix-maalol-mix",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-geiss-electric-storm-half-digital-2-fiesta-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-geiss-flexi-orb-others-i-ve-had-it-with-this-g-tree",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-geiss-plasma",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -824,55 +416,7 @@
     "reason": "black frame (mean=0.3, max=7)"
   },
   {
-    "presetId": "cotc-geiss-skin-dots-9",
-    "reason": "black frame (mean=0.4, max=7)"
-  },
-  {
     "presetId": "cotc-geiss-skin-dots-multi-layer-3-pig-jembe-acid-wretch",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-geite-spooksville-roams",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-aurora-totalis",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-ego-decontructor",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-lights-in-the-sky",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-need",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-need-desire-remix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-need-transcendance-remix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-goody-s-fatal-color-attraction-pliant-reality-remix-ps2-0-isosceles-edit",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -896,23 +440,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-halfbreak-last-in-nebula",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-halfbreak-tonymilkdrop-beautiful-sepia-mashmash",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-abyssal-dreamscape",
-    "reason": "flat frame (mean=220.0, std=0.0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -936,43 +464,11 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-hexcollie-shifter-martin-anime-vs-the-stalion-mang",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-surge",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-roams-drugs-stretch-time-wave-packe",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-thinkin-bout-u",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-hexcollie-x-warp-harsh-klive",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-hexcollie-zylot-n-phat-it-has-to-be-wrong-to-have-this-much-fun-without-any-talent",
     "reason": "black frame (mean=0.2, max=4)"
   },
   {
-    "presetId": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-eos-angels-of-decay-19-hexocollie-6",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -984,36 +480,12 @@
     "reason": "black frame (mean=1.3, max=9)"
   },
   {
-    "presetId": "cotc-loading-doctor",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-luxxx-absinthe-with-mc-escher",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-luxxx-broken-beat-machina-i",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-luxxx-fuck-ur-fractal-muscles-i",
     "reason": "black frame (mean=0.1, max=2)"
   },
   {
-    "presetId": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-luxxx-my-soul-i",
     "reason": "black frame (mean=3.3, max=25)"
-  },
-  {
-    "presetId": "cotc-luxxx-water-your-pet-goldfish-i",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-luxxx-when-the-first-aliens-came-b",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-luxxx-wip",
@@ -1036,51 +508,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-martin-hardcore-mix-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-hardcore-mix-2-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-lock-and-release",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen-aderrasi-geiss-unchained-zyl",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-pendulum-in-brass-ps2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-pendulum-in-brass-ps3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-martin-soma-in-pink",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-sphery-tales",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1088,31 +516,11 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-martin-tunnel-race-meta-mash-disciple",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-martin-tunnel-race-meta-mash-for-rats",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-midgitstraights-of-majillaen-gunthree-spher",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1132,23 +540,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-nicklepenultim",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-nicklepenultim-roam",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-nicklepenultim-the-skuzzmuppet",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-orb-blade",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-orb-cloud-burst",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1156,24 +548,8 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-orb-waaa-jelly-5-55",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-alt-colours",
     "reason": "black frame (mean=0.4, max=8)"
-  },
-  {
-    "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix",
-    "reason": "black frame (mean=0.8, max=26)"
-  },
-  {
-    "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix-alt-colours",
-    "reason": "black frame (mean=0.8, max=21)"
-  },
-  {
-    "presetId": "cotc-pieturp-hsl-tunnelvisions-morphing3",
-    "reason": "black frame (mean=3.8, max=22)"
   },
   {
     "presetId": "cotc-pieturp-hsltorgb-swirl",
@@ -1200,47 +576,11 @@
     "reason": "flat frame (mean=227.6, std=1.5)"
   },
   {
-    "presetId": "cotc-rarian-rakista-cheap-angels-23",
-    "reason": "black frame (mean=0.5, max=18)"
-  },
-  {
-    "presetId": "cotc-rce-ordinary-want-nevermore-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-rovastar-geiss-hyperkaleidoscope-glow-2-multitonal",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-rovastar-stahlregen-touchdown-on-jelly-planet-bccn-v4",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-royal-mashup-102",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-103",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-104",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-royal-mashup-115",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-130",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-131",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1249,10 +589,6 @@
   },
   {
     "presetId": "cotc-royal-mashup-160",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-162",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1276,10 +612,6 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-royal-mashup-215",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-royal-mashup-270",
     "reason": "black frame (mean=0.0, max=0)"
   },
@@ -1288,27 +620,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-royal-mashup-376",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-377",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-380",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-381",
-    "reason": "flat frame (mean=255.0, std=0.2)"
-  },
-  {
     "presetId": "cotc-royal-mashup-395",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-405",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1316,39 +628,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-royal-mashup-484",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-505",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-509",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-royal-mashup-524",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-58",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-59",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-62",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-83",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-royal-mashup-96",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1357,10 +637,6 @@
   },
   {
     "presetId": "cotc-serge-adam-eatit-mashup-fx-2-martin001",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-serge-circles007b",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1376,36 +652,8 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-serge-martin-crystal-palace001c",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-sewn-to-slavish-memes",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-shifter-dark-tides-eos-phat-whisps-of-doom-mix-mash0000-salt-dunes-time-lapse",
     "reason": "flat frame (mean=0.6, std=1.3)"
-  },
-  {
-    "presetId": "cotc-shifter-fishbrain-witchcraft-i-m-melting",
-    "reason": "flat frame (mean=253.3, std=1.9)"
-  },
-  {
-    "presetId": "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
@@ -1428,42 +676,6 @@
     "reason": "flat frame (mean=253.1, std=0.4)"
   },
   {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-bass-spectre-ps2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-stahlregen-boz-eos-phat-rovastar-zylot-machine-code-01010010-01000001-01010111-2",
     "reason": "black frame (mean=1.7, max=17)"
   },
@@ -1472,35 +684,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killphreqs-mix4-flacc",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-downpour",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-downpour-x-spectre-ps2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-downpour-x-spectre-ps2-contact-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-stahlregen-downpour-x-spectre-ps2b",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-eckshack-s-eyeball-floater-mix-plastic",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-eckshack-s-eyeball-popped-eyeball-mix",
-    "reason": "flat frame (mean=0.5, std=2.3)"
-  },
-  {
-    "presetId": "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1508,19 +692,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-dense",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-glowing",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku-yaqui-graph",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1532,47 +704,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-geiss-martin-tiger-no5-random-color-metal",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-stahlregen-geiss-orb-etheral-waves-mashup-20",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-5-5",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-hypnotron-v-0-5",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-stahlregen-sparkling",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-actually-i-didn-t-eat-last-night",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1580,75 +712,15 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-and-i-will-have-salmon-for-dinner",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-as-for-me-i-take-medicines",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-as-for-me-i-take-medicines2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-at-the-root-of-open-the-graves",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-barnacle-coated-hemoclubbin",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-bmelgren-hungry-orbits-mash0000-sir-i-can-t-help-you-over-here-isosceles-edit",
     "reason": "flat frame (mean=1.4, std=2.4)"
-  },
-  {
-    "presetId": "cotc-suksma-circle-of-the-taeyrunts",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-suksma-circle-of-the-taeyrunts-phairess-imbularse-deign-offal",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-confetti-manslut",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-cuneinformal-basilihistrionix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-daryl-feels-my-hellish-lonliness",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-deconstrue-orbaet",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-distort-crops-of-horror-torture",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-distort-crops-of-horror-torture-blackode",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1660,27 +732,11 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-fed-shd",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-j4-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-j4-flacc",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1708,10 +764,6 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-dotes-hostile-undertake-you-can-buy-hate-flacc",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted",
     "reason": "black frame (mean=0.0, max=0)"
   },
@@ -1720,43 +772,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-estrangedaholic-grandfather-cloques",
-    "reason": "black frame (mean=0.0, max=48)"
-  },
-  {
-    "presetId": "cotc-suksma-farming-equipment-ice-shower",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-feeling-abort",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-feeling-ignore",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-feeling-retry",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-fickle-will-dive-fed-shd",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-fig-leaves-can-t-cover-that-much",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1784,43 +800,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-foolish-mash",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-frustratingly-incomplete-wasteland",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-gapes-to-spelunkcide-dada-hate-art-isn-t-art",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-geiss-dotes-orb",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-gss-sth-hogwoman-style-incantation-onward-to-golgotha-christening-the-afterbirth-fla",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-gss-sth-hogwoman-style-starin-at-sports-carscryin-schnig-flacc",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1834,26 +814,6 @@
   {
     "presetId": "cotc-suksma-indecision-about-how-to-die-decision-made",
     "reason": "black frame (mean=0.3, max=67)"
-  },
-  {
-    "presetId": "cotc-suksma-lackstastique-j4",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-last-thing-i-remember-was-reading-tombstones",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies2",
-    "reason": "black frame (mean=0.0, max=0)"
   },
   {
     "presetId": "cotc-suksma-moistened-gills-in-latent-galaxy-raggy",
@@ -1872,23 +832,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-mtn-flx-flacc-roam3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-mundane-side-of-eden",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-never-churchmouth",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-never-throck",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1896,23 +840,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-passive-probabilistic-roaming-coin-gods",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-race-for-hot-dog-log-smell-2",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1920,23 +848,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-this-pain-was-saved-for-you-maggot-filigree-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-time-is-a-prison",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1944,31 +856,7 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-suksma-truth-rarity-isosceles-edit08",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-suksma-truth-rarity-isosceles-edit09",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-truth-raritys-isosceles-edit-11",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-twist-fiber-wrap-cut-circulation",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-uhnfareknesce-roosta-conflarian",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-syst3mfailur-satanic-ring-phat-eos-diety-freequency-remix",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -1980,55 +868,11 @@
     "reason": "black frame (mean=13.0, max=13)"
   },
   {
-    "presetId": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-the-ng-stahlregen-boz-eos-geiss-phat-rovastar-zylot-flexi-martin-fishbrain-machine-code-in-",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex-isosceles-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse-isosceles-edit",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
@@ -2092,863 +936,19 @@
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-tripgnosis-firestar",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tripgnosis-flameorb",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-tripgnosis-neon-algebra",
     "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-tripgnosis-triadular",
-    "reason": "black frame (mean=7.3, max=28)"
   },
   {
     "presetId": "cotc-undermines-him-in-the-subtlest-ways-mega-schoob-1d-serial-flashline-projection-creator",
     "reason": "black frame (mean=0.0, max=0)"
   },
   {
-    "presetId": "cotc-undulate-harque-amaz-inge",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-undulate-harque-brit-tlee",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-undulate-harque-pain-tthe",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-undulate-harque-zing",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-va-ultramix-381",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-va-ultramix-430",
-    "reason": "flat frame (mean=254.6, std=1.1)"
-  },
-  {
     "presetId": "cotc-va-ultramix2-156-1",
     "reason": "black frame (mean=0.1, max=2)"
   },
   {
-    "presetId": "cotc-va-ultramix2-296-1",
-    "reason": "black frame (mean=0.5, max=8)"
-  },
-  {
-    "presetId": "cotc-waltra-furry-synthesis-isosceles-edit2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-waltra-galactic-super-perspective",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-waltra-monodream",
-    "reason": "black frame (mean=0.4, max=255)"
-  },
-  {
-    "presetId": "cotc-waltra-time-travel",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-xtramartin-3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-xtramartin-459",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
     "presetId": "cotc-zylot-and-fishbrain-i-am-the-witch",
     "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-zylot-crystal-ball",
-    "reason": "black frame (mean=0.2, max=26)"
-  },
-  {
-    "presetId": "cotc-zylot-crystalball-aren-tfractals",
-    "reason": "black frame (mean=0.4, max=19)"
-  },
-  {
-    "presetId": "cotc-zylot-shifter-tartan-silent-heaven-mix",
-    "reason": "black frame (mean=2.4, max=30)"
-  },
-  {
-    "presetId": "cotc-zylot-the-collective-unconcious-jelly-5-5",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "cotc-zylot-visionarie-geiss-aspect-ratio-fix-mash0000-infinitely-dense-massless-particle",
-    "reason": "black frame (mean=0.1, max=16)"
-  },
-  {
-    "presetId": "dbleja-hovering-over-mars",
-    "reason": "flat frame (mean=255.0, std=0.1)"
-  },
-  {
-    "presetId": "dbleja-hovering-over-pluto",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "dbleja-inside-the-tree-blue-mix",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "eo-s-multisphere-01-b-phat-ra-mix",
-    "reason": "black frame (mean=0.1, max=74)"
-  },
-  {
-    "presetId": "eo-s-phat-cool-bug",
-    "reason": "black frame (mean=2.0, max=31)"
-  },
-  {
-    "presetId": "eo-s-phat-cool-bug-v2-krash-s-beat-detection",
-    "reason": "black frame (mean=1.7, max=30)"
-  },
-  {
-    "presetId": "eo-s-phat-shipwreaked-v3",
-    "reason": "black frame (mean=0.2, max=11)"
-  },
-  {
-    "presetId": "eo-s-phat-spectrum-bubble-new-colors-v2",
-    "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "eo-s-phat-the-lights-at-night-spikes",
-    "reason": "black frame (mean=0.0, max=1)"
-  },
-  {
-    "presetId": "eo-s-repeater-08-rave-on-a-lot-of-acid-and-some-k",
-    "reason": "black frame (mean=0.5, max=19)"
-  },
-  {
-    "presetId": "eo-s-repeater-13-definitive",
-    "reason": "black frame (mean=0.7, max=23)"
-  },
-  {
-    "presetId": "eos-heater-core-c",
-    "reason": "black frame (mean=1.2, max=13)"
-  },
-  {
-    "presetId": "eos-matrix-cube-c",
-    "reason": "black frame (mean=6.6, max=26)"
-  },
-  {
-    "presetId": "eos-phat-linear-clouds-v2",
-    "reason": "black frame (mean=0.2, max=12)"
-  },
-  {
-    "presetId": "eosphat-shipwreakedv5b",
-    "reason": "black frame (mean=3.2, max=23)"
-  },
-  {
-    "presetId": "evet-responsive-acid-iris",
-    "reason": "flat frame (mean=0.5, std=1.2)"
-  },
-  {
-    "presetId": "fishbrain-geiss-witchcraft-glow-mix",
-    "reason": "black frame (mean=0.2, max=19)"
-  },
-  {
-    "presetId": "fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin",
-    "reason": "flat frame (mean=149.7, std=1.0)"
-  },
-  {
-    "presetId": "fishbrain-when-robots-take-over-the-world",
-    "reason": "black frame (mean=2.3, max=25)"
-  },
-  {
-    "presetId": "fishbrain-witchcraft",
-    "reason": "black frame (mean=0.2, max=33)"
-  },
-  {
-    "presetId": "fishbrain-witchcraft-necromancer-remix-phat-edit-v3",
-    "reason": "black frame (mean=0.0, max=19)"
-  },
-  {
-    "presetId": "flexi-100-shader-fractal-origami-edit",
-    "reason": "flat frame (mean=149.7, std=0.0)"
-  },
-  {
-    "presetId": "flexi-3d-mosaic-glass-test-mash0000-9d-tuscan-slop-ram",
-    "reason": "black frame (mean=0.2, max=6)"
-  },
-  {
-    "presetId": "flexi-adamfx-hexcollie-moebius-morbid-vision-crack",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-black-holes-sucking-fractals-for-breakfast",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-bouncing-balls-grafitti-mix",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-braggadocio",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-can-t-think-of-mosaic-cages",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery",
-    "reason": "flat frame (mean=254.9, std=0.2)"
-  },
-  {
-    "presetId": "flexi-geiss-pogo-cubes-on-tokamak-matter-bccn-jelly-v4",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-geiss-pogo-cubes-on-tokamak-matter-jelly-5-55",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-geiss-tokamak-fallout-repellor",
-    "reason": "flat frame (mean=59.6, std=1.4)"
-  },
-  {
-    "presetId": "flexi-gravitational-chaos",
-    "reason": "flat frame (mean=178.6, std=0.3)"
-  },
-  {
-    "presetId": "flexi-infused-with-the-spiral-bc-cn-jelly-v4",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-intensive-shader-fractal",
-    "reason": "black frame (mean=29.1, max=29)"
-  },
-  {
-    "presetId": "flexi-intensive-shader-fractal-suksma-comp-shader-mix",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2",
-    "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "flexi-martin-geiss-dedicated-to-the-sherwin-maxawow",
-    "reason": "flat frame (mean=105.3, std=0.0)"
-  },
-  {
-    "presetId": "flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-martin-tunnel-of-supraschismatika",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-meta4free-3-my-time-is-not-your-time",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-mindblob-2-0-bc-cn-jelly-4",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-mom-why-the-sky-looks-different-today",
-    "reason": "black frame (mean=29.1, max=29)"
-  },
-  {
-    "presetId": "flexi-nitorami-beat-explorer-cn-bc-jelly-4",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-oldschool-tree",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-phat-fractal-star-child-restless",
-    "reason": "black frame (mean=0.4, max=30)"
-  },
-  {
-    "presetId": "flexi-stahlregen-a-car-crash-you-can-t-defocus-2",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-stahlregen-jelly-strike",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "flexi-the-bouncer-and-the-crasher-random-mashup",
-    "reason": "flat frame (mean=254.8, std=1.8)"
-  },
-  {
-    "presetId": "flexi-trickster-zenarchy",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "fumbling-foo-flexi-martin-orb-star-forge-v16",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "fvese-the-tunnel-final-stage-mix",
-    "reason": "black frame (mean=1.4, max=28)"
-  },
-  {
-    "presetId": "fvese-zoom-effects-remix-3",
-    "reason": "black frame (mean=0.7, max=32)"
-  },
-  {
-    "presetId": "geiss-experimental-spiral-artifact-filament-mix-scallop-mix",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides",
-    "reason": "black frame (mean=0.1, max=70)"
-  },
-  {
-    "presetId": "geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides-2",
-    "reason": "black frame (mean=0.1, max=106)"
-  },
-  {
-    "presetId": "geiss-liquid-beats-janky-ripple-warp-reflecto",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "geiss-mega-swirl-2",
-    "reason": "black frame (mean=0.8, max=25)"
-  },
-  {
-    "presetId": "geiss-mega-swirl-3",
-    "reason": "black frame (mean=0.8, max=30)"
-  },
-  {
-    "presetId": "geiss-microcheckers-2",
-    "reason": "flat frame (mean=254.3, std=2.5)"
-  },
-  {
-    "presetId": "geiss-octopus",
-    "reason": "black frame (mean=2.6, max=28)"
-  },
-  {
-    "presetId": "geiss-reducto-ad-nauseum",
-    "reason": "duplicate of geiss-reaction-diffusion-3"
-  },
-  {
-    "presetId": "geiss-rose-3",
-    "reason": "flat frame (mean=254.9, std=1.4)"
-  },
-  {
-    "presetId": "geiss-rose-4-shifted-tiles",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "geiss-skin-dots-multi-layer-3-pig-fuck-jembe-acid-wretch-dildonic",
-    "reason": "black frame (mean=0.7, max=26)"
-  },
-  {
-    "presetId": "geiss-spiral-artifact",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "geiss-spiral-artifact-filament-mix-beat-dots-mix",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "goody-aurora-totalis",
-    "reason": "flat frame (mean=249.9, std=0.5)"
-  },
-  {
-    "presetId": "goody-clouded-reason-revisited",
-    "reason": "flat frame (mean=237.0, std=0.2)"
-  },
-  {
-    "presetId": "goody-lsd-zoomtunnel",
-    "reason": "black frame (mean=3.3, max=17)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-aqua-lumens",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-ocular-anima",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-need-desire-remix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "goody-vertigo-revisited",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "idiot-9-7-02-remix-2",
-    "reason": "black frame (mean=1.8, max=14)"
-  },
-  {
-    "presetId": "idiot-tentacle-dreams",
-    "reason": "flat frame (mean=1.2, std=2.0)"
-  },
-  {
-    "presetId": "idiot-what-is",
-    "reason": "black frame (mean=1.1, max=12)"
-  },
-  {
-    "presetId": "krash-digital-flame",
-    "reason": "black frame (mean=0.9, max=25)"
-  },
-  {
-    "presetId": "krash-techno-rhythmic-mantas-painterly",
-    "reason": "flat frame (mean=159.9, std=1.2)"
-  },
-  {
-    "presetId": "krash-vinyl-disk",
-    "reason": "black frame (mean=1.0, max=15)"
-  },
-  {
-    "presetId": "krash-war-machine-shifting-complexity-mix",
-    "reason": "black frame (mean=1.1, max=15)"
-  },
-  {
-    "presetId": "lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "luxxx-melt-ur-face-i",
-    "reason": "flat frame (mean=105.3, std=0.0)"
-  },
-  {
-    "presetId": "martin-adrift-on-a-dead-planet-lard-mix",
-    "reason": "black frame (mean=0.8, max=10)"
-  },
-  {
-    "presetId": "martin-adrift-on-a-dead-planet-lite",
-    "reason": "black frame (mean=1.5, max=14)"
-  },
-  {
-    "presetId": "martin-axon3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-basal-ganglion",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-cherry-brain-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-cope-laser-dome",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-crystal-palace",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-crystal-palace-nz",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-deep-blue",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-elusive-impressions-mix1",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-extreme-heat",
-    "reason": "black frame (mean=1.3, max=23)"
-  },
-  {
-    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-flexi-laser-dome-bipolar-focus-intent",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-gate-to-moria",
-    "reason": "black frame (mean=0.3, max=9)"
-  },
-  {
-    "presetId": "martin-golden-mirror",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-liquid-gold",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-mandelbox-explorer-high-speed-demo-version",
-    "reason": "flat frame (mean=210.1, std=1.6)"
-  },
-  {
-    "presetId": "martin-pendulum-in-brass-ps3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-purple-pulsator",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-rogue-wave-ps2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-rogue-wave-ps3",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "martin-stahlregen-martin-in-da-mash-12",
-    "reason": "flat frame (mean=149.7, std=0.0)"
-  },
-  {
-    "presetId": "martin-unholy-amulet",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz",
-    "reason": "black frame (mean=0.0, max=41)"
-  },
-  {
-    "presetId": "mig-008",
-    "reason": "black frame (mean=0.0, max=17)"
-  },
-  {
-    "presetId": "mig-colorful9",
-    "reason": "flat frame (mean=253.9, std=2.3)"
-  },
-  {
-    "presetId": "mstress-acoustic-nerve-impulses-primary-colors-of-sound-mix",
-    "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "mstress-scattered-gravity-smoked-mix",
-    "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "new-milktrend-trend-setters-amandio-c-flexi-ft-adamfx-n-stahlregen-martin-ufoz-identified",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "orb-acid-cycle-gas-giant",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "orb-acid-in-my-eyes",
-    "reason": "flat frame (mean=254.3, std=1.6)"
-  },
-  {
-    "presetId": "orb-solar-radiation",
-    "reason": "black frame (mean=4.1, max=24)"
-  },
-  {
-    "presetId": "orb-solar-sail",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "phat-eo-s-data-swimmer",
-    "reason": "flat frame (mean=254.0, std=2.0)"
-  },
-  {
-    "presetId": "phat-eo-s-eyes-spiral-mix",
-    "reason": "black frame (mean=0.3, max=44)"
-  },
-  {
-    "presetId": "phat-eo-s-our-own-personal-demon",
-    "reason": "black frame (mean=0.6, max=15)"
-  },
-  {
-    "presetId": "phat-eo-s-rainbow-bubble-mid3-fuck-me-dood",
-    "reason": "preset did not apply (active: phat-eo-s-rainbow-bubble-mid3-f-me-dood) for phat-eo-s-rainbow-bubble-mid3-fuck-me-dood."
-  },
-  {
-    "presetId": "phat-eo-s-single-cel-angel-birth",
-    "reason": "black frame (mean=0.4, max=14)"
-  },
-  {
-    "presetId": "phat-it-sjustnumbers",
-    "reason": "flat frame (mean=254.8, std=1.0)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-krash-i-hope-someone-will-see-this-triping-v2b",
-    "reason": "black frame (mean=0.8, max=27)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-square-faces-v2-alt-colours",
-    "reason": "black frame (mean=1.0, max=24)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-strate-lines",
-    "reason": "black frame (mean=0.8, max=25)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-trippy-rotation-weird-boxs-mix",
-    "reason": "black frame (mean=1.4, max=22)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-work-with-lines",
-    "reason": "black frame (mean=0.6, max=17)"
-  },
-  {
-    "presetId": "phat-zylot-eo-s-work-with-lines-alt",
-    "reason": "black frame (mean=0.7, max=26)"
-  },
-  {
-    "presetId": "phat-zylot-eos-trippy-rotation",
-    "reason": "black frame (mean=0.6, max=16)"
-  },
-  {
-    "presetId": "pieturp-sunflare",
-    "reason": "black frame (mean=22.4, max=22)"
-  },
-  {
-    "presetId": "redi-jedi-off-the-fadar",
-    "reason": "black frame (mean=1.6, max=21)"
-  },
-  {
-    "presetId": "redi-jedi-off-the-fadar-no-sweeps-or-bleeps-but-alotta-creeps",
-    "reason": "black frame (mean=2.3, max=15)"
-  },
-  {
-    "presetId": "reenen-geiss-soft-triple-feedback",
-    "reason": "black frame (mean=0.7, max=10)"
-  },
-  {
-    "presetId": "reenen-geiss-triple-feedback-phat-edit",
-    "reason": "flat frame (mean=254.7, std=0.8)"
-  },
-  {
-    "presetId": "rovastar-geiss-hurricane-nightmare-gold-chrome-mix",
-    "reason": "black frame (mean=0.2, max=18)"
-  },
-  {
-    "presetId": "rovastar-halcyon-dreams-3",
-    "reason": "flat frame (mean=1.5, std=2.4)"
-  },
-  {
-    "presetId": "rovastar-harlequin-s-fractal-encounter",
-    "reason": "black frame (mean=1.0, max=1)"
-  },
-  {
-    "presetId": "rovastar-jester-s-calling-2",
-    "reason": "black frame (mean=1.4, max=30)"
-  },
-  {
-    "presetId": "rovastar-oozing-resistance",
-    "reason": "black frame (mean=0.9, max=28)"
-  },
-  {
-    "presetId": "rovastar-solarized-space",
-    "reason": "black frame (mean=1.4, max=11)"
-  },
-  {
-    "presetId": "rovastar-sunflower-passion",
-    "reason": "black frame (mean=0.9, max=25)"
-  },
-  {
-    "presetId": "rovastar-sunflower-passion-simple-mix",
-    "reason": "flat frame (mean=1.1, std=1.7)"
-  },
-  {
-    "presetId": "rovastar-sunflower-passion-simple-mix-phat-eo-s-werid-angle-mix",
-    "reason": "flat frame (mean=1.2, std=1.9)"
-  },
-  {
-    "presetId": "rovastar-tripmaker-space-trip-mix",
-    "reason": "black frame (mean=9.3, max=27)"
-  },
-  {
-    "presetId": "rovastar-trippy-sperm-jelly",
-    "reason": "black frame (mean=2.2, max=19)"
-  },
-  {
-    "presetId": "rovastar-voov-s-movement-after-dark-mix-painterly",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "rovastar-zylot-crystal-ball-many-visions-mix",
-    "reason": "black frame (mean=4.4, max=18)"
-  },
-  {
-    "presetId": "royal-mashup-177",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "royal-mashup-197",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "schglasmia-danqueer",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "shifter-dark-tides-eo-s-phat-whisps-of-doom-mix",
-    "reason": "flat frame (mean=0.6, std=1.3)"
-  },
-  {
-    "presetId": "shifter-digi",
-    "reason": "black frame (mean=0.1, max=2)"
-  },
-  {
-    "presetId": "shifter-eo-s-phat-fractical-dancer-inside-the-neural-net",
-    "reason": "black frame (mean=0.6, max=20)"
-  },
-  {
-    "presetId": "shifter-geiss-neon-pulse-glow-mix",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "shifter-mandala",
-    "reason": "black frame (mean=1.5, max=12)"
-  },
-  {
-    "presetId": "shifter-robotopia",
-    "reason": "black frame (mean=0.3, max=4)"
-  },
-  {
-    "presetId": "shifter-snakeskin",
-    "reason": "black frame (mean=2.0, max=13)"
-  },
-  {
-    "presetId": "shifter-spectro",
-    "reason": "black frame (mean=14.6, max=31)"
-  },
-  {
-    "presetId": "shifter-spills-blender-krash-beatdetect-mash0000-here-comb-your-hair-with-this-planet",
-    "reason": "black frame (mean=0.0, max=1)"
-  },
-  {
-    "presetId": "shifter-spincycle-remix-love-at-home-electroplasmic-pissbowel-roam3",
-    "reason": "flat frame (mean=208.6, std=1.4)"
-  },
-  {
-    "presetId": "stahlregen-dots-pixels-blocky-jelly-v2",
-    "reason": "flat frame (mean=254.9, std=0.4)"
-  },
-  {
-    "presetId": "stahlregen-dots-pixels-blocky-reverse-jelly-v3",
-    "reason": "flat frame (mean=254.0, std=0.5)"
-  },
-  {
-    "presetId": "stahlregen-eo-s-flexi-phat-rovastar-zylot-screenspace-fractopia-rmx",
-    "reason": "flat frame (mean=105.3, std=0.0)"
-  },
-  {
-    "presetId": "stahlregen-old-school-baby-spiral-ornament-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "stahlregen-spiral-beats-fluctuating-flowers",
-    "reason": "black frame (mean=3.6, max=21)"
-  },
-  {
-    "presetId": "stahlregen-spiral-hundertwasser-2-painterly",
-    "reason": "flat frame (mean=255.0, std=0.0)"
-  },
-  {
-    "presetId": "stahlregen-unchained-psychedelic-flower-kung-fu-corrupt",
-    "reason": "flat frame (mean=193.4, std=0.0)"
-  },
-  {
-    "presetId": "studio-music-and-unchained-rapid-alteration",
-    "reason": "black frame (mean=2.9, max=28)"
-  },
-  {
-    "presetId": "suksma-aderrasi-martin-raron-geiss-are-you-mad-at-me",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "suksma-feign-shoulder-concern-when-i-should-be-executed-everything-is-eternally-shrinking",
-    "reason": "black frame (mean=0.1, max=95)"
-  },
-  {
-    "presetId": "suksma-gaeomaentaec-log-smell-2-steaming-wienies2",
-    "reason": "black frame (mean=0.0, max=1)"
-  },
-  {
-    "presetId": "suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "telek-slow-thing-spiderman-mix",
-    "reason": "black frame (mean=7.2, max=18)"
-  },
-  {
-    "presetId": "unchained-cartoon-factory",
-    "reason": "flat frame (mean=77.9, std=0.4)"
-  },
-  {
-    "presetId": "unchained-in-memory-of-peg",
-    "reason": "flat frame (mean=233.5, std=0.5)"
-  },
-  {
-    "presetId": "unchained-making-a-science-of-it-2",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money",
-    "reason": "black frame (mean=0.0, max=0)"
-  },
-  {
-    "presetId": "wulfson-crumple-nth-power-mix",
-    "reason": "black frame (mean=14.3, max=21)"
-  },
-  {
-    "presetId": "yin-293-sonic-brainstorm-inner-state-group-experience-mix",
-    "reason": "flat frame (mean=249.8, std=2.4)"
-  },
-  {
-    "presetId": "zylot-building-block-of-color-bitcore-tweak",
-    "reason": "black frame (mean=0.9, max=5)"
   }
 ]

--- a/public/milkdrop-presets/preview-failures.json
+++ b/public/milkdrop-presets/preview-failures.json
@@ -1,18 +1,2954 @@
 [
   {
-    "presetId": "eo-s-repeater-08-rave-on-a-lot-of-acid-and-some-k",
-    "reason": "black frame (mean=0.4, max=145)"
+    "presetId": "250-wavecode",
+    "reason": "black frame (mean=0.4, max=21)"
   },
   {
-    "presetId": "martin-axon3",
+    "presetId": "252-wavecode-spectrum2",
+    "reason": "black frame (mean=1.4, max=25)"
+  },
+  {
+    "presetId": "27-super-goats-orbus-maximus",
+    "reason": "flat frame (mean=253.5, std=2.1)"
+  },
+  {
+    "presetId": "300-beatdetect-bassmidtreb",
+    "reason": "black frame (mean=0.3, max=19)"
+  },
+  {
+    "presetId": "a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual",
+    "reason": "black frame (mean=0.1, max=50)"
+  },
+  {
+    "presetId": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7",
+    "reason": "flat frame (mean=149.7, std=0.0)"
+  },
+  {
+    "presetId": "aderrasi-causeway-of-dreams-point-mix",
+    "reason": "black frame (mean=1.9, max=27)"
+  },
+  {
+    "presetId": "aderrasi-chromatic-abyss-refined-abyss-mix",
+    "reason": "black frame (mean=1.8, max=29)"
+  },
+  {
+    "presetId": "aderrasi-ghast-entity",
+    "reason": "flat frame (mean=0.9, std=2.0)"
+  },
+  {
+    "presetId": "aderrasi-horvath-s-holistic-abyss",
+    "reason": "black frame (mean=1.6, max=23)"
+  },
+  {
+    "presetId": "aderrasi-madness-teaches-us-to-fly",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "aderrasi-roaming-star-himalaya-brach-office-mash0000-creaming-the-summit",
+    "reason": "black frame (mean=3.2, max=23)"
+  },
+  {
+    "presetId": "aderrasi-songflower-moss-posy",
+    "reason": "black frame (mean=0.5, max=1)"
+  },
+  {
+    "presetId": "aderrasi-variants-of-eternity",
+    "reason": "black frame (mean=1.0, max=20)"
+  },
+  {
+    "presetId": "amandio-c-flashy-thing",
+    "reason": "black frame (mean=0.1, max=5)"
+  },
+  {
+    "presetId": "amandio-c-fume",
+    "reason": "black frame (mean=0.1, max=3)"
+  },
+  {
+    "presetId": "amandio-c-odd-star",
+    "reason": "black frame (mean=0.3, max=4)"
+  },
+  {
+    "presetId": "amandio-c-salty-beats-spiral",
+    "reason": "black frame (mean=2.2, max=16)"
+  },
+  {
+    "presetId": "bdrv-al-aderrasi-oracle-bdrv-et-al-rmx-a",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "bdrv-al-eo-s-phat-intergalactic-conquest-flag2b",
+    "reason": "black frame (mean=0.4, max=16)"
+  },
+  {
+    "presetId": "bdrv-al-eo-s-phat-intergalactic-fuzzball",
+    "reason": "black frame (mean=0.3, max=22)"
+  },
+  {
+    "presetId": "bdrv-al-phat-and-eo-s-shapes-are-cool-slow-colour-melting-edit-bdrv-et-al-rmxmix32",
+    "reason": "flat frame (mean=254.9, std=0.3)"
+  },
+  {
+    "presetId": "bdrv-al-telek-spirality",
+    "reason": "flat frame (mean=253.8, std=2.1)"
+  },
+  {
+    "presetId": "bdrv-al-zylot-pinwheelw",
+    "reason": "black frame (mean=0.5, max=14)"
+  },
+  {
+    "presetId": "best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-23",
+    "reason": "flat frame (mean=255.0, std=0.2)"
+  },
+  {
+    "presetId": "beta106i-songflower-orchid-field-mash0000-too-drunk-and-high-at-club",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "bmelgren-krash-rainbow-orb-peacock-lonely-signal-gone-mad-mix",
+    "reason": "black frame (mean=2.7, max=19)"
+  },
+  {
+    "presetId": "brainstain-blackwidow",
+    "reason": "black frame (mean=0.4, max=12)"
+  },
+  {
+    "presetId": "brainstain-boiling-mix2-redi-jedi-full-carb-mix",
+    "reason": "flat frame (mean=220.0, std=0.0)"
+  },
+  {
+    "presetId": "brainstain-re-entry",
+    "reason": "black frame (mean=0.4, max=28)"
+  },
+  {
+    "presetId": "che-terracarbon-stream",
+    "reason": "black frame (mean=2.5, max=32)"
+  },
+  {
+    "presetId": "cope-27-super-goats-orbus-maximus-breach-the-egg-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cope-ferrofluid",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cope-flexi-mother-of-whirl-no-fnords-were-hurt",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cope-martin-mother-of-pearl",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cope-the-drain-to-heaven",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cotc-101",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-102",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-103",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-13",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-14",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-141",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-146",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-16",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-170",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-174",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-19",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-22",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-220",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-228",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-288",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-307",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-308",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-310",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-312",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-313",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-314",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-315",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-316",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-317",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-318",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-338",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-34",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-345",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-367",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-368",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-370",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-372",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-423",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-429",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-455",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-99",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-bit-storm-effected-by-adamfx-2-shadowharlequin-bit-storm-ft-dancing-petals",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-hexocollie-flexi-adamfx-",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-amandio-c-ifs-01",
     "reason": "black frame (mean=0.4, max=5)"
   },
   {
-    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations",
+    "presetId": "cotc-amandio-c-iterative-squares-1",
+    "reason": "black frame (mean=2.2, max=17)"
+  },
+  {
+    "presetId": "cotc-amandio-c-iterative-squares-4",
+    "reason": "black frame (mean=2.4, max=20)"
+  },
+  {
+    "presetId": "cotc-amandio-c-moving-ripple-intraphereonts-pad-urn",
+    "reason": "black frame (mean=0.1, max=1)"
+  },
+  {
+    "presetId": "cotc-amandio-c-moving-ripple-reproducing-the-end-feeling-of-doing-anything-in-the-mind",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-amandio-c-orbitin-around-3",
+    "reason": "black frame (mean=0.0, max=3)"
+  },
+  {
+    "presetId": "cotc-amandio-c-sierpinsky-s-triangle",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-amandio-c-water-ripples-2d",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-bdrv-aderrasi-true-subject-star-pure-medium-bdrv-etal",
+    "reason": "flat frame (mean=1.0, std=2.2)"
+  },
+  {
+    "presetId": "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-bdrv-etal-nighthawk-dark-crystal",
+    "reason": "black frame (mean=0.1, max=3)"
+  },
+  {
+    "presetId": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot4-isosceles-e",
+    "reason": "black frame (mean=2.4, max=16)"
+  },
+  {
+    "presetId": "cotc-beta106i-old-myths-and-fairytales",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-beta106i-songflower-ice-flower",
+    "reason": "black frame (mean=1.0, max=1)"
+  },
+  {
+    "presetId": "cotc-bleeding-like-a-horsey",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-bleeding-like-a-horsey-roams-i-just-got-through-watching-planet-bboy-and-boy-do-i-feel-emba",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-camel-llama",
+    "reason": "black frame (mean=0.6, max=6)"
+  },
+  {
+    "presetId": "cotc-cantstop-adamfx-2-flexi-geiss-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-hex",
+    "reason": "black frame (mean=2.6, max=19)"
+  },
+  {
+    "presetId": "cotc-cope-flexi-julia-set-strange-days-bdrv2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-dbleja-horizontology-blue-mix",
+    "reason": "flat frame (mean=255.0, std=0.1)"
+  },
+  {
+    "presetId": "cotc-dbleja-horizontology-red-mix",
+    "reason": "flat frame (mean=255.0, std=0.1)"
+  },
+  {
+    "presetId": "cotc-dbleja-horizontology-white-mix",
+    "reason": "flat frame (mean=255.0, std=0.1)"
+  },
+  {
+    "presetId": "cotc-drugsincombat-reactive-molecule-v-05a",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-3d",
+    "reason": "black frame (mean=0.6, max=17)"
+  },
+  {
+    "presetId": "cotc-eos-apocalypse-b",
+    "reason": "black frame (mean=2.2, max=30)"
+  },
+  {
+    "presetId": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-flexi-s-reflections-phat-s-r",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2-border-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2e-feat-martin-flexi-phat",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-magnetosphere-04",
+    "reason": "black frame (mean=1.4, max=31)"
+  },
+  {
+    "presetId": "cotc-eos-magnetosphere-06-birthegg",
+    "reason": "black frame (mean=1.1, max=25)"
+  },
+  {
+    "presetId": "cotc-eos-multisphere-01-b-phat-ra-mix-nexus-roams-falling-through-9-time",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eos-phat-i-v2-gradients",
+    "reason": "black frame (mean=3.0, max=25)"
+  },
+  {
+    "presetId": "cotc-eos-phat-i-v2-gradients-rot",
+    "reason": "black frame (mean=1.5, max=30)"
+  },
+  {
+    "presetId": "cotc-eos-phat-linear-clouds-solarized-points-of-light",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cotc-eos-phat-linear-clouds-solarized-points-of-light-v2",
+    "reason": "flat frame (mean=254.6, std=0.9)"
+  },
+  {
+    "presetId": "cotc-eos-phat-technicolor-f-breather-c",
+    "reason": "black frame (mean=0.3, max=12)"
+  },
+  {
+    "presetId": "cotc-eos-phat-technicolor-f-breather-d",
+    "reason": "black frame (mean=0.4, max=9)"
+  },
+  {
+    "presetId": "cotc-eos-phat-technicolor-f-breather-e",
+    "reason": "black frame (mean=0.2, max=16)"
+  },
+  {
+    "presetId": "cotc-eos-phat-the-lights-at-night",
     "reason": "black frame (mean=0.5, max=5)"
   },
   {
+    "presetId": "cotc-eos-phat-the-lights-at-night-spikes",
+    "reason": "black frame (mean=0.2, max=2)"
+  },
+  {
+    "presetId": "cotc-eos-rename-2b",
+    "reason": "black frame (mean=1.2, max=16)"
+  },
+  {
+    "presetId": "cotc-eos-subtraction-fade",
+    "reason": "flat frame (mean=254.4, std=0.8)"
+  },
+  {
+    "presetId": "cotc-evet-ball-lightning-1",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-evet-ball-lightning-1-isosceles-edit1",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-evet-ball-lightning-1-isosceles-edit2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-evet-flexi-geiss-tokamak-fractal-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-evet-jewelsmoke",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-evet-waterrgate",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-eviljim-11-ice-drops",
+    "reason": "black frame (mean=1.1, max=8)"
+  },
+  {
+    "presetId": "cotc-eviljim-ice-drops",
+    "reason": "black frame (mean=0.8, max=7)"
+  },
+  {
+    "presetId": "cotc-fishbrain-betelguese3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-betelguese3-aa",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-david-bowie-cpe",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-evolution-3d-phat-edit-v2",
+    "reason": "flat frame (mean=0.5, std=1.7)"
+  },
+  {
+    "presetId": "cotc-fishbrain-flexi-stitchcraft-n",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-flexi-witchcraft-unleashed-00-the-template",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-flexi-witchcraft-unleashed-01-stepping-into-it",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-geiss-witchcraft-glow-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-submarine-exp-ame-med",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-fishbrain-swarming-glory-spiral-remix",
+    "reason": "black frame (mean=2.8, max=32)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft",
+    "reason": "flat frame (mean=0.6, std=1.7)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-alcoholic-remix",
+    "reason": "flat frame (mean=0.5, std=2.3)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-metropolish-remix",
+    "reason": "flat frame (mean=0.7, std=2.3)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-metropolish-remix-motor-up-pre-air-filter-cyclone-argon-tweecer",
+    "reason": "black frame (mean=0.2, max=21)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-metropolish-remix-test",
+    "reason": "black frame (mean=0.3, max=12)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-necromancer-remix",
+    "reason": "black frame (mean=0.2, max=46)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-necromancer-remix-busy",
+    "reason": "black frame (mean=0.3, max=43)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit",
+    "reason": "black frame (mean=0.2, max=1)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit-v2",
+    "reason": "black frame (mean=0.1, max=30)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit-v3",
+    "reason": "black frame (mean=0.3, max=18)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-neuromancer-remix",
+    "reason": "flat frame (mean=0.5, std=1.1)"
+  },
+  {
+    "presetId": "cotc-fishbrain-witchcraft-sorcery-remix",
+    "reason": "black frame (mean=0.1, max=21)"
+  },
+  {
+    "presetId": "cotc-fleekus-flokus-violent-and-insane-homicidal-air-molecules-beat-code-experiment2-gss",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-110-satanic-teleprompter-05",
+    "reason": "black frame (mean=0.4, max=11)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-110-so-call-the-police",
+    "reason": "black frame (mean=0.2, max=7)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90",
+    "reason": "black frame (mean=0.2, max=6)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter",
+    "reason": "black frame (mean=0.4, max=10)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-01",
+    "reason": "black frame (mean=0.2, max=6)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-02",
+    "reason": "black frame (mean=0.2, max=5)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-03",
+    "reason": "black frame (mean=0.3, max=7)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-04",
+    "reason": "black frame (mean=0.2, max=6)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-05",
+    "reason": "black frame (mean=0.2, max=7)"
+  },
+  {
+    "presetId": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-on",
+    "reason": "black frame (mean=0.2, max=6)"
+  },
+  {
+    "presetId": "cotc-flexi-fishbrain-geiss-unchained-others-plaidcraft",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-heartbleeding-emocore-will-get-the-rest-of-you",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-identity-killing-petting-colon-gonad-type8",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-identity-killing-petting-colon-gonad-type9",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-leaving-colors-crazy-cogitations-centrifuge-collapsing-cosmos-creation-oh-thats-still",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-stahlregen-jewelry-tiles",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-flexi-wolfram-s-rule-110-rise-of-the-log-attack",
+    "reason": "black frame (mean=0.3, max=9)"
+  },
+  {
+    "presetId": "cotc-flexi-wolfram-s-rule-90-rise-of-the-log-attack",
+    "reason": "black frame (mean=0.2, max=5)"
+  },
+  {
+    "presetId": "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-cepia-dither",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-cosmic-dust-2-laplacian-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-cosmic-dust-2-laplacian-mix-maalol-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-electric-storm-half-digital-2-fiesta-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-flexi-orb-others-i-ve-had-it-with-this-g-tree",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-plasma",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-3-janky-diffusion-effect-warp",
+    "reason": "black frame (mean=0.3, max=4)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-3-janky-ripples",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-3-janky-ripples-warp",
+    "reason": "black frame (mean=0.3, max=3)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-reaction-diffusion-simple-squamous-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-10",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-10b",
+    "reason": "black frame (mean=0.2, max=3)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-10c",
+    "reason": "black frame (mean=0.5, max=13)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-11-crossfire-composite",
+    "reason": "black frame (mean=0.8, max=4)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-11b",
+    "reason": "black frame (mean=0.3, max=7)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-9",
+    "reason": "black frame (mean=0.4, max=7)"
+  },
+  {
+    "presetId": "cotc-geiss-skin-dots-multi-layer-3-pig-jembe-acid-wretch",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-geite-spooksville-roams",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-aurora-totalis",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-ego-decontructor",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-lights-in-the-sky",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-need",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-need-desire-remix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-need-transcendance-remix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-s-fatal-color-attraction-pliant-reality-remix-ps2-0-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-s-fatal-color-attraction-ps2-0",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-s-portfolio-acid-angel",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-woven-beads",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-goody-woven-beads-ps2-0",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-halfbreak-caramelize-serpentine",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-halfbreak-last-in-nebula",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-halfbreak-tonymilkdrop-beautiful-sepia-mashmash",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-abyssal-dreamscape",
+    "reason": "flat frame (mean=220.0, std=0.0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-demonic-afterimages",
+    "reason": "black frame (mean=0.1, max=4)"
+  },
+  {
+    "presetId": "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-julian-shader-wars3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-julian-shader-wars4",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-shifter-martin-anime-vs-the-stalion-mang",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-surge",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-roams-drugs-stretch-time-wave-packe",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-thinkin-bout-u",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-x-warp-harsh-klive",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-hexcollie-zylot-n-phat-it-has-to-be-wrong-to-have-this-much-fun-without-any-talent",
+    "reason": "black frame (mean=0.2, max=4)"
+  },
+  {
+    "presetId": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-eos-angels-of-decay-19-hexocollie-6",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-isosceles-mashup23",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-isosceles-mashup25",
+    "reason": "black frame (mean=1.3, max=9)"
+  },
+  {
+    "presetId": "cotc-loading-doctor",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-absinthe-with-mc-escher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-broken-beat-machina-i",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-fuck-ur-fractal-muscles-i",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-my-soul-i",
+    "reason": "black frame (mean=3.3, max=25)"
+  },
+  {
+    "presetId": "cotc-luxxx-water-your-pet-goldfish-i",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-when-the-first-aliens-came-b",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-luxxx-wip",
+    "reason": "flat frame (mean=255.0, std=1.6)"
+  },
+  {
+    "presetId": "cotc-luxxx-wip-isosceles-edit",
+    "reason": "flat frame (mean=255.0, std=0.2)"
+  },
+  {
+    "presetId": "cotc-martin-another-kind-of-groove",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-diabolo",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-diabolo-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-hardcore-mix-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-hardcore-mix-2-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-lock-and-release",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen-aderrasi-geiss-unchained-zyl",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-pendulum-in-brass-ps2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-pendulum-in-brass-ps3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-soma-in-pink",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-sphery-tales",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-sphery-tales-slow-version",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-tunnel-race-meta-mash-disciple",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-martin-tunnel-race-meta-mash-for-rats",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-midgitstraights-of-majillaen-gunthree-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34",
+    "reason": "flat frame (mean=254.3, std=0.6)"
+  },
+  {
+    "presetId": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral",
+    "reason": "flat frame (mean=254.8, std=0.4)"
+  },
+  {
+    "presetId": "cotc-new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-nicklepenultim",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-nicklepenultim-roam",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-nicklepenultim-the-skuzzmuppet",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-orb-blade",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-orb-cloud-burst",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-orb-lazer-ride",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-orb-waaa-jelly-5-55",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-alt-colours",
+    "reason": "black frame (mean=0.4, max=8)"
+  },
+  {
+    "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix",
+    "reason": "black frame (mean=0.8, max=26)"
+  },
+  {
+    "presetId": "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix-alt-colours",
+    "reason": "black frame (mean=0.8, max=21)"
+  },
+  {
+    "presetId": "cotc-pieturp-hsl-tunnelvisions-morphing3",
+    "reason": "black frame (mean=3.8, max=22)"
+  },
+  {
+    "presetId": "cotc-pieturp-hsltorgb-swirl",
+    "reason": "black frame (mean=0.0, max=1)"
+  },
+  {
+    "presetId": "cotc-pieturp-stripes-goingfastmix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-pieturp-stripes-goingslowmix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cotc-pieturp-stripes-hippiestyle",
+    "reason": "black frame (mean=0.2, max=12)"
+  },
+  {
+    "presetId": "cotc-pieturp-stripes-tvstyle",
+    "reason": "black frame (mean=0.3, max=18)"
+  },
+  {
+    "presetId": "cotc-pieturp-sunflare2",
+    "reason": "flat frame (mean=227.6, std=1.5)"
+  },
+  {
+    "presetId": "cotc-rarian-rakista-cheap-angels-23",
+    "reason": "black frame (mean=0.5, max=18)"
+  },
+  {
+    "presetId": "cotc-rce-ordinary-want-nevermore-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-rovastar-geiss-hyperkaleidoscope-glow-2-multitonal",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-rovastar-stahlregen-touchdown-on-jelly-planet-bccn-v4",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-102",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-103",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-104",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-115",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-130",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-131",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-157",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-160",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-162",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-183",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-189",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-190",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-192",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-21",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-215",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-270",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-29",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-376",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-377",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-380",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-381",
+    "reason": "flat frame (mean=255.0, std=0.2)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-395",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-405",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-444",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-484",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-505",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-509",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-524",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-58",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-59",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-62",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-83",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-royal-mashup-96",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-158-002",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-adam-eatit-mashup-fx-2-martin001",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-circles007b",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-martin-crystal-palace000",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-martin-crystal-palace001",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-martin-crystal-palace001b",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-serge-martin-crystal-palace001c",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-sewn-to-slavish-memes",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-dark-tides-eos-phat-whisps-of-doom-mix-mash0000-salt-dunes-time-lapse",
+    "reason": "flat frame (mean=0.6, std=1.3)"
+  },
+  {
+    "presetId": "cotc-shifter-fishbrain-witchcraft-i-m-melting",
+    "reason": "flat frame (mean=253.3, std=1.9)"
+  },
+  {
+    "presetId": "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-geiss-neon-pulse-glow-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-glassworms-flare-jelly-5-5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-shifter-neon-pulse-reactive",
+    "reason": "black frame (mean=8.4, max=29)"
+  },
+  {
+    "presetId": "cotc-shifter-yak-yetanotherkaleidoscope-01",
+    "reason": "flat frame (mean=253.1, std=0.4)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-bass-spectre-ps2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-boz-eos-phat-rovastar-zylot-machine-code-01010010-01000001-01010111-2",
+    "reason": "black frame (mean=1.7, max=17)"
+  },
+  {
+    "presetId": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killgaia-mix2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killphreqs-mix4-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-downpour",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-downpour-x-spectre-ps2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-downpour-x-spectre-ps2-contact-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-downpour-x-spectre-ps2b",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-eckshack-s-eyeball-floater-mix-plastic",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-eckshack-s-eyeball-popped-eyeball-mix",
+    "reason": "flat frame (mean=0.5, std=2.3)"
+  },
+  {
+    "presetId": "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-fishbrain-flexi-geiss-martin-shifter-stonecraft-martin-s-metallics",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-dense",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-glowing",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku-yaqui-graph",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-flexi-geiss-shifter-swirlz-hue-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-martin-tiger-no5-random-color-metal",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-orb-etheral-waves-mashup-20",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-5-5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-hypnotron-v-0-5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-stahlregen-sparkling",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-actually-i-didn-t-eat-last-night",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-and-i-will-have-salmon-for-dinner",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-as-for-me-i-take-medicines",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-as-for-me-i-take-medicines2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-at-the-root-of-open-the-graves",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-barnacle-coated-hemoclubbin",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-bmelgren-hungry-orbits-mash0000-sir-i-can-t-help-you-over-here-isosceles-edit",
+    "reason": "flat frame (mean=1.4, std=2.4)"
+  },
+  {
+    "presetId": "cotc-suksma-circle-of-the-taeyrunts",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-circle-of-the-taeyrunts-phairess-imbularse-deign-offal",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-confetti-manslut",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-cuneinformal-basilihistrionix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-daryl-feels-my-hellish-lonliness",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-deconstrue-orbaet",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-distort-crops-of-horror-torture",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-distort-crops-of-horror-torture-blackode",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-fed-shd",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-j4-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-j4-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-offx-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-one-too-many-days-under-the-iron-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-pacific-heights-flacc-roams-higher-self-lower-self-battles",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-hostile-undertake-you-can-buy-hate-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-estrangedaholic-grandfather-cloques",
+    "reason": "black frame (mean=0.0, max=48)"
+  },
+  {
+    "presetId": "cotc-suksma-farming-equipment-ice-shower",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-feeling-abort",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-feeling-ignore",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-feeling-retry",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-fickle-will-dive-fed-shd",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-fig-leaves-can-t-cover-that-much",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-fishbrain-hexcollie-martin-bioluminescent-aerodynamic-poltergeist",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-fishbrain-witchcraft-phugly-megalopolish-remix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-flaming-bag-of-wisconsin-i-being-the-last-thing-you-remember-is-the-last-thing-i-rem",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-flaring-squamoid-mode-placement",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-flukerication-machinist",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-foldrinymicull",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-foolish-mash",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-frustratingly-incomplete-wasteland",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-gapes-to-spelunkcide-dada-hate-art-isn-t-art",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-geiss-dotes-orb",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-gss-sth-hogwoman-style-incantation-onward-to-golgotha-christening-the-afterbirth-fla",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-gss-sth-hogwoman-style-starin-at-sports-carscryin-schnig-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-her-sideways-crawl-through-your-bank-accounts",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-hypnocinagenic-drift",
+    "reason": "black frame (mean=0.3, max=10)"
+  },
+  {
+    "presetId": "cotc-suksma-indecision-about-how-to-die-decision-made",
+    "reason": "black frame (mean=0.3, max=67)"
+  },
+  {
+    "presetId": "cotc-suksma-lackstastique-j4",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-last-thing-i-remember-was-reading-tombstones",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-moistened-gills-in-latent-galaxy-raggy",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mtn-flx-flacc",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mtn-flx-flacc-choilan-collapsar",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mtn-flx-flacc-roam3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-mundane-side-of-eden",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-never-churchmouth",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-never-throck",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-no-grip-chute-reinvents-terror",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-passive-probabilistic-roaming-coin-gods",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-race-for-hot-dog-log-smell-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-rechivalrizing-tents",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-this-pain-was-saved-for-you-maggot-filigree-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-time-is-a-prison",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-trapstract",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-truth-rarity-isosceles-edit08",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-truth-rarity-isosceles-edit09",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-truth-raritys-isosceles-edit-11",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-twist-fiber-wrap-cut-circulation",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-uhnfareknesce-roosta-conflarian",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-syst3mfailur-satanic-ring-phat-eos-diety-freequency-remix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-telek-goodoldcollingwoodforever",
+    "reason": "black frame (mean=6.2, max=16)"
+  },
+  {
+    "presetId": "cotc-telek-goodoldcollingwoodforever-isosceles-edit",
+    "reason": "black frame (mean=13.0, max=13)"
+  },
+  {
+    "presetId": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-the-ng-stahlregen-boz-eos-geiss-phat-rovastar-zylot-flexi-martin-fishbrain-machine-code-in-",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tonymilkdrop-tricolors-flexi-true-meaning-alien-complex-isosceles-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-acid-astralmatics",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-astral-calculations-5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-astralacid",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-circular-unlogic",
+    "reason": "black frame (mean=0.2, max=14)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-diffused-mana-pattern-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-firestar",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-flameorb",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-neon-algebra",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-tripgnosis-triadular",
+    "reason": "black frame (mean=7.3, max=28)"
+  },
+  {
+    "presetId": "cotc-undermines-him-in-the-subtlest-ways-mega-schoob-1d-serial-flashline-projection-creator",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-undulate-harque-amaz-inge",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-undulate-harque-brit-tlee",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-undulate-harque-pain-tthe",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-undulate-harque-zing",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-va-ultramix-381",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-va-ultramix-430",
+    "reason": "flat frame (mean=254.6, std=1.1)"
+  },
+  {
+    "presetId": "cotc-va-ultramix2-156-1",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "cotc-va-ultramix2-296-1",
+    "reason": "black frame (mean=0.5, max=8)"
+  },
+  {
+    "presetId": "cotc-waltra-furry-synthesis-isosceles-edit2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-waltra-galactic-super-perspective",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-waltra-monodream",
+    "reason": "black frame (mean=0.4, max=255)"
+  },
+  {
+    "presetId": "cotc-waltra-time-travel",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-xtramartin-3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-xtramartin-459",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-zylot-and-fishbrain-i-am-the-witch",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-zylot-crystal-ball",
+    "reason": "black frame (mean=0.2, max=26)"
+  },
+  {
+    "presetId": "cotc-zylot-crystalball-aren-tfractals",
+    "reason": "black frame (mean=0.4, max=19)"
+  },
+  {
+    "presetId": "cotc-zylot-shifter-tartan-silent-heaven-mix",
+    "reason": "black frame (mean=2.4, max=30)"
+  },
+  {
+    "presetId": "cotc-zylot-the-collective-unconcious-jelly-5-5",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "cotc-zylot-visionarie-geiss-aspect-ratio-fix-mash0000-infinitely-dense-massless-particle",
+    "reason": "black frame (mean=0.1, max=16)"
+  },
+  {
+    "presetId": "dbleja-hovering-over-mars",
+    "reason": "flat frame (mean=255.0, std=0.1)"
+  },
+  {
+    "presetId": "dbleja-hovering-over-pluto",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "dbleja-inside-the-tree-blue-mix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "eo-s-multisphere-01-b-phat-ra-mix",
+    "reason": "black frame (mean=0.1, max=74)"
+  },
+  {
+    "presetId": "eo-s-phat-cool-bug",
+    "reason": "black frame (mean=2.0, max=31)"
+  },
+  {
+    "presetId": "eo-s-phat-cool-bug-v2-krash-s-beat-detection",
+    "reason": "black frame (mean=1.7, max=30)"
+  },
+  {
+    "presetId": "eo-s-phat-shipwreaked-v3",
+    "reason": "black frame (mean=0.2, max=11)"
+  },
+  {
+    "presetId": "eo-s-phat-spectrum-bubble-new-colors-v2",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "eo-s-phat-the-lights-at-night-spikes",
+    "reason": "black frame (mean=0.0, max=1)"
+  },
+  {
+    "presetId": "eo-s-repeater-08-rave-on-a-lot-of-acid-and-some-k",
+    "reason": "black frame (mean=0.5, max=19)"
+  },
+  {
+    "presetId": "eo-s-repeater-13-definitive",
+    "reason": "black frame (mean=0.7, max=23)"
+  },
+  {
+    "presetId": "eos-heater-core-c",
+    "reason": "black frame (mean=1.2, max=13)"
+  },
+  {
+    "presetId": "eos-matrix-cube-c",
+    "reason": "black frame (mean=6.6, max=26)"
+  },
+  {
+    "presetId": "eos-phat-linear-clouds-v2",
+    "reason": "black frame (mean=0.2, max=12)"
+  },
+  {
+    "presetId": "eosphat-shipwreakedv5b",
+    "reason": "black frame (mean=3.2, max=23)"
+  },
+  {
+    "presetId": "evet-responsive-acid-iris",
+    "reason": "flat frame (mean=0.5, std=1.2)"
+  },
+  {
+    "presetId": "fishbrain-geiss-witchcraft-glow-mix",
+    "reason": "black frame (mean=0.2, max=19)"
+  },
+  {
+    "presetId": "fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin",
+    "reason": "flat frame (mean=149.7, std=1.0)"
+  },
+  {
+    "presetId": "fishbrain-when-robots-take-over-the-world",
+    "reason": "black frame (mean=2.3, max=25)"
+  },
+  {
+    "presetId": "fishbrain-witchcraft",
+    "reason": "black frame (mean=0.2, max=33)"
+  },
+  {
+    "presetId": "fishbrain-witchcraft-necromancer-remix-phat-edit-v3",
+    "reason": "black frame (mean=0.0, max=19)"
+  },
+  {
+    "presetId": "flexi-100-shader-fractal-origami-edit",
+    "reason": "flat frame (mean=149.7, std=0.0)"
+  },
+  {
+    "presetId": "flexi-3d-mosaic-glass-test-mash0000-9d-tuscan-slop-ram",
+    "reason": "black frame (mean=0.2, max=6)"
+  },
+  {
+    "presetId": "flexi-adamfx-hexcollie-moebius-morbid-vision-crack",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-black-holes-sucking-fractals-for-breakfast",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-bouncing-balls-grafitti-mix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-braggadocio",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-can-t-think-of-mosaic-cages",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery",
+    "reason": "flat frame (mean=254.9, std=0.2)"
+  },
+  {
+    "presetId": "flexi-geiss-pogo-cubes-on-tokamak-matter-bccn-jelly-v4",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-geiss-pogo-cubes-on-tokamak-matter-jelly-5-55",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-geiss-tokamak-fallout-repellor",
+    "reason": "flat frame (mean=59.6, std=1.4)"
+  },
+  {
+    "presetId": "flexi-gravitational-chaos",
+    "reason": "flat frame (mean=178.6, std=0.3)"
+  },
+  {
+    "presetId": "flexi-infused-with-the-spiral-bc-cn-jelly-v4",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-intensive-shader-fractal",
+    "reason": "black frame (mean=29.1, max=29)"
+  },
+  {
+    "presetId": "flexi-intensive-shader-fractal-suksma-comp-shader-mix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "flexi-martin-geiss-dedicated-to-the-sherwin-maxawow",
+    "reason": "flat frame (mean=105.3, std=0.0)"
+  },
+  {
+    "presetId": "flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-martin-tunnel-of-supraschismatika",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-meta4free-3-my-time-is-not-your-time",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-mindblob-2-0-bc-cn-jelly-4",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-mom-why-the-sky-looks-different-today",
+    "reason": "black frame (mean=29.1, max=29)"
+  },
+  {
+    "presetId": "flexi-nitorami-beat-explorer-cn-bc-jelly-4",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-oldschool-tree",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-phat-fractal-star-child-restless",
+    "reason": "black frame (mean=0.4, max=30)"
+  },
+  {
+    "presetId": "flexi-stahlregen-a-car-crash-you-can-t-defocus-2",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-stahlregen-jelly-strike",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "flexi-the-bouncer-and-the-crasher-random-mashup",
+    "reason": "flat frame (mean=254.8, std=1.8)"
+  },
+  {
+    "presetId": "flexi-trickster-zenarchy",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "fumbling-foo-flexi-martin-orb-star-forge-v16",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "fvese-the-tunnel-final-stage-mix",
+    "reason": "black frame (mean=1.4, max=28)"
+  },
+  {
+    "presetId": "fvese-zoom-effects-remix-3",
+    "reason": "black frame (mean=0.7, max=32)"
+  },
+  {
+    "presetId": "geiss-experimental-spiral-artifact-filament-mix-scallop-mix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides",
+    "reason": "black frame (mean=0.1, max=70)"
+  },
+  {
+    "presetId": "geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides-2",
+    "reason": "black frame (mean=0.1, max=106)"
+  },
+  {
+    "presetId": "geiss-liquid-beats-janky-ripple-warp-reflecto",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "geiss-mega-swirl-2",
+    "reason": "black frame (mean=0.8, max=25)"
+  },
+  {
+    "presetId": "geiss-mega-swirl-3",
+    "reason": "black frame (mean=0.8, max=30)"
+  },
+  {
+    "presetId": "geiss-microcheckers-2",
+    "reason": "flat frame (mean=254.3, std=2.5)"
+  },
+  {
+    "presetId": "geiss-octopus",
+    "reason": "black frame (mean=2.6, max=28)"
+  },
+  {
+    "presetId": "geiss-reducto-ad-nauseum",
+    "reason": "duplicate of geiss-reaction-diffusion-3"
+  },
+  {
+    "presetId": "geiss-rose-3",
+    "reason": "flat frame (mean=254.9, std=1.4)"
+  },
+  {
+    "presetId": "geiss-rose-4-shifted-tiles",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "geiss-skin-dots-multi-layer-3-pig-fuck-jembe-acid-wretch-dildonic",
+    "reason": "black frame (mean=0.7, max=26)"
+  },
+  {
+    "presetId": "geiss-spiral-artifact",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "geiss-spiral-artifact-filament-mix-beat-dots-mix",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "goody-aurora-totalis",
+    "reason": "flat frame (mean=249.9, std=0.5)"
+  },
+  {
+    "presetId": "goody-clouded-reason-revisited",
+    "reason": "flat frame (mean=237.0, std=0.2)"
+  },
+  {
+    "presetId": "goody-lsd-zoomtunnel",
+    "reason": "black frame (mean=3.3, max=17)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-aqua-lumens",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-ocular-anima",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-need-desire-remix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "goody-vertigo-revisited",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "idiot-9-7-02-remix-2",
+    "reason": "black frame (mean=1.8, max=14)"
+  },
+  {
+    "presetId": "idiot-tentacle-dreams",
+    "reason": "flat frame (mean=1.2, std=2.0)"
+  },
+  {
+    "presetId": "idiot-what-is",
+    "reason": "black frame (mean=1.1, max=12)"
+  },
+  {
+    "presetId": "krash-digital-flame",
+    "reason": "black frame (mean=0.9, max=25)"
+  },
+  {
+    "presetId": "krash-techno-rhythmic-mantas-painterly",
+    "reason": "flat frame (mean=159.9, std=1.2)"
+  },
+  {
+    "presetId": "krash-vinyl-disk",
+    "reason": "black frame (mean=1.0, max=15)"
+  },
+  {
+    "presetId": "krash-war-machine-shifting-complexity-mix",
+    "reason": "black frame (mean=1.1, max=15)"
+  },
+  {
+    "presetId": "lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "luxxx-melt-ur-face-i",
+    "reason": "flat frame (mean=105.3, std=0.0)"
+  },
+  {
+    "presetId": "martin-adrift-on-a-dead-planet-lard-mix",
+    "reason": "black frame (mean=0.8, max=10)"
+  },
+  {
+    "presetId": "martin-adrift-on-a-dead-planet-lite",
+    "reason": "black frame (mean=1.5, max=14)"
+  },
+  {
+    "presetId": "martin-axon3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-basal-ganglion",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-cherry-brain-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-cope-laser-dome",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-crystal-palace",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-crystal-palace-nz",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-deep-blue",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-elusive-impressions-mix1",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-extreme-heat",
+    "reason": "black frame (mean=1.3, max=23)"
+  },
+  {
+    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-flexi-laser-dome-bipolar-focus-intent",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-gate-to-moria",
+    "reason": "black frame (mean=0.3, max=9)"
+  },
+  {
+    "presetId": "martin-golden-mirror",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-liquid-gold",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-mandelbox-explorer-high-speed-demo-version",
+    "reason": "flat frame (mean=210.1, std=1.6)"
+  },
+  {
+    "presetId": "martin-pendulum-in-brass-ps3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-purple-pulsator",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-rogue-wave-ps2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-rogue-wave-ps3",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "martin-stahlregen-martin-in-da-mash-12",
+    "reason": "flat frame (mean=149.7, std=0.0)"
+  },
+  {
+    "presetId": "martin-unholy-amulet",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz",
+    "reason": "black frame (mean=0.0, max=41)"
+  },
+  {
+    "presetId": "mig-008",
+    "reason": "black frame (mean=0.0, max=17)"
+  },
+  {
+    "presetId": "mig-colorful9",
+    "reason": "flat frame (mean=253.9, std=2.3)"
+  },
+  {
+    "presetId": "mstress-acoustic-nerve-impulses-primary-colors-of-sound-mix",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "mstress-scattered-gravity-smoked-mix",
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "new-milktrend-trend-setters-amandio-c-flexi-ft-adamfx-n-stahlregen-martin-ufoz-identified",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "orb-acid-cycle-gas-giant",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "orb-acid-in-my-eyes",
+    "reason": "flat frame (mean=254.3, std=1.6)"
+  },
+  {
+    "presetId": "orb-solar-radiation",
+    "reason": "black frame (mean=4.1, max=24)"
+  },
+  {
+    "presetId": "orb-solar-sail",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "phat-eo-s-data-swimmer",
+    "reason": "flat frame (mean=254.0, std=2.0)"
+  },
+  {
+    "presetId": "phat-eo-s-eyes-spiral-mix",
+    "reason": "black frame (mean=0.3, max=44)"
+  },
+  {
+    "presetId": "phat-eo-s-our-own-personal-demon",
+    "reason": "black frame (mean=0.6, max=15)"
+  },
+  {
+    "presetId": "phat-eo-s-rainbow-bubble-mid3-fuck-me-dood",
+    "reason": "preset did not apply (active: phat-eo-s-rainbow-bubble-mid3-f-me-dood) for phat-eo-s-rainbow-bubble-mid3-fuck-me-dood."
+  },
+  {
+    "presetId": "phat-eo-s-single-cel-angel-birth",
+    "reason": "black frame (mean=0.4, max=14)"
+  },
+  {
+    "presetId": "phat-it-sjustnumbers",
+    "reason": "flat frame (mean=254.8, std=1.0)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-krash-i-hope-someone-will-see-this-triping-v2b",
+    "reason": "black frame (mean=0.8, max=27)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-square-faces-v2-alt-colours",
+    "reason": "black frame (mean=1.0, max=24)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-strate-lines",
+    "reason": "black frame (mean=0.8, max=25)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-trippy-rotation-weird-boxs-mix",
+    "reason": "black frame (mean=1.4, max=22)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-work-with-lines",
+    "reason": "black frame (mean=0.6, max=17)"
+  },
+  {
+    "presetId": "phat-zylot-eo-s-work-with-lines-alt",
+    "reason": "black frame (mean=0.7, max=26)"
+  },
+  {
+    "presetId": "phat-zylot-eos-trippy-rotation",
+    "reason": "black frame (mean=0.6, max=16)"
+  },
+  {
+    "presetId": "pieturp-sunflare",
+    "reason": "black frame (mean=22.4, max=22)"
+  },
+  {
+    "presetId": "redi-jedi-off-the-fadar",
+    "reason": "black frame (mean=1.6, max=21)"
+  },
+  {
+    "presetId": "redi-jedi-off-the-fadar-no-sweeps-or-bleeps-but-alotta-creeps",
+    "reason": "black frame (mean=2.3, max=15)"
+  },
+  {
+    "presetId": "reenen-geiss-soft-triple-feedback",
+    "reason": "black frame (mean=0.7, max=10)"
+  },
+  {
+    "presetId": "reenen-geiss-triple-feedback-phat-edit",
+    "reason": "flat frame (mean=254.7, std=0.8)"
+  },
+  {
+    "presetId": "rovastar-geiss-hurricane-nightmare-gold-chrome-mix",
+    "reason": "black frame (mean=0.2, max=18)"
+  },
+  {
+    "presetId": "rovastar-halcyon-dreams-3",
+    "reason": "flat frame (mean=1.5, std=2.4)"
+  },
+  {
+    "presetId": "rovastar-harlequin-s-fractal-encounter",
+    "reason": "black frame (mean=1.0, max=1)"
+  },
+  {
+    "presetId": "rovastar-jester-s-calling-2",
+    "reason": "black frame (mean=1.4, max=30)"
+  },
+  {
+    "presetId": "rovastar-oozing-resistance",
+    "reason": "black frame (mean=0.9, max=28)"
+  },
+  {
+    "presetId": "rovastar-solarized-space",
+    "reason": "black frame (mean=1.4, max=11)"
+  },
+  {
+    "presetId": "rovastar-sunflower-passion",
+    "reason": "black frame (mean=0.9, max=25)"
+  },
+  {
+    "presetId": "rovastar-sunflower-passion-simple-mix",
+    "reason": "flat frame (mean=1.1, std=1.7)"
+  },
+  {
+    "presetId": "rovastar-sunflower-passion-simple-mix-phat-eo-s-werid-angle-mix",
+    "reason": "flat frame (mean=1.2, std=1.9)"
+  },
+  {
+    "presetId": "rovastar-tripmaker-space-trip-mix",
+    "reason": "black frame (mean=9.3, max=27)"
+  },
+  {
+    "presetId": "rovastar-trippy-sperm-jelly",
+    "reason": "black frame (mean=2.2, max=19)"
+  },
+  {
+    "presetId": "rovastar-voov-s-movement-after-dark-mix-painterly",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "rovastar-zylot-crystal-ball-many-visions-mix",
+    "reason": "black frame (mean=4.4, max=18)"
+  },
+  {
+    "presetId": "royal-mashup-177",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "royal-mashup-197",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "schglasmia-danqueer",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "shifter-dark-tides-eo-s-phat-whisps-of-doom-mix",
+    "reason": "flat frame (mean=0.6, std=1.3)"
+  },
+  {
     "presetId": "shifter-digi",
-    "reason": "black frame (mean=0.2, max=13)"
+    "reason": "black frame (mean=0.1, max=2)"
+  },
+  {
+    "presetId": "shifter-eo-s-phat-fractical-dancer-inside-the-neural-net",
+    "reason": "black frame (mean=0.6, max=20)"
+  },
+  {
+    "presetId": "shifter-geiss-neon-pulse-glow-mix",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "shifter-mandala",
+    "reason": "black frame (mean=1.5, max=12)"
+  },
+  {
+    "presetId": "shifter-robotopia",
+    "reason": "black frame (mean=0.3, max=4)"
+  },
+  {
+    "presetId": "shifter-snakeskin",
+    "reason": "black frame (mean=2.0, max=13)"
+  },
+  {
+    "presetId": "shifter-spectro",
+    "reason": "black frame (mean=14.6, max=31)"
+  },
+  {
+    "presetId": "shifter-spills-blender-krash-beatdetect-mash0000-here-comb-your-hair-with-this-planet",
+    "reason": "black frame (mean=0.0, max=1)"
+  },
+  {
+    "presetId": "shifter-spincycle-remix-love-at-home-electroplasmic-pissbowel-roam3",
+    "reason": "flat frame (mean=208.6, std=1.4)"
+  },
+  {
+    "presetId": "stahlregen-dots-pixels-blocky-jelly-v2",
+    "reason": "flat frame (mean=254.9, std=0.4)"
+  },
+  {
+    "presetId": "stahlregen-dots-pixels-blocky-reverse-jelly-v3",
+    "reason": "flat frame (mean=254.0, std=0.5)"
+  },
+  {
+    "presetId": "stahlregen-eo-s-flexi-phat-rovastar-zylot-screenspace-fractopia-rmx",
+    "reason": "flat frame (mean=105.3, std=0.0)"
+  },
+  {
+    "presetId": "stahlregen-old-school-baby-spiral-ornament-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "stahlregen-spiral-beats-fluctuating-flowers",
+    "reason": "black frame (mean=3.6, max=21)"
+  },
+  {
+    "presetId": "stahlregen-spiral-hundertwasser-2-painterly",
+    "reason": "flat frame (mean=255.0, std=0.0)"
+  },
+  {
+    "presetId": "stahlregen-unchained-psychedelic-flower-kung-fu-corrupt",
+    "reason": "flat frame (mean=193.4, std=0.0)"
+  },
+  {
+    "presetId": "studio-music-and-unchained-rapid-alteration",
+    "reason": "black frame (mean=2.9, max=28)"
+  },
+  {
+    "presetId": "suksma-aderrasi-martin-raron-geiss-are-you-mad-at-me",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "suksma-feign-shoulder-concern-when-i-should-be-executed-everything-is-eternally-shrinking",
+    "reason": "black frame (mean=0.1, max=95)"
+  },
+  {
+    "presetId": "suksma-gaeomaentaec-log-smell-2-steaming-wienies2",
+    "reason": "black frame (mean=0.0, max=1)"
+  },
+  {
+    "presetId": "suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "telek-slow-thing-spiderman-mix",
+    "reason": "black frame (mean=7.2, max=18)"
+  },
+  {
+    "presetId": "unchained-cartoon-factory",
+    "reason": "flat frame (mean=77.9, std=0.4)"
+  },
+  {
+    "presetId": "unchained-in-memory-of-peg",
+    "reason": "flat frame (mean=233.5, std=0.5)"
+  },
+  {
+    "presetId": "unchained-making-a-science-of-it-2",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money",
+    "reason": "black frame (mean=0.0, max=0)"
+  },
+  {
+    "presetId": "wulfson-crumple-nth-power-mix",
+    "reason": "black frame (mean=14.3, max=21)"
+  },
+  {
+    "presetId": "yin-293-sonic-brainstorm-inner-state-group-experience-mix",
+    "reason": "flat frame (mean=249.8, std=2.4)"
+  },
+  {
+    "presetId": "zylot-building-block-of-color-bitcore-tweak",
+    "reason": "black frame (mean=0.9, max=5)"
   }
 ]

--- a/public/preset-meta.json
+++ b/public/preset-meta.json
@@ -4923,5 +4923,2598 @@
   "yin-385-magic-ride-distance-based-hue": [
     "yin - 385 - Magic ride (distance based hue)",
     "yin"
+  ],
+  "000-empty": ["000 Empty", ""],
+  "001-line": ["001 Line", ""],
+  "100-square": ["100 Square", ""],
+  "101-per_frame": ["101 Per Frame", ""],
+  "102-per_frame3": ["102 Per Frame3", ""],
+  "103-multiple-eqn": ["103 Multiple Eqn", ""],
+  "104-continued-eqn": ["104 Continued Eqn", ""],
+  "105-per_frame_init": ["105 Per Frame Init", ""],
+  "110-per_pixel": ["110 Per Pixel", ""],
+  "200-wave": ["200 Wave", ""],
+  "201-wave": ["201 Wave", ""],
+  "202-wave": ["202 Wave", ""],
+  "203-wave": ["203 Wave", ""],
+  "204-wave": ["204 Wave", ""],
+  "205-wave": ["205 Wave", ""],
+  "206-wave": ["206 Wave", ""],
+  "207-wave": ["207 Wave", ""],
+  "208-wave": ["208 Wave", ""],
+  "209-wave": ["209 Wave", ""],
+  "210-wave": ["210 Wave", ""],
+  "211-wave": ["211 Wave", ""],
+  "212-wave": ["212 Wave", ""],
+  "213-wave": ["213 Wave", ""],
+  "214-wave": ["214 Wave", ""],
+  "215-wave": ["215 Wave", ""],
+  "240-wave-smooth-00": ["240 Wave Smooth 00", ""],
+  "241-wave-smooth-01": ["241 Wave Smooth 01", ""],
+  "242-wave-smooth-80": ["242 Wave Smooth 80", ""],
+  "243-wave-smooth-90": ["243 Wave Smooth 90", ""],
+  "244-wave-smooth-99": ["244 Wave Smooth 99", ""],
+  "245-wave-smooth-100": ["245 Wave Smooth 100", ""],
+  "250-wavecode": ["250 Wavecode", ""],
+  "251-wavecode-spectrum": ["251 Wavecode Spectrum", ""],
+  "252-wavecode-spectrum2": ["252 Wavecode Spectrum2", ""],
+  "260-compshader-noise_lq": ["260 Compshader Noise Lq", ""],
+  "261-compshader-noisevol_lq": ["261 Compshader Noisevol Lq", ""],
+  "300-beatdetect-bassmidtreb": ["300 Beatdetect Bassmidtreb", ""],
+  "cotc-suksma-passive-probabilistic-roaming-coin-gods": [
+    "suksma - passive probabilistic roaming coin gods",
+    "suksma"
+  ],
+  "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-phat-zyl": [
+    "BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs reaction diffusion + Another Flexi + Fishbrain  + Phat Zylot 8",
+    "BEST OF ADAMFX 2 Flexi + Geiss"
+  ],
+  "cotc-royal-mashup-291": ["$$$ Royal - Mashup (291)", "$$$ Royal"],
+  "cotc-geiss-skin-dots-10b": ["Geiss - Skin Dots 10b", "Geiss"],
+  "cotc-beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-an": [
+    "beta106i - Brilliance (Space-Time Breaking) - mash0000 - it's 2009 and you haven't replaced your analog tv with digital",
+    "beta106i"
+  ],
+  "cotc-royal-mashup-131": ["$$$ Royal - Mashup (131)", "$$$ Royal"],
+  "cotc-stahlregen-geiss-martin-tiger-no5-random-color-metal": [
+    "Stahlregen & Geiss + martin - Tiger No5 (random color metal)",
+    "Stahlregen & Geiss + martin"
+  ],
+  "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-eos-angels-of-decay-19-hexocollie-6": [
+    "Including Adam FX 2 flexi + fishbrain - operation fatcap + Eos Angels of Decay 19 + Hexocollie 6",
+    "Including Adam FX 2 flexi + fishbrain"
+  ],
+  "cotc-isosceles-mashup25": ["Isosceles mashup25", ""],
+  "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-hexocollie-flexi-adamfx-": [
+    "A Feature Preset Master Exclusive ORB - Planetary Alignment Acidburn - Hexocollie, Flexi AdamFX,Martin  b",
+    "A Feature Preset Master Exclusive ORB"
+  ],
+  "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-5-5": [
+    "Stahlregen & Geiss + Rovastar - Fields of Flowers (Jelly 5-5)",
+    "Stahlregen & Geiss + Rovastar"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-geiss-and-zylot-aurora-industrialis": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Geiss and Zylot + Aurora Industrialis + ORb acid cycle  + triptrap",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2": [
+    "NeW Adam Master Mashup FX 2 Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2)",
+    "NeW Adam Master Mashup FX 2 Geiss and Zylot"
+  ],
+  "cotc-suksma-daryl-feels-my-hellish-lonliness": [
+    "suksma - daryl feels my hellish lonliness",
+    "suksma"
+  ],
+  "cotc-mashup-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-flexi-and": [
+    "Mashup ADAMFX 2 Flexi + Geiss - Bipolar vs reaction diffusion + Another Flexi + Fishbrain  + Flexi And ADAMFX 10",
+    "Mashup ADAMFX 2 Flexi + Geiss"
+  ],
+  "cotc-zylot-visionarie-geiss-aspect-ratio-fix-mash0000-infinitely-dense-massless-particle": [
+    "Zylot - Visionarie (geiss aspect ratio fix) - mash0000 - infinitely dense massless particle",
+    "Zylot"
+  ],
+  "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot": [
+    "suksma - adam martin geiss - come into my closet of rot",
+    "suksma"
+  ],
+  "cotc-isosceles-mashup24": ["Isosceles mashup24", ""],
+  "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2-amazing-mas": [
+    "NeW Adam Master Mashup FX 2 Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2) AMAZING MASUP Various Workwithlines 8",
+    "NeW Adam Master Mashup FX 2 Geiss and Zylot"
+  ],
+  "cotc-jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue": [
+    "Jim & Geiss - Bass Zoom Symmetry - mash0000 - the god damn pen is rrrroyal blue",
+    "Jim & Geiss"
+  ],
+  "cotc-geiss-three-kinds-of-amphetamines-mash0000-jester-od-s-on-back-alley-clown-juice": [
+    "Geiss - Three Kinds Of Amphetamines - mash0000 - jester OD's on back alley clown juice",
+    "Geiss"
+  ],
+  "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot6": [
+    "BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs reaction diffusion + Aderassi Phat Zylot6",
+    "BEST OF ADAMFX 2 Flexi + Geiss"
+  ],
+  "cotc-suksma-jim-geiss-inverse-bass-zoom-mash0000-aim-your-scream-toward-the-avalanche": [
+    "suksma - Jim & Geiss - Inverse Bass Zoom - mash0000 - aim your scream toward the avalanche",
+    "suksma"
+  ],
+  "cotc-geiss-reaction-diffusion-3-janky-diffusion-effect-warp": [
+    "Geiss - Reaction Diffusion 3 (janky diffusion effect warp)",
+    "Geiss"
+  ],
+  "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer": [
+    "Geiss - Tadpole Hunter - mash0000 - humiliate the god with spencer",
+    "Geiss"
+  ],
+  "cotc-geiss-skin-dots-10c": ["Geiss - Skin Dots 10c", "Geiss"],
+  "cotc-halfbreak-caramelize-serpentine": [
+    "Halfbreak - Caramelize Serpentine",
+    "Halfbreak"
+  ],
+  "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx": [
+    "Stahlregen & Geiss - Tiger No5 (MashUp 16 - Seizure-Inducing Confetti Kaleidoscope RMX)",
+    "Stahlregen & Geiss"
+  ],
+  "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback": [
+    "Halfbreak + Flexi and goody + geiss + benski - Sparkly LSB Feedback'",
+    "Halfbreak + Flexi and goody + geiss + benski"
+  ],
+  "cotc-suksma-bmelgren-hungry-orbits-mash0000-sir-i-can-t-help-you-over-here-isosceles-edit": [
+    "suksma - Bmelgren - Hungry Orbits - mash0000 - sir, i can't help you over here",
+    "suksma"
+  ],
+  "cotc-geiss-skin-dots-11b": ["Geiss - Skin Dots 11b", "Geiss"],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Swelling Spiral",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-luxxx-geiss-game-of-life-4": [
+    "LuxXx - Geiss - Game of Life 4",
+    "LuxXx"
+  ],
+  "cotc-royal-mashup-130": ["$$$ Royal - Mashup (130)", "$$$ Royal"],
+  "cotc-geiss-reaction-diffusion-3-janky-ripples-warp": [
+    "Geiss - Reaction Diffusion 3 (janky ripples warp)",
+    "Geiss"
+  ],
+  "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin": [
+    "Stahlregen & Geiss + EoS + Martin + Rovastar - Halcyon Jelly Skin",
+    "Stahlregen & Geiss + EoS + Martin + Rovastar"
+  ],
+  "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill": [
+    "Hexcollie, Flexi n Geiss - Caught in the vortex of the mystery pill",
+    "Hexcollie, Flexi n Geiss"
+  ],
+  "cotc-halfbreak-last-in-nebula": ["Halfbreak - Last in Nebula", "Halfbreak"],
+  "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx": [
+    "A HD ADAMFX Creation !!FT  Martin + flexi +  Rovastar MDropFX Collaboration E Adam HD INFECTIONFX",
+    ""
+  ],
+  "cotc-isosceles-mashup02": ["Isosceles mashup02", ""],
+  "cotc-rovastar-unchained-life-after-pie-remix-girl-powa": [
+    "Rovastar + Unchained - Life After Pie (Remix) girl powa",
+    "Rovastar + Unchained"
+  ],
+  "cotc-geiss-reaction-diffusion-2": ["Geiss - Reaction Diffusion 2", "Geiss"],
+  "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless": [
+    "Hexcollie - Melodic pulsing leds - mash0000 - vegas doesn't make life less pointless",
+    "Hexcollie"
+  ],
+  "cotc-a-bit-storm-effected-by-adamfx-2-shadowharlequin-bit-storm-ft-dancing-petals": [
+    "A Bit Storm Effected by AdamFX 2 shadowharlequin - bit storm Ft dancing petals",
+    "A Bit Storm Effected by AdamFX 2 shadowharlequin"
+  ],
+  "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs": [
+    "shifter - crosshatch colony beta6 - loved to death by nymphs",
+    "shifter"
+  ],
+  "cotc-royal-mashup-155": ["$$$ Royal - Mashup (155)", "$$$ Royal"],
+  "cotc-royal-mashup-157": ["$$$ Royal - Mashup (157)", "$$$ Royal"],
+  "cotc-tripgnosis-acid-astralmatics": [
+    "Tripgnosis - Acid Astralmatics",
+    "Tripgnosis"
+  ],
+  "cotc-stahlregen-fishbrain-geiss-witchcraft-dense-2": [
+    "Stahlregen & fishbrain + Geiss - Witchcraft (Dense)2",
+    "Stahlregen & fishbrain + Geiss"
+  ],
+  "cotc-suksma-hypnocinagenic-drift": [
+    "suksma - hypnocinagenic drift",
+    "suksma"
+  ],
+  "cotc-stahlregen-fishbrain-geiss-witchcraft-dense": [
+    "Stahlregen & fishbrain + Geiss - Witchcraft (Dense)",
+    "Stahlregen & fishbrain + Geiss"
+  ],
+  "cotc-stahlregen-fishbrain-geiss-witchcraft-cents": [
+    "Stahlregen & fishbrain + Geiss - Witchcraft (cents)",
+    "Stahlregen & fishbrain + Geiss"
+  ],
+  "cotc-suksma-my-malice-tears-space-time-fabric-putting-black-holes-to-shame": [
+    "suksma - my malice tears space time fabric putting black holes to shame",
+    "suksma"
+  ],
+  "cotc-fishbrain-geiss-witchcraft-glow-mix": [
+    "fiShbRaiN + geiss - witchcraft (Glow Mix)",
+    "fiShbRaiN + geiss"
+  ],
+  "cotc-234": ["234", ""],
+  "cotc-suksma-fig-leaves-can-t-cover-that-much": [
+    "suksma - fig leaves can't cover that much",
+    "suksma"
+  ],
+  "cotc-fishbrain-quark-matrix": ["fiShbRaiN - quark matrix", "fiShbRaiN"],
+  "cotc-tripgnosis-diffused-mana-pattern-2": [
+    "Tripgnosis - Diffused Mana pattern 2",
+    "Tripgnosis"
+  ],
+  "cotc-suksma-cuneinformal-basilihistrionix": [
+    "suksma - cuneinformal basilihistrionix",
+    "suksma"
+  ],
+  "cotc-zylot-and-fishbrain-i-am-the-witch": [
+    "Zylot and FishBrain - I am the witch",
+    "Zylot and FishBrain"
+  ],
+  "cotc-tripgnosis-astral-calculations-5": [
+    "Tripgnosis - Astral Calculations 5",
+    "Tripgnosis"
+  ],
+  "cotc-the-ng-martin-flexi-witchcraft-when-lines-get-desperate-isosceles-edit": [
+    "The NG + martin + Flexi - witchcraft (When Lines Get Desperate)",
+    "The NG + martin + Flexi"
+  ],
+  "cotc-suksma-my-malice-tears-space-time-fabric-putting-black-holes-to-shame-roam2": [
+    "suksma - my malice tears space time fabric putting black holes to shame roam2",
+    "suksma"
+  ],
+  "cotc-suksma-descentive-maxhorroral-fences": [
+    "suksma - descentive maxhorroral fences",
+    "suksma"
+  ],
+  "cotc-suksma-indecision-about-how-to-die-decision-made": [
+    "suksma - indecision about how to die - decision made",
+    "suksma"
+  ],
+  "cotc-fishbrain-witchcraft-dmt-remix": [
+    "fiShbRaiN - witchcraft (DMT remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft": [
+    "Including Adam FX 2 flexi + fishbrain - operation fatcap + Fishbrain and WitchCraft",
+    "Including Adam FX 2 flexi + fishbrain"
+  ],
+  "cotc-fishbrain-flexi-martin-grafitti-tagging-witchcraft-must-be-overrated-demonlord-shaders-lamp": [
+    "fiShbRaiN, flexi + martin - grafitti tagging witchcraft must be overrated - demonlord shaders - lampshade hubrys",
+    "fiShbRaiN, flexi + martin"
+  ],
+  "cotc-repressed-americans-certain-of-spectral-diffucktion": [
+    "repressed americans - certain of spectral diffucktion",
+    "repressed americans"
+  ],
+  "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit": [
+    "fiShbRaiN - witchcraft (necromancer remix)_phat_edit",
+    "fiShbRaiN"
+  ],
+  "cotc-tripgnosis-neon-algebra": ["Tripgnosis - Neon Algebra", "Tripgnosis"],
+  "cotc-hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start": [
+    "Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It's a start",
+    "Hexcollie, Aderassi, BDRV, AdamFX n Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-01": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter 01]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-03": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter 03]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-05": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter 05]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-02": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter 02]",
+    "Flexi"
+  ],
+  "cotc-amandio-c-ifs-01": ["amandio c - IFS 01", "amandio c"],
+  "cotc-flexi-disruptor-wolfram-s-rule-90": [
+    "Flexi - disruptor [wolfram's rule 90]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-04": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter 04]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-on": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter ON]",
+    "Flexi"
+  ],
+  "cotc-amandio-c-sierpinsky-s-triangle": [
+    "amandio c - Sierpinsky's triangle",
+    "amandio c"
+  ],
+  "cotc-flexi-wolfram-s-rule-110-rise-of-the-log-attack": [
+    "Flexi - wolfram's rule 110 [rise of the log attack]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-110-so-call-the-police": [
+    "Flexi - disruptor [wolfram's rule 110 so call the police;]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter": [
+    "Flexi - disruptor [wolfram's rule 90 satanic teleprompter]",
+    "Flexi"
+  ],
+  "cotc-flexi-wolfram-s-rule-90-rise-of-the-log-attack": [
+    "Flexi - wolfram's rule 90 [rise of the log attack]",
+    "Flexi"
+  ],
+  "cotc-flexi-disruptor-wolfram-s-rule-110-satanic-teleprompter-05": [
+    "Flexi - disruptor [wolfram's rule 110 satanic teleprompter 05]",
+    "Flexi"
+  ],
+  "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors2": [
+    "suksma - now for only $19-95, you can pray to a whole array of saviors2",
+    "suksma"
+  ],
+  "cotc-suksma-enough-strange-candles-to-lay": [
+    "suksma - enough strange candles to lay",
+    "suksma"
+  ],
+  "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors": [
+    "suksma - now for only $19-95, you can pray to a whole array of saviors",
+    "suksma"
+  ],
+  "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy2": [
+    "suksma - aaron funcking god and his mod file savvy2",
+    "suksma"
+  ],
+  "cotc-shadowharlequin-crystal-liquid-eos-phat-the-lights-at-night-spikes": [
+    "ShadowHarlequin - Crystal Liquid - [EoS + Phat - the lights at night_spikes]",
+    "ShadowHarlequin"
+  ],
+  "cotc-suksma-squasm-minor-plot-frugal-koonut-kalifee": [
+    "suksma - squasm minor plot frugal koonut kalifee",
+    "suksma"
+  ],
+  "cotc-suksma-camden-defib-lancaster-tucker-s-neck": [
+    "suksma - camden defib lancaster tucker's neck",
+    "suksma"
+  ],
+  "cotc-shifter-bronchiole-eos-phat-edit-tethered": [
+    "shifter - bronchiole (EoS+Phat edit) tethered",
+    "shifter"
+  ],
+  "cotc-eos-phat-fractical-dancer-light-in-the-distance": [
+    "EoS+Phat Fractical_dancer - light in the distance",
+    "EoS+Phat Fractical_dancer"
+  ],
+  "cotc-suksma-frustratingly-incomplete-wasteland": [
+    "suksma - frustratingly incomplete wasteland",
+    "suksma"
+  ],
+  "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy": [
+    "suksma - aaron funcking god and his mod file savvy",
+    "suksma"
+  ],
+  "cotc-suksma-no-i-don-t-know-what-the-hell-it-is-but-i-m-eating-it-for-mind-lunch-demonlard-axed-": [
+    "suksma - no, i don't know what the hell it is, but i'm eating it for mind lunch - + demonlard - axed me to say some mc rhymes",
+    "suksma"
+  ],
+  "cotc-salvia-with-chip-harris-culminatorics": [
+    "salvia with chip harris - culminatorics",
+    "salvia with chip harris"
+  ],
+  "cotc-suksma-estrangedaholic-grandfather-cloques": [
+    "suksma - estrangedaholic grandfather cloques",
+    "suksma"
+  ],
+  "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit": [
+    "suksma - nothing to remember you by - logsmeltitdealtit",
+    "suksma"
+  ],
+  "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis": [
+    "bdrv + al EoS - Pulsecubebdrv etAL  Rmxmix 25 - qabalistic space invading homo-nutrient mouth swish transmuting 9d symbiosis - fed",
+    "bdrv + al EoS"
+  ],
+  "cotc-suksma-gapes-to-spelunkcide-dada-hate-art-isn-t-art": [
+    "suksma - gapes to spelunkcide - dada hate art isn't art",
+    "suksma"
+  ],
+  "cotc-fishbrain-submarine": ["fiShbRaiN - submarine", "fiShbRaiN"],
+  "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos-isosceles-edit": [
+    "suksma - this pain was saved for you - roams stephen hill hos",
+    "suksma"
+  ],
+  "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5": [
+    "rovastar + loadus + geiss - tone-mapped fractaldrop 4 (jelly v5)",
+    "rovastar + loadus + geiss"
+  ],
+  "cotc-fishbrain-submarine-exp-ame-med": [
+    "fiShbRaiN - submarine - exp ame med",
+    "fiShbRaiN"
+  ],
+  "cotc-beta106i-airhandler-last-breath-crab-hand": [
+    "beta106i - Airhandler (Last Breath - Crab Hand)",
+    "beta106i"
+  ],
+  "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j": [
+    "Starz in MilkHDFX - Stahlregen & Aderrasi + EoS + Geiss + Unchained + Zylot + Flexi + Martin + AdamFX J",
+    "Starz in MilkHDFX"
+  ],
+  "cotc-suksma-movement-within-the-trout-i-love-you-i-thank-you-it-meant-everything-don-t-forget": [
+    "suksma - movement within the trout - i love you, i thank you, it meant everything, don't forget",
+    "suksma"
+  ],
+  "cotc-new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-": [
+    "New Creation Sensation - AdamFx,Flexi,Amandio c n Martin - Star to Another World ft Hexocollie,ShadowH,Geiss n Fishbrain K",
+    "New Creation Sensation"
+  ],
+  "cotc-evet-esotic-krash-rolly-poly": [
+    "EVET + Esotic & Krash - Rolly Poly",
+    "EVET + Esotic & Krash"
+  ],
+  "cotc-nicklepenultim-roam": ["nicklepenultim roam", ""],
+  "cotc-nicklepenultim": ["nicklepenultim", ""],
+  "cotc-nicklepenultim-the-skuzzmuppet": [
+    "nicklepenultim - the skuzzmuppet",
+    "nicklepenultim"
+  ],
+  "cotc-camel-llama": ["camel llama", ""],
+  "cotc-suksma-at-the-root-of-open-the-graves": [
+    "suksma - at the root of - open the graves",
+    "suksma"
+  ],
+  "cotc-goody-on-mushrooms-hexcollie-n-fyornulis-cellsmosis-acid-angelated": [
+    "Goody on mushrooms + Hexcollie n Fyornulis - Cellsmosis (acid angelated)",
+    "Goody on mushrooms + Hexcollie n Fyornulis"
+  ],
+  "cotc-eos-angels-of-decay-01-soul": ["EoS - angels of decay 01 soul", "EoS"],
+  "cotc-amandio-c-iterative-squares-2": [
+    "amandio c - iterative - squares 2",
+    "amandio c"
+  ],
+  "cotc-suksma-truth-rarity-isosceles-edit08": [
+    "suksma - truth, rarity",
+    "suksma"
+  ],
+  "cotc-phat-eos-blah-smooth-colors-shadow-dancer": [
+    "Phat + EoS - blah_Smooth_Colors_Shadow_Dancer",
+    "Phat + EoS"
+  ],
+  "cotc-suksma-truth-rarity-isosceles-edit09": [
+    "suksma - truth, rarity",
+    "suksma"
+  ],
+  "cotc-amandio-c-iterative-squares-3": [
+    "amandio c - iterative - squares 3",
+    "amandio c"
+  ],
+  "cotc-eos-rename-2b": ["EoS - rename 2b", "EoS"],
+  "cotc-suksma-truth-rarity-isosceles-edit05": [
+    "suksma - truth, rarity",
+    "suksma"
+  ],
+  "cotc-rarian-rakista-cheap-angels-23": [
+    "rarian rakista - Cheap Angels 23",
+    "rarian rakista"
+  ],
+  "cotc-eos-multisphere-01-b-phat-ra-mix-nexus-roams-falling-through-9-time": [
+    "EoS - multisphere 01 B_Phat_Ra_mix nexus roams falling through 9 time",
+    "EoS"
+  ],
+  "cotc-amandio-c-iterative-squares-4": [
+    "amandio c - iterative - squares 4",
+    "amandio c"
+  ],
+  "cotc-suksma-foldrinymicull": ["suksma - foldrinymicull", "suksma"],
+  "cotc-eos-angels-of-decay": ["EoS - angels of decay", "EoS"],
+  "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher": [
+    "cope + flexi - strange attractor (jewellery tile mix) spher",
+    "cope + flexi"
+  ],
+  "cotc-suksma-truth-rarity-isosceles-edit02": [
+    "suksma - truth, rarity",
+    "suksma"
+  ],
+  "cotc-amandio-c-secret-garden-6": [
+    "amandio c - secret garden 6",
+    "amandio c"
+  ],
+  "cotc-amandio-c-orbitin-around-3": [
+    "amandio c - Orbitin' around 3",
+    "amandio c"
+  ],
+  "cotc-hexcollie-zylot-n-phat-it-has-to-be-wrong-to-have-this-much-fun-without-any-talent": [
+    "Hexcollie, Zylot n Phat - It has to be wrong to have this much fun without any talent",
+    "Hexcollie, Zylot n Phat"
+  ],
+  "cotc-shifter-lazerspecs-phat-edit": [
+    "shifter - lazerspecs_phat_edit",
+    "shifter"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-ghosts-gaseous": [
+    "EoS - glowsticks v2 04 music minimal - ghosts gaseous",
+    "EoS"
+  ],
+  "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova": [
+    "Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)3",
+    "Inside A Black Whole AdamFX 2 martin"
+  ],
+  "cotc-suksma-truth-rarity-isosceles-edit03": [
+    "suksma - truth, rarity",
+    "suksma"
+  ],
+  "cotc-amandio-c-secret-garden-7": [
+    "amandio c - secret garden 7",
+    "amandio c"
+  ],
+  "cotc-phat-eos-blah-smooth-colors-shadow-dancer-v2": [
+    "Phat + EoS - blah_Smooth_Colors_Shadow_Dancer_V2",
+    "Phat + EoS"
+  ],
+  "cotc-shifter-lazerspecs": ["shifter - lazerspecs", "shifter"],
+  "cotc-fishbrain-evolution-3d-phat-edit-v2": [
+    "fiShbRaiN - evolution (3d)_phat_edit_v2",
+    "fiShbRaiN"
+  ],
+  "cotc-orb-mega-spectrum-1-04": ["ORB - Mega Spectrum 1-04", "ORB"],
+  "cotc-orb-mega-spectrum": ["ORB - Mega Spectrum", "ORB"],
+  "cotc-orb-solar-sail": ["ORB - Solar Sail", "ORB"],
+  "cotc-amandio-c-secret-garden-4": [
+    "amandio c - secret garden 4",
+    "amandio c"
+  ],
+  "cotc-eos-more-waveforms": ["EoS - more waveforms", "EoS"],
+  "cotc-stuttler-kaleidoscope-from-hell": [
+    "Stuttler - Kaleidoscope From Hell",
+    "Stuttler"
+  ],
+  "cotc-amandio-c-secret-garden-5": [
+    "amandio c - secret garden 5",
+    "amandio c"
+  ],
+  "cotc-pinbi7-stuttler-trackdown": ["Pinbi7&stuttler-trackdown", ""],
+  "cotc-amandio-c-goldline-fireworks": [
+    "Amandio C - Goldline (fireworks)",
+    "Amandio C"
+  ],
+  "cotc-orb-space-time": ["ORB - Space Time", "ORB"],
+  "cotc-royal-mashup-162": ["$$$ Royal - Mashup (162)", "$$$ Royal"],
+  "cotc-eos-phat-crazy": ["EoS_Phat craZy", ""],
+  "cotc-fishbrain-blueprint": ["fiShbRaiN - blueprint", "fiShbRaiN"],
+  "cotc-suksma-truth-raritys-isosceles-edit-11": [
+    "suksma - truth, raritys",
+    "suksma"
+  ],
+  "cotc-phat-eos-blah": ["Phat + EoS - blah", "Phat + EoS"],
+  "cotc-eos-multisphere-01-b-phat-ra-mix-nexus": [
+    "EoS - multisphere 01 B_Phat_Ra_mix nexus",
+    "EoS"
+  ],
+  "cotc-orb-space-time2": ["ORB - Space Time2", "ORB"],
+  "cotc-rarian-rakista-cheap-angels": [
+    "rarian rakista - Cheap Angels",
+    "rarian rakista"
+  ],
+  "cotc-orb-saturns-rings": ["ORB - Saturns Rings", "ORB"],
+  "cotc-evet-dreamy-days": ["EVET - Dreamy Days", "EVET"],
+  "cotc-amandio-c-iterative-squares-1": [
+    "amandio c - iterative - squares 1",
+    "amandio c"
+  ],
+  "cotc-eos-angels-of-decay-02-phat-soulmate": [
+    "EoS - angels of decay 02 + Phat - soulmate",
+    "EoS"
+  ],
+  "cotc-yin-253-artificial-poles-of-the-continuum-remix-3": [
+    "yin - 253 - Artificial poles of the continuum (remix #3)",
+    "yin"
+  ],
+  "cotc-syst3mfailur-satanic-ring-v2": [
+    "Syst3mFailur - satanic ring V2",
+    "Syst3mFailur"
+  ],
+  "cotc-yin-250-artificial-poles-of-the-continuum-3": [
+    "Yin - 250 - Artificial Poles Of The Continuum 3",
+    "Yin"
+  ],
+  "cotc-yin-252-artificial-poles-of-the-continuum-remix-2": [
+    "yin - 252 - Artificial poles of the continuum (remix #2)",
+    "yin"
+  ],
+  "cotc-eos-apocalypse-g": ["EoS - Apocalypse G", "EoS"],
+  "cotc-yin-250-artificial-poles-of-the-continuum-phat-s-star-mix": [
+    "yin - 250 - Artificial poles of the continuum_Phat's_star_mix",
+    "yin"
+  ],
+  "cotc-yin-253-artificial-poles-of-the-continuum-remix-3-1": [
+    "yin - 253 - Artificial poles of the continuum (remix #3)_1",
+    "yin"
+  ],
+  "cotc-syst3mfailur-satanic-ring-phat-eos-diety-freequency-remix": [
+    "Syst3mFailur - satanic ring_Phat+EoS_DIEty_FREEquency_Remix",
+    "Syst3mFailur"
+  ],
+  "cotc-yin-251-artificial-poles-of-the-continuum-remix-1": [
+    "yin - 251 - Artificial poles of the continuum (remix #1)",
+    "yin"
+  ],
+  "cotc-syst3mfailur-satanic-ring": [
+    "Syst3mFailur - satanic ring",
+    "Syst3mFailur"
+  ],
+  "cotc-yin-253-artificial-poles-of-the-continuum-remix-3-2": [
+    "yin - 253 - Artificial poles of the continuum (remix #3) (2)",
+    "yin"
+  ],
+  "cotc-eos-apocalypse-c": ["EoS - Apocalypse C", "EoS"],
+  "cotc-evet-desmond-axis-2": ["EVET - Desmond Axis 2", "EVET"],
+  "cotc-eos-apocalypse-b": ["EoS - Apocalypse B", "EoS"],
+  "cotc-stahlregen-do-the-wave-v2-celestial-butterfly": [
+    "Stahlregen - Do the Wave (V2 - celestial butterfly)",
+    "Stahlregen"
+  ],
+  "cotc-adamfx-2-aderrasi-airhandler-last-breath-calm-ilusional-discontent2": [
+    "AdamFx 2 Aderrasi - Airhandler (Last Breath - Calm)Ilusional Discontent2",
+    "AdamFx 2 Aderrasi"
+  ],
+  "cotc-bmelgren-unchained-a-spinningrainmix": [
+    "Bmelgren&unchained-a(spinningrainmix)",
+    ""
+  ],
+  "cotc-pithlit-nova-rainbow-mix": ["Pithlit - Nova(Rainbow mix)", "Pithlit"],
+  "cotc-royal-mashup-168": ["$$$ Royal - Mashup (168)", "$$$ Royal"],
+  "cotc-evet-waterrgate": ["EVET - Waterrgate", "EVET"],
+  "cotc-pithlit-nova": ["Pithlit - Nova", "Pithlit"],
+  "cotc-tripgnosis-hypesurrealism": [
+    "Tripgnosis - Hypesurrealism",
+    "Tripgnosis"
+  ],
+  "cotc-phat-eos-blah-smooth-colors-morph-blah": [
+    "Phat + EoS - blah_Smooth_Colors_morph blah",
+    "Phat + EoS"
+  ],
+  "cotc-royal-mashup-28": ["$$$ Royal - Mashup (28)", "$$$ Royal"],
+  "cotc-bmelgren-unchained-amb-mythicrainmix": [
+    "Bmelgren&unchained-amb(mythicrainmix)",
+    ""
+  ],
+  "cotc-royal-mashup-29": ["$$$ Royal - Mashup (29)", "$$$ Royal"],
+  "cotc-geiss-plasma": ["Geiss - Plasma", "Geiss"],
+  "cotc-rocke-personal-comet": ["Rocke - Personal Comet", "Rocke"],
+  "cotc-tripgnosis-flameorb": ["Tripgnosis - FlameOrb", "Tripgnosis"],
+  "cotc-royal-mashup-380": ["$$$ Royal - Mashup (380)", "$$$ Royal"],
+  "cotc-pieturp-hsl-tunnelvisions-morphing3": [
+    "PieturP - HSL-tunnelvisions_morphing3",
+    "PieturP"
+  ],
+  "cotc-pieturp-hsl-tunnelvisions-morphing2": [
+    "PieturP - HSL-tunnelvisions_morphing2",
+    "PieturP"
+  ],
+  "cotc-145": ["145", ""],
+  "cotc-305": ["305", ""],
+  "cotc-138": ["138", ""],
+  "cotc-fishbrain-betelguese3": ["fiShbRaiN - betelguese3", "fiShbRaiN"],
+  "cotc-suksma-foolish-mash": ["suksma - foolish mash", "suksma"],
+  "cotc-pieturp-sunflare2": ["PieturP - sunflare2", "PieturP"],
+  "cotc-royal-mashup-395": ["$$$ Royal - Mashup (395)", "$$$ Royal"],
+  "cotc-hexcollie-first": ["Hexcollie - First", "Hexcollie"],
+  "cotc-royal-mashup-377": ["$$$ Royal - Mashup (377)", "$$$ Royal"],
+  "cotc-eos-phat-the-lights-at-night": [
+    "EoS+Phat - the lights at night",
+    "EoS+Phat"
+  ],
+  "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate": [
+    "suksma - Dark One - Clouds - das yi hyper phosphene ejaculate",
+    "suksma"
+  ],
+  "cotc-yin-314-ocean-of-light-ascending-nadi-mix": [
+    "yin - 314 - Ocean of Light (ascending nadi mix)",
+    "yin"
+  ],
+  "cotc-yin-315-ocean-of-light-moreacidplz-eos-phat": [
+    "yin - 315 - Ocean of Light (moreacidplz EoS-Phat)",
+    "yin"
+  ],
+  "cotc-yin-313-ocean-of-light-esp": [
+    "yin - 313 - Ocean of Light (ESP)",
+    "yin"
+  ],
+  "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher": [
+    "yin - 314 - Ocean of Light (ascending nadi mix) spher",
+    "yin"
+  ],
+  "cotc-goody-lights-in-the-sky": ["Goody - Lights in the Sky", "Goody"],
+  "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy": [
+    "skipper skipper kiss me hard - thank god for martin nitorami - maps of hell roams saucy",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher": [
+    "skipper skipper kiss me hard - slut warm spher",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell": [
+    "skipper skipper kiss me hard - thank god for martin nitorami - maps of hell",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-suksma-farming-equipment-ice-shower": [
+    "suksma - farming equipment - ice shower",
+    "suksma"
+  ],
+  "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami": [
+    "skipper skipper kiss me hard - thank god for martin nitorami",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear": [
+    "skipper skipper kiss me hard - thank god for martin nitorami - a rip in mommy's underwear",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-suksma-phairess-weale-mrt-flx": [
+    "suksma - phairess weale + mrt,flx",
+    "suksma"
+  ],
+  "cotc-suksma-penattrition-geiss-crossfire-shaders": [
+    "suksma - penattrition - geiss crossfire shaders",
+    "suksma"
+  ],
+  "cotc-royal-mashup-40": ["$$$ Royal - Mashup (40)", "$$$ Royal"],
+  "cotc-bdrv-al-eos-more-waveforms-5-mx": [
+    "bdrv + al EoS - more waveforms 5 mx",
+    "bdrv + al EoS"
+  ],
+  "cotc-undulate-harque-auto-thef": [
+    "undulate harque - auto thef",
+    "undulate harque"
+  ],
+  "cotc-undulate-harque-zing": ["undulate harque - zing", "undulate harque"],
+  "cotc-suksma-circle-of-the-taeyrunts-phairess-imbularse-deign-offal": [
+    "suksma - circle of the taeyrunts, phairess imbularse deign offal",
+    "suksma"
+  ],
+  "cotc-amandio-c-pulse": ["amandio c - pulse", "amandio c"],
+  "cotc-geite-spooksville-roams": ["geite' - spooksville roams", "geite'"],
+  "cotc-undulate-harque-pain-tthe": [
+    "undulate harque - pain tthe",
+    "undulate harque"
+  ],
+  "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit": [
+    "hypra-a-astral hypra-a-plane fairlly amazing bullshit",
+    ""
+  ],
+  "cotc-fvese-lips-isosceles-edit": ["Fvese-lips", ""],
+  "cotc-gentlekid-cosmic-dust-2-digital-data-loss": [
+    "Gentlekid - Cosmic Dust 2 - Digital Data loss",
+    "Gentlekid"
+  ],
+  "cotc-goody-s-fatal-color-attraction-pliant-reality-remix-ps2-0-isosceles-edit": [
+    "Goody's Fatal Color Attraction (pliant reality remix) PS2-0",
+    ""
+  ],
+  "cotc-geiss-vapor-echo": ["Geiss - Vapor Echo", "Geiss"],
+  "cotc-stahlregen-do-the-wave-v2-minimal-ps2-blur": [
+    "Stahlregen - Do the Wave (V2 minimal - PS2 blur)",
+    "Stahlregen"
+  ],
+  "cotc-suksma-accredited-omniversidioty": [
+    "suksma - accredited omniversidioty",
+    "suksma"
+  ],
+  "cotc-rovastar-geiss-dynamic-swirls-3-broken-destiny-mix": [
+    "Rovastar & Geiss - Dynamic Swirls 3 (Broken Destiny Mix)",
+    "Rovastar & Geiss"
+  ],
+  "cotc-lux-geiss-spacefurnace": ["LuX_-_Geiss - spacefurnace", "LuX_-_Geiss"],
+  "cotc-stahlregen-bass-spectre-ps2": [
+    "Stahlregen - Bass Spectre (PS2)",
+    "Stahlregen"
+  ],
+  "cotc-stahlregen-downpour-x-spectre-ps2b": [
+    "Stahlregen - Downpour x Spectre PS2b",
+    "Stahlregen"
+  ],
+  "cotc-rovastar-idiot24-7-juanita": [
+    "Rovastar & Idiot24-7 - Juanita",
+    "Rovastar & Idiot24-7"
+  ],
+  "cotc-fishbrain-geiss-witchcraft-grow-mix-2-a-a": [
+    "fiShbRaiN + geiss - witchcraft (Grow Mix)2 a a",
+    "fiShbRaiN + geiss"
+  ],
+  "cotc-geiss-electric-storm-half-digital-2-fiesta-mix": [
+    "Geiss - Electric Storm Half-Digital 2 (Fiesta Mix)",
+    "Geiss"
+  ],
+  "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit": [
+    "TonyMilkdrop - This Is A Painting [Flexi - let's trade + techstyle]",
+    "TonyMilkdrop"
+  ],
+  "cotc-bmelgren-rovastar-jester-sawakening-r": [
+    "Bmelgren&Rovastar-Jester'sAwakening(R",
+    ""
+  ],
+  "cotc-beta106i-jupiter-divine-lances": [
+    "beta106i - Jupiter (Divine Lances)",
+    "beta106i"
+  ],
+  "cotc-goody-s-fatal-color-attraction-pliant-reality-remix-ps2-0": [
+    "Goody's Fatal Color Attraction (pliant reality remix) PS2-0",
+    ""
+  ],
+  "cotc-suksma-awareness-implodes-disappears": [
+    "suksma - awareness implodes disappears",
+    "suksma"
+  ],
+  "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix": [
+    "Geiss - Cosmic Dust 2 - Tiny Reaction Diffusion Mix",
+    "Geiss"
+  ],
+  "cotc-suksma-race-for-hot-dog-log-smell-2": [
+    "suksma - race for hot dog - log smell 2",
+    "suksma"
+  ],
+  "cotc-stahlregen-geiss-orb-etheral-waves-mashup-20": [
+    "Stahlregen & Geiss + ORB - Etheral Waves (MashUp 20)",
+    "Stahlregen & Geiss + ORB"
+  ],
+  "cotc-mig-091b": ["Mig_091b", ""],
+  "cotc-geiss-motion-blur-2": ["Geiss - Motion Blur 2", "Geiss"],
+  "cotc-goody-vertigo-revisited": ["Goody - Vertigo - revisited", "Goody"],
+  "cotc-mig-oscilloscope021": ["Mig_Oscilloscope021", ""],
+  "cotc-geiss-tokamak-plus-painterly": [
+    "Geiss - Tokamak Plus Painterly",
+    "Geiss"
+  ],
+  "cotc-geiss-cepia-dither": ["Geiss - Cepia Dither", "Geiss"],
+  "cotc-stahlregen-do-the-wave-v2": [
+    "Stahlregen - Do the Wave (V2)",
+    "Stahlregen"
+  ],
+  "cotc-stahlregen-downpour-x-spectre-ps2-contact-mix": [
+    "Stahlregen - Downpour x Spectre PS2 (Contact Mix)",
+    "Stahlregen"
+  ],
+  "cotc-goody-s-fatal-color-attraction-ps2-0": [
+    "Goody's Fatal Color Attraction PS2-0",
+    ""
+  ],
+  "cotc-eos-waveform-01": ["EoS - waveform 01", "EoS"],
+  "cotc-geiss-cosmic-dust-2-laplacian-mix-maalol-mix": [
+    "Geiss - Cosmic Dust 2 - Laplacian Mix maalol mix",
+    "Geiss"
+  ],
+  "cotc-stahlregen-do-the-wave-v2-minimal-w": [
+    "Stahlregen - Do the Wave (V2 minimal - W)",
+    "Stahlregen"
+  ],
+  "cotc-evet-lovegates": ["EVET - Lovegates", "EVET"],
+  "cotc-fishbrain-white-scream-firefly": [
+    "fiShbRaiN - white scream firefly",
+    "fiShbRaiN"
+  ],
+  "cotc-stahlregen-do-the-wave": ["Stahlregen - Do the Wave", "Stahlregen"],
+  "cotc-luxxx-broken-beat-machina-i": [
+    "LuxXx - Broken Beat Machina i",
+    "LuxXx"
+  ],
+  "cotc-geiss-cosmic-dust-2-laplacian-mix": [
+    "Geiss - Cosmic Dust 2 - Laplacian Mix",
+    "Geiss"
+  ],
+  "cotc-stahlregen-downpour-x-spectre-ps2": [
+    "Stahlregen - Downpour x Spectre PS2",
+    "Stahlregen"
+  ],
+  "cotc-14": ["14", ""],
+  "cotc-evet-jewelsmoke": ["EVET - Jewelsmoke", "EVET"],
+  "cotc-mig-036version3": ["Mig_036version3", ""],
+  "cotc-suksma-deconstrue-orbaet": ["suksma - deconstrue orbaet", "suksma"],
+  "cotc-martin-another-kind-of-groove": [
+    "martin - another kind of groove",
+    "martin"
+  ],
+  "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares": [
+    "suksma - g-martin m-m w-!mu$ wp-m c-m - getting beat isn't embarrassing, it's no one cares",
+    "suksma"
+  ],
+  "cotc-xtramartin-3": ["xtramartin (3)", ""],
+  "cotc-orb-radiation2": ["ORB - Radiation2", "ORB"],
+  "cotc-suksma-trapstract": ["suksma - trapstract", "suksma"],
+  "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching": [
+    "shifter - flashburn roams use fishing line to keep the spiral plates from touching",
+    "shifter"
+  ],
+  "cotc-flexi-suksma-goody-fed-other-artists-blarfff-throwing-up-cubes": [
+    "flexi +  suksma + goody + fed + other artists - blarfff (throwing up cubes)",
+    "flexi +  suksma + goody + fed + other artists"
+  ],
+  "cotc-suksma-never-churchmouth": ["suksma - never churchmouth", "suksma"],
+  "cotc-luxxx-water-your-pet-goldfish-i": [
+    "LuxXx - Water Your Pet Goldfish i",
+    "LuxXx"
+  ],
+  "cotc-suksma-flaring-squamoid-mode-placement": [
+    "suksma - flaring squamoid mode placement",
+    "suksma"
+  ],
+  "cotc-luxxx-absinthe-with-mc-escher": [
+    "LuxXx - Absinthe with MC Escher",
+    "LuxXx"
+  ],
+  "cotc-luxxx-badballz": ["LuxXx - BadBallz", "LuxXx"],
+  "cotc-suksma-never-throck": ["suksma - never throck", "suksma"],
+  "cotc-luxxx-when-the-first-aliens-came-b": [
+    "LuxXx - When the First Aliens Came b",
+    "LuxXx"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Swelling Spiral  + Liquid Fire",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-geiss-flexi-orb-others-i-ve-had-it-with-this-g-tree": [
+    "geiss + flexi + orb + others - i've had it with this g tree",
+    "geiss + flexi + orb + others"
+  ],
+  "cotc-orb-fire-poi": ["ORB - Fire Poi", "ORB"],
+  "cotc-serge-circles007b": ["Serge circles007b", ""],
+  "cotc-serge-martin-crystal-palace000": [
+    "Serge + martin - crystal palace000",
+    "Serge + martin"
+  ],
+  "cotc-serge-martin-crystal-palace001": [
+    "Serge + martin - crystal palace001",
+    "Serge + martin"
+  ],
+  "cotc-serge-158-002": ["Serge + 158 002", ""],
+  "cotc-martin-pendulum-in-brass-ps2": [
+    "martin - pendulum in brass ps2",
+    "martin"
+  ],
+  "cotc-martin-pendulum-in-brass-ps3": [
+    "martin - pendulum in brass ps3",
+    "martin"
+  ],
+  "cotc-serge-martin-crystal-palace001b": [
+    "Serge + martin - crystal palace001b",
+    "Serge + martin"
+  ],
+  "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e": [
+    "Starz in MilkHDFX - Stahlregen & Aderrasi + EoS + Geiss + Unchained + Zylot + Flexi + Martin + AdamFX E",
+    "Starz in MilkHDFX"
+  ],
+  "cotc-serge-martin-crystal-palace001c": [
+    "Serge + martin - crystal palace001c",
+    "Serge + martin"
+  ],
+  "cotc-suksma-uhnfareknesce-roosta-conflarian": [
+    "suksma - uhnfareknesce roosta conflarian",
+    "suksma"
+  ],
+  "cotc-jc-lovely-bones": ["Jc - Lovely Bones", "Jc"],
+  "cotc-288": ["288", ""],
+  "cotc-beta106i-songflower-ice-flower": [
+    "beta106i - Songflower (Ice Flower)",
+    "beta106i"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-ghosts-gaseous-2": [
+    "EoS - glowsticks v2 04 music minimal - ghosts gaseous 2",
+    "EoS"
+  ],
+  "cotc-eos-planetfunk-10-tracers-e-phat-edit": [
+    "EoS planetfunk-10 - tracers E_phat_edit",
+    "EoS planetfunk-10"
+  ],
+  "cotc-amandio-c-secret-garden-3": [
+    "amandio c - secret garden 3",
+    "amandio c"
+  ],
+  "cotc-fishbrain-betelguese": ["fiShbRaiN - betelguese", "fiShbRaiN"],
+  "cotc-hexcollie-curly-que-1": ["Hexcollie - Curly Que (1)", "Hexcollie"],
+  "cotc-hexcollie-x-warp-harsh-klive": [
+    "Hexcollie - X warp harsh - klive",
+    "Hexcollie"
+  ],
+  "cotc-flexi-heartbleeding-emocore-will-get-the-rest-of-you": [
+    "Flexi - heartbleeding emocore will get the rest of you",
+    "Flexi"
+  ],
+  "cotc-suksma-as-for-me-i-take-medicines2": [
+    "suksma - as for me, i take medicines2",
+    "suksma"
+  ],
+  "cotc-goody-need-desire-remix": ["Goody - Need - Desire remix", "Goody"],
+  "cotc-goody-aurora-totalis": ["Goody - Aurora Totalis", "Goody"],
+  "cotc-fed-dsc-011-lsd-edit-4": ["fed - DSC-011 LSD Edit 4", "fed"],
+  "cotc-101": ["101", ""],
+  "cotc-316": ["316", ""],
+  "cotc-royal-mashup-215": ["$$$ Royal - Mashup (215)", "$$$ Royal"],
+  "cotc-orb-blade": ["ORB - Blade", "ORB"],
+  "cotc-hexcollie-shifter-martin-anime-vs-the-stalion-mang": [
+    "Hexcollie, shifter, martin - Anime vs The stalion Mang",
+    "Hexcollie, shifter, martin"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire-geiss-a": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Swelling Spiral  + Liquid Fire  + Geiss an65",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again": [
+    "Geiss - Reaction Diffusion 3 (Janky Ripple Effect again)",
+    "Geiss"
+  ],
+  "cotc-cantstop-adamfx-2-flexi-geiss-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-hex": [
+    "CantStop ADAMFX 2 Flexi + Geiss + Fishbrain  + Swelling Spiral + Work With Lines + Deamon Lord + EOS + HEX 2",
+    ""
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 3",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx": [
+    "Stahlregen & AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack's Playful Thumbdrum Planet RMX) - mash0000 - closer",
+    "Stahlregen & AdamFX + flexi + Geiss"
+  ],
+  "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin": [
+    "geiss - reaction diffusion 3 (rippling leopard skin)",
+    "geiss"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-shifter-etw": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Aurora Industrialis +  Shifter ETW",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-hexcollie-julian-shader-wars4": [
+    "Hexcollie - Julian Shader Wars4",
+    "Hexcollie"
+  ],
+  "cotc-mig-colorful9": ["Mig_COLORFUL9", ""],
+  "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3": [
+    "Geiss, Flexi + Stahlregen - Thumbdrum Tokamak [crossfiring aftermath jelly mashup] yay3",
+    "Geiss, Flexi + Stahlregen"
+  ],
+  "cotc-isosceles-mashup01": ["Isosceles mashup01", ""],
+  "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx": [
+    "Stahlregen & bdrv + flexi + Geiss + shifter - Hypno Swirl (MashUp 38 - Coral Trance RMX)",
+    "Stahlregen & bdrv + flexi + Geiss + shifter"
+  ],
+  "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off": [
+    "LuxXx - Inhale this Golden Rate Tax Stamp for 025 Credits Off!",
+    "LuxXx"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-shifter-dark-tides-eos-phat-whisps-of-doom-mix-mash0000-salt-dunes-time-lapse": [
+    "shifter - dark tides (EoS+phat_whisps of doom mix) - mash0000 - salt dunes time lapse",
+    "shifter"
+  ],
+  "cotc-aderrasi-airhandler-last-breath-angel-evolution-mash0000-your-mints-have-arrived-sir": [
+    "Aderrasi - Airhandler (Last Breath - Angel Evolution) - mash0000 - your mints have arrived, sir",
+    "Aderrasi"
+  ],
+  "cotc-geiss-reaction-diffusion-3-janky-ripples": [
+    "Geiss - Reaction Diffusion 3 (janky ripples)",
+    "Geiss"
+  ],
+  "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada": [
+    "A Feature Preset Master Exclusive ORB - Planetary Alignment Acidburn - BitStorm Intune With AdamFX,Shado",
+    "A Feature Preset Master Exclusive ORB"
+  ],
+  "cotc-geiss-skin-dots-10": ["Geiss - Skin Dots 10", "Geiss"],
+  "cotc-royal-mashup-127": ["$$$ Royal - Mashup (127)", "$$$ Royal"],
+  "cotc-geiss-reaction-diffusion-simple-squamous-mix": [
+    "Geiss - Reaction Diffusion - Simple Squamous Mix",
+    "Geiss"
+  ],
+  "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot4-isosceles-e": [
+    "BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs reaction diffusion + Aderassi Phat Zylot4",
+    "BEST OF ADAMFX 2 Flexi + Geiss"
+  ],
+  "cotc-geiss-skin-dots-9": ["Geiss - Skin Dots 9", "Geiss"],
+  "cotc-suksma-lackstastique-j4": ["suksma - lackstastique - j4+", "suksma"],
+  "cotc-shifter-crosshatch-colony-beta6-gaseous-lives": [
+    "shifter - crosshatch colony beta6 - gaseous lives",
+    "shifter"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-molten-glass": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Aurora Industrialis +  Molten Glass",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-geiss-skin-dots-11-crossfire-composite": [
+    "Geiss - Skin Dots 11 Crossfire Composite",
+    "Geiss"
+  ],
+  "cotc-eos-particle-daemon-forge-mash0000-the-itchy-and-scratchy-show-meets-the-adam-s-family": [
+    "EoS - particle daemon (forge) - mash0000 - the itchy and scratchy show meets the adam's family",
+    "EoS"
+  ],
+  "cotc-suksma-bmelgren-unchained-ambrosia-myth-spinning-rain-mix-mash0000-fucked-up-dreams-about-a": [
+    "suksma - Bmelgren & Unchained - Ambrosia Myth (Spinning Rain Mix) - mash0000 - fucked up dreams about a six dimensional",
+    "suksma"
+  ],
+  "cotc-hexcollie-julian-shader-wars3": [
+    "Hexcollie - Julian Shader Wars3",
+    "Hexcollie"
+  ],
+  "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-orb-acid-cycle": [
+    "NeW Adam Master Mashup FX 2 Geiss - Reaction Diffusion 34 + Aurora Industrialis + ORb acid cycle",
+    "NeW Adam Master Mashup FX 2 Geiss"
+  ],
+  "cotc-geiss-skin-dots-multi-layer-1": [
+    "Geiss - Skin Dots Multi-layer 1",
+    "Geiss"
+  ],
+  "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi": [
+    "shifter - crosshatch colony beta6 - loved to death by nymphs and hentai succubi",
+    "shifter"
+  ],
+  "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad": [
+    "A Feature Preset Master Exclusive ORB - Planetary Alignment Acidburn - Eso - Demon Released by AdamFXIntrusionnn B",
+    "A Feature Preset Master Exclusive ORB"
+  ],
+  "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2": [
+    "Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2)",
+    "Geiss and Zylot"
+  ],
+  "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a": [
+    "A HD ADAMFX Creation  !!FT  Martin + flexi +  Rovastar MDropFX Collaboration E Adam HD INFECTIONFX A",
+    ""
+  ],
+  "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang": [
+    "suksma - g-thea ceo m-zylo v w-27su om wp-xxx c-stah j5+ - heiyin taiyang",
+    "suksma"
+  ],
+  "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens": [
+    "Stahlregen & Geiss + Rovastar - Fields of Flowers (Jelly Zen Gardens)",
+    "Stahlregen & Geiss + Rovastar"
+  ],
+  "cotc-geiss-skin-dots-multi-layer-3-pig-jembe-acid-wretch": [
+    "Geiss - Skin Dots Multi-layer 3 - pig - jembe acid wretch",
+    "Geiss"
+  ],
+  "cotc-va-ultramix-05-2": ["va ultramix - 05_2", "va ultramix"],
+  "cotc-luxxx-my-soul-i": ["LuxXx - My Soul i", "LuxXx"],
+  "cotc-phat-zylot-eos-trippy-rotation-v2-alt-colours": [
+    "Phat_Zylot_EoS Trippy_rotation_v2_alt_colours",
+    ""
+  ],
+  "cotc-va-ultramix2-296-1": ["va ultramix2 - 296_1", "va ultramix2"],
+  "cotc-bdrv-monster-wave-flexis-color-bleeding-ivories": [
+    "bdrv - monster wave [flexis color bleeding ivories]",
+    "bdrv"
+  ],
+  "cotc-beta106i-antidote-crying-pan": [
+    "beta106i - Antidote (Crying Pan)",
+    "beta106i"
+  ],
+  "cotc-rce-ordinary-want-nevermore-mix": [
+    "rce-ordinary - want (nevermore mix)",
+    "rce-ordinary"
+  ],
+  "cotc-beta106i-potion-of-smoke": ["beta106i - Potion of Smoke", "beta106i"],
+  "cotc-bdrv-al-rovastar-explosive-minds-bug-mix-wait-a-moment-rmx": [
+    "bdrv + al Rovastar - Explosive Minds Bug Mix wait a moment  rmx",
+    "bdrv + al Rovastar"
+  ],
+  "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix": [
+    "Phat_Zylot_EoS Trippy_rotation_v2_sector_mix",
+    ""
+  ],
+  "cotc-flexi-leaving-colors-crazy-cogitations-centrifuge-collapsing-cosmos-creation-oh-thats-still": [
+    "Flexi - leaving colors - crazy cogitations centrifuge [collapsing cosmos creation] oh thats still harmless",
+    "Flexi"
+  ],
+  "cotc-va-ultramix2-253": ["va ultramix2 - 253", "va ultramix2"],
+  "cotc-beta106i-airhandler-radial-dreamers": [
+    "beta106i - Airhandler (Radial Dreamers)",
+    "beta106i"
+  ],
+  "cotc-phat-zylot-eos-trippy-rotation-v2-sector-mix-alt-colours": [
+    "Phat_Zylot_EoS Trippy_rotation_v2_sector_mix_alt_colours",
+    ""
+  ],
+  "cotc-hexcollie-alex2": ["hexcollie - Alex2", "hexcollie"],
+  "cotc-stahlregen-flexi-geiss-shifter-swirlz-hue-mix": [
+    "Stahlregen & flexi + Geiss + shifter - Swirlz (Hue Mix)",
+    "Stahlregen & flexi + Geiss + shifter"
+  ],
+  "cotc-phat-zylot-eos-spiral-movements": [
+    "Phat_Zylot_EoS spiral_Movements",
+    ""
+  ],
+  "cotc-rovastar-destiny-star-starbrust-mix": [
+    "Rovastar - Destiny Star (Starbrust Mix)",
+    "Rovastar"
+  ],
+  "cotc-va-ultramix2-208-1": ["va ultramix2 - 208_1", "va ultramix2"],
+  "cotc-va-ultramix-430": ["va ultramix - 430", "va ultramix"],
+  "cotc-aderrasi-graft-first-rate-heart": [
+    "Aderrasi - Graft (First Rate Heart)",
+    "Aderrasi"
+  ],
+  "cotc-beta106i-airhandler-radial-dreamers-nightmare": [
+    "beta106i - Airhandler (Radial Dreamers - Nightmare)",
+    "beta106i"
+  ],
+  "cotc-suksma-youtube-pqswlhvukk8-something-else-dumb": [
+    "suksma - youtube PQsWLhvuKk8 - something else dumb",
+    "suksma"
+  ],
+  "cotc-suksma-no-grip-chute-reinvents-terror": [
+    "suksma - no grip chute reinvents terror",
+    "suksma"
+  ],
+  "cotc-loading-doctor": ["loading doctor", ""],
+  "cotc-suksma-moistened-gills-in-latent-galaxy-raggy": [
+    "suksma - moistened gills in latent galaxy raggy",
+    "suksma"
+  ],
+  "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul": [
+    "suksma - daryl feels my hellish lonliness - creamy layers of junk mail drips with soul",
+    "suksma"
+  ],
+  "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else": [
+    "men in reverse in reverse time born to breath, not much else",
+    ""
+  ],
+  "cotc-suksma-feeling-ignore": ["suksma - feeling ignore", "suksma"],
+  "cotc-suksma-everyone-knows-your-alleged-secret-none-care-but-to-whisper-and-laugh-and-quickly-mo": [
+    "suksma - everyone knows your alleged secret, none care but to whisper and laugh and quickly move on2",
+    "suksma"
+  ],
+  "cotc-fishbrain-witchcraft-metropolis-remix": [
+    "fiShbRaiN - witchcraft (metropolis remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-stahlregen-eos-fishbrain-flexi-fvese-geiss-rovastar-shifter-stonecraft-mashup-19-paranormal": [
+    "Stahlregen & EoS + fiShbRaiN + flexi + fvese + Geiss + Rovastar + shifter - Stonecraft (MashUp 19 - Paranormal Reflecto Static Blur RMX)",
+    "Stahlregen & EoS + fiShbRaiN + flexi + fvese + Geiss + Rovastar + shifter"
+  ],
+  "cotc-414": ["414", ""],
+  "cotc-fishbrain-witchcraft-necromancer-remix-busy": [
+    "fiShbRaiN - witchcraft (necromancer remix) - busy",
+    "fiShbRaiN"
+  ],
+  "cotc-flexi-fishbrain-geiss-unchained-others-plaidcraft": [
+    "flexi + fishbrain + geiss + unchained + others - Plaidcraft",
+    "flexi + fishbrain + geiss + unchained + others"
+  ],
+  "cotc-fishbrain-witchcraft-sorcery-remix": [
+    "fiShbRaiN - witchcraft (sorcery remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-suksma-feeling-retry": ["suksma - feeling retry", "suksma"],
+  "cotc-fishbrain-witchcraft-ritual-dance-remix": [
+    "fiShbRaiN - witchcraft (ritual dance remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-fishbrain-when-coathangers-dream-phat-edit": [
+    "fiShbRaiN - when coathangers dream_phat_edit",
+    "fiShbRaiN"
+  ],
+  "cotc-fishbrain-flexi-witchcraft-unleashed-01-stepping-into-it": [
+    "fiShbRaiN + Flexi - witchcraft unleashed [01 stepping into it]",
+    "fiShbRaiN + Flexi"
+  ],
+  "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo": [
+    "414 bowel rebranding pr skinned to the teeth loadus morons like me who indulge in crying wolf chicken little paradigms",
+    ""
+  ],
+  "cotc-423": ["423", ""],
+  "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku": [
+    "Stahlregen & fishbrain + geiss + martin - Flowercraft (reflecto upfcku)",
+    "Stahlregen & fishbrain + geiss + martin"
+  ],
+  "cotc-fishbrain-witchcraft-alcoholic-remix": [
+    "fiShbRaiN - witchcraft (alcoholic remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth": [
+    "414 bowel rebranding pr skinned to the teeth",
+    ""
+  ],
+  "cotc-flexi-identity-killing-petting-colon-gonad-type8": [
+    "flexi - identity-killing petting - colon gonad type8",
+    "flexi"
+  ],
+  "cotc-shifter-fishbrain-witchcraft-i-m-melting": [
+    "shifter & fiShbRaiN - witchcraft (i'm melting)",
+    "shifter & fiShbRaiN"
+  ],
+  "cotc-stahlregen-fishbrain-flexi-geiss-martin-shifter-stonecraft-martin-s-metallics": [
+    "Stahlregen & fiSHbRaiN + flexi + Geiss + martin + shifter - Stonecraft (martin's metallics)",
+    "Stahlregen & fiSHbRaiN + flexi + Geiss + martin + shifter"
+  ],
+  "cotc-suksma-rechivalrizing-tents": [
+    "suksma - rechivalrizing tents",
+    "suksma"
+  ],
+  "cotc-fishbrain-witchcraft": ["fiShbRaiN - witchcraft", "fiShbRaiN"],
+  "cotc-suksma-purple-9-d-rubber-coins-embossed-with-cataverses": [
+    "suksma - purple 9-d rubber coins embossed with cataverses",
+    "suksma"
+  ],
+  "cotc-fishbrain-flexi-witchcraft-unleashed-00-the-template": [
+    "fiShbRaiN + Flexi - witchcraft unleashed [00 the template]",
+    "fiShbRaiN + Flexi"
+  ],
+  "cotc-fishbrain-witchcraft-metropolish-remix": [
+    "fiShbRaiN - witchcraft (metropolish remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-fishbrain-flexi-stitchcraft-n": [
+    "fiShbRaiN + Flexi - stitchcraft n",
+    "fiShbRaiN + Flexi"
+  ],
+  "cotc-fishbrain-witchcraft-metropolish-remix-test": [
+    "fiShbRaiN - witchcraft (metropolish remix) - test",
+    "fiShbRaiN"
+  ],
+  "cotc-tripgnosis-circular-unlogic": [
+    "Tripgnosis - Circular Unlogic",
+    "Tripgnosis"
+  ],
+  "cotc-429": ["429", ""],
+  "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going": [
+    "414 bowel rebranding pr skinned to the teeth loadus morons who don't think things are going to collapse",
+    ""
+  ],
+  "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine": [
+    "suksma - g-martin m-m w-fishbrain wp-m c-m - tanked on pure neoepinephrine",
+    "suksma"
+  ],
+  "cotc-flexi-identity-killing-petting-colon-gonad-type9": [
+    "flexi - identity-killing petting - colon gonad type9",
+    "flexi"
+  ],
+  "cotc-suksma-feeling-abort": ["suksma - feeling abort", "suksma"],
+  "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus": [
+    "414 bowel rebranding pr skinned to the teeth loadus",
+    ""
+  ],
+  "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz": [
+    "414 bowel rebranding pr skinned to the teeth loadus veracruz",
+    ""
+  ],
+  "cotc-tripgnosis-astralacid": ["Tripgnosis - Astralacid", "Tripgnosis"],
+  "cotc-fishbrain-witchcraft-necromancer-remix": [
+    "fiShbRaiN - witchcraft (necromancer remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-dense": [
+    "Stahlregen & fiSHbRaiN + flexi + Geiss + shifter - Stonecraft (Dense)",
+    "Stahlregen & fiSHbRaiN + flexi + Geiss + shifter"
+  ],
+  "cotc-serge-adam-eatit-mashup-fx-2-martin001": [
+    "Serge + Adam Eatit Mashup FX 2 martin001",
+    ""
+  ],
+  "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit-v2": [
+    "fiShbRaiN - witchcraft (necromancer remix)_phat_edit_v2",
+    "fiShbRaiN"
+  ],
+  "cotc-fishbrain-witchcraft-necromancer-remix-phat-edit-v3": [
+    "fiShbRaiN - witchcraft (necromancer remix)_phat_edit_v3",
+    "fiShbRaiN"
+  ],
+  "cotc-fishbrain-witchcraft-metropolish-remix-motor-up-pre-air-filter-cyclone-argon-tweecer": [
+    "fiShbRaiN - witchcraft (metropolish remix) - motor up, pre air filter cyclone, argon, tweecer",
+    "fiShbRaiN"
+  ],
+  "cotc-halfbreak-tonymilkdrop-beautiful-sepia-mashmash": [
+    "Halfbreak + TonyMilkdrop - Beautiful Sepia - mashmash",
+    "Halfbreak + TonyMilkdrop"
+  ],
+  "cotc-fishbrain-witchcraft-neuromancer-remix": [
+    "fiShbRaiN - witchcraft (neuromancer remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-suksma-her-sideways-crawl-through-your-bank-accounts": [
+    "suksma - her sideways crawl through your bank accounts",
+    "suksma"
+  ],
+  "cotc-midgitstraights-of-majillaen-gunthree-spher": [
+    "midgitstraights of majillaen - gunthree spher",
+    "midgitstraights of majillaen"
+  ],
+  "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swellin1": [
+    "BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs reaction diffusion + Another Flexi + Fishbrain  + Swellin12",
+    "BEST OF ADAMFX 2 Flexi + Geiss"
+  ],
+  "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-glowing": [
+    "stahlregen & fishbrain + flexi + geiss + shifter - stonecraft (glowing)",
+    "stahlregen & fishbrain + flexi + geiss + shifter"
+  ],
+  "cotc-tripgnosis-triadular": ["Tripgnosis - Triadular", "Tripgnosis"],
+  "cotc-suksma-twist-fiber-wrap-cut-circulation": [
+    "suksma - twist fiber wrap cut circulation",
+    "suksma"
+  ],
+  "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku-yaqui-graph": [
+    "Stahlregen & fishbrain + geiss + martin - Flowercraft (reflecto upfcku) - yaqui graph",
+    "Stahlregen & fishbrain + geiss + martin"
+  ],
+  "cotc-suksma-fishbrain-witchcraft-phugly-megalopolish-remix": [
+    "suksma - fiShbRaiN - witchcraft (phugly megalopolish remix)",
+    "suksma"
+  ],
+  "cotc-goody-s-portfolio-acid-angel": [
+    "Goody's Portfolio - Acid Angel",
+    "Goody's Portfolio"
+  ],
+  "cotc-waltra-monodream": ["Waltra - Monodream", "Waltra"],
+  "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse-isosceles-edit": [
+    "TonyMilkdrop - Rhythm Of My Life [Flexi - multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-true-meaning-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - true meaning + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - the touch and the tough + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex": [
+    "TonyMilkdrop - Rhythm Of My Life [Flexi - alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - the psyched out about loop + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - gettogether + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit": [
+    "TonyMilkdrop - Angels Of Glory [Flexi - don't play with those kids + multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Angels Of Glory [Flexi - an excuse taken back + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2": [
+    "TonyMilkdrop - Nuclear [Flexi - why even bother + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all": [
+    "flexi + bdrv - ultramix#05 [alien complex mix] [not roaring at all]",
+    "flexi + bdrv"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - have you listened anyway + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - pump up the jam + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1": [
+    "TonyMilkdrop - Nuclear [Flexi - why even bother + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - priming + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Rhythm Of My Life [Flexi - alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse": [
+    "TonyMilkdrop - Rhythm Of My Life [Flexi - multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground": [
+    "The NG + flexi + bdrv - ultramix#05 [alien complex mix] [underground]",
+    "The NG + flexi + bdrv"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - pump up the jam + multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit": [
+    "TonyMilkdrop - Tricolors [Flexi - gettogether + multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-evet-flexi-geiss-tokamak-fractal-2": [
+    "EVET - flexi + geiss - tokamak fractal 2",
+    "EVET"
+  ],
+  "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit": [
+    "TonyMilkdrop - Angels Of Glory [Flexi - safer sex + multiverse]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex": [
+    "TonyMilkdrop - Nuclear [Flexi - why even bother + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit": [
+    "TonyMilkdrop - Angels Of Glory [Flexi - safer sex + alien complex]",
+    "TonyMilkdrop"
+  ],
+  "cotc-suksma-salutatorian-s-teat": ["suksma - salutatorian's teat", "suksma"],
+  "cotc-beta106i-airhandler-last-breath-clam": [
+    "beta106i - Airhandler (Last Breath - Clam)",
+    "beta106i"
+  ],
+  "cotc-zylot-crystal-ball-magical-reaction-mix": [
+    "Zylot - Crystal Ball (Magical Reaction Mix)",
+    "Zylot"
+  ],
+  "cotc-zylot-crystal-ball": ["Zylot - Crystal Ball", "Zylot"],
+  "cotc-beta106i-airhandler-last-breath-clam-handler": [
+    "beta106i - Airhandler (Last Breath - Clam Handler)",
+    "beta106i"
+  ],
+  "cotc-luxxx-fuck-ur-fractal-muscles-i": [
+    "LuxXx - Fuck ur Fractal Muscles I",
+    "LuxXx"
+  ],
+  "cotc-suksma-fickle-will-dive-fed-shd": [
+    "suksma - fickle will - dive - fed shd",
+    "suksma"
+  ],
+  "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2": [
+    "suksma - nothing to remember you by - logsmeltitdealtit2",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-fed-shd": [
+    "suksma - dotes hostile undertake - fed shd",
+    "suksma"
+  ],
+  "cotc-suksma-this-pain-was-saved-for-you-maggot-filigree-isosceles-edit": [
+    "suksma - this pain was saved for you - maggot filigree",
+    "suksma"
+  ],
+  "cotc-suksma-distort-crops-of-horror-torture-blackode": [
+    "suksma - distort crops of horror torture - blackode",
+    "suksma"
+  ],
+  "cotc-suksma-flaming-bag-of-wisconsin-i-being-the-last-thing-you-remember-is-the-last-thing-i-rem": [
+    "suksma - flaming bag of wisconsin - i being the last thing you remember is the last thing i remember roams satanick ckristianity",
+    "suksma"
+  ],
+  "cotc-pieturp-hsltorgb-swirl": ["PieturP - HSLtoRGB-swirl", "PieturP"],
+  "cotc-shifter-interference-field-v3-phat-darken-pop-edit-v4-eos-edit-b-dickless": [
+    "shifter - interference field v3_Phat_Darken_Pop_Edit_v4 EoS edit B dickless",
+    "shifter"
+  ],
+  "cotc-zylot-crystalball-aren-tfractals": [
+    "Zylot-CrystalBall(Aren'tFractals",
+    ""
+  ],
+  "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos": [
+    "suksma - this pain was saved for you - roams stephen hill hos",
+    "suksma"
+  ],
+  "cotc-suksma-distort-crops-of-horror-torture": [
+    "suksma - distort crops of horror torture",
+    "suksma"
+  ],
+  "cotc-zylot-shifter-tartan-silent-heaven-mix": [
+    "Zylot & Shifter - Tartan (Silent Heaven Mix)",
+    "Zylot & Shifter"
+  ],
+  "cotc-stahlregen-boz-eos-phat-rovastar-zylot-machine-code-01010010-01000001-01010111-2": [
+    "Stahlregen & Boz + EoS + Phat + Rovastar + Zylot - Machine Code (01010010 01000001 01010111)_2",
+    "Stahlregen & Boz + EoS + Phat + Rovastar + Zylot"
+  ],
+  "cotc-stahlregen-downpour": ["Stahlregen - Downpour", "Stahlregen"],
+  "cotc-tonymilkdrop-go-to-heaven-isosceles-edit": [
+    "TonyMilkdrop - Go To Heaven",
+    "TonyMilkdrop"
+  ],
+  "cotc-eviljim-11-ice-drops": ["EvilJim - #11 Ice Drops", "EvilJim"],
+  "cotc-the-ng-stahlregen-boz-eos-geiss-phat-rovastar-zylot-flexi-martin-fishbrain-machine-code-in-": [
+    "The NG + Stahlregen & Boz + EoS + Geiss + Phat + Rovastar + Zylot + Flexi + martin + Fishbrain - Machine Code (In The Wind Tunnel)",
+    "The NG + Stahlregen & Boz + EoS + Geiss + Phat + Rovastar + Zylot + Flexi + martin + Fishbrain"
+  ],
+  "cotc-eviljim-ice-drops": ["EvilJim - Ice Drops", "EvilJim"],
+  "cotc-pieturp-stripes-hippiestyle": [
+    "PieturP - stripes-hippiestyle",
+    "PieturP"
+  ],
+  "cotc-shifter-ice-ripples": ["shifter - ice ripples", "shifter"],
+  "cotc-pieturp-stripes-tvstyle": ["PieturP - stripes-tvstyle", "PieturP"],
+  "cotc-stahlregen-crossroads-rainbow-falls": [
+    "Stahlregen - Crossroads (Rainbow Falls)",
+    "Stahlregen"
+  ],
+  "cotc-96": ["96", ""],
+  "cotc-eos-phat-i-v2-gradients": ["EoS+Phat - I_v2 gradients", "EoS+Phat"],
+  "cotc-eos-phat-i-v2-gradients-rot": [
+    "EoS+Phat - I_v2 gradients rot",
+    "EoS+Phat"
+  ],
+  "cotc-shifter-geiss-neon-pulse-glow-mix": [
+    "shifter + geiss - neon pulse (glow mix)",
+    "shifter + geiss"
+  ],
+  "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress": [
+    "By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar + Orb  + Mstress",
+    "By Adam FX 2 shifter + geiss"
+  ],
+  "cotc-flexi-stahlregen-jewelry-tiles": [
+    "flexi + stahlregen - jewelry tiles",
+    "flexi + stahlregen"
+  ],
+  "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec": [
+    "By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar + Orb  + Mstress - mash0000 - prismatic spectral haze filter",
+    "By Adam FX 2 shifter + geiss"
+  ],
+  "cotc-shifter-neon-pulse": ["shifter - neon pulse", "shifter"],
+  "cotc-98": ["98", ""],
+  "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto": [
+    "flexi + geiss - bipolar vs reaction diffusion [mirror scoped] (+phat's reflecto)",
+    "flexi + geiss"
+  ],
+  "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar": [
+    "By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar",
+    "By Adam FX 2 shifter + geiss"
+  ],
+  "cotc-shifter-neon-pulse-reactive": [
+    "shifter - neon pulse (reactive)",
+    "shifter"
+  ],
+  "cotc-shifter-yak-yetanotherkaleidoscope-02": [
+    "Shifter-yak(yetanotherkaleidoscope)02",
+    ""
+  ],
+  "cotc-eos-phat-linear-clouds-solarized-points-of-light-v2": [
+    "EoS+Phat - linear clouds_solarized_points_of_light_v2",
+    "EoS+Phat"
+  ],
+  "cotc-eos-phat-linear-clouds-solarized-points-of-light": [
+    "EoS+Phat - linear clouds_solarized_points_of_light",
+    "EoS+Phat"
+  ],
+  "cotc-shifter-yak-yetanotherkaleidoscope-01": [
+    "Shifter-yak(yetanotherkaleidoscope)01",
+    ""
+  ],
+  "cotc-shifter-yak-yetanotherkaleidoscope-00": [
+    "Shifter-yak(yetanotherkaleidoscope)00",
+    ""
+  ],
+  "cotc-orb-cosmic-dream": ["ORB - Cosmic Dream", "ORB"],
+  "cotc-bdrv-aderrasi-inhuman-emotion-bw5": [
+    "Bdrv Aderrasi - Inhuman Emotion bw5",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-bdrv-aderrasi-true-subject-star-pure-medium-bdrv-etal": [
+    "Bdrv Aderrasi - True Subject Star (Pure Medium) bdrv etAL",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-bdrv-aderrasi-divine-finery-vishnu-s-tophat-bdrv-etal3": [
+    "Bdrv Aderrasi - Divine Finery (Vishnu's Tophat) bdrv etAL3",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-bdrv-aderrasi-armada-battleship-bdrv-etal": [
+    "Bdrv Aderrasi - Armada (Battleship) bdrv etAL",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-va-ultramix2-156-1": ["va ultramix2 - 156_1", "va ultramix2"],
+  "cotc-va-ultramix-381": ["va ultramix - 381", "va ultramix"],
+  "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-": [
+    "Bdrv Aderrasi - Accelerator (Orbital Migraine) BDRV et  AL  rmx8 - sorry to hear you're not liking the f",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-bdrv-etal-aderrasi-accelerator-contractor-core-rmx": [
+    "bdrv etAL Aderrasi - Accelerator (contractor Core) rmx",
+    "bdrv etAL Aderrasi"
+  ],
+  "cotc-northern-lights-throbbing-bud": ["Northern Lights Throbbing Bud", ""],
+  "cotc-cope-flexi-julia-set-strange-days-bdrv2": [
+    "Cope + flexi - julia set (strange days)bdrv2",
+    "Cope + flexi"
+  ],
+  "cotc-rovastar-voov-s-light-pattern": [
+    "Rovastar - VooV's Light Pattern",
+    "Rovastar"
+  ],
+  "cotc-rovastar-studiomusic-spider-in-the-mind": [
+    "Rovastar & StudioMusic - Spider In the Mind",
+    "Rovastar & StudioMusic"
+  ],
+  "cotc-bdrv-aderrasi-negative-sun-haze-star-bdrv-et-al-rmxmix4": [
+    "Bdrv Aderrasi - Negative Sun (Haze Star)BDRV et  AL  rmxmix4",
+    "Bdrv Aderrasi"
+  ],
+  "cotc-bdrv-etal-nighthawk-dark-crystal": [
+    "bdrv etAL Nighthawk - dark Crystal",
+    "bdrv etAL Nighthawk"
+  ],
+  "cotc-evet-superstrings-2": ["EVET - Superstrings 2", "EVET"],
+  "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself": [
+    "Martin n AdamFX - Hardcore Mix Collision in Myself",
+    "Martin n AdamFX"
+  ],
+  "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain": [
+    "Martin n AdamFX - Hardcore Mix Collision in Myself Ft - Flexi Shifter n Fishbrain",
+    "Martin n AdamFX"
+  ],
+  "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac": [
+    "Martin n AdamFX - Hardcore Mix Collision in Myself Ft - AC",
+    "Martin n AdamFX"
+  ],
+  "cotc-martin-tunnel-race-meta-mash-for-rats": [
+    "martin - tunnel race [meta mash] - for rats",
+    "martin"
+  ],
+  "cotc-xtramartin-459": ["xtramartin (459)", ""],
+  "cotc-martin-hardcore-mix-2-2": ["martin - hardcore mix 2 (2)", "martin"],
+  "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen-aderrasi-geiss-unchained-zyl": [
+    "Martin n AdamFX - Hardcore Mix Collision in Myself ft Stahlregen - Aderrasi - Geiss - Unchained - Zylot",
+    "Martin n AdamFX"
+  ],
+  "cotc-martin-tunnel-race-meta-mash-disciple": [
+    "martin - tunnel race [meta mash] - disciple'",
+    "martin"
+  ],
+  "cotc-martin-hardcore-mix-2": ["martin - hardcore mix 2", "martin"],
+  "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen": [
+    "Martin n AdamFX - Hardcore Mix Collision in Myself ft Stahlregen",
+    "Martin n AdamFX"
+  ],
+  "cotc-sewn-to-slavish-memes": ["sewn to slavish memes", ""],
+  "cotc-suksma-mundane-side-of-eden": [
+    "suksma - mundane side of eden",
+    "suksma"
+  ],
+  "cotc-orb-waaa-lamersass-remix-4": ["ORB - Waaa (LamersAss Remix 4)", "ORB"],
+  "cotc-orb-waaa-lamersass-remix-2": ["ORB - Waaa (LamersAss Remix 2)", "ORB"],
+  "cotc-suksma-never-poo": ["suksma - never poo", "suksma"],
+  "cotc-orb-waaa-lamersass-remix-3": ["ORB - Waaa (LamersAss Remix 3)", "ORB"],
+  "cotc-amandio-c-salty-bits-5": ["amandio c - salty bits - 5", "amandio c"],
+  "cotc-krash-yin-phat-electric-universe-uncertainty-principle-unknown-mix": [
+    "Krash & yin + Phat - Electric universe (uncertainty principle)_unknown_mix",
+    "Krash & yin + Phat"
+  ],
+  "cotc-krash-yin-electric-universe-variable-spin-004": [
+    "Krash & yin - Electric universe (variable spin - 004)",
+    "Krash & yin"
+  ],
+  "cotc-krash-yin-electric-universe-nuclear-secrets-phat-nuleus-mix": [
+    "Krash & yin - Electric universe (nuclear secrets) (Phat_nuleus_mix)",
+    "Krash & yin"
+  ],
+  "cotc-krash-yin-electric-universe-variable-spin": [
+    "Krash & yin - Electric universe (variable spin)",
+    "Krash & yin"
+  ],
+  "cotc-krash-yin-phat-electric-universe-uncertainty-principle-remix-v2": [
+    "Krash & yin + Phat - Electric universe (uncertainty principle)_remix_v2",
+    "Krash & yin + Phat"
+  ],
+  "cotc-krash-yin-electric-universe-nuclear-secrets-phat-carbon-mix": [
+    "Krash & yin - Electric universe (nuclear secrets) (Phat_Carbon_mix)",
+    "Krash & yin"
+  ],
+  "cotc-krash-yin-electric-universe-uncertainty-principle": [
+    "Krash & yin - Electric universe (uncertainty principle)",
+    "Krash & yin"
+  ],
+  "cotc-krash-yin-phat-electric-universe-uncertainty-principle-remix": [
+    "Krash & yin + Phat - Electric universe (uncertainty principle)_remix",
+    "Krash & yin + Phat"
+  ],
+  "cotc-goody-ego-decontructor": ["Goody - Ego Decontructor", "Goody"],
+  "cotc-goody-woven-beads-ps2-0": ["goody - woven beads (ps2-0)", "goody"],
+  "cotc-goody-woven-beads": ["goody - woven beads", "goody"],
+  "cotc-amandio-c-typhoon-season-inside": [
+    "amandio c - typhoon season (inside)",
+    "amandio c"
+  ],
+  "cotc-amandio-c-moving-ripple-intraphereonts-pad-urn": [
+    "amandio c - moving ripple - intraphereonts pad urn",
+    "amandio c"
+  ],
+  "cotc-amandio-c-moving-ripple-reproducing-the-end-feeling-of-doing-anything-in-the-mind": [
+    "amandio c - moving ripple - reproducing the end feeling of doing anything in the mind",
+    "amandio c"
+  ],
+  "cotc-amandio-c-typhoon-season-inside-eid-sdi": [
+    "amandio c - typhoon season (inside) - eid (-sdi)",
+    "amandio c"
+  ],
+  "cotc-amandio-c-water-ripples-2d": [
+    "amandio c - water ripples - 2D",
+    "amandio c"
+  ],
+  "cotc-dbleja-horizontology-red-mix": [
+    "Dbleja - Horizontology (Red Mix)",
+    "Dbleja"
+  ],
+  "cotc-telek-goodoldcollingwoodforever": [
+    "Telek-goodoldcollingwoodforever",
+    ""
+  ],
+  "cotc-royal-mashup-524": ["$$$ Royal - Mashup (524)", "$$$ Royal"],
+  "cotc-orb-waaa-lamersass-remix-5": ["ORB - Waaa (LamersAss Remix 5)", "ORB"],
+  "cotc-royal-mashup-505": ["$$$ Royal - Mashup (505)", "$$$ Royal"],
+  "cotc-orb-waaa-lamersass-remix-1": ["ORB - Waaa (LamersAss Remix 1)", "ORB"],
+  "cotc-pieturp-stripes-goingslowmix": [
+    "PieturP - stripes-goingSlowMix",
+    "PieturP"
+  ],
+  "cotc-pieturp-stripes-goingfastmix": [
+    "PieturP - stripes-goingFastMix",
+    "PieturP"
+  ],
+  "cotc-dbleja-horizontology-white-mix": [
+    "Dbleja - Horizontology (White Mix)",
+    "Dbleja"
+  ],
+  "cotc-royal-mashup-509": ["$$$ Royal - Mashup (509)", "$$$ Royal"],
+  "cotc-dbleja-horizontology-blue-mix": [
+    "Dbleja - Horizontology (Blue Mix)",
+    "Dbleja"
+  ],
+  "cotc-telek-goodoldcollingwoodforever-isosceles-edit": [
+    "Telek-goodoldcollingwoodforever",
+    ""
+  ],
+  "cotc-eos-3d": ["EoS 3d", ""],
+  "cotc-eos-planetfunk-07-tracers-b-syst3mfailur-bluespin-remix": [
+    "EoS planetfunk-07 - tracers B(Syst3mFailur - bluespin remix)",
+    "EoS planetfunk-07"
+  ],
+  "cotc-eos-magnetosphere-06-birthegg": [
+    "EoS - magnetosphere 06 - birthegg",
+    "EoS"
+  ],
+  "cotc-eos-magnetosphere-05": ["EoS - magnetosphere 05", "EoS"],
+  "cotc-eos-magnetosphere-11-polarsphere-warp": [
+    "EoS - magnetosphere 11 - polarsphere-warp",
+    "EoS"
+  ],
+  "cotc-eos-magnetosphere-04": ["EoS - magnetosphere 04", "EoS"],
+  "cotc-eos-magnetosphere-08-quantum": [
+    "EoS - magnetosphere 08 - quantum",
+    "EoS"
+  ],
+  "cotc-eos-magnetosphere-03": ["EoS - magnetosphere 03", "EoS"],
+  "cotc-evet-mindmelt-responsive-mix": [
+    "EVET - Mindmelt Responsive mix",
+    "EVET"
+  ],
+  "cotc-incubus-our-destiny": ["InCUbuS - Our Destiny", "InCUbuS"],
+  "cotc-royal-mashup-276": ["$$$ Royal - Mashup (276)", "$$$ Royal"],
+  "cotc-royal-mashup-385-isosceles-edit": [
+    "$$$ Royal - Mashup (385)",
+    "$$$ Royal"
+  ],
+  "cotc-orb-cloud-burst": ["ORB - Cloud Burst", "ORB"],
+  "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall": [
+    "suksma + rovaster eos phat gastly geiss stahlgren - copper mine shaft fall",
+    "suksma + rovaster eos phat gastly geiss stahlgren"
+  ],
+  "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit": [
+    "goody + amandio c - final hour - eclipse shader rmx",
+    "goody + amandio c"
+  ],
+  "cotc-dark-one-happy-sad-daisy": ["Dark One - Happy Sad Daisy", "Dark One"],
+  "cotc-dark-one-clouds": ["Dark One - Clouds", "Dark One"],
+  "cotc-royal-mashup-444": ["$$$ Royal - Mashup (444)", "$$$ Royal"],
+  "cotc-fishbrain-swarming-glory-geomancy-remix": [
+    "fiShbRaiN - swarming glory (geomancy remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-suksma-type-o-negative-world-coming-down": [
+    "suksma - type o negative - world coming down",
+    "suksma"
+  ],
+  "cotc-evet-fishbrain-betelguese-hyperdrive-remix": [
+    "EVET - fiShbRaiN - betelguese (hyperdrive remix)",
+    "EVET"
+  ],
+  "cotc-fishbrain-swarming-glory-angry-remix": [
+    "fiShbRaiN - swarming glory (angry remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-royal-mashup-376": ["$$$ Royal - Mashup (376)", "$$$ Royal"],
+  "cotc-suksma-time-is-a-prison": ["suksma - time is a prison", "suksma"],
+  "cotc-royal-mashup-69": ["$$$ Royal - Mashup (69)", "$$$ Royal"],
+  "cotc-tag-cradle-of-life-remix-of-yin-315": [
+    "Tag - Cradle of Life(remix of yin 315)",
+    "Tag"
+  ],
+  "cotc-eos-phat-the-lights-at-night-spikes": [
+    "EoS+Phat - the lights at night_spikes",
+    "EoS+Phat"
+  ],
+  "cotc-suksma-apparitions-tear-at-your-b": [
+    "suksma - apparitions tear at your b",
+    "suksma"
+  ],
+  "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul": [
+    "suksma + var eos geiss goody - god parasite dissonance palms your soul",
+    "suksma + var eos geiss goody"
+  ],
+  "cotc-custom1": ["custom1", ""],
+  "cotc-royal-mashup-276-isosceles-edit": [
+    "$$$ Royal - Mashup (276)",
+    "$$$ Royal"
+  ],
+  "cotc-royal-mashup-381": ["$$$ Royal - Mashup (381)", "$$$ Royal"],
+  "cotc-fishbrain-betelguese-hyperdrive-remix": [
+    "fiShbRaiN - betelguese (hyperdrive remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-tripgnosis-firestar": ["Tripgnosis - Firestar", "Tripgnosis"],
+  "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain": [
+    "suksma - Dark One - Clouds - i forcibly shoved the crowbar down my skeletal remain",
+    "suksma"
+  ],
+  "cotc-fishbrain-betelguese3-aa": ["fiShbRaiN - betelguese3 aa", "fiShbRaiN"],
+  "cotc-royal-mashup-382": ["$$$ Royal - Mashup (382)", "$$$ Royal"],
+  "cotc-suksma-fishbrain-hexcollie-martin-bioluminescent-aerodynamic-poltergeist": [
+    "suksma + fishbrain hexcollie martin - bioluminescent aerodynamic poltergeist",
+    "suksma + fishbrain hexcollie martin"
+  ],
+  "cotc-rovastar-rocke-answer42-trippy-sperm-mix": [
+    "Rovastar & Rocke - Answer42 (Trippy Sperm Mix)",
+    "Rovastar & Rocke"
+  ],
+  "cotc-hexcollie-abyssal-dreamscape": [
+    "Hexcollie - Abyssal Dreamscape",
+    "Hexcollie"
+  ],
+  "cotc-fishbrain-david-bowie-cpe": [
+    "fiShbRaiN - david bowie cpe",
+    "fiShbRaiN"
+  ],
+  "cotc-eos-phat-recursion-frustum-02-ananda-flash-remix-zion-6-orange-hold": [
+    "EoS + Phat - recursion frustum 02_Ananda_Flash_Remix zion 6 orange hold",
+    "EoS + Phat"
+  ],
+  "cotc-orb-waaa-jelly-5-55": ["ORB - Waaa (Jelly 5-55)", "ORB"],
+  "cotc-orb-wheel-of-fire": ["ORB - Wheel of Fire", "ORB"],
+  "cotc-royal-mashup-59": ["$$$ Royal - Mashup (59)", "$$$ Royal"],
+  "cotc-royal-mashup-85": ["$$$ Royal - Mashup (85)", "$$$ Royal"],
+  "cotc-royal-mashup-290": ["$$$ Royal - Mashup (290)", "$$$ Royal"],
+  "cotc-royal-mashup-405": ["$$$ Royal - Mashup (405)", "$$$ Royal"],
+  "cotc-royal-mashup-83": ["$$$ Royal - Mashup (83)", "$$$ Royal"],
+  "cotc-royal-mashup-58": ["$$$ Royal - Mashup (58)", "$$$ Royal"],
+  "cotc-royal-mashup-96": ["$$$ Royal - Mashup (96)", "$$$ Royal"],
+  "cotc-orb-fire-and-fumes-2": ["ORB - Fire and Fumes 2", "ORB"],
+  "cotc-orb-waaa": ["ORB - Waaa", "ORB"],
+  "cotc-bmelgren-liqurido2": ["bmelgren - Liqurido2", "bmelgren"],
+  "cotc-hexcollie-surge": ["Hexcollie - Surge", "Hexcollie"],
+  "cotc-northern-lights-ii": ["Northern Lights II", ""],
+  "cotc-waltra-furry-synthesis-isosceles-edit2": [
+    "Waltra - Furry Synthesis",
+    "Waltra"
+  ],
+  "cotc-eos-phat-trinary-02-afterlife": [
+    "EoS + phat - trinary 02 - afterlife",
+    "EoS + phat"
+  ],
+  "cotc-syst3mfailur-phat-eos-planetfunk-tracers-devilglobe-4": [
+    "Syst3mFailur - phat - EoS planetfunk-tracers(devilglobe-4)",
+    "Syst3mFailur"
+  ],
+  "cotc-suksma-last-thing-i-remember-was-reading-tombstones": [
+    "suksma - last thing i remember was reading tombstones",
+    "suksma"
+  ],
+  "cotc-rovastar-geiss-hyperkaleidoscope-glow-2-multitonal": [
+    "Rovastar + Geiss - Hyperkaleidoscope Glow 2 Multitonal",
+    "Rovastar + Geiss"
+  ],
+  "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams": [
+    "skipper skipper kiss me hard - thank god for martin nitorami - a rip in mommy's underwear roams",
+    "skipper skipper kiss me hard"
+  ],
+  "cotc-suksma-as-for-me-i-take-medicines": [
+    "suksma - as for me, i take medicines",
+    "suksma"
+  ],
+  "cotc-undulate-harque-amaz-inge": [
+    "undulate harque - amaz inge",
+    "undulate harque"
+  ],
+  "cotc-suksma-circle-of-the-taeyrunts": [
+    "suksma - circle of the taeyrunts",
+    "suksma"
+  ],
+  "cotc-undulate-harque-brit-tlee": [
+    "undulate harque - brit tlee",
+    "undulate harque"
+  ],
+  "cotc-shifter-plasmic": ["shifter - plasmic", "shifter"],
+  "cotc-extreme-paranoia-and-fear-unleash-in-spontaneous-suicide-flails-slapping-the-elite-roam3": [
+    "extreme paranoia and fear unleash in spontaneous suicide flails - slapping the elite roam3",
+    "extreme paranoia and fear unleash in spontaneous suicide flails"
+  ],
+  "cotc-extreme-paranoia-and-fear-unleash-in-spontaneous-suicide-flails-slapping-the-elite": [
+    "extreme paranoia and fear unleash in spontaneous suicide flails - slapping the elite",
+    "extreme paranoia and fear unleash in spontaneous suicide flails"
+  ],
+  "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies": [
+    "suksma - log smell via gandalf pipeweed taint - flashies",
+    "suksma"
+  ],
+  "cotc-suksma-hordes-and-legions-of-unborn": [
+    "suksma - hordes and legions of unborn",
+    "suksma"
+  ],
+  "cotc-suksma-confetti-manslut": ["suksma - confetti manslut", "suksma"],
+  "cotc-goody-in-the-passenger-seat-with-a-head-full-of-acid-ps2-0": [
+    "Goody - In the Passenger Seat with a Head Full of Acid (PS2-0)",
+    "Goody"
+  ],
+  "cotc-stahlregen-hyperspace-rainbow": [
+    "Stahlregen - Hyperspace Rainbow",
+    "Stahlregen"
+  ],
+  "cotc-suksma-flukerication-machinist": [
+    "suksma - flukerication machinist",
+    "suksma"
+  ],
+  "cotc-suksma-actually-i-didn-t-eat-last-night": [
+    "suksma - actually i didn't eat last night",
+    "suksma"
+  ],
+  "cotc-suksma-and-i-will-have-salmon-for-dinner": [
+    "suksma - and i will have salmon for dinner",
+    "suksma"
+  ],
+  "cotc-suksma-log-smell-via-gandalf-pipeweed-taint": [
+    "suksma - log smell via gandalf pipeweed taint",
+    "suksma"
+  ],
+  "cotc-rovastar-kronos-twisted-spawn": [
+    "Rovastar - Kronos' Twisted Spawn",
+    "Rovastar"
+  ],
+  "cotc-suksma-barnacle-coated-hemoclubbin": [
+    "suksma - barnacle coated hemoclubbin'",
+    "suksma"
+  ],
+  "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies2": [
+    "suksma - log smell via gandalf pipeweed taint - flashies2",
+    "suksma"
+  ],
+  "cotc-suksma-cad-bury-chalk-let-egz-demonlord-i-am-aware-of-the-fools-i-follow-there-s-nothing-be": [
+    "suksma - cad bury chalk let egz + demonlord - i am aware of the fools i follow, there's nothing better to do",
+    "suksma"
+  ],
+  "cotc-eos-pointfield-07-insek-mash0000-shiny-bladed-homicide-machine-at-dusk": [
+    "EoS - pointfield 07 insek - mash0000 - shiny-bladed homicide machine at dusk",
+    "EoS"
+  ],
+  "cotc-border-magic": ["Border-magic", ""],
+  "cotc-waltra-galactic-super-perspective": [
+    "Waltra - Galactic Super Perspective",
+    "Waltra"
+  ],
+  "cotc-eos-and-pieturp-starfield-with-huge-stars": [
+    "EoS and PieturP - Starfield-with-huge-stars",
+    "EoS and PieturP"
+  ],
+  "cotc-fishbrain-swarming-glory": ["fiShbRaiN - swarming glory", "fiShbRaiN"],
+  "cotc-fishbrain-swarming-glory-spiral-remix": [
+    "fiShbRaiN - swarming glory (spiral remix)",
+    "fiShbRaiN"
+  ],
+  "cotc-53": ["53", ""],
+  "cotc-martin-soma-in-pink": ["martin - soma in pink", "martin"],
+  "cotc-suksma-passive-probabilistic-roaming": [
+    "suksma - passive probabilistic roaming",
+    "suksma"
+  ],
+  "cotc-fishbrain-swarming-glory-suksma-shapes": [
+    "fiShbRaiN - swarming glory suksma shapes",
+    "fiShbRaiN"
+  ],
+  "cotc-eos-pointfield-08-insek-nebula": [
+    "EoS - pointfield 08 insek nebula",
+    "EoS"
+  ],
+  "cotc-eos-pointfield-09-the-gases-beyond-85b-3d": [
+    "EoS - pointfield 09 the gases beyond 85b 3d",
+    "EoS"
+  ],
+  "cotc-220": ["220", ""],
+  "cotc-beta106i-burning-form-seething-mass-mash0000-fire-paint-easter-egg-internals-isosceles-edit": [
+    "beta106i - Burning Form (Seething Mass) - mash0000 - fire paint easter egg internals",
+    "beta106i"
+  ],
+  "cotc-fishbrain-gandalf-does-it-best-pipeweed-remix-v2-phat-rose-mix": [
+    "fiShbRaiN - gandalf does it best (pipeweed remix v2)_phat_rose_mix",
+    "fiShbRaiN"
+  ],
+  "cotc-royal-mashup-103": ["$$$ Royal - Mashup (103)", "$$$ Royal"],
+  "cotc-eos-pointfield-09-the-gases-beyond-85b-3d-v2": [
+    "EoS - pointfield 09 the gases beyond 85b 3d_v2",
+    "EoS"
+  ],
+  "cotc-174": ["174", ""],
+  "cotc-royal-mashup-104": ["$$$ Royal - Mashup (104)", "$$$ Royal"],
+  "cotc-suksma-ritually-invoking-the-irrational-slaves": [
+    "suksma - ritually invoking the irrational slaves",
+    "suksma"
+  ],
+  "cotc-shifter-rapid-birth": ["shifter - rapid birth", "shifter"],
+  "cotc-royal-mashup-102": ["$$$ Royal - Mashup (102)", "$$$ Royal"],
+  "cotc-shifter-fuzzball-implosion": [
+    "shifter - fuzzball (implosion)",
+    "shifter"
+  ],
+  "cotc-shifter-rapid-birth-bright": [
+    "shifter - rapid birth bright",
+    "shifter"
+  ],
+  "cotc-royal-mashup-62": ["$$$ Royal - Mashup (62)", "$$$ Royal"],
+  "cotc-flexi-space-voyage-organic-aftermath-1": [
+    "Flexi - space voyage [organic aftermath 1]",
+    "Flexi"
+  ],
+  "cotc-eos-particle-storm-c": ["EoS - particle storm C", "EoS"],
+  "cotc-eos-pointfield-02-complex": ["EoS - pointfield 02 complex", "EoS"],
+  "cotc-eos-particle-storm-b": ["EoS - particle storm B", "EoS"],
+  "cotc-waltra-time-travel": ["Waltra - Time Travel", "Waltra"],
+  "cotc-eos-linefield-more-demon": ["EoS - linefield more demon", "EoS"],
+  "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2": [
+    "Stahlregen & EoS + Geiss + Krash + PieturP + Zylot - Dandelion_2",
+    "Stahlregen & EoS + Geiss + Krash + PieturP + Zylot"
+  ],
+  "cotc-isosceles-mashup23": ["Isosceles mashup23", ""],
+  "cotc-eos-cubetrace-particlefly-phat-solarized-mix": [
+    "EoS - cubetrace particlefly_Phat_Solarized_Mix",
+    "EoS"
+  ],
+  "cotc-eos-pointfield-09-the-gases-beyond-85b": [
+    "EoS - pointfield 09 the gases beyond 85b",
+    "EoS"
+  ],
+  "cotc-317": ["317", ""],
+  "cotc-goody-need-transcendance-remix": [
+    "Goody - Need - Transcendance remix",
+    "Goody"
+  ],
+  "cotc-141": ["141", ""],
+  "cotc-19": ["19", ""],
+  "cotc-146": ["146", ""],
+  "cotc-beta106i-arise-padded": ["beta106i - Arise! (Padded)", "beta106i"],
+  "cotc-310": ["310", ""],
+  "cotc-367": ["367", ""],
+  "cotc-170": ["170", ""],
+  "cotc-370": ["370", ""],
+  "cotc-13": ["13", ""],
+  "cotc-307": ["307", ""],
+  "cotc-312": ["312", ""],
+  "cotc-345": ["345", ""],
+  "cotc-308": ["308", ""],
+  "cotc-372": ["372", ""],
+  "cotc-368": ["368", ""],
+  "cotc-313": ["313", ""],
+  "cotc-318": ["318", ""],
+  "cotc-fed-s-spectro-2": ["fed's spectro 2", ""],
+  "cotc-16": ["16", ""],
+  "cotc-goody-need": ["Goody - Need", "Goody"],
+  "cotc-314": ["314", ""],
+  "cotc-338": ["338", ""],
+  "cotc-103": ["103", ""],
+  "cotc-102": ["102", ""],
+  "cotc-99": ["99", ""],
+  "cotc-315": ["315", ""],
+  "cotc-rovastar-stahlregen-touchdown-on-jelly-planet-bccn-v4": [
+    "Rovastar + Stahlregen - Touchdown on Jelly Planet (bccn V4)",
+    "Rovastar + Stahlregen"
+  ],
+  "cotc-bmelgren-shimmer-n-shine": ["Bmelgren - Shimmer N Shine", "Bmelgren"],
+  "cotc-zylot-rays-burst": ["Zylot - Rays (Burst)", "Zylot"],
+  "cotc-zylot-the-collective-unconcious-jelly-5-5": [
+    "Zylot - The Collective Unconcious (Jelly 5-5)",
+    "Zylot"
+  ],
+  "cotc-stahlregen-bass-pulsing-ps2": [
+    "Stahlregen - Bass Pulsing (PS2)",
+    "Stahlregen"
+  ],
+  "cotc-stahlregen-sparkling": ["Stahlregen - sparkling", "Stahlregen"],
+  "cotc-geiss-flower": ["Geiss - Flower", "Geiss"],
+  "cotc-stahlregen-eckshack-s-eyeball-floater-mix-plastic": [
+    "Stahlregen - Eckshack's Eyeball (floater mix) (Plastic)",
+    "Stahlregen"
+  ],
+  "cotc-geiss-drift-1-02-version": ["Geiss - Drift (1-02 Version)", "Geiss"],
+  "cotc-geiss-drift": ["Geiss - Drift", "Geiss"],
+  "cotc-bmelgren-tonic": ["Bmelgren - Tonic", "Bmelgren"],
+  "cotc-stahlregen-pulse-dark": ["Stahlregen - Pulse (Dark)", "Stahlregen"],
+  "cotc-beta106i-old-myths-and-fairytales": [
+    "beta106i - Old Myths and Fairytales",
+    "beta106i"
+  ],
+  "cotc-rovastar-unchained-life-after-pie-remix": [
+    "Rovastar + Unchained - Life After Pie (Remix)",
+    "Rovastar + Unchained"
+  ],
+  "cotc-bmelgren-krash-rainbo-unknowablemix1": [
+    "Bmelgren&krash-rainbo(unknowablemix1)",
+    ""
+  ],
+  "cotc-brownian-bass": ["Brownian Bass", ""],
+  "cotc-suksma-rovastar-goody-geiss-rism-1982-gremlin-pinto-hybrid-440-block-2000-watts-obscura-bla": [
+    "suksma + rovastar goody geiss rism - 1982 gremlin pinto hybrid 440 block 2000 watts obscura blaster dasd",
+    "suksma + rovastar goody geiss rism"
+  ],
+  "cotc-stahlregen-esotic-idiot24-7-rozzer-zylot-digital-heartbeat-3": [
+    "Stahlregen & Esotic + Idiot24-7 + Rozzer + Zylot - Digital Heartbeat_3",
+    "Stahlregen & Esotic + Idiot24-7 + Rozzer + Zylot"
+  ],
+  "cotc-cellular-growth": ["cellular growth", ""],
+  "cotc-bmelgren-morpherous3": ["Bmelgren-morpherous3", ""],
+  "cotc-fvese-mvfun4": ["Fvese-mvfun4", ""],
+  "cotc-rovastar-explosive-minds-kay": [
+    "Rovastar - Explosive Minds kay",
+    "Rovastar"
+  ],
+  "cotc-stahlregen-hypnotron-v-0-5": [
+    "stahlregen - hypnotron v 0-5",
+    "stahlregen"
+  ],
+  "cotc-stahlregen-eckshack-s-eyeball-popped-eyeball-mix": [
+    "Stahlregen - Eckshack's Eyeball (popped eyeball mix)",
+    "Stahlregen"
+  ],
+  "cotc-goody-s-unstable-sonic-reactor-inside-of-it-all-remix-aspect-fix": [
+    "Goody's Unstable Sonic Reactor (Inside of it all remix - aspect fix)",
+    "Goody's Unstable Sonic Reactor (Inside of it all remix"
+  ],
+  "cotc-ed-nameless": ["Ed - Nameless", "Ed"],
+  "cotc-royal-mashup-484": ["$$$ Royal - Mashup (484)", "$$$ Royal"],
+  "cotc-royal-mashup-270": ["$$$ Royal - Mashup (270)", "$$$ Royal"],
+  "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with": [
+    "shifter + flexi - american pie artifactory - never contribute - given 7 inches to bath with",
+    "shifter + flexi"
+  ],
+  "cotc-orb-lazer-ride": ["ORB - Lazer Ride", "ORB"],
+  "cotc-royal-mashup-160": ["$$$ Royal - Mashup (160)", "$$$ Royal"],
+  "cotc-royal-mashup-183": ["$$$ Royal - Mashup (183)", "$$$ Royal"],
+  "cotc-orb-fire-poi-2": ["ORB - Fire Poi 2", "ORB"],
+  "cotc-martin-sphery-tales-slow-version": [
+    "martin - sphery tales slow version",
+    "martin"
+  ],
+  "cotc-martin-sphery-tales": ["martin - sphery tales", "martin"],
+  "cotc-martin-lock-and-release": ["martin - lock and release", "martin"],
+  "cotc-shifter-glassworms-flare-jelly-5-5": [
+    "shifter - glassworms flare (Jelly 5-5)",
+    "shifter"
+  ],
+  "cotc-shifter-glassworms-original": [
+    "shifter - glassworms original",
+    "shifter"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-ghosts": [
+    "EoS - glowsticks v2 04 music minimal - ghosts",
+    "EoS"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-swim-color": [
+    "EoS - glowsticks v2 04 music minimal - swim color",
+    "EoS"
+  ],
+  "cotc-shifter-glassworms-flare-xbmc-speed-tweak": [
+    "shifter - glassworms flare (xbmc speed tweak)",
+    "shifter"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-swim": [
+    "EoS - glowsticks v2 04 music minimal - swim",
+    "EoS"
+  ],
+  "cotc-shifter-glassworms-flare-1": [
+    "shifter - glassworms flare_1",
+    "shifter"
+  ],
+  "cotc-shifter-glassworms-flip": ["shifter - glassworms flip", "shifter"],
+  "cotc-eos-more-waveforms-7": ["EoS - more waveforms 7", "EoS"],
+  "cotc-eos-phat-technicolor-e-breather-b": [
+    "EoS_Phat technicolor E breather B",
+    ""
+  ],
+  "cotc-eos-more-waveforms-7-phat-edit": [
+    "EoS - more waveforms 7_phat_edit",
+    "EoS"
+  ],
+  "cotc-hexcollie-eos-n-phat-just-an-object": [
+    "Hexcollie, EoS n Phat - Just an object",
+    "Hexcollie, EoS n Phat"
+  ],
+  "cotc-eos-phat-technicolor-f-breather-c": [
+    "EoS_Phat technicolor F breather C",
+    ""
+  ],
+  "cotc-eos-phat-3d-tracers": ["EoS_Phat_3d tracers", ""],
+  "cotc-eos-phat-technicolor-f-breather-d": [
+    "EoS_Phat technicolor F breather D",
+    ""
+  ],
+  "cotc-eos-phat-technicolor-f-breather-e": [
+    "EoS_Phat technicolor F breather E",
+    ""
+  ],
+  "cotc-eos-more-waveforms-8": ["EoS - more waveforms 8", "EoS"],
+  "cotc-evet-ball-lightning-1": ["EVET - Ball Lightning 1", "EVET"],
+  "cotc-evet-ball-lightning-1-isosceles-edit1": [
+    "EVET - Ball Lightning 1",
+    "EVET"
+  ],
+  "cotc-martin-diabolo-isosceles-edit": ["Martin - Diabolo", "Martin"],
+  "cotc-martin-diabolo": ["Martin - Diabolo", "Martin"],
+  "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk": [
+    "mrt ei cynical engineers working for a backward system unite in circle jerk",
+    ""
+  ],
+  "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink": [
+    "mrt ei cynical engineers working for a backward system unite in circle jerk oink",
+    ""
+  ],
+  "cotc-evet-ball-lightning-1-isosceles-edit2": [
+    "EVET - Ball Lightning 1",
+    "EVET"
+  ],
+  "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2e-feat-martin-flexi-phat": [
+    "EoS - glowsticks v2 03 music shifter edit b (Stahl's Reactive RMX V2e - feat martin, flexi + phat)",
+    "EoS"
+  ],
+  "cotc-royal-mashup-115": ["$$$ Royal - Mashup (115)", "$$$ Royal"],
+  "cotc-eos-glowsticks-02-phat-edit": ["EoS - glowsticks 02_Phat_edit", "EoS"],
+  "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2-border-mix": [
+    "EoS - glowsticks v2 03 music shifter edit b (Stahl's Reactive RMX V2) (border mix)",
+    "EoS"
+  ],
+  "cotc-royal-mashup-190": ["$$$ Royal - Mashup (190)", "$$$ Royal"],
+  "cotc-79": ["79", ""],
+  "cotc-hexcollie-this-is-where-we-begin-stripped": [
+    "Hexcollie - This is where we begin stripped",
+    "Hexcollie"
+  ],
+  "cotc-eos-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix099": [
+    "EoS - glowsticks v2 05 and proton lights (+Krash's beat code) _Phat_remix099",
+    "EoS"
+  ],
+  "cotc-eos-angleform-2-phat-decay-edit-v2throw-water-v2": [
+    "EoS - angleform 2_Phat_Decay_Edit_v2Throw_water_v2",
+    "EoS"
+  ],
+  "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic": [
+    "EoS - glowsticks v2 04 music minimal oscilloscope vomit mix keylontic",
+    "EoS"
+  ],
+  "cotc-royal-mashup-189": ["$$$ Royal - Mashup (189)", "$$$ Royal"],
+  "cotc-tripgnosis-firesticks-isosceles-edit04": [
+    "Tripgnosis - Firesticks",
+    "Tripgnosis"
+  ],
+  "cotc-455": ["455", ""],
+  "cotc-228": ["228", ""],
+  "cotc-eos-subtraction-fade": ["EoS - subtraction fade", "EoS"],
+  "cotc-luxxx-flowwerpowwer": ["LuxXx - Flowwerpowwer", "LuxXx"],
+  "cotc-royal-mashup-192": ["$$$ Royal - Mashup (192)", "$$$ Royal"],
+  "cotc-22": ["22", ""],
+  "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-flexi-s-reflections-phat-s-r": [
+    "EoS - glowsticks v2 03 music shifter edit b (Stahl's Reactive RMX + flexi's reflections + phat's reflecto)",
+    "EoS"
+  ],
+  "cotc-hexcollie-demonic-afterimages": [
+    "Hexcollie - Demonic Afterimages",
+    "Hexcollie"
+  ],
+  "cotc-34": ["34", ""],
+  "cotc-royal-mashup-21": ["$$$ Royal - Mashup (21)", "$$$ Royal"],
+  "cotc-eos-angleform-4mirror": ["EoS - angleform 4mirror", "EoS"],
+  "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff-isosceles-edit": [
+    "Hexcollie, TI@N, Suksma n Zylot - BLARFFFF",
+    "Hexcollie, TI@N, Suksma n Zylot"
+  ],
+  "cotc-suksma-water-cooled-red-uranium-vs-dotes-here-have-a-hoho-flacc-grey-budget-never-ending-ba": [
+    "suksma - water cooled red uranium vs dotes - here, have a hoho - flacc+ - grey budget (never ending babes)",
+    "suksma"
+  ],
+  "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killphreqs-mix4-flacc": [
+    "stahlregen - dots (layered) - suksma world humanvirus replication killphreqs mix4 - flacc",
+    "stahlregen"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-you-can-buy-hate-flacc": [
+    "suksma - dotes hostile undertake - you can buy hate - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis": [
+    "suksma - ed geining hateops - flx if it is selfish to have your focus, then i am an ever unsatisfied hedonist - 1000 zeroes",
+    "suksma"
+  ],
+  "cotc-bleeding-like-a-horsey": ["bleeding like a horsey", ""],
+  "cotc-compelling-vision": ["Compelling Vision", ""],
+  "cotc-suksma-geiss-dotes-roams-proph": [
+    "suksma - geiss + dotes roams proph",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc": [
+    "suksma - dotes hostile undertake - finished breathing sir - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-geiss-dotes-roams": ["suksma - geiss + dotes roams", "suksma"],
+  "cotc-suksma-dotes-hostile-undertake-offx-flacc": [
+    "suksma - dotes hostile undertake - offx - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-mtn-flx-flacc-roam3": [
+    "suksma - mtn,flx - flacc roam3",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-demonlord-blood-in-your-eyes-again-flacc": [
+    "suksma - dotes hostile undertake + demonlord - blood in your eyes again - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills": [
+    "suksma - dotes hostile undertake - dying visions2 - flacc roams thee 'big rip' of wills",
+    "suksma"
+  ],
+  "cotc-suksma-gss-sth-hogwoman-style-starin-at-sports-carscryin-schnig-flacc": [
+    "suksma - gss,sth - hogwoman style - starin' at sports carscryin' - schnig - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-j4-flacc": [
+    "suksma - dotes hostile undertake - j4+ - flacc",
+    "suksma"
+  ],
+  "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-thinkin-bout-u": [
+    "hexcollie, ti@n, suksma, zylot, orb, martin n flexi - blarffff [thinkin bout u]",
+    "hexcollie, ti@n, suksma, zylot, orb, martin n flexi"
+  ],
+  "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff": [
+    "Hexcollie, TI@N, Suksma n Zylot - BLARFFFF",
+    "Hexcollie, TI@N, Suksma n Zylot"
+  ],
+  "cotc-suksma-geiss-dotes-orb": ["suksma - geiss + dotes orb", "suksma"],
+  "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi": [
+    "suksma - dotes hostile undertake - autoclayve - flacc das yi",
+    "suksma"
+  ],
+  "cotc-suksma-gss-sth-hogwoman-style-deaf-delphying-flacc-signal-propagation-rhythm": [
+    "suksma - gss,sth - hogwoman style - deaf delphying - flacc signal propagation rhythm",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats": [
+    "suksma - dotes hostile undertake - dying visions2 - flacc roams thee 'big rip' of wills rce beats",
+    "suksma"
+  ],
+  "cotc-suksma-geiss-dotes-orb-extreme-elegance": [
+    "suksma - geiss + dotes orb extreme elegance",
+    "suksma"
+  ],
+  "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire": [
+    "hexcollie, ti@n, suksma, zylot n orb - blarffff fire",
+    "hexcollie, ti@n, suksma, zylot n orb"
+  ],
+  "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi": [
+    "suksma - mtn,flx - flacc - choilan - stenter phi",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-j4-2": [
+    "suksma - dotes hostile undertake - j4+2",
+    "suksma"
+  ],
+  "cotc-luxxx-wip": ["LuxXx - WIP", "LuxXx"],
+  "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire-isosceles-edit": [
+    "hexcollie, ti@n, suksma, zylot n orb - blarffff fire",
+    "hexcollie, ti@n, suksma, zylot n orb"
+  ],
+  "cotc-bleeding-like-a-horsey-roams-i-just-got-through-watching-planet-bboy-and-boy-do-i-feel-emba": [
+    "bleeding like a horsey roams i just got through watching planet bboy and boy do i feel embarrassed for myself and all the world",
+    ""
+  ],
+  "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam": [
+    "suksma - dotes hostile undertake - autoclayve - flacc das yi roam",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher": [
+    "suksma - dotes hostile undertake - yada yaka yada - flacc spher",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam": [
+    "suksma - dotes hostile undertake - finished breathing sir flacc roam",
+    "suksma"
+  ],
+  "cotc-suksma-mtn-flx-flacc-choilan-collapsar": [
+    "suksma - mtn,flx - flacc - choilan - collapsar",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted": [
+    "suksma - dotes var - eyes built to fuck - flacc - when we touch, i get disgusted",
+    "suksma"
+  ],
+  "cotc-drugsincombat-reactive-molecule-v-05a": [
+    "drugsincombat - reactive molecule v-05a",
+    "drugsincombat"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-pacific-heights-flacc-roams-higher-self-lower-self-battles": [
+    "suksma - dotes hostile undertake - pacific heights - flacc roams higher self lower self battles",
+    "suksma"
+  ],
+  "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore": [
+    "suksma - mtn,flx - flacc - choilan - duncan dodo boid dna kodak whore",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid": [
+    "suksma - dotes hostile undertake - j4+ - flacc - bryan fnord kool aid",
+    "suksma"
+  ],
+  "cotc-luxxx-wip-isosceles-edit": ["LuxXx - WIP", "LuxXx"],
+  "cotc-fleekus-flokus-violent-and-insane-homicidal-air-molecules-beat-code-experiment2-gss": [
+    "fleekus flokus - violent and insane homicidal air molecules - beat code experiment2 gss",
+    "fleekus flokus"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher": [
+    "suksma - dotes hostile undertake - painterly oil reflection - flacc spher",
+    "suksma"
+  ],
+  "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killgaia-mix2": [
+    "stahlregen - dots (layered) - suksma world humanvirus replication killgaia mix2",
+    "stahlregen"
+  ],
+  "cotc-suksma-geiss-dotes-holiday-hidden-in-plain-sight-clown": [
+    "suksma - geiss + dotes - holiday hidden in plain sight clown",
+    "suksma"
+  ],
+  "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist": [
+    "suksma - question authority, take what you want, be a nihilist",
+    "suksma"
+  ],
+  "cotc-suksma-mtn-flx-flacc": ["suksma - mtn,flx - flacc", "suksma"],
+  "cotc-krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision": [
+    "Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren's Compelling Vision)",
+    "Krash + Rovastar"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-one-too-many-days-under-the-iron-flacc": [
+    "suksma - dotes hostile undertake - one too many days under the iron - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc": [
+    "suksma - ed geining hateops - flx maggotillion flacc",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam2": [
+    "suksma - dotes var - eyes built to fuck - flacc - when we touch, i get disgusted roam2",
+    "suksma"
+  ],
+  "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed": [
+    "Stahlregen & Flexi + Geiss - Liquidity (Dynamic Swirls) - mess flout tessed",
+    "Stahlregen & Flexi + Geiss"
+  ],
+  "cotc-undermines-him-in-the-subtlest-ways-mega-schoob-1d-serial-flashline-projection-creator": [
+    "undermines him in the subtlest ways mega schoob 1d serial flashline projection creator",
+    ""
+  ],
+  "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam3": [
+    "suksma - dotes var - eyes built to fuck - flacc - when we touch, i get disgusted roam3",
+    "suksma"
+  ],
+  "cotc-suksma-gss-sth-hogwoman-style-incantation-onward-to-golgotha-christening-the-afterbirth-fla": [
+    "suksma - gss,sth - hogwoman style - incantation - onward to golgotha - christening the afterbirth - flacc",
+    "suksma"
+  ],
+  "cotc-orb-inferno-burnt-to-a-crisp-ngdbthzs-avoid-homozoidne": [
+    "orb - inferno - burnt to a crisp - ngdbthzs avoid homozoidne",
+    "orb"
+  ],
+  "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-roams-drugs-stretch-time-wave-packe": [
+    "hexcollie, ti@n, suksma, zylot, orb, martin n flexi - blarffff roams drugs = stretch time wave packet",
+    "hexcollie, ti@n, suksma, zylot, orb, martin n flexi"
+  ],
+  "cotc-suksma-gss-sth-hogwoman-style-deaf-delphying-flacc": [
+    "suksma - gss,sth - hogwoman style - deaf delphying - flacc",
+    "suksma"
+  ],
+  "cotc-suksma-dotes-hostile-undertake-demonlord-blood-in-your-eyes-again-flacc-roam3": [
+    "suksma - dotes hostile undertake + demonlord - blood in your eyes again - flacc roam3",
+    "suksma"
   ]
 }

--- a/public/sitemap-1.xml
+++ b/public/sitemap-1.xml
@@ -24,7 +24,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/audio-reactive</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -35,7 +35,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/ambient</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -46,7 +46,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/fractal</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -57,7 +57,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/geometric</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -68,7 +68,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/hall-of-fame</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -79,7 +79,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/neon</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -90,7 +90,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/particles</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -101,7 +101,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/psychedelic</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -112,7 +112,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/retro</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -123,7 +123,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/space</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -134,7 +134,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/trippy</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -145,7 +145,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/tunnel</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -156,7 +156,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/waveform</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>
@@ -167,7 +167,7 @@
   </url>
   <url>
     <loc>https://toil.fyi/discover/webgpu-showcase</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
     <image:image>

--- a/public/sitemap-2.xml
+++ b/public/sitemap-2.xml
@@ -6,7 +6,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-glowsticks-v2-03-music</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-glowsticks-v2-03-music.png</image:loc>
       <image:title>Eo.S. - Glowsticks v2 03 Music | Stims</image:title>
       <image:caption>Eo.S. - Glowsticks v2 03 Music by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -17,7 +17,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-parallel-universe</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-parallel-universe.png</image:loc>
       <image:title>Rovastar - Parallel Universe | Stims</image:title>
       <image:caption>Rovastar - Parallel Universe by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -28,7 +28,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-cubetrace-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-cubetrace-v2.png</image:loc>
       <image:title>Eo.S. + Phat - Cubetrace v2 | Stims</image:title>
       <image:caption>Eo.S. + Phat - Cubetrace v2 by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -39,7 +39,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-cerebral-demons-stars</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-cerebral-demons-stars.png</image:loc>
       <image:title>Krash &amp; Rovastar - Cerebral Demons (Stars Remix) | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - Cerebral Demons (Stars Remix) by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -50,7 +50,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-potion-of-spirits</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-potion-of-spirits.png</image:loc>
       <image:title>Aderrasi - Potion of Spirits | Stims</image:title>
       <image:caption>Aderrasi - Potion of Spirits by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -61,7 +61,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-casino</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-casino.png</image:loc>
       <image:title>Geiss - Casino | Stims</image:title>
       <image:caption>Geiss - Casino by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -72,7 +72,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-snakeskin</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-snakeskin.png</image:loc>
       <image:title>Shifter - Snakeskin | Stims</image:title>
       <image:caption>Shifter - Snakeskin by Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -83,7 +83,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-swarm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-swarm.png</image:loc>
       <image:title>Shifter - Swarm | Stims</image:title>
       <image:caption>Shifter - Swarm by Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -94,7 +94,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-curlique</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-curlique.png</image:loc>
       <image:title>Shifter - Curlique | Stims</image:title>
       <image:caption>Shifter - Curlique by Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -105,7 +105,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequins-liquid-dragon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequins-liquid-dragon.png</image:loc>
       <image:title>Rovastar - Harlequin&apos;s Liquid Dragon | Stims</image:title>
       <image:caption>Rovastar - Harlequin&apos;s Liquid Dragon by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -116,7 +116,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-heater-core-c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-heater-core-c.png</image:loc>
       <image:title>Eo.S. - Heater Core C | Stims</image:title>
       <image:caption>Eo.S. - Heater Core C by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -127,7 +127,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-radiation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-radiation.png</image:loc>
       <image:title>Orb - Radiation | Stims</image:title>
       <image:caption>Orb - Radiation by Orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -138,7 +138,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-apocalypse</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-apocalypse.png</image:loc>
       <image:title>Eo.S. - Apocalypse | Stims</image:title>
       <image:caption>Eo.S. - Apocalypse by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -149,7 +149,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=dbleja-hovering-over-mars</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/dbleja-hovering-over-mars.png</image:loc>
       <image:title>Dbleja - Hovering - Over - Mars | Stims</image:title>
       <image:caption>Dbleja - Hovering - Over - Mars by Dbleja, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -160,7 +160,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=dbleja-hovering-over-pluto</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/dbleja-hovering-over-pluto.png</image:loc>
       <image:title>Dbleja - Hovering - Over - Pluto | Stims</image:title>
       <image:caption>Dbleja - Hovering - Over - Pluto by Dbleja, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -171,7 +171,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=dbleja-inside-the-tree-blue-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/dbleja-inside-the-tree-blue-mix.png</image:loc>
       <image:title>Dbleja - Inside - The - Tree - Blue - Mix | Stims</image:title>
       <image:caption>Dbleja - Inside - The - Tree - Blue - Mix by Dbleja, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -182,7 +182,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-dark-side-of-the-moon-clean-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-dark-side-of-the-moon-clean-mix.png</image:loc>
       <image:title>Eos - Dark - Side - Of - The - Moon - Clean - Mix | Stims</image:title>
       <image:caption>Eos - Dark - Side - Of - The - Moon - Clean - Mix by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -193,7 +193,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-ether-posession-phat-edit-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-ether-posession-phat-edit-v3.png</image:loc>
       <image:title>Eos - Ether - Posession - Phat - Edit - V3 | Stims</image:title>
       <image:caption>Eos - Ether - Posession - Phat - Edit - V3 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -204,7 +204,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-ether</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-ether.png</image:loc>
       <image:title>Eos - Ether | Stims</image:title>
       <image:caption>Eos - Ether by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -215,7 +215,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-matrix-cube-c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-matrix-cube-c.png</image:loc>
       <image:title>Eos - Matrix - Cube - C | Stims</image:title>
       <image:caption>Eos - Matrix - Cube - C by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -226,7 +226,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-cat-scan-nirvana</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-cat-scan-nirvana.png</image:loc>
       <image:title>Eos - Phat - Cat - Scan - Nirvana | Stims</image:title>
       <image:caption>Eos - Phat - Cat - Scan - Nirvana by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -237,7 +237,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-dark-heart</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-dark-heart.png</image:loc>
       <image:title>Eos - Phat - Dark - Heart | Stims</image:title>
       <image:caption>Eos - Phat - Dark - Heart by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -248,7 +248,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-linear-clouds-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-linear-clouds-v2.png</image:loc>
       <image:title>Eos - Phat - Linear - Clouds - V2 | Stims</image:title>
       <image:caption>Eos - Phat - Linear - Clouds - V2 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -259,7 +259,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-magnetosphere-13-pulsar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-magnetosphere-13-pulsar.png</image:loc>
       <image:title>Eos - Phat - Magnetosphere - 13 - Pulsar | Stims</image:title>
       <image:caption>Eos - Phat - Magnetosphere - 13 - Pulsar by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -270,7 +270,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-phat-vacuum-deification</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-phat-vacuum-deification.png</image:loc>
       <image:title>Eos - Phat - Vacuum - Deification | Stims</image:title>
       <image:caption>Eos - Phat - Vacuum - Deification by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -281,7 +281,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-quasar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-quasar.png</image:loc>
       <image:title>Eos - Quasar | Stims</image:title>
       <image:caption>Eos - Quasar by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -292,7 +292,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eos-starburst-05-phasing</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eos-starburst-05-phasing.png</image:loc>
       <image:title>Eos - Starburst - 05 - Phasing | Stims</image:title>
       <image:caption>Eos - Starburst - 05 - Phasing by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -303,7 +303,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=evet-proteus-core-element-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/evet-proteus-core-element-5.png</image:loc>
       <image:title>Evet - Proteus - Core - Element - 5 | Stims</image:title>
       <image:caption>Evet - Proteus - Core - Element - 5 by Evet, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -314,7 +314,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=evet-responsive-acid-iris</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/evet-responsive-acid-iris.png</image:loc>
       <image:title>Evet - Responsive - Acid - Iris | Stims</image:title>
       <image:caption>Evet - Responsive - Acid - Iris by Evet, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -325,7 +325,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bipolar-x</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bipolar-x.png</image:loc>
       <image:title>Geiss - Bipolar X | Stims</image:title>
       <image:caption>Geiss - Bipolar X by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -336,7 +336,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-happy-drops</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-happy-drops.png</image:loc>
       <image:title>Geiss - Happy Drops | Stims</image:title>
       <image:caption>Geiss - Happy Drops by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -347,7 +347,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-in-my-eyes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-in-my-eyes.png</image:loc>
       <image:title>Orb - Acid - In - My - Eyes | Stims</image:title>
       <image:caption>Orb - Acid - In - My - Eyes by Orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -358,7 +358,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-cloud-scope</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-cloud-scope.png</image:loc>
       <image:title>Orb - Cloud - Scope | Stims</image:title>
       <image:caption>Orb - Cloud - Scope by Orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -369,7 +369,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orbasonic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orbasonic.png</image:loc>
       <image:title>Orbasonic | Stims</image:title>
       <image:caption>Orbasonic by Orbasonic, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -380,7 +380,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=pieturp-sunflare</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/pieturp-sunflare.png</image:loc>
       <image:title>Pieturp - Sunflare | Stims</image:title>
       <image:caption>Pieturp - Sunflare by Pieturp, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -391,7 +391,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-and-idiot24-7-abstract-psychaos</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-and-idiot24-7-abstract-psychaos.png</image:loc>
       <image:title>Rovastar - And - Idiot24 - 7 - Abstract - Psychaos | Stims</image:title>
       <image:caption>Rovastar - And - Idiot24 - 7 - Abstract - Psychaos by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -402,7 +402,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-dark-ritual-star-of-destiny-denied-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-dark-ritual-star-of-destiny-denied-mix.png</image:loc>
       <image:title>Rovastar - Dark - Ritual - Star - Of - Destiny - Denied - Mix | Stims</image:title>
       <image:caption>Rovastar - Dark - Ritual - Star - Of - Destiny - Denied - Mix by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -413,7 +413,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-mosaics-of-ages</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-mosaics-of-ages.png</image:loc>
       <image:title>Rovastar - Mosaics - Of - Ages | Stims</image:title>
       <image:caption>Rovastar - Mosaics - Of - Ages by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -424,7 +424,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-oozing-resistance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-oozing-resistance.png</image:loc>
       <image:title>Rovastar - Oozing - Resistance | Stims</image:title>
       <image:caption>Rovastar - Oozing - Resistance by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -435,7 +435,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-glassworms-flare</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-glassworms-flare.png</image:loc>
       <image:title>Shifter - Glassworms - Flare | Stims</image:title>
       <image:caption>Shifter - Glassworms - Flare by Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -446,7 +446,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-spectro</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-spectro.png</image:loc>
       <image:title>Shifter - Spectro | Stims</image:title>
       <image:caption>Shifter - Spectro by Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -457,7 +457,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-rovastar-eos-square-faces-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-rovastar-eos-square-faces-v2.png</image:loc>
       <image:title>Phat + Rovastar + Eo.S. - Square Faces v2 | Stims</image:title>
       <image:caption>Phat + Rovastar + Eo.S. - Square Faces v2 by Phat + Rovastar + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -468,7 +468,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eos-trippy-rotation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eos-trippy-rotation.png</image:loc>
       <image:title>Phat + Rovastar + Eo.S. - Square Faces v2 | Stims</image:title>
       <image:caption>Phat + Rovastar + Eo.S. - Square Faces v2 by Phat + Rovastar + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -479,7 +479,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic12-3d-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic12-3d-2.png</image:loc>
       <image:title>!!!---flexi + amandio c - organic12-3d-2 | Stims</image:title>
       <image:caption>!!!---flexi + amandio c - organic12-3d-2 by !!!---flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -490,7 +490,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-160</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-160.png</image:loc>
       <image:title>$$$ Royal - Mashup (160) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (160) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -501,7 +501,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-169</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-169.png</image:loc>
       <image:title>$$$ Royal - Mashup (169) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (169) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -512,7 +512,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-177</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-177.png</image:loc>
       <image:title>$$$ Royal - Mashup (177) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (177) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -523,7 +523,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-197</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-197.png</image:loc>
       <image:title>$$$ Royal - Mashup (197) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (197) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -534,7 +534,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-220</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-220.png</image:loc>
       <image:title>$$$ Royal - Mashup (220) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (220) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -545,7 +545,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-222</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-222.png</image:loc>
       <image:title>$$$ Royal - Mashup (222) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (222) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -556,7 +556,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-253</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-253.png</image:loc>
       <image:title>$$$ Royal - Mashup (253) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (253) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -567,7 +567,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-273</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-273.png</image:loc>
       <image:title>$$$ Royal - Mashup (273) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (273) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -578,7 +578,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-307</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-307.png</image:loc>
       <image:title>$$$ Royal - Mashup (307) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (307) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -589,7 +589,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-326</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-326.png</image:loc>
       <image:title>$$$ Royal - Mashup (326) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (326) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -600,7 +600,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-337</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-337.png</image:loc>
       <image:title>$$$ Royal - Mashup (337) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (337) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -611,7 +611,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-383</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-383.png</image:loc>
       <image:title>$$$ Royal - Mashup (383) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (383) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -622,7 +622,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-431</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-431.png</image:loc>
       <image:title>$$$ Royal - Mashup (431) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (431) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -633,7 +633,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=royal-mashup-441</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/royal-mashup-441.png</image:loc>
       <image:title>$$$ Royal - Mashup (441) | Stims</image:title>
       <image:caption>$$$ Royal - Mashup (441) by $$$ Royal, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -644,7 +644,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=11</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/11.png</image:loc>
       <image:title>11 | Stims</image:title>
       <image:caption>11, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -655,7 +655,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=124</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/124.png</image:loc>
       <image:title>124 | Stims</image:title>
       <image:caption>124, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -666,7 +666,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=158</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/158.png</image:loc>
       <image:title>158 | Stims</image:title>
       <image:caption>158, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -677,7 +677,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=185</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/185.png</image:loc>
       <image:title>185 | Stims</image:title>
       <image:caption>185, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -688,7 +688,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=27-super-goats-have-you-ever-been-knocked-out-before-sunshine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/27-super-goats-have-you-ever-been-knocked-out-before-sunshine.png</image:loc>
       <image:title>27_super_goats - have you ever been knocked out before, sunshine. | Stims</image:title>
       <image:caption>27_super_goats - have you ever been knocked out before, sunshine. by 27_super_goats, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -699,7 +699,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=27-super-goats-neon-country-frequent-flier-program</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/27-super-goats-neon-country-frequent-flier-program.png</image:loc>
       <image:title>27_super_goats - neon country frequent flier program | Stims</image:title>
       <image:caption>27_super_goats - neon country frequent flier program by 27_super_goats, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -710,7 +710,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=27-super-goats-orbus-maximus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/27-super-goats-orbus-maximus.png</image:loc>
       <image:title>27_super_goats-orbus_maximus | Stims</image:title>
       <image:caption>27_super_goats-orbus_maximus, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -721,7 +721,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=36</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/36.png</image:loc>
       <image:title>36 | Stims</image:title>
       <image:caption>36, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -732,7 +732,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=3dragons-rovastar-cave-life-mash0000-fire-beams-smoke</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/3dragons-rovastar-cave-life-mash0000-fire-beams-smoke.png</image:loc>
       <image:title>3dRaGoNs &amp; Rovastar - CaVe LiFe - mash0000 - fire, beams, smoke | Stims</image:title>
       <image:caption>3dRaGoNs &amp; Rovastar - CaVe LiFe - mash0000 - fire, beams, smoke by 3dRaGoNs &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -743,7 +743,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=3dragons-unchained-dragon-science</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/3dragons-unchained-dragon-science.png</image:loc>
       <image:title>3dRaGoNs &amp; Unchained - Dragon Science | Stims</image:title>
       <image:caption>3dRaGoNs &amp; Unchained - Dragon Science by 3dRaGoNs &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -754,7 +754,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=414-bowel-rebranding-pr-whore-skinned-to-the-teeth-shader-serial-killer-common-glut</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/414-bowel-rebranding-pr-whore-skinned-to-the-teeth-shader-serial-killer-common-glut.png</image:loc>
       <image:title>414 bowel rebranding pr whore skinned to the teeth shader serial killer common glut | Stims</image:title>
       <image:caption>414 bowel rebranding pr whore skinned to the teeth shader serial killer common glut, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -765,7 +765,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=414-bowel-rebranding-pr-whore-skinned-to-the-teeth-shader-serial-killer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/414-bowel-rebranding-pr-whore-skinned-to-the-teeth-shader-serial-killer.png</image:loc>
       <image:title>414 bowel rebranding pr whore skinned to the teeth shader serial killer | Stims</image:title>
       <image:caption>414 bowel rebranding pr whore skinned to the teeth shader serial killer, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -776,7 +776,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=444</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/444.png</image:loc>
       <image:title>444 | Stims</image:title>
       <image:caption>444, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -787,7 +787,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=86</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/86.png</image:loc>
       <image:title>86 | Stims</image:title>
       <image:caption>86, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -798,7 +798,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=93</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/93.png</image:loc>
       <image:title>93 | Stims</image:title>
       <image:caption>93, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -809,7 +809,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual.png</image:loc>
       <image:title>A Milk Art Detail 2 flexi - moebius transformation ft Martin With AdamFX B sentensual | Stims</image:title>
       <image:caption>A Milk Art Detail 2 flexi - moebius transformation ft Martin With AdamFX B sentensual by A Milk Art Detail 2 flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -820,7 +820,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=a-new-wave-trend-in-milk-martin-discomix-3-ft-phat-yin-n-adamfx-a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/a-new-wave-trend-in-milk-martin-discomix-3-ft-phat-yin-n-adamfx-a.png</image:loc>
       <image:title>A New Wave Trend in Milk - Martin - DiscoMix  3 Ft Phat Yin n AdamFX  A | Stims</image:title>
       <image:caption>A New Wave Trend in Milk - Martin - DiscoMix  3 Ft Phat Yin n AdamFX  A by A New Wave Trend in Milk, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -831,7 +831,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=a-tribute-to-martin-bombyx-mori-ft-flexi-adamfx-stahlregen-krash-rovastar-hd-in-milk-t</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/a-tribute-to-martin-bombyx-mori-ft-flexi-adamfx-stahlregen-krash-rovastar-hd-in-milk-t.png</image:loc>
       <image:title>A Tribute to Martin - bombyx mori - Ft Flexi - AdamFX - StahlRegen - Krash - Rovastar -  Hd in Milk T | Stims</image:title>
       <image:caption>A Tribute to Martin - bombyx mori - Ft Flexi - AdamFX - StahlRegen - Krash - Rovastar -  Hd in Milk T by A Tribute to Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -842,7 +842,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=a-twistin-infusion-martin-shiny-tunnel-rewiredfx-ft-adamfx-infusionfx-electricpoolfx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/a-twistin-infusion-martin-shiny-tunnel-rewiredfx-ft-adamfx-infusionfx-electricpoolfx.png</image:loc>
       <image:title>A Twistin Infusion - Martin - shiny tunnel rewiredFX  Ft AdamFX InfusionFX (ElectricPoolFX) | Stims</image:title>
       <image:caption>A Twistin Infusion - Martin - shiny tunnel rewiredFX  Ft AdamFX InfusionFX (ElectricPoolFX) by A Twistin Infusion, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -853,7 +853,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-aderrasi-2-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-aderrasi-2-1.png</image:loc>
       <image:title>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Aderrasi 2_1 | Stims</image:title>
       <image:caption>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Aderrasi 2_1 by Adam Eatit Mashup FX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -864,7 +864,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-baked-ft-another-adamfx-mashup-7-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-baked-ft-another-adamfx-mashup-7-1.png</image:loc>
       <image:title>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Baked Ft another AdamFX Mashup 7_1 | Stims</image:title>
       <image:caption>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Baked Ft another AdamFX Mashup 7_1 by Adam Eatit Mashup FX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -875,7 +875,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-eos-ft-flexi-n-hexocollie-baked-santa-fucking-claus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-eatit-mashup-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-eos-ft-flexi-n-hexocollie-baked-santa-fucking-claus.png</image:loc>
       <image:title>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Eos Ft Flexi n Hexocollie + Baked + Santa Fucking Claus | Stims</image:title>
       <image:caption>Adam Eatit Mashup FX 2 martin - disco mix + Lodus + Geiss + Ludicrous speed + Eos Ft Flexi n Hexocollie + Baked + Santa Fucking Claus by Adam Eatit Mashup FX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -886,7 +886,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-fx-2-zylot-age-of-science-fierceness-16-mash0000-gerber-full-heaving-baby</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-fx-2-zylot-age-of-science-fierceness-16-mash0000-gerber-full-heaving-baby.png</image:loc>
       <image:title>Adam Fx 2 Zylot - Age of Science Fierceness 16 - mash0000 - gerber full heaving baby | Stims</image:title>
       <image:caption>Adam Fx 2 Zylot - Age of Science Fierceness 16 - mash0000 - gerber full heaving baby by Adam Fx 2 Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -897,7 +897,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs-geiss-composite-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs-geiss-composite-mix.png</image:loc>
       <image:title>Adam Fx 2 Zylot - Age of Science Fierceness BEAST2 - mash0000 - ethics is for weiner dogs - Geiss composite mix | Stims</image:title>
       <image:caption>Adam Fx 2 Zylot - Age of Science Fierceness BEAST2 - mash0000 - ethics is for weiner dogs - Geiss composite mix by Adam Fx 2 Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -908,7 +908,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs.png</image:loc>
       <image:title>Adam Fx 2 Zylot - Age of Science Fierceness BEAST2 - mash0000 - ethics is for weiner dogs | Stims</image:title>
       <image:caption>Adam Fx 2 Zylot - Age of Science Fierceness BEAST2 - mash0000 - ethics is for weiner dogs by Adam Fx 2 Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -919,7 +919,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-fx-2-zylot-age-of-science-fierceness-starburst-5-mash0000</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-fx-2-zylot-age-of-science-fierceness-starburst-5-mash0000.png</image:loc>
       <image:title>Adam Fx 2 Zylot - Age of Science Fierceness Starburst 5 - mash0000 | Stims</image:title>
       <image:caption>Adam Fx 2 Zylot - Age of Science Fierceness Starburst 5 - mash0000 by Adam Fx 2 Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -930,7 +930,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-angelic-staine-glass-chapters-6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-angelic-staine-glass-chapters-6.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up - Angelic  Staine Glass Chapters 6 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up - Angelic  Staine Glass Chapters 6 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -941,7 +941,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-angelic-staine-glass-chapters-6-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-angelic-staine-glass-chapters-6-1.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up - Angelic  Staine Glass Chapters 6_1 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up - Angelic  Staine Glass Chapters 6_1 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -952,7 +952,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-angelic-spike-living-stained-glass-chapters</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-angelic-spike-living-stained-glass-chapters.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up - Angelic Spike Living Stained Glass Chapters | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up - Angelic Spike Living Stained Glass Chapters by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -963,7 +963,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -974,7 +974,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye2.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye2 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye2 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -985,7 +985,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye3.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye3 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye3 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -996,7 +996,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye4.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye4 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye4 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1007,7 +1007,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye6.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye6 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye6 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1018,7 +1018,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7.png</image:loc>
       <image:title>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye7 | Stims</image:title>
       <image:caption>AdamFX 2 Geiss - Mash-Up Sphere Xibit Graffiti Warp me Tydye7 by AdamFX 2 Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1029,7 +1029,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-mashup-2-martin-reflections-on-black-tile-raron-n-flexi</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-mashup-2-martin-reflections-on-black-tile-raron-n-flexi.png</image:loc>
       <image:title>AdamFX Mashup 2 Martin - reflections on black tile + Raron N Flexi  | Stims</image:title>
       <image:caption>AdamFX Mashup 2 Martin - reflections on black tile + Raron N Flexi  by AdamFX Mashup 2 Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1040,7 +1040,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-aderrasi-airhandler-last-breath-calm-ilusional-discontent2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-aderrasi-airhandler-last-breath-calm-ilusional-discontent2.png</image:loc>
       <image:title>AdamFx 2 Aderrasi - Airhandler (Last Breath - Calm)Ilusional Discontent2 | Stims</image:title>
       <image:caption>AdamFx 2 Aderrasi - Airhandler (Last Breath - Calm)Ilusional Discontent2 by AdamFx 2 Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1051,7 +1051,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-somewhat-distort-me-3-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-somewhat-distort-me-3-1.png</image:loc>
       <image:title>AdamFx 2 Geiss -Somewhat Distort Me 3_1 | Stims</image:title>
       <image:caption>AdamFx 2 Geiss -Somewhat Distort Me 3_1 by AdamFX + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1062,7 +1062,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adamfx-2-geiss-zylot-and-flexi-reaction-diffusion-3-overload-mix-2-eatit4-bccnj4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adamfx-2-geiss-zylot-and-flexi-reaction-diffusion-3-overload-mix-2-eatit4-bccnj4.png</image:loc>
       <image:title>AdamFx 2 Geiss, Zylot and Flexi - Reaction Diffusion 3 (Overload Mix 2) EATIT4 (BCCNJ4) | Stims</image:title>
       <image:caption>AdamFx 2 Geiss, Zylot and Flexi - Reaction Diffusion 3 (Overload Mix 2) EATIT4 (BCCNJ4) by AdamFx 2 Geiss, Zylot and Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1073,7 +1073,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-flexi-airhandler-last-breath-calm-moebius-morbid-vision-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-flexi-airhandler-last-breath-calm-moebius-morbid-vision-edit.png</image:loc>
       <image:title>Aderrasi + Flexi - Airhandler (Last Breath - Calm) [moebius morbid vision edit] | Stims</image:title>
       <image:caption>Aderrasi + Flexi - Airhandler (Last Breath - Calm) [moebius morbid vision edit] by Aderrasi + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1084,7 +1084,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-geiss-airhandler-kali-mix-canvas-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-geiss-airhandler-kali-mix-canvas-mix.png</image:loc>
       <image:title>Aderrasi + Geiss - Airhandler (Kali Mix) - Canvas Mix | Stims</image:title>
       <image:caption>Aderrasi + Geiss - Airhandler (Kali Mix) - Canvas Mix by Aderrasi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1095,7 +1095,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-geiss-airhandler-kali-mix-painterly-kaleidoscope-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-geiss-airhandler-kali-mix-painterly-kaleidoscope-2.png</image:loc>
       <image:title>Aderrasi + Geiss - Airhandler (Kali Mix) - Painterly Kaleidoscope 2 | Stims</image:title>
       <image:caption>Aderrasi + Geiss - Airhandler (Kali Mix) - Painterly Kaleidoscope 2 by Aderrasi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1106,7 +1106,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-geiss-airhandler-kali-mix-painterly-tendrils-colorfast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-geiss-airhandler-kali-mix-painterly-tendrils-colorfast.png</image:loc>
       <image:title>Aderrasi + Geiss - Airhandler (Kali Mix) - Painterly Tendrils Colorfast | Stims</image:title>
       <image:caption>Aderrasi + Geiss - Airhandler (Kali Mix) - Painterly Tendrils Colorfast by Aderrasi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1117,7 +1117,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-geiss-airhandler-painterly-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-geiss-airhandler-painterly-relief-mix.png</image:loc>
       <image:title>Aderrasi + Geiss - Airhandler (Painterly Relief Mix) | Stims</image:title>
       <image:caption>Aderrasi + Geiss - Airhandler (Painterly Relief Mix) by Aderrasi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1128,7 +1128,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-geiss-airhandler-square-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-geiss-airhandler-square-mix.png</image:loc>
       <image:title>Aderrasi + Geiss - Airhandler (Square Mix) | Stims</image:title>
       <image:caption>Aderrasi + Geiss - Airhandler (Square Mix) by Aderrasi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1139,7 +1139,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-accelerator-hot-lead-transfusion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-accelerator-hot-lead-transfusion.png</image:loc>
       <image:title>Aderrasi - Accelerator (Hot Lead Transfusion) | Stims</image:title>
       <image:caption>Aderrasi - Accelerator (Hot Lead Transfusion) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1150,7 +1150,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-agitator</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-agitator.png</image:loc>
       <image:title>Aderrasi - Agitator | Stims</image:title>
       <image:caption>Aderrasi - Agitator by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1161,7 +1161,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-kali-mix-painterly-geiss-composite-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-kali-mix-painterly-geiss-composite-mix.png</image:loc>
       <image:title>Aderrasi - Airhandler (Kali Mix) - Painterly (Geiss composite mix) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Kali Mix) - Painterly (Geiss composite mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1172,7 +1172,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-kali-mix-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-kali-mix-painterly.png</image:loc>
       <image:title>Aderrasi - Airhandler (Kali Mix) - Painterly | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Kali Mix) - Painterly by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1183,7 +1183,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-kali-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-kali-mix.png</image:loc>
       <image:title>Aderrasi - Airhandler (Kali Mix) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Kali Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1194,7 +1194,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-last-breath-calm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-last-breath-calm.png</image:loc>
       <image:title>Aderrasi - Airhandler (Last Breath - Calm) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Last Breath - Calm) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1205,7 +1205,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-last-breath-crab</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-last-breath-crab.png</image:loc>
       <image:title>Aderrasi - Airhandler (Last Breath - Crab) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Last Breath - Crab) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1216,7 +1216,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-last-breath-eden</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-last-breath-eden.png</image:loc>
       <image:title>Aderrasi - Airhandler (Last Breath - Eden) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Last Breath - Eden) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1227,7 +1227,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-airhandler-principle-of-sharing</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-airhandler-principle-of-sharing.png</image:loc>
       <image:title>Aderrasi - Airhandler (Principle of Sharing) | Stims</image:title>
       <image:caption>Aderrasi - Airhandler (Principle of Sharing) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1238,7 +1238,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-bitterfeld-crystal-border-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-bitterfeld-crystal-border-mix.png</image:loc>
       <image:title>Aderrasi - Bitterfeld (Crystal Border Mix) | Stims</image:title>
       <image:caption>Aderrasi - Bitterfeld (Crystal Border Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1249,7 +1249,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-bow-to-gravity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-bow-to-gravity.png</image:loc>
       <image:title>Aderrasi - Bow To Gravity | Stims</image:title>
       <image:caption>Aderrasi - Bow To Gravity by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1260,7 +1260,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-brakefreak-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-brakefreak-bitcore-tweak.png</image:loc>
       <image:title>Aderrasi - Brakefreak-bitcore tweak | Stims</image:title>
       <image:caption>Aderrasi - Brakefreak-bitcore tweak by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1271,7 +1271,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-calabi-jau-space-bar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-calabi-jau-space-bar.png</image:loc>
       <image:title>Aderrasi - Calabi-Jau Space Bar | Stims</image:title>
       <image:caption>Aderrasi - Calabi-Jau Space Bar by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1282,7 +1282,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-can-itself-mash0000-rotating-piss-clams</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-can-itself-mash0000-rotating-piss-clams.png</image:loc>
       <image:title>Aderrasi - Can Itself - mash0000 - rotating piss clams | Stims</image:title>
       <image:caption>Aderrasi - Can Itself - mash0000 - rotating piss clams by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1293,7 +1293,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-causeway-of-dreams-point-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-causeway-of-dreams-point-mix.png</image:loc>
       <image:title>Aderrasi - Causeway of Dreams (Point Mix) | Stims</image:title>
       <image:caption>Aderrasi - Causeway of Dreams (Point Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1304,7 +1304,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-chromatic-abyss-refined-abyss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-chromatic-abyss-refined-abyss-mix.png</image:loc>
       <image:title>Aderrasi - Chromatic Abyss (Refined Abyss Mix) | Stims</image:title>
       <image:caption>Aderrasi - Chromatic Abyss (Refined Abyss Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1315,7 +1315,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-contortion-escher-s-tunnel-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-contortion-escher-s-tunnel-mix.png</image:loc>
       <image:title>Aderrasi - Contortion (Escher′s Tunnel Mix) | Stims</image:title>
       <image:caption>Aderrasi - Contortion (Escher′s Tunnel Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1326,7 +1326,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-contortion-wide-twist-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-contortion-wide-twist-mix.png</image:loc>
       <image:title>Aderrasi - Contortion (Wide Twist Mix) | Stims</image:title>
       <image:caption>Aderrasi - Contortion (Wide Twist Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1337,7 +1337,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-curse-of-the-mirror-emu</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-curse-of-the-mirror-emu.png</image:loc>
       <image:title>Aderrasi - Curse of the Mirror Emu | Stims</image:title>
       <image:caption>Aderrasi - Curse of the Mirror Emu by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1348,7 +1348,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-ert-wary-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-ert-wary-mix.png</image:loc>
       <image:title>Aderrasi - Ert (Wary Mix) | Stims</image:title>
       <image:caption>Aderrasi - Ert (Wary Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1359,7 +1359,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-ghast-full-circle-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-ghast-full-circle-mix.png</image:loc>
       <image:title>Aderrasi - Ghast (Full Circle Mix) | Stims</image:title>
       <image:caption>Aderrasi - Ghast (Full Circle Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1370,7 +1370,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-ghast-quarter-past-ghast-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-ghast-quarter-past-ghast-mix.png</image:loc>
       <image:title>Aderrasi - Ghast (Quarter Past Ghast Mix) | Stims</image:title>
       <image:caption>Aderrasi - Ghast (Quarter Past Ghast Mix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1381,7 +1381,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-ghast-entity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-ghast-entity.png</image:loc>
       <image:title>Aderrasi - Ghast Entity | Stims</image:title>
       <image:caption>Aderrasi - Ghast Entity by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1392,7 +1392,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-hackproof-mash0000-stare-at-tv-static-remote-viewing-technique</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-hackproof-mash0000-stare-at-tv-static-remote-viewing-technique.png</image:loc>
       <image:title>Aderrasi - Hackproof - mash0000 - stare at tv static remote viewing technique | Stims</image:title>
       <image:caption>Aderrasi - Hackproof - mash0000 - stare at tv static remote viewing technique by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1403,7 +1403,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-halls-of-centrifuge</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-halls-of-centrifuge.png</image:loc>
       <image:title>Aderrasi - Halls Of Centrifuge | Stims</image:title>
       <image:caption>Aderrasi - Halls Of Centrifuge by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1414,7 +1414,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-hard-drink-half-infinitea</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-hard-drink-half-infinitea.png</image:loc>
       <image:title>Aderrasi - Hard Drink (Half-Infinitea) | Stims</image:title>
       <image:caption>Aderrasi - Hard Drink (Half-Infinitea) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1425,7 +1425,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-horvath-s-holistic-abyss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-horvath-s-holistic-abyss.png</image:loc>
       <image:title>Aderrasi - Horvath′s Holistic Abyss | Stims</image:title>
       <image:caption>Aderrasi - Horvath′s Holistic Abyss by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1436,7 +1436,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-kevlar-abyss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-kevlar-abyss.png</image:loc>
       <image:title>Aderrasi - Kevlar Abyss | Stims</image:title>
       <image:caption>Aderrasi - Kevlar Abyss by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1447,7 +1447,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-kevlar-ore-deposit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-kevlar-ore-deposit.png</image:loc>
       <image:title>Aderrasi - Kevlar Ore Deposit | Stims</image:title>
       <image:caption>Aderrasi - Kevlar Ore Deposit by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1458,7 +1458,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-kevlar-tunnel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-kevlar-tunnel.png</image:loc>
       <image:title>Aderrasi - Kevlar Tunnel | Stims</image:title>
       <image:caption>Aderrasi - Kevlar Tunnel by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1469,7 +1469,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-madness-teaches-us-to-fly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-madness-teaches-us-to-fly.png</image:loc>
       <image:title>Aderrasi - Madness Teaches us to Fly | Stims</image:title>
       <image:caption>Aderrasi - Madness Teaches us to Fly by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1480,7 +1480,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-mother-of-pearl-mash0000-how-to-piss-off-your-eyes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-mother-of-pearl-mash0000-how-to-piss-off-your-eyes.png</image:loc>
       <image:title>Aderrasi - Mother Of Pearl - mash0000 - how to piss off your eyes | Stims</image:title>
       <image:caption>Aderrasi - Mother Of Pearl - mash0000 - how to piss off your eyes by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1491,7 +1491,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-party-mutant</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-party-mutant.png</image:loc>
       <image:title>Aderrasi - Party Mutant | Stims</image:title>
       <image:caption>Aderrasi - Party Mutant by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1502,7 +1502,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-roaming-star-himalaya-brach-office-mash0000-creaming-the-summit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-roaming-star-himalaya-brach-office-mash0000-creaming-the-summit.png</image:loc>
       <image:title>Aderrasi - Roaming Star (Himalaya Brach Office) - mash0000 - creaming the summit | Stims</image:title>
       <image:caption>Aderrasi - Roaming Star (Himalaya Brach Office) - mash0000 - creaming the summit by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1513,7 +1513,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-see</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-see.png</image:loc>
       <image:title>Aderrasi - See | Stims</image:title>
       <image:caption>Aderrasi - See by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1524,7 +1524,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-songflower-hybrid-plant-neohm-s-internet-ghosts-remix.png</image:loc>
       <image:title>Aderrasi - Songflower (Hybrid Plant+ NEOhm′s Internet Ghosts Remix) | Stims</image:title>
       <image:caption>Aderrasi - Songflower (Hybrid Plant+ NEOhm′s Internet Ghosts Remix) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1535,7 +1535,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-songflower-moss-posy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-songflower-moss-posy.png</image:loc>
       <image:title>Aderrasi - Songflower (Moss Posy) | Stims</image:title>
       <image:caption>Aderrasi - Songflower (Moss Posy) by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1546,7 +1546,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-storm-of-the-eye-thunder-mash0000-quasi-pseudo-meta-concentrics</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-storm-of-the-eye-thunder-mash0000-quasi-pseudo-meta-concentrics.png</image:loc>
       <image:title>Aderrasi - Storm of the Eye (Thunder) - mash0000 - quasi pseudo meta concentrics | Stims</image:title>
       <image:caption>Aderrasi - Storm of the Eye (Thunder) - mash0000 - quasi pseudo meta concentrics by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1557,7 +1557,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-the-lurker-twin-mix-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-the-lurker-twin-mix-bitcore-tweak.png</image:loc>
       <image:title>Aderrasi - The Lurker (Twin Mix) - Bitcore Tweak | Stims</image:title>
       <image:caption>Aderrasi - The Lurker (Twin Mix) - Bitcore Tweak by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1568,7 +1568,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-tool-of-construction-mash0000-use-the-toilet-to-construct-parliment</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-tool-of-construction-mash0000-use-the-toilet-to-construct-parliment.png</image:loc>
       <image:title>Aderrasi - Tool of Construction - mash0000 - use the toilet to construct parliment | Stims</image:title>
       <image:caption>Aderrasi - Tool of Construction - mash0000 - use the toilet to construct parliment by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1579,7 +1579,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-variants-of-eternity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-variants-of-eternity.png</image:loc>
       <image:title>Aderrasi - Variants Of Eternity | Stims</image:title>
       <image:caption>Aderrasi - Variants Of Eternity by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1590,7 +1590,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-veil-of-steel-steel-storm-mash0000-bob-ross-finally-loses-it</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-veil-of-steel-steel-storm-mash0000-bob-ross-finally-loses-it.png</image:loc>
       <image:title>Aderrasi - Veil of Steel (Steel Storm) - mash0000 - bob ross finally loses it | Stims</image:title>
       <image:caption>Aderrasi - Veil of Steel (Steel Storm) - mash0000 - bob ross finally loses it by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1601,7 +1601,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-visitor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-visitor.png</image:loc>
       <image:title>Aderrasi - Visitor | Stims</image:title>
       <image:caption>Aderrasi - Visitor by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1612,7 +1612,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-what-cannot-be</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-what-cannot-be.png</image:loc>
       <image:title>Aderrasi - What cannot be | Stims</image:title>
       <image:caption>Aderrasi - What cannot be by Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1623,7 +1623,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=an-adamfx-n-martin-infusion-2-flexi-why-the-sky-looks-diffrent-today-adamfx-n-martin-infusion-tack-tile-disfunction-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/an-adamfx-n-martin-infusion-2-flexi-why-the-sky-looks-diffrent-today-adamfx-n-martin-infusion-tack-tile-disfunction-b.png</image:loc>
       <image:title>An AdamFX n Martin Infusion 2 flexi - Why The Sky Looks Diffrent Today - AdamFx n Martin Infusion - Tack Tile Disfunction B | Stims</image:title>
       <image:caption>An AdamFX n Martin Infusion 2 flexi - Why The Sky Looks Diffrent Today - AdamFx n Martin Infusion - Tack Tile Disfunction B by An AdamFX n Martin Infusion 2 flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1634,7 +1634,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=anandamide-i-don-t-want-to-go-back-to-earth</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/anandamide-i-don-t-want-to-go-back-to-earth.png</image:loc>
       <image:title>Anandamide_I_Don′t_Want_To_Go_Back_To_Earth | Stims</image:title>
       <image:caption>Anandamide_I_Don′t_Want_To_Go_Back_To_Earth, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1645,7 +1645,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=anandamide-pastels-n-cream</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/anandamide-pastels-n-cream.png</image:loc>
       <image:title>Anandamide_Pastels_N_Cream | Stims</image:title>
       <image:caption>Anandamide_Pastels_N_Cream, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1656,7 +1656,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-random-color.png</image:loc>
       <image:title>Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit + random color) | Stims</image:title>
       <image:caption>Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit + random color) by Anandmide _ Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1667,7 +1667,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/anandmide-shifter-fractical-dancer-mtm-mix-stahlregen-s-geiss-chaos-tile-edit-2.png</image:loc>
       <image:title>Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit 2) | Stims</image:title>
       <image:caption>Anandmide _ Shifter - Fractical_Dancer_MTM_mix (Stahlregen′s Geiss Chaos Tile edit 2) by Anandmide _ Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1678,7 +1678,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-et-al-shifter-tumbling-cubic-juno-vibe2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-et-al-shifter-tumbling-cubic-juno-vibe2.png</image:loc>
       <image:title>BDRV et AL shifter - tumbling cubic juno vibe2 | Stims</image:title>
       <image:caption>BDRV et AL shifter - tumbling cubic juno vibe2 by BDRV et AL shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1689,7 +1689,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-23</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-23.png</image:loc>
       <image:title>BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs. reaction diffusion + Another Flexi + Fishbrain  + Swelling Spiral + Work With Lines + Deamon Lord + EOS 23 | Stims</image:title>
       <image:caption>BEST OF ADAMFX 2 Flexi + Geiss - Bipolar vs. reaction diffusion + Another Flexi + Fishbrain  + Swelling Spiral + Work With Lines + Deamon Lord + EOS 23 by BEST OF ADAMFX 2 Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1700,7 +1700,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-eo-s-redi-jedi-frequency-analysis-glowsticks-glow-o-scope-male-left-handed-complements-milkdrop-beta-ver2-bdrv-et-al-rmx2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-eo-s-redi-jedi-frequency-analysis-glowsticks-glow-o-scope-male-left-handed-complements-milkdrop-beta-ver2-bdrv-et-al-rmx2.png</image:loc>
       <image:title>Bdrv Eo.S. + Redi Jedi - frequency analysis + glowsticks -  glow - o - scope male left handed complements (Milkdrop beta ver2) BDRV et  AL  rmx2 | Stims</image:title>
       <image:caption>Bdrv Eo.S. + Redi Jedi - frequency analysis + glowsticks -  glow - o - scope male left handed complements (Milkdrop beta ver2) BDRV et  AL  rmx2 by Bdrv Eo.S. + Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1711,7 +1711,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-eo-s-pulsecube-bdrv-et-al-rmxmixx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-eo-s-pulsecube-bdrv-et-al-rmxmixx.png</image:loc>
       <image:title>Bdrv Eo.S. - pulsecube BDRV et  AL  rmxmixx | Stims</image:title>
       <image:caption>Bdrv Eo.S. - pulsecube BDRV et  AL  rmxmixx by Bdrv Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1722,7 +1722,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=benjam-zylot-dust-on-the-lens-light-of-the-ancient-ones-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/benjam-zylot-dust-on-the-lens-light-of-the-ancient-ones-mix.png</image:loc>
       <image:title>Benjam &amp; Zylot - Dust on the Lens (Light of the Ancient Ones mix) | Stims</image:title>
       <image:caption>Benjam &amp; Zylot - Dust on the Lens (Light of the Ancient Ones mix) by Benjam &amp; Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1733,7 +1733,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=benjam-and-zylot-tie-dye-supernova-sunspots-mix-praise-martin-and-flexi-forever-nz-understarted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/benjam-and-zylot-tie-dye-supernova-sunspots-mix-praise-martin-and-flexi-forever-nz-understarted.png</image:loc>
       <image:title>Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) - praise martin and flexi forever nz+ understarted | Stims</image:title>
       <image:caption>Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) - praise martin and flexi forever nz+ understarted by Benjam and Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1744,7 +1744,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/benjam-and-zylot-tie-dye-supernova-sunspots-mix-flx-mrt-maybe-go-to-the-beach-drizzle.png</image:loc>
       <image:title>Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle′ | Stims</image:title>
       <image:caption>Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) flx mrt - maybe go to the beach - drizzle′ by Benjam and Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1755,7 +1755,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=benski-atom-smasher</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/benski-atom-smasher.png</image:loc>
       <image:title>Benski - Atom Smasher | Stims</image:title>
       <image:caption>Benski - Atom Smasher by Benski, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1766,7 +1766,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-krash-rainbow-orb-peacock-lonely-signal-gone-mad-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-krash-rainbow-orb-peacock-lonely-signal-gone-mad-mix.png</image:loc>
       <image:title>Bmelgren &amp; Krash - Rainbow Orb Peacock (Lonely Signal Gone Mad Mix) | Stims</image:title>
       <image:caption>Bmelgren &amp; Krash - Rainbow Orb Peacock (Lonely Signal Gone Mad Mix) by Bmelgren &amp; Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1777,7 +1777,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-rovastar-schisathing-2-mash0000-schrodinger-s-dog-massage.png</image:loc>
       <image:title>Bmelgren &amp; Rovastar - Schisathing 2 - mash0000 - schrodinger′s dog massage | Stims</image:title>
       <image:caption>Bmelgren &amp; Rovastar - Schisathing 2 - mash0000 - schrodinger′s dog massage by Bmelgren &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1788,7 +1788,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-rovastar-schisathing-6-mash0001-hellraiser-s-molten-consciousness.png</image:loc>
       <image:title>Bmelgren &amp; Rovastar - Schisathing 6 - mash0001 - hellraiser′s molten consciousness | Stims</image:title>
       <image:caption>Bmelgren &amp; Rovastar - Schisathing 6 - mash0001 - hellraiser′s molten consciousness by Bmelgren &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1799,7 +1799,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz.png</image:loc>
       <image:title>Bmelgren &amp; Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+ | Stims</image:title>
       <image:caption>Bmelgren &amp; Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+ by Bmelgren &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1810,7 +1810,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-geiss-godhead-canvas-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-geiss-godhead-canvas-mix.png</image:loc>
       <image:title>Bmelgren + Geiss - Godhead (Canvas Mix) | Stims</image:title>
       <image:caption>Bmelgren + Geiss - Godhead (Canvas Mix) by Bmelgren + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1821,7 +1821,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-krash-rainbow-orb-peacock-centred-journey-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-krash-rainbow-orb-peacock-centred-journey-mix-2.png</image:loc>
       <image:title>Bmelgren + Krash - Rainbow Orb Peacock (Centred Journey Mix 2) | Stims</image:title>
       <image:caption>Bmelgren + Krash - Rainbow Orb Peacock (Centred Journey Mix 2) by Bmelgren + Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1832,7 +1832,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bmelgren-pentultimate-nerual-slipstream-tweak-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bmelgren-pentultimate-nerual-slipstream-tweak-2.png</image:loc>
       <image:title>Bmelgren - Pentultimate Nerual Slipstream (Tweak 2) | Stims</image:title>
       <image:caption>Bmelgren - Pentultimate Nerual Slipstream (Tweak 2) by Bmelgren, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1843,7 +1843,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=boz-flip-d-moshun-mash0000-forced-to-exist-freely</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/boz-flip-d-moshun-mash0000-forced-to-exist-freely.png</image:loc>
       <image:title>Boz - Flip′d Moshun - mash0000 - forced to exist freely | Stims</image:title>
       <image:caption>Boz - Flip′d Moshun - mash0000 - forced to exist freely by Boz, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1854,7 +1854,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=brainstain-boiling-mix2-redi-jedi-full-carb-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/brainstain-boiling-mix2-redi-jedi-full-carb-mix.png</image:loc>
       <image:title>BrainStain- boiling-mix2(redi jedi full carb mix) | Stims</image:title>
       <image:caption>BrainStain- boiling-mix2(redi jedi full carb mix), a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1865,7 +1865,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=brainstain-blackwidow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/brainstain-blackwidow.png</image:loc>
       <image:title>BrainStain-Blackwidow | Stims</image:title>
       <image:caption>BrainStain-Blackwidow, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1876,7 +1876,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=brainstain-projection-room-mash0000-locustration</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/brainstain-projection-room-mash0000-locustration.png</image:loc>
       <image:title>BrainStain-projection room - mash0000 - locustration | Stims</image:title>
       <image:caption>BrainStain-projection room - mash0000 - locustration by BrainStain-projection room, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1887,7 +1887,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=brainstain-re-entry</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/brainstain-re-entry.png</image:loc>
       <image:title>BrainStain-re entry | Stims</image:title>
       <image:caption>BrainStain-re entry, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1898,7 +1898,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spectral-haze-filter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spectral-haze-filter.png</image:loc>
       <image:title>By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar + Orb  + Mstress - mash0000 - prismatic spectral haze filter | Stims</image:title>
       <image:caption>By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar + Orb  + Mstress - mash0000 - prismatic spectral haze filter by By Adam FX 2 shifter + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1909,7 +1909,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar.png</image:loc>
       <image:title>By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar  | Stims</image:title>
       <image:caption>By Adam FX 2 shifter + geiss - neon pulse (glow mix) + Rovastar  by By Adam FX 2 shifter + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1920,7 +1920,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=che-escape</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/che-escape.png</image:loc>
       <image:title>Che - Escape | Stims</image:title>
       <image:caption>Che - Escape by Che, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1931,7 +1931,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=che-terracarbon-stream</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/che-terracarbon-stream.png</image:loc>
       <image:title>Che - Terracarbon Stream | Stims</image:title>
       <image:caption>Che - Terracarbon Stream by Che, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1942,7 +1942,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-cartune-extrusion-machine-fixed</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-cartune-extrusion-machine-fixed.png</image:loc>
       <image:title>Cope - Cartune (extrusion machine) [fixed] | Stims</image:title>
       <image:caption>Cope - Cartune (extrusion machine) [fixed] by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1953,7 +1953,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-keanu-reeves-is-a-bad-actor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-keanu-reeves-is-a-bad-actor.png</image:loc>
       <image:title>Cope - Keanu Reeves Is A Bad Actor | Stims</image:title>
       <image:caption>Cope - Keanu Reeves Is A Bad Actor by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1964,7 +1964,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-passage-mandala-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-passage-mandala-mix.png</image:loc>
       <image:title>Cope - Passage (mandala mix) | Stims</image:title>
       <image:caption>Cope - Passage (mandala mix) by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1975,7 +1975,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-passage-mandala-mix-flexis-kaleidoscope-ap3-colonosc-roam3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-passage-mandala-mix-flexis-kaleidoscope-ap3-colonosc-roam3.png</image:loc>
       <image:title>Cope - Passage (mandala mix)[Flexis kaleidoscope] - ap3 colonosc roam3 | Stims</image:title>
       <image:caption>Cope - Passage (mandala mix)[Flexis kaleidoscope] - ap3 colonosc roam3 by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1986,7 +1986,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-the-neverending-explosion-of-red-liquid-fire</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-the-neverending-explosion-of-red-liquid-fire.png</image:loc>
       <image:title>Cope - The Neverending Explosion of Red Liquid Fire | Stims</image:title>
       <image:caption>Cope - The Neverending Explosion of Red Liquid Fire by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1997,7 +1997,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-the-red</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-the-red.png</image:loc>
       <image:title>Cope - The Red | Stims</image:title>
       <image:caption>Cope - The Red by Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2008,7 +2008,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-wip-strange-attractor-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-wip-strange-attractor-2.png</image:loc>
       <image:title>Cope-WIP - Strange Attractor 2 | Stims</image:title>
       <image:caption>Cope-WIP - Strange Attractor 2 by Cope-WIP, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2019,7 +2019,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice.png</image:loc>
       <image:title>DemonLD_-_Toxic_water_diffusion threx angela vs debi brown (nice) | Stims</image:title>
       <image:caption>DemonLD_-_Toxic_water_diffusion threx angela vs debi brown (nice), a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2030,7 +2030,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=empr-random-changing-polyevolution</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/empr-random-changing-polyevolution.png</image:loc>
       <image:title>EMPR - Random - Changing Polyevolution | Stims</image:title>
       <image:caption>EMPR - Random - Changing Polyevolution by EMPR, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2041,7 +2041,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=evet-flexi-rainbox-splash-poolz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/evet-flexi-rainbox-splash-poolz.png</image:loc>
       <image:title>EVET + Flexi - Rainbox Splash Poolz | Stims</image:title>
       <image:caption>EVET + Flexi - Rainbox Splash Poolz by EVET + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2052,7 +2052,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=evet-rgb-singularity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/evet-rgb-singularity.png</image:loc>
       <image:title>EVET - RGB Singularity | Stims</image:title>
       <image:caption>EVET - RGB Singularity by EVET, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2063,7 +2063,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-geiss-glowsticks-v2-02-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-geiss-glowsticks-v2-02-relief-mix.png</image:loc>
       <image:title>Eo.S. + Geiss - glowsticks v2 02 (Relief Mix) | Stims</image:title>
       <image:caption>Eo.S. + Geiss - glowsticks v2 02 (Relief Mix) by Eo.S. + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2074,7 +2074,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-psychedelic-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-psychedelic-mix.png</image:loc>
       <image:title>Eo.S. + Geiss - glowsticks v2 03 music shifter edit b (Psychedelic Mix) | Stims</image:title>
       <image:caption>Eo.S. + Geiss - glowsticks v2 03 music shifter edit b (Psychedelic Mix) by Eo.S. + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2085,7 +2085,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-water-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-water-mix.png</image:loc>
       <image:title>Eo.S. + Geiss - glowsticks v2 03 music shifter edit b (water mix) | Stims</image:title>
       <image:caption>Eo.S. + Geiss - glowsticks v2 03 music shifter edit b (water mix) by Eo.S. + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2096,7 +2096,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-geiss-sarc-c-phats-zoom-mix-reflecto</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-geiss-sarc-c-phats-zoom-mix-reflecto.png</image:loc>
       <image:title>Eo.S. + Geiss - sarc c_Phats Zoom Mix Reflecto | Stims</image:title>
       <image:caption>Eo.S. + Geiss - sarc c_Phats Zoom Mix Reflecto by Eo.S. + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2107,7 +2107,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-geiss-chasers-15-sentinels-male-and-female-dementia-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-geiss-chasers-15-sentinels-male-and-female-dementia-mix.png</image:loc>
       <image:title>Eo.S. + Phat + Geiss - chasers 15 sentinels male and female (Dementia Mix) | Stims</image:title>
       <image:caption>Eo.S. + Phat + Geiss - chasers 15 sentinels male and female (Dementia Mix) by Eo.S. + Phat + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2118,7 +2118,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-cat-scan-nirvana-flux</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-cat-scan-nirvana-flux.png</image:loc>
       <image:title>Eo.S. + Phat - CAT Scan (Nirvana flux) | Stims</image:title>
       <image:caption>Eo.S. + Phat - CAT Scan (Nirvana flux) by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2129,7 +2129,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-emergent-factors</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-emergent-factors.png</image:loc>
       <image:title>Eo.S. + Phat - Emergent factors | Stims</image:title>
       <image:caption>Eo.S. + Phat - Emergent factors by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2140,7 +2140,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-fractical-dancer-light-in-the-distance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-fractical-dancer-light-in-the-distance.png</image:loc>
       <image:title>Eo.S. + Phat - Fractical_dancer - light in the distance | Stims</image:title>
       <image:caption>Eo.S. + Phat - Fractical_dancer - light in the distance by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2151,7 +2151,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-11-sentinel-c-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-11-sentinel-c-jelly-v2.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 11 sentinel C (Jelly V2) | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 11 sentinel C (Jelly V2) by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2162,7 +2162,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-11-sentinel-c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-11-sentinel-c.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 11 sentinel C | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 11 sentinel C by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2173,7 +2173,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-11-sentinel-c-poltergeist-mix-response-daemon-geiss-flicker-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-11-sentinel-c-poltergeist-mix-response-daemon-geiss-flicker-fix.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 11 sentinel C_poltergeist_mix response daemon (geiss flicker fix) | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 11 sentinel C_poltergeist_mix response daemon (geiss flicker fix) by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2184,7 +2184,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-11-sentinel-c-poltergeist-mix-response-daemon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-11-sentinel-c-poltergeist-mix-response-daemon.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 11 sentinel C_poltergeist_mix response daemon | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 11 sentinel C_poltergeist_mix response daemon by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2195,7 +2195,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-12-sentinel-daemon-mash0000-multi-band-time-distortion-aurora-granules</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-12-sentinel-daemon-mash0000-multi-band-time-distortion-aurora-granules.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 12 sentinel Daemon - mash0000 - multi-band time-distortion aurora granules | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 12 sentinel Daemon - mash0000 - multi-band time-distortion aurora granules by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2206,7 +2206,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-14-sentinel-616</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-14-sentinel-616.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 14 sentinel 616 | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 14 sentinel 616 by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2217,7 +2217,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-15-sentinels-male-and-female</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-15-sentinels-male-and-female.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 15 sentinels male and female | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 15 sentinels male and female by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2228,7 +2228,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-18-hallway</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-18-hallway.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 18 hallway | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 18 hallway by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2239,7 +2239,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-19-portal-geiss-flicker-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-19-portal-geiss-flicker-fix.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 19 Portal (geiss flicker fix) | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 19 Portal (geiss flicker fix) by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2250,7 +2250,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-19-portal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-19-portal.png</image:loc>
       <image:title>Eo.S. + Phat - chasers 19 Portal | Stims</image:title>
       <image:caption>Eo.S. + Phat - chasers 19 Portal by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2261,7 +2261,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-cubetrace-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-cubetrace-v2.png</image:loc>
       <image:title>Eo.S. + Phat - cubetrace - v2 | Stims</image:title>
       <image:caption>Eo.S. + Phat - cubetrace - v2 by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2272,7 +2272,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-last-of-it-s-kind-sinking</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-last-of-it-s-kind-sinking.png</image:loc>
       <image:title>Eo.S. + Phat - last of it′s kind_sinking | Stims</image:title>
       <image:caption>Eo.S. + Phat - last of it′s kind_sinking by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2283,7 +2283,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-spectrum-bubble-field</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-spectrum-bubble-field.png</image:loc>
       <image:title>Eo.S. + Phat - spectrum bubble field | Stims</image:title>
       <image:caption>Eo.S. + Phat - spectrum bubble field by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2294,7 +2294,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-the-lights-at-night-spikes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-the-lights-at-night-spikes.png</image:loc>
       <image:title>Eo.S. + Phat - the lights at night_spikes | Stims</image:title>
       <image:caption>Eo.S. + Phat - the lights at night_spikes by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2305,7 +2305,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-vacuum-deity-watching-you</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-vacuum-deity-watching-you.png</image:loc>
       <image:title>Eo.S. + Phat - vacuum deity watching you | Stims</image:title>
       <image:caption>Eo.S. + Phat - vacuum deity watching you by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2316,7 +2316,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-zen-prophetmind-wtf-is-it-v2-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-zen-prophetmind-wtf-is-it-v2-bitcore-tweak.png</image:loc>
       <image:title>Eo.S. + Phat - zen prophetmind WTF is it_v2 - Bitcore Tweak | Stims</image:title>
       <image:caption>Eo.S. + Phat - zen prophetmind WTF is it_v2 - Bitcore Tweak by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2327,7 +2327,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-cubetrace-cybercity-madness-remix-mash0000-evaporating-crystal-pharma</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-cubetrace-cybercity-madness-remix-mash0000-evaporating-crystal-pharma.png</image:loc>
       <image:title>Eo.S. + Phat cubetrace (cybercity madness remix) - mash0000 - evaporating crystal pharma | Stims</image:title>
       <image:caption>Eo.S. + Phat cubetrace (cybercity madness remix) - mash0000 - evaporating crystal pharma by Eo.S. + Phat cubetrace, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2338,7 +2338,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-zylot-skylight-stained-glass-majesty-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-zylot-skylight-stained-glass-majesty-mix.png</image:loc>
       <image:title>Eo.S. + Zylot - skylight (Stained Glass Majesty mix) | Stims</image:title>
       <image:caption>Eo.S. + Zylot - skylight (Stained Glass Majesty mix) by Eo.S. + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2349,7 +2349,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix.png</image:loc>
       <image:title>Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b + illumination (Stahl′s Mix) | Stims</image:title>
       <image:caption>Eo.S. + flexi - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b + illumination (Stahl′s Mix) by Eo.S. + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2360,7 +2360,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-apocalypse-f2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-apocalypse-f2.png</image:loc>
       <image:title>Eo.S. - Apocalypse F2 | Stims</image:title>
       <image:caption>Eo.S. - Apocalypse F2 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2371,7 +2371,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-gases-beyond</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-gases-beyond.png</image:loc>
       <image:title>Eo.S. - Gases Beyond | Stims</image:title>
       <image:caption>Eo.S. - Gases Beyond by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2382,7 +2382,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-angels-of-decay</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-angels-of-decay.png</image:loc>
       <image:title>Eo.S. - angels of decay | Stims</image:title>
       <image:caption>Eo.S. - angels of decay by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2393,7 +2393,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-dark-side-of-the-moon-plus-a-few-more-hits-and-a-pill</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-dark-side-of-the-moon-plus-a-few-more-hits-and-a-pill.png</image:loc>
       <image:title>Eo.S. - dark side of the moon (plus a few more hits and a pill) | Stims</image:title>
       <image:caption>Eo.S. - dark side of the moon (plus a few more hits and a pill) by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2404,7 +2404,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-02</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-02.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 02 | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 02 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2415,7 +2415,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-03-music-shifter-edit-b-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-03-music-shifter-edit-b-jelly-v2.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 03 music shifter edit b (Jelly V2) | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 03 music shifter edit b (Jelly V2) by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2426,7 +2426,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2i2-feat-flexi-phat.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 03 music shifter edit b (Stahl′s Reactive RMX V2i2 - feat. flexi + phat) | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 03 music shifter edit b (Stahl′s Reactive RMX V2i2 - feat. flexi + phat) by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2437,7 +2437,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-03-music-shifter-edit-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-03-music-shifter-edit-b.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 03 music shifter edit b | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 03 music shifter edit b by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2448,7 +2448,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-03-music</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-03-music.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 03 music | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 03 music by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2459,7 +2459,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code)  | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code)  by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2470,7 +2470,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix02b by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2481,7 +2481,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix03-madhatter-v2.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix03 madhatter_v2 | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix03 madhatter_v2 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2492,7 +2492,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07-recursive-demons.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 recursive demons | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 recursive demons by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2503,7 +2503,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix07.png</image:loc>
       <image:title>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 | Stims</image:title>
       <image:caption>Eo.S. - glowsticks v2 05 and proton lights (+Krash′s beat code) _Phat_remix07 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2514,7 +2514,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-heater-core-c-phat-s-class-sparks-mix-mash0000-flaring-colored-zebra-gum.png</image:loc>
       <image:title>Eo.S. - heater core C_Phat′s_class + sparks_mix - mash0000 - flaring colored zebra gum | Stims</image:title>
       <image:caption>Eo.S. - heater core C_Phat′s_class + sparks_mix - mash0000 - flaring colored zebra gum by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2525,7 +2525,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-heater-core-c-phat-s-class-sparks-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-heater-core-c-phat-s-class-sparks-mix.png</image:loc>
       <image:title>Eo.S. - heater core C_Phat′s_class + sparks_mix | Stims</image:title>
       <image:caption>Eo.S. - heater core C_Phat′s_class + sparks_mix by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2536,7 +2536,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-multisphere-01-b-phat-ra-mix-geiss-flicker-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-multisphere-01-b-phat-ra-mix-geiss-flicker-fix.png</image:loc>
       <image:title>Eo.S. - multisphere 01 B_Phat_Ra_mix (geiss flicker fix) | Stims</image:title>
       <image:caption>Eo.S. - multisphere 01 B_Phat_Ra_mix (geiss flicker fix) by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2547,7 +2547,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-multisphere-01-b-phat-ra-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-multisphere-01-b-phat-ra-mix.png</image:loc>
       <image:title>Eo.S. - multisphere 01 B_Phat_Ra_mix | Stims</image:title>
       <image:caption>Eo.S. - multisphere 01 B_Phat_Ra_mix by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2558,7 +2558,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-nematodes-e-daemon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-nematodes-e-daemon.png</image:loc>
       <image:title>Eo.S. - nematodes E daemon | Stims</image:title>
       <image:caption>Eo.S. - nematodes E daemon by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2569,7 +2569,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-pointfield-01-complex</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-pointfield-01-complex.png</image:loc>
       <image:title>Eo.S. - pointfield 01 complex | Stims</image:title>
       <image:caption>Eo.S. - pointfield 01 complex by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2580,7 +2580,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-pointfield-04-arcs-demon-phat-edit-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-pointfield-04-arcs-demon-phat-edit-v3.png</image:loc>
       <image:title>Eo.S. - pointfield 04 arcs demon_phat edit_v3 | Stims</image:title>
       <image:caption>Eo.S. - pointfield 04 arcs demon_phat edit_v3 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2591,7 +2591,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-pointfield-09-the-gases-beyond-85c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-pointfield-09-the-gases-beyond-85c.png</image:loc>
       <image:title>Eo.S. - pointfield 09 the gases beyond 85c | Stims</image:title>
       <image:caption>Eo.S. - pointfield 09 the gases beyond 85c by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2602,7 +2602,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-pulsecube-f-demon-mash0000-yakuza-gut-cake</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-pulsecube-f-demon-mash0000-yakuza-gut-cake.png</image:loc>
       <image:title>Eo.S. - pulsecube f demon - mash0000 - yakuza gut cake | Stims</image:title>
       <image:caption>Eo.S. - pulsecube f demon - mash0000 - yakuza gut cake by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2613,7 +2613,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-repeater-08-rave-on-a-lot-of-acid-and-some-k</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-repeater-08-rave-on-a-lot-of-acid-and-some-k.png</image:loc>
       <image:title>Eo.S. - repeater 08 - rave on a lot of acid and some K | Stims</image:title>
       <image:caption>Eo.S. - repeater 08 - rave on a lot of acid and some K by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2624,7 +2624,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-repeater-13-definitive-fast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-repeater-13-definitive-fast.png</image:loc>
       <image:title>Eo.S. - repeater 13 - definitive fast | Stims</image:title>
       <image:caption>Eo.S. - repeater 13 - definitive fast by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2635,7 +2635,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-repeater-13-definitive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-repeater-13-definitive.png</image:loc>
       <image:title>Eo.S. - repeater 13 - definitive | Stims</image:title>
       <image:caption>Eo.S. - repeater 13 - definitive by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2646,7 +2646,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-repeater-15-kaleidoscope-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-repeater-15-kaleidoscope-b.png</image:loc>
       <image:title>Eo.S. - repeater 15 - kaleidoscope b | Stims</image:title>
       <image:caption>Eo.S. - repeater 15 - kaleidoscope b by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2657,7 +2657,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-sarc-c-phats-zoom-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-sarc-c-phats-zoom-mix.png</image:loc>
       <image:title>Eo.S. - sarc c_Phats Zoom Mix | Stims</image:title>
       <image:caption>Eo.S. - sarc c_Phats Zoom Mix by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2668,7 +2668,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-skylight-a1-music-warp-switch</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-skylight-a1-music-warp-switch.png</image:loc>
       <image:title>Eo.S. - skylight a1 [music warp switch] | Stims</image:title>
       <image:caption>Eo.S. - skylight a1 [music warp switch] by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2679,7 +2679,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-spark-c-phat-jester-mix-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-spark-c-phat-jester-mix-v2.png</image:loc>
       <image:title>Eo.S. - spark C_Phat_Jester_Mix_v2 | Stims</image:title>
       <image:caption>Eo.S. - spark C_Phat_Jester_Mix_v2 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2690,7 +2690,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-starburst-01</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-starburst-01.png</image:loc>
       <image:title>Eo.S. - starburst 01 | Stims</image:title>
       <image:caption>Eo.S. - starburst 01 by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2701,7 +2701,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-tumbler-demon-mix-high-fps-phat-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-tumbler-demon-mix-high-fps-phat-edit.png</image:loc>
       <image:title>Eo.S. - tumbler demon mix high fps Phat_edit | Stims</image:title>
       <image:caption>Eo.S. - tumbler demon mix high fps Phat_edit by Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2712,7 +2712,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-and-zylot-skylight-stained-glass-majesty-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-and-zylot-skylight-stained-glass-majesty-mix.png</image:loc>
       <image:title>Eo.S. and Zylot - skylight (Stained Glass Majesty mix) | Stims</image:title>
       <image:caption>Eo.S. and Zylot - skylight (Stained Glass Majesty mix) by Eo.S. and Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2723,7 +2723,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-arm-upgrades-transformer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-arm-upgrades-transformer.png</image:loc>
       <image:title>Eo.S.+Phat - Arm_upgrades - transformer | Stims</image:title>
       <image:caption>Eo.S.+Phat - Arm_upgrades - transformer by Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2734,7 +2734,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-flare-dig-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-flare-dig-mix.png</image:loc>
       <image:title>Eo.S.+Phat - Flare_dig_mix | Stims</image:title>
       <image:caption>Eo.S.+Phat - Flare_dig_mix by Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2745,7 +2745,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-detached-centerpoint</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-detached-centerpoint.png</image:loc>
       <image:title>Eo.S.+Phat - detached centerpoint | Stims</image:title>
       <image:caption>Eo.S.+Phat - detached centerpoint by Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2756,7 +2756,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-spectrum-bubble-new-colors-wf2-chaos-theory</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-spectrum-bubble-new-colors-wf2-chaos-theory.png</image:loc>
       <image:title>Eo.S.+Phat - spectrum bubble new colors WF2 chaos theory | Stims</image:title>
       <image:caption>Eo.S.+Phat - spectrum bubble new colors WF2 chaos theory by Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2767,7 +2767,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-spectrum-bubble-new-colors-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-spectrum-bubble-new-colors-v2.png</image:loc>
       <image:title>Eo.S.+Phat - spectrum bubble new colors_v2 | Stims</image:title>
       <image:caption>Eo.S.+Phat - spectrum bubble new colors_v2 by Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2778,7 +2778,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-eater-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-eater-v2.png</image:loc>
       <image:title>Eo.S.+Phat -Eater_v2 | Stims</image:title>
       <image:caption>Eo.S.+Phat -Eater_v2 by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2789,7 +2789,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-shipwreaked-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-shipwreaked-v3.png</image:loc>
       <image:title>Eo.S.+Phat -Shipwreaked_v3 | Stims</image:title>
       <image:caption>Eo.S.+Phat -Shipwreaked_v3 by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2800,7 +2800,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-cool-bug-v2-krash-s-beat-detection</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-cool-bug-v2-krash-s-beat-detection.png</image:loc>
       <image:title>Eo.S.+Phat Cool Bug v2 + (Krash′s beat detection) | Stims</image:title>
       <image:caption>Eo.S.+Phat Cool Bug v2 + (Krash′s beat detection) by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2811,7 +2811,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-cool-bug</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-cool-bug.png</image:loc>
       <image:title>Eo.S.+Phat Cool Bug | Stims</image:title>
       <image:caption>Eo.S.+Phat Cool Bug by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2822,7 +2822,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-emergent-factors-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-emergent-factors-bitcore-tweak.png</image:loc>
       <image:title>Eo.S.+Phat Emergent factors - Bitcore Tweak | Stims</image:title>
       <image:caption>Eo.S.+Phat Emergent factors - Bitcore Tweak by Eo.S.+Phat Emergent factors, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2833,7 +2833,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-fractical-dancer-v2d</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-fractical-dancer-v2d.png</image:loc>
       <image:title>Eo.S.+Phat Fractical_dancer_v2d | Stims</image:title>
       <image:caption>Eo.S.+Phat Fractical_dancer_v2d by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2844,7 +2844,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-speak-with-the-orb-rotation-mix-time-mod</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-speak-with-the-orb-rotation-mix-time-mod.png</image:loc>
       <image:title>Eo.S.+Phat Speak with the orb_rotation_mix_time_mod | Stims</image:title>
       <image:caption>Eo.S.+Phat Speak with the orb_rotation_mix_time_mod by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2855,7 +2855,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-trail-of-darkness</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-trail-of-darkness.png</image:loc>
       <image:title>Eo.S.+Phat trail_of_darkness | Stims</image:title>
       <image:caption>Eo.S.+Phat trail_of_darkness by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2866,7 +2866,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-technicolor-f-breather-e-god-cock-gaia-pussy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-technicolor-f-breather-e-god-cock-gaia-pussy.png</image:loc>
       <image:title>Eo.S._Phat technicolor F breather E god cock gaia pussy | Stims</image:title>
       <image:caption>Eo.S._Phat technicolor F breather E god cock gaia pussy by Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2877,7 +2877,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-and-pieturp-alienspaceshipinvasion-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-and-pieturp-alienspaceshipinvasion-2.png</image:loc>
       <image:title>Eo.s and PieturP - AlienSpaceshipInvasion 2 | Stims</image:title>
       <image:caption>Eo.s and PieturP - AlienSpaceshipInvasion 2 by Eo.s and PieturP, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2888,7 +2888,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eosphat-shipwreakedv5b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eosphat-shipwreakedv5b.png</image:loc>
       <image:title>Eosphat-shipwreakedv5b | Stims</image:title>
       <image:caption>Eosphat-shipwreakedv5b, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2899,7 +2899,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=esotic-rozzer-hippie-hypnotizer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/esotic-rozzer-hippie-hypnotizer.png</image:loc>
       <image:title>Esotic &amp; Rozzer - Hippie Hypnotizer | Stims</image:title>
       <image:caption>Esotic &amp; Rozzer - Hippie Hypnotizer by Esotic &amp; Rozzer, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2910,7 +2910,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=esotic-rozzer-now-and-later</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/esotic-rozzer-now-and-later.png</image:loc>
       <image:title>Esotic &amp; Rozzer - Now And Later | Stims</image:title>
       <image:caption>Esotic &amp; Rozzer - Now And Later by Esotic &amp; Rozzer, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2921,7 +2921,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=esotic-rozzer-the-dark-side-of-my-moon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/esotic-rozzer-the-dark-side-of-my-moon.png</image:loc>
       <image:title>Esotic &amp; Rozzer - The Dark Side Of My Moon | Stims</image:title>
       <image:caption>Esotic &amp; Rozzer - The Dark Side Of My Moon by Esotic &amp; Rozzer, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2932,7 +2932,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=esotic-rozzor-pixie-party-light-no-wave-invasion-mandala-chill-red-yellow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/esotic-rozzor-pixie-party-light-no-wave-invasion-mandala-chill-red-yellow-mix.png</image:loc>
       <image:title>Esotic &amp; Rozzor - Pixie Party Light ((No Wave Invasion) Mandala Chill Red Yellow Mix) | Stims</image:title>
       <image:caption>Esotic &amp; Rozzor - Pixie Party Light ((No Wave Invasion) Mandala Chill Red Yellow Mix) by Esotic &amp; Rozzor, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2943,7 +2943,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-demon-lord-unholy-tokamak-clot-plot</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-demon-lord-unholy-tokamak-clot-plot.png</image:loc>
       <image:title>Flexi + Geiss + Demon Lord - unholy tokamak clot-plot | Stims</image:title>
       <image:caption>Flexi + Geiss + Demon Lord - unholy tokamak clot-plot by Flexi + Geiss + Demon Lord, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2954,7 +2954,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-bipolar-vs-reaction-diffusion-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-bipolar-vs-reaction-diffusion-mix.png</image:loc>
       <image:title>Flexi + Geiss - Bipolar vs. Reaction Diffusion mix | Stims</image:title>
       <image:caption>Flexi + Geiss - Bipolar vs. Reaction Diffusion mix by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2965,7 +2965,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-tokamak-mindblob-2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-tokamak-mindblob-2-0.png</image:loc>
       <image:title>Flexi + Geiss - Tokamak mindblob 2.0 | Stims</image:title>
       <image:caption>Flexi + Geiss - Tokamak mindblob 2.0 by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2976,7 +2976,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-antagonizing-beat-detection-codes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-antagonizing-beat-detection-codes.png</image:loc>
       <image:title>Flexi + Geiss - antagonizing beat detection codes | Stims</image:title>
       <image:caption>Flexi + Geiss - antagonizing beat detection codes by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2987,7 +2987,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-on-tokamak-matter-jelly-5-55</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-on-tokamak-matter-jelly-5-55.png</image:loc>
       <image:title>Flexi + Geiss - pogo-cubes on tokamak matter (Jelly 5.55) | Stims</image:title>
       <image:caption>Flexi + Geiss - pogo-cubes on tokamak matter (Jelly 5.55) by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2998,7 +2998,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix.png</image:loc>
       <image:title>Flexi + Geiss - pogo-cubes on tokamak matter [mind over matter remix] | Stims</image:title>
       <image:caption>Flexi + Geiss - pogo-cubes on tokamak matter [mind over matter remix] by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3009,7 +3009,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-on-tokamak-matter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-on-tokamak-matter.png</image:loc>
       <image:title>Flexi + Geiss - pogo-cubes on tokamak matter | Stims</image:title>
       <image:caption>Flexi + Geiss - pogo-cubes on tokamak matter by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3020,7 +3020,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-relief-2-anim-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-relief-2-anim-remix.png</image:loc>
       <image:title>Flexi + Geiss - relief 2 (Anim Remix) | Stims</image:title>
       <image:caption>Flexi + Geiss - relief 2 (Anim Remix) by Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3031,7 +3031,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-astral-projection</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-astral-projection.png</image:loc>
       <image:title>Flexi + Martin - astral projection | Stims</image:title>
       <image:caption>Flexi + Martin - astral projection by Flexi + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3042,7 +3042,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-cascading-decay-swing</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-cascading-decay-swing.png</image:loc>
       <image:title>Flexi + Martin - cascading decay swing | Stims</image:title>
       <image:caption>Flexi + Martin - cascading decay swing by Flexi + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3053,7 +3053,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-dive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-dive.png</image:loc>
       <image:title>Flexi + Martin - dive | Stims</image:title>
       <image:caption>Flexi + Martin - dive by Flexi + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3064,7 +3064,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-tunnel-of-supraschismatika</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-tunnel-of-supraschismatika.png</image:loc>
       <image:title>Flexi + Martin - tunnel of supraschismatika | Stims</image:title>
       <image:caption>Flexi + Martin - tunnel of supraschismatika by Flexi + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3075,7 +3075,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-phat-fractal-star-child-restless</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-phat-fractal-star-child-restless.png</image:loc>
       <image:title>Flexi + Phat fractal Star_Child_Restless | Stims</image:title>
       <image:caption>Flexi + Phat fractal Star_Child_Restless by Flexi + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3086,7 +3086,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-rovastar-fractopia-blame-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-rovastar-fractopia-blame-hexcollie.png</image:loc>
       <image:title>Flexi + Rovastar - Fractopia [blame hexcollie] | Stims</image:title>
       <image:caption>Flexi + Rovastar - Fractopia [blame hexcollie] by Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3097,7 +3097,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-rovastar-fractopia-lovecraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-rovastar-fractopia-lovecraft.png</image:loc>
       <image:title>Flexi + Rovastar - Fractopia [lovecraft] | Stims</image:title>
       <image:caption>Flexi + Rovastar - Fractopia [lovecraft] by Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3108,7 +3108,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-rovastar-landing-on-fractopia</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-rovastar-landing-on-fractopia.png</image:loc>
       <image:title>Flexi + Rovastar - landing on Fractopia | Stims</image:title>
       <image:caption>Flexi + Rovastar - landing on Fractopia by Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3119,7 +3119,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-shifter-sublimal-spaceship</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-shifter-sublimal-spaceship.png</image:loc>
       <image:title>Flexi + Shifter - sublimal spaceship | Stims</image:title>
       <image:caption>Flexi + Shifter - sublimal spaceship by Flexi + Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3130,7 +3130,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-piercing-05-kopie-2-kopie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-piercing-05-kopie-2-kopie.png</image:loc>
       <image:title>Flexi + amandio c - piercing 05 - Kopie (2) - Kopie | Stims</image:title>
       <image:caption>Flexi + amandio c - piercing 05 - Kopie (2) - Kopie by Flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3141,7 +3141,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bdrv-va-ultramix-148-fucking-infinity-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bdrv-va-ultramix-148-fucking-infinity-mix.png</image:loc>
       <image:title>Flexi + bdrv - va ultramix #148 [fucking infinity mix] | Stims</image:title>
       <image:caption>Flexi + bdrv - va ultramix #148 [fucking infinity mix] by Flexi + bdrv, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3152,7 +3152,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bdrv-what-to-do-phat-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bdrv-what-to-do-phat-edit.png</image:loc>
       <image:title>Flexi + bdrv - what to do [Phat edit] | Stims</image:title>
       <image:caption>Flexi + bdrv - what to do [Phat edit] by Flexi + bdrv, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3163,7 +3163,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-operation-fatcap-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-operation-fatcap-ii.png</image:loc>
       <image:title>Flexi + fiShbRaiN - operation fatcap II | Stims</image:title>
       <image:caption>Flexi + fiShbRaiN - operation fatcap II by Flexi + fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3174,7 +3174,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-operation-fatcap-techstyle-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-operation-fatcap-techstyle-random-mashup.png</image:loc>
       <image:title>Flexi + fiShbRaiN - operation fatcap [techstyle] [random mashup] | Stims</image:title>
       <image:caption>Flexi + fiShbRaiN - operation fatcap [techstyle] [random mashup] by Flexi + fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3185,7 +3185,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-operation-fatcap-techstyle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-operation-fatcap-techstyle.png</image:loc>
       <image:title>Flexi + fiShbRaiN - operation fatcap [techstyle] | Stims</image:title>
       <image:caption>Flexi + fiShbRaiN - operation fatcap [techstyle] by Flexi + fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3196,7 +3196,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-the-deep-diver-s-manifesto-metaphorfree</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-the-deep-diver-s-manifesto-metaphorfree.png</image:loc>
       <image:title>Flexi + geiss - the deep diver′s manifesto [metaphorfree] | Stims</image:title>
       <image:caption>Flexi + geiss - the deep diver′s manifesto [metaphorfree] by Flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3207,7 +3207,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-jelly-showoff-parade</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-jelly-showoff-parade.png</image:loc>
       <image:title>Flexi + stahlregen - jelly showoff parade | Stims</image:title>
       <image:caption>Flexi + stahlregen - jelly showoff parade by Flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3218,7 +3218,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-jelly-space</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-jelly-space.png</image:loc>
       <image:title>Flexi + stahlregen - jelly space | Stims</image:title>
       <image:caption>Flexi + stahlregen - jelly space by Flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3229,7 +3229,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-sto-aftermath</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-sto-aftermath.png</image:loc>
       <image:title>Flexi + sto - aftermath | Stims</image:title>
       <image:caption>Flexi + sto - aftermath by Flexi + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3240,7 +3240,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-sto-learning-curve</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-sto-learning-curve.png</image:loc>
       <image:title>Flexi + sto - learning curve  | Stims</image:title>
       <image:caption>Flexi + sto - learning curve  by Flexi + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3251,7 +3251,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-100-shader-fractal-origami-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-100-shader-fractal-origami-edit.png</image:loc>
       <image:title>Flexi - 100% shader fractal [origami edit] | Stims</image:title>
       <image:caption>Flexi - 100% shader fractal [origami edit] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3262,7 +3262,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishies</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishies.png</image:loc>
       <image:title>Flexi - Fishies! | Stims</image:title>
       <image:caption>Flexi - Fishies! by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3273,7 +3273,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-fractal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-fractal.png</image:loc>
       <image:title>Flexi - Julia fractal | Stims</image:title>
       <image:caption>Flexi - Julia fractal by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3284,7 +3284,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-milkcore-martin-s-ripple-on-water-insertion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-milkcore-martin-s-ripple-on-water-insertion.png</image:loc>
       <image:title>Flexi - Milkcore [Martin′s ripple on water insertion] | Stims</image:title>
       <image:caption>Flexi - Milkcore [Martin′s ripple on water insertion] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3295,7 +3295,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-milkcore</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-milkcore.png</image:loc>
       <image:title>Flexi - Milkcore | Stims</image:title>
       <image:caption>Flexi - Milkcore by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3306,7 +3306,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-age-of-shading-chaos</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-age-of-shading-chaos.png</image:loc>
       <image:title>Flexi - age of shading chaos | Stims</image:title>
       <image:caption>Flexi - age of shading chaos by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3317,7 +3317,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-fader</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-fader.png</image:loc>
       <image:title>Flexi - alien fader | Stims</image:title>
       <image:caption>Flexi - alien fader by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3328,7 +3328,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-fish-pond</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-fish-pond.png</image:loc>
       <image:title>Flexi - alien fish pond | Stims</image:title>
       <image:caption>Flexi - alien fish pond by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3339,7 +3339,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-web-bouncer-26</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-web-bouncer-26.png</image:loc>
       <image:title>Flexi - alien web bouncer [26] | Stims</image:title>
       <image:caption>Flexi - alien web bouncer [26] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3350,7 +3350,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-web-bouncer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-web-bouncer.png</image:loc>
       <image:title>Flexi - alien web bouncer | Stims</image:title>
       <image:caption>Flexi - alien web bouncer by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3361,7 +3361,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-area-51-reaction-diffusion-on-lotka-volterra-vertex-warp-alien-edge-glow-kaleidoscope-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-area-51-reaction-diffusion-on-lotka-volterra-vertex-warp-alien-edge-glow-kaleidoscope-version.png</image:loc>
       <image:title>Flexi - area 51 [reaction-diffusion on lotka-volterra vertex warp, alien edge glow kaleidoscope version] | Stims</image:title>
       <image:caption>Flexi - area 51 [reaction-diffusion on lotka-volterra vertex warp, alien edge glow kaleidoscope version] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3372,7 +3372,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-area-51</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-area-51.png</image:loc>
       <image:title>Flexi - area 51 | Stims</image:title>
       <image:caption>Flexi - area 51 by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3383,7 +3383,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-blame-hexcollie-twice</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-blame-hexcollie-twice.png</image:loc>
       <image:title>Flexi - blame hexcollie twice | Stims</image:title>
       <image:caption>Flexi - blame hexcollie twice by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3394,7 +3394,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-braggadocio</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-braggadocio.png</image:loc>
       <image:title>Flexi - braggadocio | Stims</image:title>
       <image:caption>Flexi - braggadocio by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3405,7 +3405,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-cell-tissue</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-cell-tissue.png</image:loc>
       <image:title>Flexi - cell tissue | Stims</image:title>
       <image:caption>Flexi - cell tissue by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3416,7 +3416,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-crush-ice-72</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-crush-ice-72.png</image:loc>
       <image:title>Flexi - crush ice 72 | Stims</image:title>
       <image:caption>Flexi - crush ice 72 by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3427,7 +3427,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-dawn-has-broken</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-dawn-has-broken.png</image:loc>
       <image:title>Flexi - dawn has broken | Stims</image:title>
       <image:caption>Flexi - dawn has broken by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3438,7 +3438,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-dimensions-projection-and-abstraction</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-dimensions-projection-and-abstraction.png</image:loc>
       <image:title>Flexi - dimensions, projection and abstraction | Stims</image:title>
       <image:caption>Flexi - dimensions, projection and abstraction by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3449,7 +3449,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-disruptor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-disruptor.png</image:loc>
       <image:title>Flexi - disruptor | Stims</image:title>
       <image:caption>Flexi - disruptor by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3460,7 +3460,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-evolution-3-mash0000-orbiting-satellite-coral-reef-time-lapse</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-evolution-3-mash0000-orbiting-satellite-coral-reef-time-lapse.png</image:loc>
       <image:title>Flexi - evolution 3 - mash0000 - orbiting satellite coral reef time lapse | Stims</image:title>
       <image:caption>Flexi - evolution 3 - mash0000 - orbiting satellite coral reef time lapse by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3471,7 +3471,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fractal-jellyfish-moebius-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fractal-jellyfish-moebius-mix.png</image:loc>
       <image:title>Flexi - fractal jellyfish [moebius mix] | Stims</image:title>
       <image:caption>Flexi - fractal jellyfish [moebius mix] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3482,7 +3482,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-gold-plated-maelstrom-of-chaos-mirrorized</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-gold-plated-maelstrom-of-chaos-mirrorized.png</image:loc>
       <image:title>Flexi - gold plated maelstrom of chaos [mirrorized] | Stims</image:title>
       <image:caption>Flexi - gold plated maelstrom of chaos [mirrorized] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3493,7 +3493,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-gold-plated-maelstrom-of-chaos</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-gold-plated-maelstrom-of-chaos.png</image:loc>
       <image:title>Flexi - gold plated maelstrom of chaos | Stims</image:title>
       <image:caption>Flexi - gold plated maelstrom of chaos by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3504,7 +3504,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-hue-burst</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-hue-burst.png</image:loc>
       <image:title>Flexi - hue burst | Stims</image:title>
       <image:caption>Flexi - hue burst by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3515,7 +3515,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-impulse-drive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-impulse-drive.png</image:loc>
       <image:title>Flexi - impulse drive | Stims</image:title>
       <image:caption>Flexi - impulse drive by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3526,7 +3526,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-infused-with-the-spiral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-infused-with-the-spiral.png</image:loc>
       <image:title>Flexi - infused with the spiral | Stims</image:title>
       <image:caption>Flexi - infused with the spiral by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3537,7 +3537,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-intensive-shader-fractal-suksma-comp-shader-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-intensive-shader-fractal-suksma-comp-shader-mix.png</image:loc>
       <image:title>Flexi - intensive shader fractal [suksma comp shader mix] | Stims</image:title>
       <image:caption>Flexi - intensive shader fractal [suksma comp shader mix] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3548,7 +3548,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-intensive-shader-fractal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-intensive-shader-fractal.png</image:loc>
       <image:title>Flexi - intensive shader fractal | Stims</image:title>
       <image:caption>Flexi - intensive shader fractal by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3559,7 +3559,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-intention-focus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-intention-focus.png</image:loc>
       <image:title>Flexi - intention focus | Stims</image:title>
       <image:caption>Flexi - intention focus by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3570,7 +3570,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-invisible-chains-securing-you-don-t-move-cn-bc-jelly-4.png</image:loc>
       <image:title>Flexi - invisible chains securing you don′t move (cn bc jelly 4) | Stims</image:title>
       <image:caption>Flexi - invisible chains securing you don′t move (cn bc jelly 4) by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3581,7 +3581,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-jellyfish-jam</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-jellyfish-jam.png</image:loc>
       <image:title>Flexi - jellyfish jam | Stims</image:title>
       <image:caption>Flexi - jellyfish jam by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3592,7 +3592,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julian-affairs-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julian-affairs-remix.png</image:loc>
       <image:title>Flexi - julian affairs [remix] | Stims</image:title>
       <image:caption>Flexi - julian affairs [remix] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3603,7 +3603,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-kaleidoscope-template-commented-composite-shader</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-kaleidoscope-template-commented-composite-shader.png</image:loc>
       <image:title>Flexi - kaleidoscope template [commented composite shader] | Stims</image:title>
       <image:caption>Flexi - kaleidoscope template [commented composite shader] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3614,7 +3614,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-layered-boz-buckwild</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-layered-boz-buckwild.png</image:loc>
       <image:title>Flexi - layered + Boz - Buckwild | Stims</image:title>
       <image:caption>Flexi - layered + Boz - Buckwild by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3625,7 +3625,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-layered</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-layered.png</image:loc>
       <image:title>Flexi - layered | Stims</image:title>
       <image:caption>Flexi - layered by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3636,7 +3636,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-learning-curve</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-learning-curve.png</image:loc>
       <image:title>Flexi - learning curve | Stims</image:title>
       <image:caption>Flexi - learning curve by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3647,7 +3647,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-meta4free-3-my-time-is-not-your-time</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-meta4free-3-my-time-is-not-your-time.png</image:loc>
       <image:title>Flexi - meta4free 3 - my time is not your time | Stims</image:title>
       <image:caption>Flexi - meta4free 3 - my time is not your time by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3658,7 +3658,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-2-0.png</image:loc>
       <image:title>Flexi - mindblob 2.0 | Stims</image:title>
       <image:caption>Flexi - mindblob 2.0 by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3669,7 +3669,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-shiny-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-shiny-mix.png</image:loc>
       <image:title>Flexi - mindblob [shiny mix] | Stims</image:title>
       <image:caption>Flexi - mindblob [shiny mix] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3680,7 +3680,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-mix-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-mix-random-mashup.png</image:loc>
       <image:title>Flexi - mindblob mix [random mashup] | Stims</image:title>
       <image:caption>Flexi - mindblob mix [random mashup] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3691,7 +3691,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-mix.png</image:loc>
       <image:title>Flexi - mindblob mix | Stims</image:title>
       <image:caption>Flexi - mindblob mix by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3702,7 +3702,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-molten-neon-fire-spirit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-molten-neon-fire-spirit.png</image:loc>
       <image:title>Flexi - molten neon fire spirit | Stims</image:title>
       <image:caption>Flexi - molten neon fire spirit by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3713,7 +3713,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-motion-blurred-moebius-fractal-early-alpha-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-motion-blurred-moebius-fractal-early-alpha-version.png</image:loc>
       <image:title>Flexi - motion blurred moebius fractal - early alpha version | Stims</image:title>
       <image:caption>Flexi - motion blurred moebius fractal - early alpha version by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3724,7 +3724,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-multiverse-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-multiverse-random-mashup.png</image:loc>
       <image:title>Flexi - multiverse [random mashup] | Stims</image:title>
       <image:caption>Flexi - multiverse [random mashup] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3735,7 +3735,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-multiverse</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-multiverse.png</image:loc>
       <image:title>Flexi - multiverse | Stims</image:title>
       <image:caption>Flexi - multiverse by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3746,7 +3746,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-never-expected-to-play-the-game-on-this-level</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-never-expected-to-play-the-game-on-this-level.png</image:loc>
       <image:title>Flexi - never expected to play the game on this level | Stims</image:title>
       <image:caption>Flexi - never expected to play the game on this level by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3757,7 +3757,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-oldschool-tree</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-oldschool-tree.png</image:loc>
       <image:title>Flexi - oldschool tree | Stims</image:title>
       <image:caption>Flexi - oldschool tree by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3768,7 +3768,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-piercing</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-piercing.png</image:loc>
       <image:title>Flexi - piercing | Stims</image:title>
       <image:caption>Flexi - piercing by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3779,7 +3779,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-predator-prey-spirals-geiss-laplacian-finish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-predator-prey-spirals-geiss-laplacian-finish.png</image:loc>
       <image:title>Flexi - predator-prey-spirals [geiss′ laplacian finish] | Stims</image:title>
       <image:caption>Flexi - predator-prey-spirals [geiss′ laplacian finish] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3790,7 +3790,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-predator-prey-spirals-stahlregens-gelatine-finish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-predator-prey-spirals-stahlregens-gelatine-finish.png</image:loc>
       <image:title>Flexi - predator-prey-spirals [stahlregens gelatine finish] | Stims</image:title>
       <image:caption>Flexi - predator-prey-spirals [stahlregens gelatine finish] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3801,7 +3801,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-predator-prey-spirals</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-predator-prey-spirals.png</image:loc>
       <image:title>Flexi - predator-prey-spirals | Stims</image:title>
       <image:caption>Flexi - predator-prey-spirals by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3812,7 +3812,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-psychenapping</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-psychenapping.png</image:loc>
       <image:title>Flexi - psychenapping | Stims</image:title>
       <image:caption>Flexi - psychenapping by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3823,7 +3823,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-psycho-wondermilk-s0s</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-psycho-wondermilk-s0s.png</image:loc>
       <image:title>Flexi - psycho . wondermilk [S0S] | Stims</image:title>
       <image:caption>Flexi - psycho . wondermilk [S0S] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3834,7 +3834,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-reality-tunnel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-reality-tunnel.png</image:loc>
       <image:title>Flexi - reality tunnel | Stims</image:title>
       <image:caption>Flexi - reality tunnel by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3845,7 +3845,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-science-fraction</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-science-fraction.png</image:loc>
       <image:title>Flexi - science-fraction | Stims</image:title>
       <image:caption>Flexi - science-fraction by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3856,7 +3856,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-self-similarity-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-self-similarity-7.png</image:loc>
       <image:title>Flexi - self similarity 7 | Stims</image:title>
       <image:caption>Flexi - self similarity 7 by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3867,7 +3867,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-self-lubricating</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-self-lubricating.png</image:loc>
       <image:title>Flexi - self-lubricating | Stims</image:title>
       <image:caption>Flexi - self-lubricating by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3878,7 +3878,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-smashing-fractals-2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-smashing-fractals-2-0.png</image:loc>
       <image:title>Flexi - smashing fractals 2.0 | Stims</image:title>
       <image:caption>Flexi - smashing fractals 2.0 by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3889,7 +3889,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-smashing-fractals-geiss-bas-relief-finish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-smashing-fractals-geiss-bas-relief-finish.png</image:loc>
       <image:title>Flexi - smashing fractals [Geiss′ bas relief finish] | Stims</image:title>
       <image:caption>Flexi - smashing fractals [Geiss′ bas relief finish] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3900,7 +3900,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-smashing-fractals-acid-etching-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-smashing-fractals-acid-etching-mix.png</image:loc>
       <image:title>Flexi - smashing fractals [acid etching mix] | Stims</image:title>
       <image:caption>Flexi - smashing fractals [acid etching mix] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3911,7 +3911,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-strangely-dynamic-world</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-strangely-dynamic-world.png</image:loc>
       <image:title>Flexi - strangely dynamic world | Stims</image:title>
       <image:caption>Flexi - strangely dynamic world by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3922,7 +3922,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-supersonic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-supersonic.png</image:loc>
       <image:title>Flexi - supersonic | Stims</image:title>
       <image:caption>Flexi - supersonic by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3933,7 +3933,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-swimmer-fractal-template-the-freedom-of-torusland</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-swimmer-fractal-template-the-freedom-of-torusland.png</image:loc>
       <image:title>Flexi - swimmer fractal template [the freedom of torusland] | Stims</image:title>
       <image:caption>Flexi - swimmer fractal template [the freedom of torusland] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3944,7 +3944,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-bouncer-and-the-crasher-random-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-bouncer-and-the-crasher-random-mashup-2.png</image:loc>
       <image:title>Flexi - the bouncer and the crasher [random mashup 2] | Stims</image:title>
       <image:caption>Flexi - the bouncer and the crasher [random mashup 2] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3955,7 +3955,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-bouncer-and-the-crasher-random-mashup-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-bouncer-and-the-crasher-random-mashup-3.png</image:loc>
       <image:title>Flexi - the bouncer and the crasher [random mashup 3] | Stims</image:title>
       <image:caption>Flexi - the bouncer and the crasher [random mashup 3] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3966,7 +3966,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-bouncer-and-the-crasher-random-mashup-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-bouncer-and-the-crasher-random-mashup-4.png</image:loc>
       <image:title>Flexi - the bouncer and the crasher [random mashup 4] | Stims</image:title>
       <image:caption>Flexi - the bouncer and the crasher [random mashup 4] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3977,7 +3977,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-bouncer-and-the-crasher-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-bouncer-and-the-crasher-random-mashup.png</image:loc>
       <image:title>Flexi - the bouncer and the crasher [random mashup] | Stims</image:title>
       <image:caption>Flexi - the bouncer and the crasher [random mashup] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3988,7 +3988,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-bouncer-and-the-crasher</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-bouncer-and-the-crasher.png</image:loc>
       <image:title>Flexi - the bouncer and the crasher | Stims</image:title>
       <image:caption>Flexi - the bouncer and the crasher by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3999,7 +3999,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-distant-point-between-derivative</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-distant-point-between-derivative.png</image:loc>
       <image:title>Flexi - the distant point between derivative | Stims</image:title>
       <image:caption>Flexi - the distant point between derivative by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4010,7 +4010,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-truly-soft-piece-of-software-this-is-generic-texturing-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-truly-soft-piece-of-software-this-is-generic-texturing-jelly.png</image:loc>
       <image:title>Flexi - truly soft piece of software - this is generic texturing (Jelly)  | Stims</image:title>
       <image:caption>Flexi - truly soft piece of software - this is generic texturing (Jelly)  by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4021,7 +4021,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-using-jedi-forces</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-using-jedi-forces.png</image:loc>
       <image:title>Flexi - using jedi forces | Stims</image:title>
       <image:caption>Flexi - using jedi forces by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4032,7 +4032,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-when-monopolies-were-the-future-simple-warp-non-reactive-moebius</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-when-monopolies-were-the-future-simple-warp-non-reactive-moebius.png</image:loc>
       <image:title>Flexi - when monopolies were the future [simple warp + non-reactive moebius] | Stims</image:title>
       <image:caption>Flexi - when monopolies were the future [simple warp + non-reactive moebius] by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4043,7 +4043,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-wild-at-range</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-wild-at-range.png</image:loc>
       <image:title>Flexi - wild at range | Stims</image:title>
       <image:caption>Flexi - wild at range by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4054,7 +4054,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-working-with-infinity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-working-with-infinity.png</image:loc>
       <image:title>Flexi - working with infinity | Stims</image:title>
       <image:caption>Flexi - working with infinity by Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4065,7 +4065,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell.png</image:loc>
       <image:title>Flexi, BDRV, Aderrasi et al - Potion of Resurrection [rosswell] | Stims</image:title>
       <image:caption>Flexi, BDRV, Aderrasi et al - Potion of Resurrection [rosswell] by Flexi, BDRV, Aderrasi et al, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4076,7 +4076,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-and-rovastar-chaos-layered-tokamak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-and-rovastar-chaos-layered-tokamak.png</image:loc>
       <image:title>Flexi, Geiss and Rovastar - chaos layered tokamak | Stims</image:title>
       <image:caption>Flexi, Geiss and Rovastar - chaos layered tokamak by Flexi, Geiss and Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4087,7 +4087,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit.png</image:loc>
       <image:title>Flexi, Martin, Phat, Zylot + Eo.S - one way trip trap proof of concept [epileptic zoom tunnel edit] | Stims</image:title>
       <image:caption>Flexi, Martin, Phat, Zylot + Eo.S - one way trip trap proof of concept [epileptic zoom tunnel edit] by Flexi, Martin, Phat, Zylot + Eo.S, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4098,7 +4098,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-phat-zylot-eo-s-work-with-lines-of-code</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-phat-zylot-eo-s-work-with-lines-of-code.png</image:loc>
       <image:title>Flexi, Phat, Zylot + Eo.S - work with lines of code | Stims</image:title>
       <image:caption>Flexi, Phat, Zylot + Eo.S - work with lines of code by Flexi, Phat, Zylot + Eo.S, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4109,7 +4109,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-rovastar-geiss-fractopia-vs-bas-relief</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-rovastar-geiss-fractopia-vs-bas-relief.png</image:loc>
       <image:title>Flexi, Rovastar + Geiss - Fractopia vs bas relief | Stims</image:title>
       <image:caption>Flexi, Rovastar + Geiss - Fractopia vs bas relief by Flexi, Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4120,7 +4120,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-nitorami-shifter-shader-authoring-motivation-set</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-nitorami-shifter-shader-authoring-motivation-set.png</image:loc>
       <image:title>Flexi, Stahlregen, Nitorami + Shifter - shader authoring motivation set | Stims</image:title>
       <image:caption>Flexi, Stahlregen, Nitorami + Shifter - shader authoring motivation set by Flexi, Stahlregen, Nitorami + Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4131,7 +4131,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-martin-witchery</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-martin-witchery.png</image:loc>
       <image:title>Flexi, fishbrain + Martin - witchery | Stims</image:title>
       <image:caption>Flexi, fishbrain + Martin - witchery by Flexi, fishbrain + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4142,7 +4142,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-geiss-martin-tokamak-witchery</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-geiss-martin-tokamak-witchery.png</image:loc>
       <image:title>Flexi, fishbrain, Geiss + Martin - tokamak witchery | Stims</image:title>
       <image:caption>Flexi, fishbrain, Geiss + Martin - tokamak witchery by Flexi, fishbrain, Geiss + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4153,7 +4153,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-geiss-dedicated-to-the-sherwin-maxawow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-geiss-dedicated-to-the-sherwin-maxawow.png</image:loc>
       <image:title>Flexi, martin + geiss - dedicated to the sherwin maxawow | Stims</image:title>
       <image:caption>Flexi, martin + geiss - dedicated to the sherwin maxawow by Flexi, martin + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4164,7 +4164,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-geiss-painterly-rogue-wave-strike</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-geiss-painterly-rogue-wave-strike.png</image:loc>
       <image:title>Flexi, martin + geiss - painterly rogue wave strike | Stims</image:title>
       <image:caption>Flexi, martin + geiss - painterly rogue wave strike by Flexi, martin + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4175,7 +4175,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fumbling-foo-flexi-martin-orb-star-forge-v16</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fumbling-foo-flexi-martin-orb-star-forge-v16.png</image:loc>
       <image:title>Fumbling_Foo &amp; Flexi, Martin, Orb - Star Forge v16 | Stims</image:title>
       <image:caption>Fumbling_Foo &amp; Flexi, Martin, Orb - Star Forge v16 by Fumbling_Foo &amp; Flexi, Martin, Orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4186,7 +4186,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b.png</image:loc>
       <image:title>Fumbling_Foo &amp; Flexi, Martin, Orb, Unchained - Star Nova v7b | Stims</image:title>
       <image:caption>Fumbling_Foo &amp; Flexi, Martin, Orb, Unchained - Star Nova v7b by Fumbling_Foo &amp; Flexi, Martin, Orb, Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4197,7 +4197,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=future-ligh-show-adamfx-2-martin-flexi-lodus-geiss-ludicrous-speed-baked-hexocollie-eos-suksma-adamfx-ft-che-fishbrain-bmelgren-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/future-ligh-show-adamfx-2-martin-flexi-lodus-geiss-ludicrous-speed-baked-hexocollie-eos-suksma-adamfx-ft-che-fishbrain-bmelgren-4.png</image:loc>
       <image:title>Future Ligh Show AdamFX 2 martin - Flexi + Lodus + Geiss + Ludicrous speed + Baked + Hexocollie + Eos + Suksma + AdamFX Ft Che + Fishbrain + Bmelgren 4 | Stims</image:title>
       <image:caption>Future Ligh Show AdamFX 2 martin - Flexi + Lodus + Geiss + Ludicrous speed + Baked + Hexocollie + Eos + Suksma + AdamFX Ft Che + Fishbrain + Bmelgren 4 by Future Ligh Show AdamFX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4208,7 +4208,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-rebirth-progression-rot-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-rebirth-progression-rot-mix.png</image:loc>
       <image:title>Fvese - Rebirth (Progression Rot Mix) | Stims</image:title>
       <image:caption>Fvese - Rebirth (Progression Rot Mix) by Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4219,7 +4219,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-snowflake-like-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-snowflake-like-2.png</image:loc>
       <image:title>Fvese - Snowflake Like 2 | Stims</image:title>
       <image:caption>Fvese - Snowflake Like 2 by Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4230,7 +4230,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-the-tunnel-final-stage-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-the-tunnel-final-stage-mix.png</image:loc>
       <image:title>Fvese - The Tunnel (Final Stage Mix) | Stims</image:title>
       <image:caption>Fvese - The Tunnel (Final Stage Mix) by Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4241,7 +4241,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-zoom-effects-remix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-zoom-effects-remix-2.png</image:loc>
       <image:title>Fvese - Zoom Effects (Remix 2) | Stims</image:title>
       <image:caption>Fvese - Zoom Effects (Remix 2) by Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4252,7 +4252,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-zoom-effects-remix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-zoom-effects-remix-3.png</image:loc>
       <image:title>Fvese - Zoom Effects (Remix 3) | Stims</image:title>
       <image:caption>Fvese - Zoom Effects (Remix 3) by Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4263,7 +4263,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fvese-butterfly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fvese-butterfly.png</image:loc>
       <image:title>Fvese-butterfly | Stims</image:title>
       <image:caption>Fvese-butterfly, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4274,7 +4274,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flexi-martin-disconnected</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flexi-martin-disconnected.png</image:loc>
       <image:title>Geiss + Flexi + Martin - disconnected | Stims</image:title>
       <image:caption>Geiss + Flexi + Martin - disconnected by Geiss + Flexi + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4285,7 +4285,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rovastar-julia-fractal-vectrip-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rovastar-julia-fractal-vectrip-mix.png</image:loc>
       <image:title>Geiss + Rovastar - Julia Fractal (Vectrip Mix) | Stims</image:title>
       <image:caption>Geiss + Rovastar - Julia Fractal (Vectrip Mix) by Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4296,7 +4296,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rovastar-notions-of-tonality-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rovastar-notions-of-tonality-2.png</image:loc>
       <image:title>Geiss + Rovastar - Notions Of Tonality 2 | Stims</image:title>
       <image:caption>Geiss + Rovastar - Notions Of Tonality 2 by Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4307,7 +4307,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rovastar-the-chaos-of-colours-sprouting-dimentia-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rovastar-the-chaos-of-colours-sprouting-dimentia-mix.png</image:loc>
       <image:title>Geiss + Rovastar - The Chaos Of Colours (sprouting dimentia mix) | Stims</image:title>
       <image:caption>Geiss + Rovastar - The Chaos Of Colours (sprouting dimentia mix) by Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4318,7 +4318,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rovastar-tokamak-naked-intrusion-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rovastar-tokamak-naked-intrusion-mix.png</image:loc>
       <image:title>Geiss + Rovastar - Tokamak (Naked Intrusion Mix) | Stims</image:title>
       <image:caption>Geiss + Rovastar - Tokamak (Naked Intrusion Mix) by Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4329,7 +4329,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-minefield-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-minefield-mix.png</image:loc>
       <image:title>Geiss - 3 layers (Minefield Mix) | Stims</image:title>
       <image:caption>Geiss - 3 layers (Minefield Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4340,7 +4340,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-planar-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-planar-mix.png</image:loc>
       <image:title>Geiss - 3 layers (Planar Mix) | Stims</image:title>
       <image:caption>Geiss - 3 layers (Planar Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4351,7 +4351,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-rayleigh-scattering-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-rayleigh-scattering-mix.png</image:loc>
       <image:title>Geiss - 3 layers (Rayleigh Scattering Mix) | Stims</image:title>
       <image:caption>Geiss - 3 layers (Rayleigh Scattering Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4362,7 +4362,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-tunnel-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-tunnel-mix.png</image:loc>
       <image:title>Geiss - 3 layers (Tunnel Mix) | Stims</image:title>
       <image:caption>Geiss - 3 layers (Tunnel Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4373,7 +4373,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-e</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-e.png</image:loc>
       <image:title>Geiss - 3 layers E | Stims</image:title>
       <image:caption>Geiss - 3 layers E by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4384,7 +4384,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers-g</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers-g.png</image:loc>
       <image:title>Geiss - 3 layers G | Stims</image:title>
       <image:caption>Geiss - 3 layers G by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4395,7 +4395,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-3-layers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-3-layers.png</image:loc>
       <image:title>Geiss - 3 layers | Stims</image:title>
       <image:caption>Geiss - 3 layers by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4406,7 +4406,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-all-spark-mash0000-high-on-voltage</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-all-spark-mash0000-high-on-voltage.png</image:loc>
       <image:title>Geiss - All-Spark - mash0000 - high on voltage | Stims</image:title>
       <image:caption>Geiss - All-Spark - mash0000 - high on voltage by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4417,7 +4417,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-all-spark-polar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-all-spark-polar.png</image:loc>
       <image:title>Geiss - All-Spark Polar | Stims</image:title>
       <image:caption>Geiss - All-Spark Polar by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4428,7 +4428,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-all-spark-sinews</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-all-spark-sinews.png</image:loc>
       <image:title>Geiss - All-Spark Sinews | Stims</image:title>
       <image:caption>Geiss - All-Spark Sinews by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4439,7 +4439,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-all-spark</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-all-spark.png</image:loc>
       <image:title>Geiss - All-Spark | Stims</image:title>
       <image:caption>Geiss - All-Spark by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4450,7 +4450,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-6.png</image:loc>
       <image:title>Geiss - Artifact 6 | Stims</image:title>
       <image:caption>Geiss - Artifact 6 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4461,7 +4461,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-6b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-6b.png</image:loc>
       <image:title>Geiss - Artifact 6b | Stims</image:title>
       <image:caption>Geiss - Artifact 6b by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4472,7 +4472,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-6d</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-6d.png</image:loc>
       <image:title>Geiss - Artifact 6d | Stims</image:title>
       <image:caption>Geiss - Artifact 6d by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4483,7 +4483,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-plasma-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-plasma-2.png</image:loc>
       <image:title>Geiss - Artifact Plasma 2 | Stims</image:title>
       <image:caption>Geiss - Artifact Plasma 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4494,7 +4494,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-plasma</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-plasma.png</image:loc>
       <image:title>Geiss - Artifact Plasma | Stims</image:title>
       <image:caption>Geiss - Artifact Plasma by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4505,7 +4505,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-asymptote</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-asymptote.png</image:loc>
       <image:title>Geiss - Asymptote | Stims</image:title>
       <image:caption>Geiss - Asymptote by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4516,7 +4516,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-aurora-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-aurora-2.png</image:loc>
       <image:title>Geiss - Aurora 2 | Stims</image:title>
       <image:caption>Geiss - Aurora 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4527,7 +4527,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-aurora-industrialis</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-aurora-industrialis.png</image:loc>
       <image:title>Geiss - Aurora Industrialis | Stims</image:title>
       <image:caption>Geiss - Aurora Industrialis by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4538,7 +4538,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-aurora</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-aurora.png</image:loc>
       <image:title>Geiss - Aurora | Stims</image:title>
       <image:caption>Geiss - Aurora by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4549,7 +4549,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bas-relief-mash0000-restructure-society-one-sheep-at-a-time</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bas-relief-mash0000-restructure-society-one-sheep-at-a-time.png</image:loc>
       <image:title>Geiss - Bas Relief - mash0000 - restructure society one sheep at a time | Stims</image:title>
       <image:caption>Geiss - Bas Relief - mash0000 - restructure society one sheep at a time by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4560,7 +4560,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bas-relief</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bas-relief.png</image:loc>
       <image:title>Geiss - Bas Relief | Stims</image:title>
       <image:caption>Geiss - Bas Relief by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4571,7 +4571,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bass-zoom</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bass-zoom.png</image:loc>
       <image:title>Geiss - Bass Zoom | Stims</image:title>
       <image:caption>Geiss - Bass Zoom by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4582,7 +4582,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-beat-dots-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-beat-dots-2.png</image:loc>
       <image:title>Geiss - Beat Dots 2 | Stims</image:title>
       <image:caption>Geiss - Beat Dots 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4593,7 +4593,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bipolar-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bipolar-1.png</image:loc>
       <image:title>Geiss - Bipolar 1 | Stims</image:title>
       <image:caption>Geiss - Bipolar 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4604,7 +4604,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bipolar-2-enhanced</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bipolar-2-enhanced.png</image:loc>
       <image:title>Geiss - Bipolar 2 Enhanced | Stims</image:title>
       <image:caption>Geiss - Bipolar 2 Enhanced by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4615,7 +4615,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-bipolar-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-bipolar-5.png</image:loc>
       <image:title>Geiss - Bipolar 5 | Stims</image:title>
       <image:caption>Geiss - Bipolar 5 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4626,7 +4626,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-blur-mix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-blur-mix-3.png</image:loc>
       <image:title>Geiss - Blur Mix 3 | Stims</image:title>
       <image:caption>Geiss - Blur Mix 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4637,7 +4637,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom-3-random-texture-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom-3-random-texture-mix.png</image:loc>
       <image:title>Geiss - Brain Zoom 3 (random texture mix) | Stims</image:title>
       <image:caption>Geiss - Brain Zoom 3 (random texture mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4648,7 +4648,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom-3.png</image:loc>
       <image:title>Geiss - Brain Zoom 3 | Stims</image:title>
       <image:caption>Geiss - Brain Zoom 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4659,7 +4659,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom-4.png</image:loc>
       <image:title>Geiss - Brain Zoom 4 | Stims</image:title>
       <image:caption>Geiss - Brain Zoom 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4670,7 +4670,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom.png</image:loc>
       <image:title>Geiss - Brain Zoom | Stims</image:title>
       <image:caption>Geiss - Brain Zoom by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4681,7 +4681,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cartographie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cartographie.png</image:loc>
       <image:title>Geiss - Cartographie | Stims</image:title>
       <image:caption>Geiss - Cartographie by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4692,7 +4692,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-tendrils-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-tendrils-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - Tendrils (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - Tendrils (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4703,7 +4703,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-tendrils</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-tendrils.png</image:loc>
       <image:title>Geiss - Cauldron - Tendrils | Stims</image:title>
       <image:caption>Geiss - Cauldron - Tendrils by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4714,7 +4714,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - painterly (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4725,7 +4725,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-2-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-2-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 2 (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 2 (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4736,7 +4736,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-2.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 2 | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4747,7 +4747,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-3-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-3-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 3 (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 3 (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4758,7 +4758,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-3.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 3 | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4769,7 +4769,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-4-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-4-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 4 (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 4 (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4780,7 +4780,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-4.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 4 | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4791,7 +4791,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-5-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-5-saturation-remix.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 5 (saturation remix) | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 5 (saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4802,7 +4802,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly-5.png</image:loc>
       <image:title>Geiss - Cauldron - painterly 5 | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly 5 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4813,7 +4813,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cauldron-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cauldron-painterly.png</image:loc>
       <image:title>Geiss - Cauldron - painterly | Stims</image:title>
       <image:caption>Geiss - Cauldron - painterly by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4824,7 +4824,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cepia-dither</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cepia-dither.png</image:loc>
       <image:title>Geiss - Cepia Dither | Stims</image:title>
       <image:caption>Geiss - Cepia Dither by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4835,7 +4835,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-chromatexture-paint-in-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-chromatexture-paint-in-2.png</image:loc>
       <image:title>Geiss - Chromatexture Paint-In 2 | Stims</image:title>
       <image:caption>Geiss - Chromatexture Paint-In 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4846,7 +4846,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-chrome</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-chrome.png</image:loc>
       <image:title>Geiss - Chrome | Stims</image:title>
       <image:caption>Geiss - Chrome by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4857,7 +4857,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-color-pox-acid-impression-mix-color-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-color-pox-acid-impression-mix-color-saturation-remix.png</image:loc>
       <image:title>Geiss - Color Pox (Acid Impression Mix) (color saturation remix) | Stims</image:title>
       <image:caption>Geiss - Color Pox (Acid Impression Mix) (color saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4868,7 +4868,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-color-pox-acid-impression-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-color-pox-acid-impression-mix.png</image:loc>
       <image:title>Geiss - Color Pox (Acid Impression Mix) | Stims</image:title>
       <image:caption>Geiss - Color Pox (Acid Impression Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4879,7 +4879,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-color-pox-measles-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-color-pox-measles-mix.png</image:loc>
       <image:title>Geiss - Color Pox (Measles Mix) | Stims</image:title>
       <image:caption>Geiss - Color Pox (Measles Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4890,7 +4890,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-color-pox-van-gogh-mix-color-saturation-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-color-pox-van-gogh-mix-color-saturation-remix.png</image:loc>
       <image:title>Geiss - Color Pox (Van Gogh Mix) (color saturation remix) | Stims</image:title>
       <image:caption>Geiss - Color Pox (Van Gogh Mix) (color saturation remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4901,7 +4901,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-color-pox-van-gogh-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-color-pox-van-gogh-mix.png</image:loc>
       <image:title>Geiss - Color Pox (Van Gogh Mix) | Stims</image:title>
       <image:caption>Geiss - Color Pox (Van Gogh Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4912,7 +4912,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti-kaleidoscope-mix-color-saturation-boosted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti-kaleidoscope-mix-color-saturation-boosted.png</image:loc>
       <image:title>Geiss - Confetti (Kaleidoscope Mix) (color saturation boosted) | Stims</image:title>
       <image:caption>Geiss - Confetti (Kaleidoscope Mix) (color saturation boosted) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4923,7 +4923,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti-kaleidoscope-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti-kaleidoscope-mix.png</image:loc>
       <image:title>Geiss - Confetti (Kaleidoscope Mix) | Stims</image:title>
       <image:caption>Geiss - Confetti (Kaleidoscope Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4934,7 +4934,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti-color-saturation-boosted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti-color-saturation-boosted.png</image:loc>
       <image:title>Geiss - Confetti (color saturation boosted) | Stims</image:title>
       <image:caption>Geiss - Confetti (color saturation boosted) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4945,7 +4945,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti.png</image:loc>
       <image:title>Geiss - Confetti | Stims</image:title>
       <image:caption>Geiss - Confetti by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4956,7 +4956,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-constant-velocity-angular-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-constant-velocity-angular-blur.png</image:loc>
       <image:title>Geiss - Constant Velocity - angular blur | Stims</image:title>
       <image:caption>Geiss - Constant Velocity - angular blur by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4967,7 +4967,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-constant-velocity-glow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-constant-velocity-glow.png</image:loc>
       <image:title>Geiss - Constant Velocity - glow | Stims</image:title>
       <image:caption>Geiss - Constant Velocity - glow by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4978,7 +4978,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-reverse-jelly-v3-brighter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-reverse-jelly-v3-brighter.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 (Reverse Jelly V3) (brighter) | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 (Reverse Jelly V3) (brighter) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4989,7 +4989,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-reverse-jelly-v3.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 (Reverse Jelly V3) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5000,7 +5000,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-game-of-life-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-game-of-life-mix.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - Game of Life mix | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - Game of Life mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5011,7 +5011,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-laplacian-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-laplacian-mix.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - Laplacian Mix | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - Laplacian Mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5022,7 +5022,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-tiny-reaction-diffusion-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-tiny-reaction-diffusion-mix.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - Tiny Reaction Diffusion Mix | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - Tiny Reaction Diffusion Mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5033,7 +5033,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-trails-5b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-trails-5b.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - Trails 5b | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - Trails 5b by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5044,7 +5044,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-trails-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-trails-7.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - Trails 7 | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - Trails 7 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5055,7 +5055,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-cloud-journey</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-cloud-journey.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - cloud journey | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - cloud journey by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5066,7 +5066,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-quasistatic-noise-grow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-quasistatic-noise-grow-mix.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - quasistatic noise (Grow Mix) | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - quasistatic noise (Grow Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5077,7 +5077,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-quasistatic-noise-desat-trails-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-quasistatic-noise-desat-trails-2.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - quasistatic noise desat trails 2 | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - quasistatic noise desat trails 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5088,7 +5088,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-quasistatic-noise-desat-trails</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-quasistatic-noise-desat-trails.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - quasistatic noise desat trails | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - quasistatic noise desat trails by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5099,7 +5099,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-quasistatic-noise-dual-pane-window</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-quasistatic-noise-dual-pane-window.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - quasistatic noise dual pane window | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - quasistatic noise dual pane window by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5110,7 +5110,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-static-noise</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-static-noise.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 - static noise | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 - static noise by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5121,7 +5121,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2.png</image:loc>
       <image:title>Geiss - Cosmic Dust 2 | Stims</image:title>
       <image:caption>Geiss - Cosmic Dust 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5132,7 +5132,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cruzin</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cruzin.png</image:loc>
       <image:title>Geiss - Cruzin′ | Stims</image:title>
       <image:caption>Geiss - Cruzin′ by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5143,7 +5143,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cycloid-1-painterly-vortex-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cycloid-1-painterly-vortex-3.png</image:loc>
       <image:title>Geiss - Cycloid 1 - painterly vortex 3 | Stims</image:title>
       <image:caption>Geiss - Cycloid 1 - painterly vortex 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5154,7 +5154,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cycloid-1-painterly-vortex</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cycloid-1-painterly-vortex.png</image:loc>
       <image:title>Geiss - Cycloid 1 - painterly vortex | Stims</image:title>
       <image:caption>Geiss - Cycloid 1 - painterly vortex by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5165,7 +5165,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cycloid-1-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cycloid-1-painterly.png</image:loc>
       <image:title>Geiss - Cycloid 1 - painterly | Stims</image:title>
       <image:caption>Geiss - Cycloid 1 - painterly by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5176,7 +5176,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-dancing-spirits-bright</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-dancing-spirits-bright.png</image:loc>
       <image:title>Geiss - Dancing Spirits (Bright) | Stims</image:title>
       <image:caption>Geiss - Dancing Spirits (Bright) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5187,7 +5187,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-dancing-spirits</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-dancing-spirits.png</image:loc>
       <image:title>Geiss - Dancing Spirits | Stims</image:title>
       <image:caption>Geiss - Dancing Spirits by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5198,7 +5198,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-de-la-moutard-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-de-la-moutard-1.png</image:loc>
       <image:title>Geiss - De La Moutard 1 | Stims</image:title>
       <image:caption>Geiss - De La Moutard 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5209,7 +5209,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-desert-rose-grow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-desert-rose-grow-mix.png</image:loc>
       <image:title>Geiss - Desert Rose (Grow Mix) | Stims</image:title>
       <image:caption>Geiss - Desert Rose (Grow Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5220,7 +5220,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-desert-rose-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-desert-rose-2.png</image:loc>
       <image:title>Geiss - Desert Rose 2 | Stims</image:title>
       <image:caption>Geiss - Desert Rose 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5231,7 +5231,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-desert-rose-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-desert-rose-4.png</image:loc>
       <image:title>Geiss - Desert Rose 4 | Stims</image:title>
       <image:caption>Geiss - Desert Rose 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5242,7 +5242,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-diffuser-gold-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-diffuser-gold-mix.png</image:loc>
       <image:title>Geiss - Diffuser (Gold Mix) | Stims</image:title>
       <image:caption>Geiss - Diffuser (Gold Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5253,7 +5253,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-diffuser-red-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-diffuser-red-mix.png</image:loc>
       <image:title>Geiss - Diffuser (Red Mix) | Stims</image:title>
       <image:caption>Geiss - Diffuser (Red Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5264,7 +5264,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-digitunnel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-digitunnel.png</image:loc>
       <image:title>Geiss - Digitunnel | Stims</image:title>
       <image:caption>Geiss - Digitunnel by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5275,7 +5275,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-downward-spiral-color-invert-mirror-x</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-downward-spiral-color-invert-mirror-x.png</image:loc>
       <image:title>Geiss - Downward Spiral - color invert mirror x | Stims</image:title>
       <image:caption>Geiss - Downward Spiral - color invert mirror x by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5286,7 +5286,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-drop-shadow-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-drop-shadow-1.png</image:loc>
       <image:title>Geiss - Drop Shadow 1 | Stims</image:title>
       <image:caption>Geiss - Drop Shadow 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5297,7 +5297,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-drop-shadow-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-drop-shadow-2.png</image:loc>
       <image:title>Geiss - Drop Shadow 2 | Stims</image:title>
       <image:caption>Geiss - Drop Shadow 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5308,7 +5308,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-dynamic-swirls-2-max-invert-crazytiles</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-dynamic-swirls-2-max-invert-crazytiles.png</image:loc>
       <image:title>Geiss - Dynamic Swirls 2 - max invert - crazytiles | Stims</image:title>
       <image:caption>Geiss - Dynamic Swirls 2 - max invert - crazytiles by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5319,7 +5319,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-dynamic-swirls-2-max-invert</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-dynamic-swirls-2-max-invert.png</image:loc>
       <image:title>Geiss - Dynamic Swirls 2 - max invert | Stims</image:title>
       <image:caption>Geiss - Dynamic Swirls 2 - max invert by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5330,7 +5330,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-eggs</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-eggs.png</image:loc>
       <image:title>Geiss - Eggs | Stims</image:title>
       <image:caption>Geiss - Eggs by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5341,7 +5341,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-el-cubismo-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-el-cubismo-2.png</image:loc>
       <image:title>Geiss - El Cubismo 2 | Stims</image:title>
       <image:caption>Geiss - El Cubismo 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5352,7 +5352,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-el-cubismo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-el-cubismo.png</image:loc>
       <image:title>Geiss - El Cubismo | Stims</image:title>
       <image:caption>Geiss - El Cubismo by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5363,7 +5363,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-electric-storm-half-digital-2-fiesta-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-electric-storm-half-digital-2-fiesta-mix.png</image:loc>
       <image:title>Geiss - Electric Storm Half-Digital 2 (Fiesta Mix) | Stims</image:title>
       <image:caption>Geiss - Electric Storm Half-Digital 2 (Fiesta Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5374,7 +5374,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-electric-storm-half-digital-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-electric-storm-half-digital-2.png</image:loc>
       <image:title>Geiss - Electric Storm Half-Digital 2 | Stims</image:title>
       <image:caption>Geiss - Electric Storm Half-Digital 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5385,7 +5385,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion-2.png</image:loc>
       <image:title>Geiss - Explosion 2 | Stims</image:title>
       <image:caption>Geiss - Explosion 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5396,7 +5396,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion-3-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion-3-relief-mix.png</image:loc>
       <image:title>Geiss - Explosion 3 (Relief Mix) | Stims</image:title>
       <image:caption>Geiss - Explosion 3 (Relief Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5407,7 +5407,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion-3.png</image:loc>
       <image:title>Geiss - Explosion 3 | Stims</image:title>
       <image:caption>Geiss - Explosion 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5418,7 +5418,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion.png</image:loc>
       <image:title>Geiss - Explosion | Stims</image:title>
       <image:caption>Geiss - Explosion by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5429,7 +5429,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-feedback-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-feedback-2.png</image:loc>
       <image:title>Geiss - Feedback 2 | Stims</image:title>
       <image:caption>Geiss - Feedback 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5440,7 +5440,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides-2.png</image:loc>
       <image:title>Geiss - Flotsam - mash0000 - unfathomably advanced yet psychotic aliens churn my mental insides 2 | Stims</image:title>
       <image:caption>Geiss - Flotsam - mash0000 - unfathomably advanced yet psychotic aliens churn my mental insides 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5451,7 +5451,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flotsam-mash0000-unfathomably-advanced-yet-psychotic-aliens-churn-my-mental-insides.png</image:loc>
       <image:title>Geiss - Flotsam - mash0000 - unfathomably advanced yet psychotic aliens churn my mental insides | Stims</image:title>
       <image:caption>Geiss - Flotsam - mash0000 - unfathomably advanced yet psychotic aliens churn my mental insides by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5462,7 +5462,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flower-blossom</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flower-blossom.png</image:loc>
       <image:title>Geiss - Flower Blossom | Stims</image:title>
       <image:caption>Geiss - Flower Blossom by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5473,7 +5473,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flower</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flower.png</image:loc>
       <image:title>Geiss - Flower | Stims</image:title>
       <image:caption>Geiss - Flower by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5484,7 +5484,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-fog-tunnel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-fog-tunnel.png</image:loc>
       <image:title>Geiss - Fog Tunnel | Stims</image:title>
       <image:caption>Geiss - Fog Tunnel by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5495,7 +5495,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-fog-zone</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-fog-zone.png</image:loc>
       <image:title>Geiss - Fog Zone | Stims</image:title>
       <image:caption>Geiss - Fog Zone by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5506,7 +5506,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-four-kinds-of-amphetamines-color-sat-boosted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-four-kinds-of-amphetamines-color-sat-boosted.png</image:loc>
       <image:title>Geiss - Four Kinds of Amphetamines (color sat boosted) | Stims</image:title>
       <image:caption>Geiss - Four Kinds of Amphetamines (color sat boosted) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5517,7 +5517,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-four-kinds-of-amphetamines</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-four-kinds-of-amphetamines.png</image:loc>
       <image:title>Geiss - Four Kinds of Amphetamines | Stims</image:title>
       <image:caption>Geiss - Four Kinds of Amphetamines by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5528,7 +5528,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-game-of-life-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-game-of-life-2.png</image:loc>
       <image:title>Geiss - Game of Life 2 | Stims</image:title>
       <image:caption>Geiss - Game of Life 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5539,7 +5539,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-game-of-life-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-game-of-life-3.png</image:loc>
       <image:title>Geiss - Game of Life 3 | Stims</image:title>
       <image:caption>Geiss - Game of Life 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5550,7 +5550,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-game-of-life</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-game-of-life.png</image:loc>
       <image:title>Geiss - Game of Life | Stims</image:title>
       <image:caption>Geiss - Game of Life by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5561,7 +5561,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-hurricane</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-hurricane.png</image:loc>
       <image:title>Geiss - Hurricane | Stims</image:title>
       <image:caption>Geiss - Hurricane by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5572,7 +5572,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-hyperion-lsb-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-hyperion-lsb-mix.png</image:loc>
       <image:title>Geiss - Hyperion (LSB mix) | Stims</image:title>
       <image:caption>Geiss - Hyperion (LSB mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5583,7 +5583,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-inkblot</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-inkblot.png</image:loc>
       <image:title>Geiss - Inkblot | Stims</image:title>
       <image:caption>Geiss - Inkblot by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5594,7 +5594,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-iris-storm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-iris-storm.png</image:loc>
       <image:title>Geiss - Iris Storm | Stims</image:title>
       <image:caption>Geiss - Iris Storm by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5605,7 +5605,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-iris</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-iris.png</image:loc>
       <image:title>Geiss - Iris | Stims</image:title>
       <image:caption>Geiss - Iris by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5616,7 +5616,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-julia-fractal-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-julia-fractal-2.png</image:loc>
       <image:title>Geiss - Julia Fractal 2 | Stims</image:title>
       <image:caption>Geiss - Julia Fractal 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5627,7 +5627,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-julia-fractal-3-square-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-julia-fractal-3-square-mix.png</image:loc>
       <image:title>Geiss - Julia Fractal 3 square mix | Stims</image:title>
       <image:caption>Geiss - Julia Fractal 3 square mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5638,7 +5638,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-julia-fractal-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-julia-fractal-3.png</image:loc>
       <image:title>Geiss - Julia Fractal 3 | Stims</image:title>
       <image:caption>Geiss - Julia Fractal 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5649,7 +5649,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-kaleidoscope-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-kaleidoscope-1.png</image:loc>
       <image:title>Geiss - Kaleidoscope 1 | Stims</image:title>
       <image:caption>Geiss - Kaleidoscope 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5660,7 +5660,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-lightning</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-lightning.png</image:loc>
       <image:title>Geiss - Lightning | Stims</image:title>
       <image:caption>Geiss - Lightning by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5671,7 +5671,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-liquid-beats-janky-ripple-warp-reflecto</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-liquid-beats-janky-ripple-warp-reflecto.png</image:loc>
       <image:title>Geiss - Liquid Beats (janky ripple warp reflecto) | Stims</image:title>
       <image:caption>Geiss - Liquid Beats (janky ripple warp reflecto) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5682,7 +5682,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-liquid-beats-2-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-liquid-beats-2-reverse-jelly-v3.png</image:loc>
       <image:title>Geiss - Liquid Beats 2 (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Geiss - Liquid Beats 2 (Reverse Jelly V3) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5693,7 +5693,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-liquid-beats-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-liquid-beats-2.png</image:loc>
       <image:title>Geiss - Liquid Beats 2 | Stims</image:title>
       <image:caption>Geiss - Liquid Beats 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5704,7 +5704,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-liquid-beats</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-liquid-beats.png</image:loc>
       <image:title>Geiss - Liquid Beats | Stims</image:title>
       <image:caption>Geiss - Liquid Beats by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5715,7 +5715,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-luz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-luz.png</image:loc>
       <image:title>Geiss - Luz | Stims</image:title>
       <image:caption>Geiss - Luz by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5726,7 +5726,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mash-up-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mash-up-1.png</image:loc>
       <image:title>Geiss - Mash-Up 1 | Stims</image:title>
       <image:caption>Geiss - Mash-Up 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5737,7 +5737,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mash-up-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mash-up-3.png</image:loc>
       <image:title>Geiss - Mash-Up 3 | Stims</image:title>
       <image:caption>Geiss - Mash-Up 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5748,7 +5748,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mash-up-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mash-up-4.png</image:loc>
       <image:title>Geiss - Mash-Up 4 | Stims</image:title>
       <image:caption>Geiss - Mash-Up 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5759,7 +5759,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mega-swirl-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mega-swirl-2.png</image:loc>
       <image:title>Geiss - Mega Swirl 2 | Stims</image:title>
       <image:caption>Geiss - Mega Swirl 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5770,7 +5770,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mega-swirl-3-color-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mega-swirl-3-color-tweak.png</image:loc>
       <image:title>Geiss - Mega Swirl 3 (color tweak) | Stims</image:title>
       <image:caption>Geiss - Mega Swirl 3 (color tweak) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5781,7 +5781,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mega-swirl-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mega-swirl-3.png</image:loc>
       <image:title>Geiss - Mega Swirl 3 | Stims</image:title>
       <image:caption>Geiss - Mega Swirl 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5792,7 +5792,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-microcheckers-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-microcheckers-2.png</image:loc>
       <image:title>Geiss - MicroCheckers 2 | Stims</image:title>
       <image:caption>Geiss - MicroCheckers 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5803,7 +5803,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-microcheckers-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-microcheckers-3.png</image:loc>
       <image:title>Geiss - MicroCheckers 3 | Stims</image:title>
       <image:caption>Geiss - MicroCheckers 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5814,7 +5814,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-microcheckers-5-brighter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-microcheckers-5-brighter.png</image:loc>
       <image:title>Geiss - MicroCheckers 5 (brighter) | Stims</image:title>
       <image:caption>Geiss - MicroCheckers 5 (brighter) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5825,7 +5825,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-microcheckers-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-microcheckers-5.png</image:loc>
       <image:title>Geiss - MicroCheckers 5 | Stims</image:title>
       <image:caption>Geiss - MicroCheckers 5 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5836,7 +5836,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mosaic-octopus-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mosaic-octopus-7.png</image:loc>
       <image:title>Geiss - Mosaic Octopus 7 | Stims</image:title>
       <image:caption>Geiss - Mosaic Octopus 7 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5847,7 +5847,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mosaic-octopus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mosaic-octopus.png</image:loc>
       <image:title>Geiss - Mosaic Octopus | Stims</image:title>
       <image:caption>Geiss - Mosaic Octopus by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5858,7 +5858,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mosaic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mosaic.png</image:loc>
       <image:title>Geiss - Mosaic | Stims</image:title>
       <image:caption>Geiss - Mosaic by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5869,7 +5869,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-jelly-v3.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (Jelly V3) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (Jelly V3) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5880,7 +5880,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-relief-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-relief-mix-2.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (Relief Mix 2) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (Relief Mix 2) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5891,7 +5891,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-relief-mix.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (Relief Mix) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (Relief Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5902,7 +5902,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-reverse-jelly-v3.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (Reverse Jelly V3) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5913,7 +5913,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-stahl-s-neon-jelly-2-rmx.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (Stahl′s Neon Jelly 2 RMX) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (Stahl′s Neon Jelly 2 RMX) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5924,7 +5924,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-color-sat-boost</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-color-sat-boost.png</image:loc>
       <image:title>Geiss - Motion Blur 2 (color sat boost) | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 (color sat boost) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5935,7 +5935,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2.png</image:loc>
       <image:title>Geiss - Motion Blur 2 | Stims</image:title>
       <image:caption>Geiss - Motion Blur 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5946,7 +5946,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur.png</image:loc>
       <image:title>Geiss - Motion Blur | Stims</image:title>
       <image:caption>Geiss - Motion Blur by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5957,7 +5957,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-myriad-mosaics</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-myriad-mosaics.png</image:loc>
       <image:title>Geiss - Myriad Mosaics | Stims</image:title>
       <image:caption>Geiss - Myriad Mosaics by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5968,7 +5968,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-myriad-spirals-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-myriad-spirals-relief-mix.png</image:loc>
       <image:title>Geiss - Myriad Spirals (Relief Mix) | Stims</image:title>
       <image:caption>Geiss - Myriad Spirals (Relief Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5979,7 +5979,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-myriad-spirals</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-myriad-spirals.png</image:loc>
       <image:title>Geiss - Myriad Spirals | Stims</image:title>
       <image:caption>Geiss - Myriad Spirals by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5990,7 +5990,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-neutron-radial-blur-2-firestorm-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-neutron-radial-blur-2-firestorm-mix.png</image:loc>
       <image:title>Geiss - Neutron - radial blur 2 (firestorm mix) | Stims</image:title>
       <image:caption>Geiss - Neutron - radial blur 2 (firestorm mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6001,7 +6001,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-neutron-radial-blur-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-neutron-radial-blur-2.png</image:loc>
       <image:title>Geiss - Neutron - radial blur 2 | Stims</image:title>
       <image:caption>Geiss - Neutron - radial blur 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6012,7 +6012,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-octopus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-octopus.png</image:loc>
       <image:title>Geiss - Octopus | Stims</image:title>
       <image:caption>Geiss - Octopus by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6023,7 +6023,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-pistons</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-pistons.png</image:loc>
       <image:title>Geiss - Pistons | Stims</image:title>
       <image:caption>Geiss - Pistons by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6034,7 +6034,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-planar-travel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-planar-travel.png</image:loc>
       <image:title>Geiss - Planar Travel | Stims</image:title>
       <image:caption>Geiss - Planar Travel by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6045,7 +6045,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-planet-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-planet-1.png</image:loc>
       <image:title>Geiss - Planet 1 | Stims</image:title>
       <image:caption>Geiss - Planet 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6056,7 +6056,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-plasma-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-plasma-2.png</image:loc>
       <image:title>Geiss - Plasma 2 | Stims</image:title>
       <image:caption>Geiss - Plasma 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6067,7 +6067,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-plasma</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-plasma.png</image:loc>
       <image:title>Geiss - Plasma | Stims</image:title>
       <image:caption>Geiss - Plasma by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6078,7 +6078,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-puddle-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-puddle-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion (Puddle Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion (Puddle Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6089,7 +6089,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-relief-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion (Relief Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion (Relief Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6100,7 +6100,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-royal-crown-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-royal-crown-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion (Royal Crown Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion (Royal Crown Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6111,7 +6111,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-shifting-sphere-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-shifting-sphere-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion (Shifting Sphere Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion (Shifting Sphere Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6122,7 +6122,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-squamous-flow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-squamous-flow-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion (Squamous Flow Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion (Squamous Flow Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6133,7 +6133,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-simple-squamous-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-simple-squamous-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion - Simple Squamous Mix | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion - Simple Squamous Mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6144,7 +6144,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-2.png</image:loc>
       <image:title>Geiss - Reaction Diffusion 2 | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6155,7 +6155,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-3-lichen-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-3-lichen-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion 3 (Lichen Mix) | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion 3 (Lichen Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6166,7 +6166,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-3.png</image:loc>
       <image:title>Geiss - Reaction Diffusion 3 | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6177,7 +6177,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-4-petri-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-4-petri-mix.png</image:loc>
       <image:title>Geiss - Reaction Diffusion 4 - Petri Mix | Stims</image:title>
       <image:caption>Geiss - Reaction Diffusion 4 - Petri Mix by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6188,7 +6188,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reducto-absurdum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reducto-absurdum.png</image:loc>
       <image:title>Geiss - Reducto Absurdum | Stims</image:title>
       <image:caption>Geiss - Reducto Absurdum by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6199,7 +6199,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reducto-ad-nauseum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reducto-ad-nauseum.png</image:loc>
       <image:title>Geiss - Reducto Ad Nauseum | Stims</image:title>
       <image:caption>Geiss - Reducto Ad Nauseum by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6210,7 +6210,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-ribbons</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-ribbons.png</image:loc>
       <image:title>Geiss - Ribbons | Stims</image:title>
       <image:caption>Geiss - Ribbons by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6221,7 +6221,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-3.png</image:loc>
       <image:title>Geiss - Rose 3 | Stims</image:title>
       <image:caption>Geiss - Rose 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6232,7 +6232,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-4-lsb-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-4-lsb-mix.png</image:loc>
       <image:title>Geiss - Rose 4 (LSB mix) | Stims</image:title>
       <image:caption>Geiss - Rose 4 (LSB mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6243,7 +6243,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-4-bccn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-4-bccn-jelly-v4.png</image:loc>
       <image:title>Geiss - Rose 4 (bccn Jelly V4) | Stims</image:title>
       <image:caption>Geiss - Rose 4 (bccn Jelly V4) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6254,7 +6254,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-4-composite-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-4-composite-remix.png</image:loc>
       <image:title>Geiss - Rose 4 (composite remix) | Stims</image:title>
       <image:caption>Geiss - Rose 4 (composite remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6265,7 +6265,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-4-shifted-tiles</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-4-shifted-tiles.png</image:loc>
       <image:title>Geiss - Rose 4 Shifted Tiles | Stims</image:title>
       <image:caption>Geiss - Rose 4 Shifted Tiles by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6276,7 +6276,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-4.png</image:loc>
       <image:title>Geiss - Rose 4 | Stims</image:title>
       <image:caption>Geiss - Rose 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6287,7 +6287,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-5-crossfire-beats-composite-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-5-crossfire-beats-composite-remix.png</image:loc>
       <image:title>Geiss - Rose 5 Crossfire Beats (composite remix) | Stims</image:title>
       <image:caption>Geiss - Rose 5 Crossfire Beats (composite remix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6298,7 +6298,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-5-crossfire-beats-mash0000-ill-gotten-slobber-catcher</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-5-crossfire-beats-mash0000-ill-gotten-slobber-catcher.png</image:loc>
       <image:title>Geiss - Rose 5 Crossfire Beats - mash0000 - ill gotten slobber catcher | Stims</image:title>
       <image:caption>Geiss - Rose 5 Crossfire Beats - mash0000 - ill gotten slobber catcher by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6309,7 +6309,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-rose-5-crossfire-beats</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-rose-5-crossfire-beats.png</image:loc>
       <image:title>Geiss - Rose 5 Crossfire Beats | Stims</image:title>
       <image:caption>Geiss - Rose 5 Crossfire Beats by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6320,7 +6320,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-sinews-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-sinews-1.png</image:loc>
       <image:title>Geiss - Sinews 1 | Stims</image:title>
       <image:caption>Geiss - Sinews 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6331,7 +6331,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-10</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-10.png</image:loc>
       <image:title>Geiss - Skin Dots 10 | Stims</image:title>
       <image:caption>Geiss - Skin Dots 10 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6342,7 +6342,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-10b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-10b.png</image:loc>
       <image:title>Geiss - Skin Dots 10b | Stims</image:title>
       <image:caption>Geiss - Skin Dots 10b by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6353,7 +6353,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-10c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-10c.png</image:loc>
       <image:title>Geiss - Skin Dots 10c | Stims</image:title>
       <image:caption>Geiss - Skin Dots 10c by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6364,7 +6364,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-11-crossfire-composite</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-11-crossfire-composite.png</image:loc>
       <image:title>Geiss - Skin Dots 11 Crossfire Composite | Stims</image:title>
       <image:caption>Geiss - Skin Dots 11 Crossfire Composite by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6375,7 +6375,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-11b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-11b.png</image:loc>
       <image:title>Geiss - Skin Dots 11b | Stims</image:title>
       <image:caption>Geiss - Skin Dots 11b by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6386,7 +6386,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-3.png</image:loc>
       <image:title>Geiss - Skin Dots 3 | Stims</image:title>
       <image:caption>Geiss - Skin Dots 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6397,7 +6397,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-6.png</image:loc>
       <image:title>Geiss - Skin Dots 6 | Stims</image:title>
       <image:caption>Geiss - Skin Dots 6 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6408,7 +6408,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-8b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-8b.png</image:loc>
       <image:title>Geiss - Skin Dots 8b | Stims</image:title>
       <image:caption>Geiss - Skin Dots 8b by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6419,7 +6419,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-9</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-9.png</image:loc>
       <image:title>Geiss - Skin Dots 9 | Stims</image:title>
       <image:caption>Geiss - Skin Dots 9 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6430,7 +6430,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-1.png</image:loc>
       <image:title>Geiss - Skin Dots Multi-layer 1 | Stims</image:title>
       <image:caption>Geiss - Skin Dots Multi-layer 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6441,7 +6441,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-3-pig-fuck-jembe-acid-wretch-dildonic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-3-pig-fuck-jembe-acid-wretch-dildonic.png</image:loc>
       <image:title>Geiss - Skin Dots Multi-layer 3 - pig fuck - jembe acid wretch dildonic | Stims</image:title>
       <image:caption>Geiss - Skin Dots Multi-layer 3 - pig fuck - jembe acid wretch dildonic by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6452,7 +6452,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-3.png</image:loc>
       <image:title>Geiss - Skin Dots Multi-layer 3 | Stims</image:title>
       <image:caption>Geiss - Skin Dots Multi-layer 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6463,7 +6463,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-smoke-rings</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-smoke-rings.png</image:loc>
       <image:title>Geiss - Smoke Rings | Stims</image:title>
       <image:caption>Geiss - Smoke Rings by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6474,7 +6474,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-smoke-trail</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-smoke-trail.png</image:loc>
       <image:title>Geiss - Smoke Trail | Stims</image:title>
       <image:caption>Geiss - Smoke Trail by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6485,7 +6485,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-soft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-soft.png</image:loc>
       <image:title>Geiss - Soft | Stims</image:title>
       <image:caption>Geiss - Soft by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6496,7 +6496,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-sound-and-the-fury-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-sound-and-the-fury-jelly-v3.png</image:loc>
       <image:title>Geiss - Sound And The Fury (Jelly V3) | Stims</image:title>
       <image:caption>Geiss - Sound And The Fury (Jelly V3) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6507,7 +6507,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-sound-and-the-fury</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-sound-and-the-fury.png</image:loc>
       <image:title>Geiss - Sound And The Fury | Stims</image:title>
       <image:caption>Geiss - Sound And The Fury by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6518,7 +6518,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-spiral-artifact-filament-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-spiral-artifact-filament-mix.png</image:loc>
       <image:title>Geiss - Spiral Artifact (Filament Mix) | Stims</image:title>
       <image:caption>Geiss - Spiral Artifact (Filament Mix) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6529,7 +6529,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-spiral-artifact</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-spiral-artifact.png</image:loc>
       <image:title>Geiss - Spiral Artifact | Stims</image:title>
       <image:caption>Geiss - Spiral Artifact by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6540,7 +6540,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-starfish-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-starfish-2.png</image:loc>
       <image:title>Geiss - Starfish 2 | Stims</image:title>
       <image:caption>Geiss - Starfish 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6551,7 +6551,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-sunsets</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-sunsets.png</image:loc>
       <image:title>Geiss - Sunsets | Stims</image:title>
       <image:caption>Geiss - Sunsets by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6562,7 +6562,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-swirlie-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-swirlie-1.png</image:loc>
       <image:title>Geiss - Swirlie 1 | Stims</image:title>
       <image:caption>Geiss - Swirlie 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6573,7 +6573,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-swirlie-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-swirlie-2.png</image:loc>
       <image:title>Geiss - Swirlie 2 | Stims</image:title>
       <image:caption>Geiss - Swirlie 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6584,7 +6584,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-swirlie-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-swirlie-4.png</image:loc>
       <image:title>Geiss - Swirlie 4 | Stims</image:title>
       <image:caption>Geiss - Swirlie 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6595,7 +6595,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-tadpole-hunter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-tadpole-hunter.png</image:loc>
       <image:title>Geiss - Tadpole Hunter | Stims</image:title>
       <image:caption>Geiss - Tadpole Hunter by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6606,7 +6606,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-thumb-drum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-thumb-drum.png</image:loc>
       <image:title>Geiss - Thumb Drum | Stims</image:title>
       <image:caption>Geiss - Thumb Drum by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6617,7 +6617,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-tokamak-plus-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-tokamak-plus-2.png</image:loc>
       <image:title>Geiss - Tokamak Plus 2 | Stims</image:title>
       <image:caption>Geiss - Tokamak Plus 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6628,7 +6628,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-tokamak-plus-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-tokamak-plus-3.png</image:loc>
       <image:title>Geiss - Tokamak Plus 3 | Stims</image:title>
       <image:caption>Geiss - Tokamak Plus 3 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6639,7 +6639,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-tokamak-plus-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-tokamak-plus-4.png</image:loc>
       <image:title>Geiss - Tokamak Plus 4 | Stims</image:title>
       <image:caption>Geiss - Tokamak Plus 4 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6650,7 +6650,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-tokamak-plus-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-tokamak-plus-painterly.png</image:loc>
       <image:title>Geiss - Tokamak Plus Painterly | Stims</image:title>
       <image:caption>Geiss - Tokamak Plus Painterly by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6661,7 +6661,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-trampoline</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-trampoline.png</image:loc>
       <image:title>Geiss - Trampoline | Stims</image:title>
       <image:caption>Geiss - Trampoline by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6672,7 +6672,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-two-pointed-pulsagon-mash0000-bubonic-super-fluid-centrifuge</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-two-pointed-pulsagon-mash0000-bubonic-super-fluid-centrifuge.png</image:loc>
       <image:title>Geiss - Two-Pointed Pulsagon - mash0000 - bubonic super-fluid centrifuge | Stims</image:title>
       <image:caption>Geiss - Two-Pointed Pulsagon - mash0000 - bubonic super-fluid centrifuge by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6683,7 +6683,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-two-pointed-pulsagon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-two-pointed-pulsagon.png</image:loc>
       <image:title>Geiss - Two-Pointed Pulsagon | Stims</image:title>
       <image:caption>Geiss - Two-Pointed Pulsagon by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6694,7 +6694,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-virus-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-virus-2.png</image:loc>
       <image:title>Geiss - Virus 2 | Stims</image:title>
       <image:caption>Geiss - Virus 2 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6705,7 +6705,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-virus-broth</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-virus-broth.png</image:loc>
       <image:title>Geiss - Virus Broth | Stims</image:title>
       <image:caption>Geiss - Virus Broth by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6716,7 +6716,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-vortex-1-color-sat-boosted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-vortex-1-color-sat-boosted.png</image:loc>
       <image:title>Geiss - Vortex 1 (color sat boosted) | Stims</image:title>
       <image:caption>Geiss - Vortex 1 (color sat boosted) by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6727,7 +6727,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-vortex-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-vortex-1.png</image:loc>
       <image:title>Geiss - Vortex 1 | Stims</image:title>
       <image:caption>Geiss - Vortex 1 by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6738,7 +6738,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-vortex-2-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-vortex-2-painterly.png</image:loc>
       <image:title>Geiss - Vortex 2 Painterly | Stims</image:title>
       <image:caption>Geiss - Vortex 2 Painterly by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6749,7 +6749,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-waterfall</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-waterfall.png</image:loc>
       <image:title>Geiss - Waterfall | Stims</image:title>
       <image:caption>Geiss - Waterfall by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6760,7 +6760,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-beetle-bore-color-invert-mirror-x</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-beetle-bore-color-invert-mirror-x.png</image:loc>
       <image:title>Geiss - beetle bore - color invert mirror x | Stims</image:title>
       <image:caption>Geiss - beetle bore - color invert mirror x by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6771,7 +6771,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-and-zylot-reaction-diffusion-3-overload-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-and-zylot-reaction-diffusion-3-overload-mix-2.png</image:loc>
       <image:title>Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2) | Stims</image:title>
       <image:caption>Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2) by Geiss and Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6782,7 +6782,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup.png</image:loc>
       <image:title>Geiss, Flexi + Stahlregen - Thumbdrum Tokamak [crossfiring aftermath jelly mashup] | Stims</image:title>
       <image:caption>Geiss, Flexi + Stahlregen - Thumbdrum Tokamak [crossfiring aftermath jelly mashup] by Geiss, Flexi + Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6793,7 +6793,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-nitorami-macktuesday-twitchy-paint-fact-fuct-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-nitorami-macktuesday-twitchy-paint-fact-fuct-nz.png</image:loc>
       <image:title>Geiss, Nitorami + MackTuesday - Twitchy Paint fact fuct nz+ | Stims</image:title>
       <image:caption>Geiss, Nitorami + MackTuesday - Twitchy Paint fact fuct nz+ by Geiss, Nitorami + MackTuesday, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6804,7 +6804,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-flexi-irdu-lili</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-flexi-irdu-lili.png</image:loc>
       <image:title>Goody + flexi - Irdu Lili | Stims</image:title>
       <image:caption>Goody + flexi - Irdu Lili by Goody + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6815,7 +6815,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-aqua-lumens</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-aqua-lumens.png</image:loc>
       <image:title>Goody + martin - crystal palace - Aqua Lumens | Stims</image:title>
       <image:caption>Goody + martin - crystal palace - Aqua Lumens by Goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6826,7 +6826,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-ocular-anima</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-ocular-anima.png</image:loc>
       <image:title>Goody + martin - crystal palace - Ocular Anima | Stims</image:title>
       <image:caption>Goody + martin - crystal palace - Ocular Anima by Goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6837,7 +6837,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics.png</image:loc>
       <image:title>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - Darkening mathematics | Stims</image:title>
       <image:caption>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - Darkening mathematics by Goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6848,7 +6848,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one.png</image:loc>
       <image:title>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - mess2 nz+ i have no character and feel entitled to one | Stims</image:title>
       <image:caption>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - mess2 nz+ i have no character and feel entitled to one by Goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6859,7 +6859,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom.png</image:loc>
       <image:title>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom | Stims</image:title>
       <image:caption>Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom by Goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6870,7 +6870,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-acid-angel-fallen-angel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-acid-angel-fallen-angel.png</image:loc>
       <image:title>Goody - Acid Angel - Fallen Angel | Stims</image:title>
       <image:caption>Goody - Acid Angel - Fallen Angel by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6881,7 +6881,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-acid-angel-revisitation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-acid-angel-revisitation.png</image:loc>
       <image:title>Goody - Acid Angel - REvisitation | Stims</image:title>
       <image:caption>Goody - Acid Angel - REvisitation by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6892,7 +6892,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-aurora-totalis</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-aurora-totalis.png</image:loc>
       <image:title>Goody - Aurora Totalis | Stims</image:title>
       <image:caption>Goody - Aurora Totalis by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6903,7 +6903,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-clouded-reason-revisited</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-clouded-reason-revisited.png</image:loc>
       <image:title>Goody - Clouded Reason - revisited | Stims</image:title>
       <image:caption>Goody - Clouded Reason - revisited by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6914,7 +6914,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-ego-decontructor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-ego-decontructor.png</image:loc>
       <image:title>Goody - Ego Decontructor | Stims</image:title>
       <image:caption>Goody - Ego Decontructor by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6925,7 +6925,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-lsd-zoomtunnel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-lsd-zoomtunnel.png</image:loc>
       <image:title>Goody - LSD Zoomtunnel | Stims</image:title>
       <image:caption>Goody - LSD Zoomtunnel by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6936,7 +6936,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-lights-in-the-sky</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-lights-in-the-sky.png</image:loc>
       <image:title>Goody - Lights in the Sky | Stims</image:title>
       <image:caption>Goody - Lights in the Sky by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6947,7 +6947,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-need-desire-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-need-desire-remix.png</image:loc>
       <image:title>Goody - Need - Desire remix | Stims</image:title>
       <image:caption>Goody - Need - Desire remix by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6958,7 +6958,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-need-gloam</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-need-gloam.png</image:loc>
       <image:title>Goody - Need - Gloam | Stims</image:title>
       <image:caption>Goody - Need - Gloam by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6969,7 +6969,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-need-transcendance-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-need-transcendance-remix.png</image:loc>
       <image:title>Goody - Need - Transcendance remix | Stims</image:title>
       <image:caption>Goody - Need - Transcendance remix by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6980,7 +6980,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-need</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-need.png</image:loc>
       <image:title>Goody - Need | Stims</image:title>
       <image:caption>Goody - Need by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6991,7 +6991,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-sonic-infection</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-sonic-infection.png</image:loc>
       <image:title>Goody - Sonic Infection | Stims</image:title>
       <image:caption>Goody - Sonic Infection by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7002,7 +7002,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-the-thing-that-lives-between</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-the-thing-that-lives-between.png</image:loc>
       <image:title>Goody - The Thing That Lives Between | Stims</image:title>
       <image:caption>Goody - The Thing That Lives Between by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7013,7 +7013,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-the-wild-vort</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-the-wild-vort.png</image:loc>
       <image:title>Goody - The Wild Vort | Stims</image:title>
       <image:caption>Goody - The Wild Vort by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7024,7 +7024,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-unstable-sonic-reactor-final</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-unstable-sonic-reactor-final.png</image:loc>
       <image:title>Goody - Unstable Sonic Reactor - Final | Stims</image:title>
       <image:caption>Goody - Unstable Sonic Reactor - Final by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7035,7 +7035,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-vertigo-revisited</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-vertigo-revisited.png</image:loc>
       <image:title>Goody - Vertigo - revisited | Stims</image:title>
       <image:caption>Goody - Vertigo - revisited by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7046,7 +7046,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-vertigo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-vertigo.png</image:loc>
       <image:title>Goody - Vertigo | Stims</image:title>
       <image:caption>Goody - Vertigo by Goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7057,7 +7057,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=greatwho-lasershow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/greatwho-lasershow.png</image:loc>
       <image:title>GreatWho - Lasershow | Stims</image:title>
       <image:caption>GreatWho - Lasershow by GreatWho, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7068,7 +7068,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-beautiful</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-beautiful.png</image:loc>
       <image:title>Hexcollie - Beautiful | Stims</image:title>
       <image:caption>Hexcollie - Beautiful by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7079,7 +7079,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-cell-division</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-cell-division.png</image:loc>
       <image:title>Hexcollie - Cell division | Stims</image:title>
       <image:caption>Hexcollie - Cell division by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7090,7 +7090,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-hedgehog-dreams3-mash0000-she-dream-of-bitter-pups-and-wagon-cloister</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-hedgehog-dreams3-mash0000-she-dream-of-bitter-pups-and-wagon-cloister.png</image:loc>
       <image:title>Hexcollie - Hedgehog dreams3 - mash0000 - she dream of bitter pups and wagon cloister | Stims</image:title>
       <image:caption>Hexcollie - Hedgehog dreams3 - mash0000 - she dream of bitter pups and wagon cloister by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7101,7 +7101,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-jacked-on-way-too-much-caffeine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-jacked-on-way-too-much-caffeine.png</image:loc>
       <image:title>Hexcollie - Jacked on way too much caffeine | Stims</image:title>
       <image:caption>Hexcollie - Jacked on way too much caffeine by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7112,7 +7112,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-meatball</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-meatball.png</image:loc>
       <image:title>Hexcollie - Meatball | Stims</image:title>
       <image:caption>Hexcollie - Meatball by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7123,7 +7123,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-melodic-pulsing-leds-mash0000-dou-fu-qing-jin-qing-zuo-bitch</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-melodic-pulsing-leds-mash0000-dou-fu-qing-jin-qing-zuo-bitch.png</image:loc>
       <image:title>Hexcollie - Melodic pulsing leds - mash0000 - dou fu, qing jin, qing zuo, bitch | Stims</image:title>
       <image:caption>Hexcollie - Melodic pulsing leds - mash0000 - dou fu, qing jin, qing zuo, bitch by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7134,7 +7134,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-nautalisk-mash0000-but-officer-my-fingerprint-always-changes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-nautalisk-mash0000-but-officer-my-fingerprint-always-changes.png</image:loc>
       <image:title>Hexcollie - Nautalisk - mash0000 - but officer, my fingerprint always changes | Stims</image:title>
       <image:caption>Hexcollie - Nautalisk - mash0000 - but officer, my fingerprint always changes by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7145,7 +7145,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-personal-mashup3-flexis-portal-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-personal-mashup3-flexis-portal-mix.png</image:loc>
       <image:title>Hexcollie - Personal Mashup3 [Flexis portal mix] | Stims</image:title>
       <image:caption>Hexcollie - Personal Mashup3 [Flexis portal mix] by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7156,7 +7156,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-personal-mashup3-flexi-s-portal-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-personal-mashup3-flexi-s-portal-mix.png</image:loc>
       <image:title>Hexcollie - Personal Mashup3 [Flexi′s portal mix] | Stims</image:title>
       <image:caption>Hexcollie - Personal Mashup3 [Flexi′s portal mix] by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7167,7 +7167,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-wings</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-wings.png</image:loc>
       <image:title>Hexcollie - wings | Stims</image:title>
       <image:caption>Hexcollie - wings by Hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7178,7 +7178,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start.png</image:loc>
       <image:title>Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It′s a start | Stims</image:title>
       <image:caption>Hexcollie, Aderassi, BDRV, AdamFX n Flexi - It′s a start by Hexcollie, Aderassi, BDRV, AdamFX n Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7189,7 +7189,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-bdrv-geiss-flexi-n-aderrasi-slime-slide-mash0000-holster-your-salad-shot</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-bdrv-geiss-flexi-n-aderrasi-slime-slide-mash0000-holster-your-salad-shot.png</image:loc>
       <image:title>Hexcollie, Bdrv, Geiss, Flexi n Aderrasi - Slime Slide - mash0000 - holster your salad shot | Stims</image:title>
       <image:caption>Hexcollie, Bdrv, Geiss, Flexi n Aderrasi - Slime Slide - mash0000 - holster your salad shot by Hexcollie, Bdrv, Geiss, Flexi n Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7200,7 +7200,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-fishbrain-flexi-n-eo-s-synthetic-peacock-visions</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-fishbrain-flexi-n-eo-s-synthetic-peacock-visions.png</image:loc>
       <image:title>Hexcollie, Fishbrain, Flexi n Eo.S. -  Synthetic peacock visions | Stims</image:title>
       <image:caption>Hexcollie, Fishbrain, Flexi n Eo.S. -  Synthetic peacock visions by Hexcollie, Fishbrain, Flexi n Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7211,7 +7211,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-flexi-orb-eo-s-n-danone-pineal-massage-5-minute-composite-quickshot</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-flexi-orb-eo-s-n-danone-pineal-massage-5-minute-composite-quickshot.png</image:loc>
       <image:title>Hexcollie, Flexi, ORB, Eo.S. n DaNOnE - Pineal Massage [5 minute composite quickshot] | Stims</image:title>
       <image:caption>Hexcollie, Flexi, ORB, Eo.S. n DaNOnE - Pineal Massage [5 minute composite quickshot] by Hexcollie, Flexi, ORB, Eo.S. n DaNOnE, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7222,7 +7222,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-bdrv-n-unchained-the-hive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-bdrv-n-unchained-the-hive.png</image:loc>
       <image:title>Hexcollie, bdrv n unchained - The hive | Stims</image:title>
       <image:caption>Hexcollie, bdrv n unchained - The hive by Hexcollie, bdrv n unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7233,7 +7233,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-geiss-flexi-yin-n-phat-pinwheel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-geiss-flexi-yin-n-phat-pinwheel.png</image:loc>
       <image:title>Hexcollie, geiss, Flexi, yin n Phat - Pinwheel | Stims</image:title>
       <image:caption>Hexcollie, geiss, Flexi, yin n Phat - Pinwheel by Hexcollie, geiss, Flexi, yin n Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7244,7 +7244,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-9-7-02-remix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-9-7-02-remix-2.png</image:loc>
       <image:title>Idiot - 9-7-02 (Remix 2) | Stims</image:title>
       <image:caption>Idiot - 9-7-02 (Remix 2) by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7255,7 +7255,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-9-7-02</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-9-7-02.png</image:loc>
       <image:title>Idiot - 9-7-02 | Stims</image:title>
       <image:caption>Idiot - 9-7-02 by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7266,7 +7266,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-marphets-surreal-dream-hypnotic-spiral-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-marphets-surreal-dream-hypnotic-spiral-mix.png</image:loc>
       <image:title>Idiot - Marphets Surreal Dream (Hypnotic Spiral Mix) | Stims</image:title>
       <image:caption>Idiot - Marphets Surreal Dream (Hypnotic Spiral Mix) by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7277,7 +7277,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-star-of-annon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-star-of-annon.png</image:loc>
       <image:title>Idiot - Star Of Annon | Stims</image:title>
       <image:caption>Idiot - Star Of Annon by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7288,7 +7288,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-subnormal-trance-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-subnormal-trance-remix.png</image:loc>
       <image:title>Idiot - Subnormal Trance (Remix) | Stims</image:title>
       <image:caption>Idiot - Subnormal Trance (Remix) by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7299,7 +7299,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-tentacle-dreams</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-tentacle-dreams.png</image:loc>
       <image:title>Idiot - Tentacle Dreams | Stims</image:title>
       <image:caption>Idiot - Tentacle Dreams by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7310,7 +7310,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-what-is</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-what-is.png</image:loc>
       <image:title>Idiot - What Is | Stims</image:title>
       <image:caption>Idiot - What Is by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7321,7 +7321,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-when-i-get-bored</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-when-i-get-bored.png</image:loc>
       <image:title>Idiot - When I Get Bored | Stims</image:title>
       <image:caption>Idiot - When I Get Bored by Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7332,7 +7332,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot24-7-ascending-to-heaven-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot24-7-ascending-to-heaven-2.png</image:loc>
       <image:title>Idiot24-7 - Ascending to heaven 2 | Stims</image:title>
       <image:caption>Idiot24-7 - Ascending to heaven 2 by Idiot24-7, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7343,7 +7343,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-boz-hot-air-balloon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-boz-hot-air-balloon.png</image:loc>
       <image:title>Illusion &amp; Boz - Hot Air Balloon | Stims</image:title>
       <image:caption>Illusion &amp; Boz - Hot Air Balloon by Illusion &amp; Boz, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7354,7 +7354,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-boz-lord-of-stars-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-boz-lord-of-stars-1.png</image:loc>
       <image:title>Illusion &amp; Boz - Lord Of Stars 1 | Stims</image:title>
       <image:caption>Illusion &amp; Boz - Lord Of Stars 1 by Illusion &amp; Boz, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7365,7 +7365,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-rovastar-clouded-bottle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-rovastar-clouded-bottle.png</image:loc>
       <image:title>Illusion &amp; Rovastar - Clouded Bottle | Stims</image:title>
       <image:caption>Illusion &amp; Rovastar - Clouded Bottle by Illusion &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7376,7 +7376,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-rovastar-dotty-mad-space-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-rovastar-dotty-mad-space-jelly.png</image:loc>
       <image:title>Illusion &amp; Rovastar - Dotty Mad Space (Jelly) | Stims</image:title>
       <image:caption>Illusion &amp; Rovastar - Dotty Mad Space (Jelly) by Illusion &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7387,7 +7387,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-unchained-new-strategy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-unchained-new-strategy.png</image:loc>
       <image:title>Illusion &amp; Unchained - New Strategy | Stims</image:title>
       <image:caption>Illusion &amp; Unchained - New Strategy by Illusion &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7398,7 +7398,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-dance-of-the-planets</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-dance-of-the-planets.png</image:loc>
       <image:title>Illusion - Dance Of The Planets | Stims</image:title>
       <image:caption>Illusion - Dance Of The Planets by Illusion, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7409,7 +7409,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=illusion-heavenly-eye-radial-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/illusion-heavenly-eye-radial-blur.png</image:loc>
       <image:title>Illusion - Heavenly Eye - radial blur | Stims</image:title>
       <image:caption>Illusion - Heavenly Eye - radial blur by Illusion, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7420,7 +7420,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=infused-by-flexi-with-adamfx-2-stahlregen-aderrasi-eo-s-geiss-unchained-zylot-slowflowers-ft-martin-adamfxremix-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/infused-by-flexi-with-adamfx-2-stahlregen-aderrasi-eo-s-geiss-unchained-zylot-slowflowers-ft-martin-adamfxremix-7.png</image:loc>
       <image:title>Infused by Flexi with AdamFX 2 Stahlregen &amp; Aderrasi + Eo.S + Geiss + Unchained + Zylot - Slowflowers Ft Martin (AdamFXRemix)7 | Stims</image:title>
       <image:caption>Infused by Flexi with AdamFX 2 Stahlregen &amp; Aderrasi + Eo.S + Geiss + Unchained + Zylot - Slowflowers Ft Martin (AdamFXRemix)7 by Infused by Flexi with AdamFX 2 Stahlregen &amp; Aderrasi + Eo.S + Geiss + Unchained + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7431,7 +7431,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-22</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-22.png</image:loc>
       <image:title>Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 22 | Stims</image:title>
       <image:caption>Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 22 by Inside A Black Whole AdamFX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7442,7 +7442,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-6-ngorng</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-6-ngorng.png</image:loc>
       <image:title>Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 6 ngorng | Stims</image:title>
       <image:caption>Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 6 ngorng by Inside A Black Whole AdamFX 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7453,7 +7453,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=ishan-anuera</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/ishan-anuera.png</image:loc>
       <image:title>Ishan - Anuera | Stims</image:title>
       <image:caption>Ishan - Anuera by Ishan, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7464,7 +7464,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=jc-circular-logic-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/jc-circular-logic-3.png</image:loc>
       <image:title>Jc - Circular Logic 3 | Stims</image:title>
       <image:caption>Jc - Circular Logic 3 by Jc, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7475,7 +7475,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=jc-neon-star-formation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/jc-neon-star-formation.png</image:loc>
       <image:title>Jc - Neon Star Formation | Stims</image:title>
       <image:caption>Jc - Neon Star Formation by Jc, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7486,7 +7486,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue.png</image:loc>
       <image:title>Jim &amp; Geiss - Bass Zoom Symmetry - mash0000 - the god damn pen is rrrroyal blue | Stims</image:title>
       <image:caption>Jim &amp; Geiss - Bass Zoom Symmetry - mash0000 - the god damn pen is rrrroyal blue by Jim &amp; Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7497,7 +7497,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-a-million-miles-from-earth-ripple-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-a-million-miles-from-earth-ripple-mix.png</image:loc>
       <image:title>Krash &amp; Rovastar - A Million Miles from Earth (Ripple Mix) | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - A Million Miles from Earth (Ripple Mix) by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7508,7 +7508,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-cerebral-demons-phat-eo-s-killer-death-bunny-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-cerebral-demons-phat-eo-s-killer-death-bunny-remix.png</image:loc>
       <image:title>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Killer Death Bunny Remix | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Killer Death Bunny Remix by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7519,7 +7519,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-cerebral-demons-phat-eo-s-moire-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-cerebral-demons-phat-eo-s-moire-remix.png</image:loc>
       <image:title>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Moire Remix | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Moire Remix by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7530,7 +7530,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-cerebral-demons-phat-eo-s-stars-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-cerebral-demons-phat-eo-s-stars-remix.png</image:loc>
       <image:title>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Stars Remix | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - Cerebral Demons - Phat + Eo.S. Stars Remix by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7541,7 +7541,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-the-devil-is-in-the-details</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-the-devil-is-in-the-details.png</image:loc>
       <image:title>Krash &amp; Rovastar - The Devil Is In The Details | Stims</image:title>
       <image:caption>Krash &amp; Rovastar - The Devil Is In The Details by Krash &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7552,7 +7552,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-eo-s-photographic-sentinel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-eo-s-photographic-sentinel.png</image:loc>
       <image:title>Krash + Eo.S. - Photographic Sentinel | Stims</image:title>
       <image:caption>Krash + Eo.S. - Photographic Sentinel by Krash + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7563,7 +7563,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-geiss-martin-war-machine-stahl-s-ultimate-mash-mix.png</image:loc>
       <image:title>Krash + Geiss + martin - War Machine (Stahl′s ultimate Mash Mix) | Stims</image:title>
       <image:caption>Krash + Geiss + martin - War Machine (Stahl′s ultimate Mash Mix) by Krash + Geiss + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7574,7 +7574,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-illusion-geiss-spiral-movement-reaction-diffusion-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-illusion-geiss-spiral-movement-reaction-diffusion-mix.png</image:loc>
       <image:title>Krash + Illusion + Geiss - Spiral Movement (Reaction Diffusion mix) | Stims</image:title>
       <image:caption>Krash + Illusion + Geiss - Spiral Movement (Reaction Diffusion mix) by Krash + Illusion + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7585,7 +7585,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-illusion-spiral-movement</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-illusion-spiral-movement.png</image:loc>
       <image:title>Krash + Illusion - Spiral Movement | Stims</image:title>
       <image:caption>Krash + Illusion - Spiral Movement by Krash + Illusion, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7596,7 +7596,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-rainbow-orb-2-peacock-bmelgren-s-compelling-vision.png</image:loc>
       <image:title>Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren′s Compelling Vision) | Stims</image:title>
       <image:caption>Krash + Rovastar - Rainbow Orb 2 Peacock (Bmelgren′s Compelling Vision) by Krash + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7607,7 +7607,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-rovastar-rainbow-orb</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-rovastar-rainbow-orb.png</image:loc>
       <image:title>Krash + Rovastar - Rainbow Orb | Stims</image:title>
       <image:caption>Krash + Rovastar - Rainbow Orb by Krash + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7618,7 +7618,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-techno-rhythmic-mantas-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-techno-rhythmic-mantas-painterly.png</image:loc>
       <image:title>Krash + TEcHNO - Rhythmic Mantas - Painterly | Stims</image:title>
       <image:caption>Krash + TEcHNO - Rhythmic Mantas - Painterly by Krash + TEcHNO, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7629,7 +7629,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-aenema-tweak-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-aenema-tweak-4.png</image:loc>
       <image:title>Krash - Aenema tweak 4 | Stims</image:title>
       <image:caption>Krash - Aenema tweak 4 by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7640,7 +7640,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-digital-flame</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-digital-flame.png</image:loc>
       <image:title>Krash - Digital Flame | Stims</image:title>
       <image:caption>Krash - Digital Flame by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7651,7 +7651,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-snowflake-halo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-snowflake-halo.png</image:loc>
       <image:title>Krash - Snowflake Halo | Stims</image:title>
       <image:caption>Krash - Snowflake Halo by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7662,7 +7662,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-swelling-spiral-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-swelling-spiral-2.png</image:loc>
       <image:title>Krash - Swelling Spiral 2 | Stims</image:title>
       <image:caption>Krash - Swelling Spiral 2 by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7673,7 +7673,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-vinyl-disk</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-vinyl-disk.png</image:loc>
       <image:title>Krash - Vinyl Disk | Stims</image:title>
       <image:caption>Krash - Vinyl Disk by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7684,7 +7684,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-war-machine-shifting-complexity-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-war-machine-shifting-complexity-mix.png</image:loc>
       <image:title>Krash - War Machine (Shifting Complexity Mix) | Stims</image:title>
       <image:caption>Krash - War Machine (Shifting Complexity Mix) by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7695,7 +7695,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-interwoven-nightmare-weft-phats-i-wana-fuck-some-candy-kids-mash0000-elevator-to-the-drugged-up-runaway-penthouse</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-interwoven-nightmare-weft-phats-i-wana-fuck-some-candy-kids-mash0000-elevator-to-the-drugged-up-runaway-penthouse.png</image:loc>
       <image:title>Krash - interwoven (nightmare weft)_Phats_I_Wana_Fuck_Some_Candy_Kids... - mash0000 - elevator to the drugged up runaway penthouse | Stims</image:title>
       <image:caption>Krash - interwoven (nightmare weft)_Phats_I_Wana_Fuck_Some_Candy_Kids... - mash0000 - elevator to the drugged up runaway penthouse by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7706,7 +7706,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-interwoven-nightmare-weft-phats-maybe-ill-go-to-a-party</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-interwoven-nightmare-weft-phats-maybe-ill-go-to-a-party.png</image:loc>
       <image:title>Krash - interwoven (nightmare weft)_Phats_Maybe_Ill_Go_To_A_Party | Stims</image:title>
       <image:caption>Krash - interwoven (nightmare weft)_Phats_Maybe_Ill_Go_To_A_Party by Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7717,7 +7717,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=lux-life-s-game-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/lux-life-s-game-1.png</image:loc>
       <image:title>LuX - Life′s Game 1 | Stims</image:title>
       <image:caption>LuX - Life′s Game 1 by LuX, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7728,7 +7728,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-ain-t-life-a-motherfucker-iv</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-ain-t-life-a-motherfucker-iv.png</image:loc>
       <image:title>LuxXx - Ain′t Life a Motherfucker iv | Stims</image:title>
       <image:caption>LuxXx - Ain′t Life a Motherfucker iv by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7739,7 +7739,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-chillflower-blurface-ib</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-chillflower-blurface-ib.png</image:loc>
       <image:title>LuxXx - ChillFlower BlurFace Ib | Stims</image:title>
       <image:caption>LuxXx - ChillFlower BlurFace Ib by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7750,7 +7750,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-circling-the-drain-1a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-circling-the-drain-1a.png</image:loc>
       <image:title>LuxXx - Circling the Drain 1a | Stims</image:title>
       <image:caption>LuxXx - Circling the Drain 1a by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7761,7 +7761,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-circling-the-drain-1b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-circling-the-drain-1b.png</image:loc>
       <image:title>LuxXx - Circling the Drain 1b | Stims</image:title>
       <image:caption>LuxXx - Circling the Drain 1b by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7772,7 +7772,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-do-drive-and-drug-copy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-do-drive-and-drug-copy.png</image:loc>
       <image:title>LuxXx - Do Drive and Drug - Copy | Stims</image:title>
       <image:caption>LuxXx - Do Drive and Drug - Copy by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7783,7 +7783,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-fractal-overlord-overclock-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-fractal-overlord-overclock-ii.png</image:loc>
       <image:title>LuxXx - Fractal Overlord Overclock ii | Stims</image:title>
       <image:caption>LuxXx - Fractal Overlord Overclock ii by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7794,7 +7794,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-fuck-your-code-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-fuck-your-code-ii.png</image:loc>
       <image:title>LuxXx - Fuck Your Code ii | Stims</image:title>
       <image:caption>LuxXx - Fuck Your Code ii by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7805,7 +7805,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-god-is-in-the-radio-v-6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-god-is-in-the-radio-v-6.png</image:loc>
       <image:title>LuxXx - God is in the Radio v..6 | Stims</image:title>
       <image:caption>LuxXx - God is in the Radio v..6 by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7816,7 +7816,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-grindface-225-mg-dose</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-grindface-225-mg-dose.png</image:loc>
       <image:title>LuxXx - GrindFace  225 mg dose   | Stims</image:title>
       <image:caption>LuxXx - GrindFace  225 mg dose   by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7827,7 +7827,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-growing-alien-organs-i</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-growing-alien-organs-i.png</image:loc>
       <image:title>LuxXx - Growing Alien Organs i | Stims</image:title>
       <image:caption>LuxXx - Growing Alien Organs i by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7838,7 +7838,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-growing-alien-organs-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-growing-alien-organs-ii.png</image:loc>
       <image:title>LuxXx - Growing Alien Organs ii | Stims</image:title>
       <image:caption>LuxXx - Growing Alien Organs ii by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7849,7 +7849,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-growing-alien-organs-iii-pizen</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-growing-alien-organs-iii-pizen.png</image:loc>
       <image:title>LuxXx - Growing Alien Organs iii (pizen) | Stims</image:title>
       <image:caption>LuxXx - Growing Alien Organs iii (pizen) by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7860,7 +7860,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-hurty-soul-i</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-hurty-soul-i.png</image:loc>
       <image:title>LuxXx - Hurty Soul I | Stims</image:title>
       <image:caption>LuxXx - Hurty Soul I by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7871,7 +7871,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-makes-me-cry-five-makes-me-cry-so-lick-my-tears-and-get-real-high</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-makes-me-cry-five-makes-me-cry-so-lick-my-tears-and-get-real-high.png</image:loc>
       <image:title>LuxXx - Makes Me Cry (five) (Makes Me Cry, So Lick My Tears, And Get Real High) | Stims</image:title>
       <image:caption>LuxXx - Makes Me Cry (five) (Makes Me Cry, So Lick My Tears, And Get Real High) by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7882,7 +7882,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-melt-ur-face-i-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-melt-ur-face-i-b.png</image:loc>
       <image:title>LuxXx - Melt Ur Face i b | Stims</image:title>
       <image:caption>LuxXx - Melt Ur Face i b by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7893,7 +7893,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-melt-ur-face-i</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-melt-ur-face-i.png</image:loc>
       <image:title>LuxXx - Melt Ur Face i | Stims</image:title>
       <image:caption>LuxXx - Melt Ur Face i by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7904,7 +7904,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-melt-ur-maker-i</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-melt-ur-maker-i.png</image:loc>
       <image:title>LuxXx - Melt Ur Maker I | Stims</image:title>
       <image:caption>LuxXx - Melt Ur Maker I by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7915,7 +7915,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-rapeplay-v3-the-war-within-all-of-us</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-rapeplay-v3-the-war-within-all-of-us.png</image:loc>
       <image:title>LuxXx - RapePlay v3 (the war within all of us) | Stims</image:title>
       <image:caption>LuxXx - RapePlay v3 (the war within all of us) by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7926,7 +7926,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-stickverse-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-stickverse-ii.png</image:loc>
       <image:title>LuxXx - StickVerse II | Stims</image:title>
       <image:caption>LuxXx - StickVerse II by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7937,7 +7937,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-stickflower-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-stickflower-ii.png</image:loc>
       <image:title>LuxXx - Stickflower II | Stims</image:title>
       <image:caption>LuxXx - Stickflower II by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7948,7 +7948,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-subtle-hiphopflake</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-subtle-hiphopflake.png</image:loc>
       <image:title>LuxXx - Subtle HipHopFlake | Stims</image:title>
       <image:caption>LuxXx - Subtle HipHopFlake by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7959,7 +7959,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-the-feeder-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-the-feeder-ii.png</image:loc>
       <image:title>LuxXx - The Feeder II | Stims</image:title>
       <image:caption>LuxXx - The Feeder II by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7970,7 +7970,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-iwhat-happened-right-after-i-ate-that-toxic-waste-beta-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-iwhat-happened-right-after-i-ate-that-toxic-waste-beta-ii.png</image:loc>
       <image:title>LuxXx - iWhat Happened Right After I Ate That Toxic Waste beta ii | Stims</image:title>
       <image:caption>LuxXx - iWhat Happened Right After I Ate That Toxic Waste beta ii by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7981,7 +7981,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=luxxx-liquid-amma-amma-bee</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/luxxx-liquid-amma-amma-bee.png</image:loc>
       <image:title>LuxXx - liquid amma-amma bee | Stims</image:title>
       <image:caption>LuxXx - liquid amma-amma bee by LuxXx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7992,7 +7992,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-diabolo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-diabolo.png</image:loc>
       <image:title>Martin - Diabolo | Stims</image:title>
       <image:caption>Martin - Diabolo by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8003,7 +8003,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-qbikal-surface-turbulence-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-qbikal-surface-turbulence-ii.png</image:loc>
       <image:title>Martin - QBikal - Surface Turbulence II | Stims</image:title>
       <image:caption>Martin - QBikal - Surface Turbulence II by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8014,7 +8014,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-qbikal-surface-turbulence-iib</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-qbikal-surface-turbulence-iib.png</image:loc>
       <image:title>Martin - QBikal - Surface Turbulence IIb | Stims</image:title>
       <image:caption>Martin - QBikal - Surface Turbulence IIb by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8025,7 +8025,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-qbikal-surface-turbulence</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-qbikal-surface-turbulence.png</image:loc>
       <image:title>Martin - QBikal - Surface Turbulence | Stims</image:title>
       <image:caption>Martin - QBikal - Surface Turbulence by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8036,7 +8036,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-acid-wiring</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-acid-wiring.png</image:loc>
       <image:title>Martin - acid wiring | Stims</image:title>
       <image:caption>Martin - acid wiring by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8047,7 +8047,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-bombyx-mori-mix2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-bombyx-mori-mix2.png</image:loc>
       <image:title>Martin - bombyx mori mix2 | Stims</image:title>
       <image:caption>Martin - bombyx mori mix2 by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8058,7 +8058,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-charisma</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-charisma.png</image:loc>
       <image:title>Martin - charisma | Stims</image:title>
       <image:caption>Martin - charisma by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8069,7 +8069,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-cool-morning</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-cool-morning.png</image:loc>
       <image:title>Martin - cool morning | Stims</image:title>
       <image:caption>Martin - cool morning by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8080,7 +8080,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-3-fast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-3-fast.png</image:loc>
       <image:title>Martin - disco mix 3 -fast | Stims</image:title>
       <image:caption>Martin - disco mix 3 -fast by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8091,7 +8091,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-6.png</image:loc>
       <image:title>Martin - disco mix 6 | Stims</image:title>
       <image:caption>Martin - disco mix 6 by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8102,7 +8102,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-journey-into-space</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-journey-into-space.png</image:loc>
       <image:title>Martin - journey into space | Stims</image:title>
       <image:caption>Martin - journey into space by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8113,7 +8113,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-liquid-arrows</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-liquid-arrows.png</image:loc>
       <image:title>Martin - liquid arrows | Stims</image:title>
       <image:caption>Martin - liquid arrows by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8124,7 +8124,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-quantum-accelerator</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-quantum-accelerator.png</image:loc>
       <image:title>Martin - quantum accelerator | Stims</image:title>
       <image:caption>Martin - quantum accelerator by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8135,7 +8135,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-underwater-cathedral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-underwater-cathedral.png</image:loc>
       <image:title>Martin - underwater cathedral | Stims</image:title>
       <image:caption>Martin - underwater cathedral by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8146,7 +8146,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-wire-dance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-wire-dance.png</image:loc>
       <image:title>Martin - wire dance | Stims</image:title>
       <image:caption>Martin - wire dance by Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8157,7 +8157,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-n-adamfx-infusion-phat-yin-eo-s-mandala-chaser-ft-adamfx-n-martin-the-beast-mandala-chaser-fx-h</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-n-adamfx-infusion-phat-yin-eo-s-mandala-chaser-ft-adamfx-n-martin-the-beast-mandala-chaser-fx-h.png</image:loc>
       <image:title>Martin N AdamFX Infusion = Phat+Yin+Eo.S_Mandala Chaser Ft AdamFX n Martin - The Beast Mandala Chaser FX H | Stims</image:title>
       <image:caption>Martin N AdamFX Infusion = Phat+Yin+Eo.S_Mandala Chaser Ft AdamFX n Martin - The Beast Mandala Chaser FX H by Martin N AdamFX Infusion = Phat+Yin+Eo.S_Mandala Chaser Ft AdamFX n Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8168,7 +8168,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-anandamide-mandelbox-explorer-quantum-timepiece-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.png</image:loc>
       <image:title>Martin+Anandamide - Mandelbox_Explorer Quantum_Timepiece_remix | Stims</image:title>
       <image:caption>Martin+Anandamide - Mandelbox_Explorer Quantum_Timepiece_remix by Martin+Anandamide, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8179,7 +8179,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2.png</image:loc>
       <image:title>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 2] | Stims</image:title>
       <image:caption>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 2] by Martin, Fishbrain + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8190,7 +8190,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3.png</image:loc>
       <image:title>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 3] | Stims</image:title>
       <image:caption>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 3] by Martin, Fishbrain + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8201,7 +8201,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup.png</image:loc>
       <image:title>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup] | Stims</image:title>
       <image:caption>Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup] by Martin, Fishbrain + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8212,7 +8212,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fishbrain-flexi-lasercutting-binary-trees</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fishbrain-flexi-lasercutting-binary-trees.png</image:loc>
       <image:title>Martin, Fishbrain + Flexi - lasercutting binary trees | Stims</image:title>
       <image:caption>Martin, Fishbrain + Flexi - lasercutting binary trees by Martin, Fishbrain + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8223,7 +8223,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=milk-artist-at-our-best-fed-slowfast-ft-adamfx-n-martin-hd-cosmofx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/milk-artist-at-our-best-fed-slowfast-ft-adamfx-n-martin-hd-cosmofx.png</image:loc>
       <image:title>Milk Artist At our Best - FED - SlowFast Ft AdamFX n Martin - HD CosmoFX | Stims</image:title>
       <image:caption>Milk Artist At our Best - FED - SlowFast Ft AdamFX n Martin - HD CosmoFX by Milk Artist At our Best, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8234,7 +8234,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=milk-king-to-the-extreemfx-flexi-divine-struggle-ft-adamfx-n-martin-picasso-in-milk-molten-meltdown-e</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/milk-king-to-the-extreemfx-flexi-divine-struggle-ft-adamfx-n-martin-picasso-in-milk-molten-meltdown-e.png</image:loc>
       <image:title>Milk King to the ExtreemFX flexi - divine struggle - Ft AdamFX n Martin - Picasso In Milk Molten Meltdown E | Stims</image:title>
       <image:caption>Milk King to the ExtreemFX flexi - divine struggle - Ft AdamFX n Martin - Picasso In Milk Molten Meltdown E by Milk King to the ExtreemFX flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8245,7 +8245,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mstress-zylot-acid-ufo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mstress-zylot-acid-ufo.png</image:loc>
       <image:title>Mstress + Zylot - Acid UFO | Stims</image:title>
       <image:caption>Mstress + Zylot - Acid UFO by Mstress + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8256,7 +8256,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mstress-acoustic-nerve-impulses-primary-colors-of-sound-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mstress-acoustic-nerve-impulses-primary-colors-of-sound-mix.png</image:loc>
       <image:title>Mstress - Acoustic Nerve Impulses (Primary Colors Of Sound Mix) | Stims</image:title>
       <image:caption>Mstress - Acoustic Nerve Impulses (Primary Colors Of Sound Mix) by Mstress, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8267,7 +8267,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mstress-acoustic-nerve-impulses</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mstress-acoustic-nerve-impulses.png</image:loc>
       <image:title>Mstress - Acoustic Nerve Impulses | Stims</image:title>
       <image:caption>Mstress - Acoustic Nerve Impulses by Mstress, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8278,7 +8278,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2-amazing-masup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2-amazing-masup.png</image:loc>
       <image:title>NeW Adam Master Mashup FX 2 Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2) AMAZING MASUP  | Stims</image:title>
       <image:caption>NeW Adam Master Mashup FX 2 Geiss and Zylot - Reaction Diffusion 3 (Overload Mix 2) AMAZING MASUP  by NeW Adam Master Mashup FX 2 Geiss and Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8289,7 +8289,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=new-adam-master-mashup-fx-2-zylot-in-death-there-is-life-dancing-lights-mix-tumbling-cubes-3d</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/new-adam-master-mashup-fx-2-zylot-in-death-there-is-life-dancing-lights-mix-tumbling-cubes-3d.png</image:loc>
       <image:title>NeW Adam Master Mashup FX 2 Zylot - In death there is life (Dancing Lights mix)+ Tumbling Cubes 3d | Stims</image:title>
       <image:caption>NeW Adam Master Mashup FX 2 Zylot - In death there is life (Dancing Lights mix)+ Tumbling Cubes 3d by NeW Adam Master Mashup FX 2 Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8300,7 +8300,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-n-shadow-harlequin-n-geiss-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-n-shadow-harlequin-n-geiss-b.png</image:loc>
       <image:title>New Creation Sensation -  AdamFx,Flexi,Amandio c n Martin - Star to Another World ft Hexocollie  n Shadow Harlequin n Geiss B | Stims</image:title>
       <image:caption>New Creation Sensation -  AdamFx,Flexi,Amandio c n Martin - Star to Another World ft Hexocollie  n Shadow Harlequin n Geiss B by New Creation Sensation, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8311,7 +8311,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=new-milktrend-trend-setters-amandio-c-flexi-ft-adamfx-n-stahlregen-martin-ufoz-identified</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/new-milktrend-trend-setters-amandio-c-flexi-ft-adamfx-n-stahlregen-martin-ufoz-identified.png</image:loc>
       <image:title>New MilkTrend Trend Setters - Amandio c + flexi - Ft AdamFX n Stahlregen Martin - Ufoz Identified  | Stims</image:title>
       <image:caption>New MilkTrend Trend Setters - Amandio c + flexi - Ft AdamFX n Stahlregen Martin - Ufoz Identified  by New MilkTrend Trend Setters, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8322,7 +8322,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=nighthawk-eye-of-gawd-phat-spiral-edit-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/nighthawk-eye-of-gawd-phat-spiral-edit-v2.png</image:loc>
       <image:title>NiGHtHawK - Eye of Gawd_Phat_Spiral_edit_v2 | Stims</image:title>
       <image:caption>NiGHtHawK - Eye of Gawd_Phat_Spiral_edit_v2 by NiGHtHawK, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8333,7 +8333,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-cycle-gas-giant</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-cycle-gas-giant.png</image:loc>
       <image:title>ORB - Acid Cycle Gas Giant | Stims</image:title>
       <image:caption>ORB - Acid Cycle Gas Giant by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8344,7 +8344,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-cycle-flexi-composite</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-cycle-flexi-composite.png</image:loc>
       <image:title>ORB - Acid Cycle [flexi composite] | Stims</image:title>
       <image:caption>ORB - Acid Cycle [flexi composite] by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8355,7 +8355,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-cycle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-cycle.png</image:loc>
       <image:title>ORB - Acid Cycle | Stims</image:title>
       <image:caption>ORB - Acid Cycle by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8366,7 +8366,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-lamp</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-lamp.png</image:loc>
       <image:title>ORB - Acid Lamp | Stims</image:title>
       <image:caption>ORB - Acid Lamp by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8377,7 +8377,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-acid-sunrise</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-acid-sunrise.png</image:loc>
       <image:title>ORB - Acid Sunrise | Stims</image:title>
       <image:caption>ORB - Acid Sunrise by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8388,7 +8388,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-blue-emotion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-blue-emotion.png</image:loc>
       <image:title>ORB - Blue Emotion | Stims</image:title>
       <image:caption>ORB - Blue Emotion by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8399,7 +8399,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-crysal-storm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-crysal-storm.png</image:loc>
       <image:title>ORB - Crysal Storm  | Stims</image:title>
       <image:caption>ORB - Crysal Storm  by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8410,7 +8410,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-dark-omen</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-dark-omen.png</image:loc>
       <image:title>ORB - Dark Omen | Stims</image:title>
       <image:caption>ORB - Dark Omen by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8421,7 +8421,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-depth-charge-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-depth-charge-2.png</image:loc>
       <image:title>ORB - Depth Charge 2 | Stims</image:title>
       <image:caption>ORB - Depth Charge 2 by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8432,7 +8432,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-fire-and-fumes-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-fire-and-fumes-2.png</image:loc>
       <image:title>ORB - Fire and Fumes 2 | Stims</image:title>
       <image:caption>ORB - Fire and Fumes 2 by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8443,7 +8443,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-fireworks-sparkle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-fireworks-sparkle.png</image:loc>
       <image:title>ORB - Fireworks Sparkle | Stims</image:title>
       <image:caption>ORB - Fireworks Sparkle by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8454,7 +8454,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-inferno</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-inferno.png</image:loc>
       <image:title>ORB - Inferno | Stims</image:title>
       <image:caption>ORB - Inferno by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8465,7 +8465,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-kalidescope</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-kalidescope.png</image:loc>
       <image:title>ORB - Kalidescope | Stims</image:title>
       <image:caption>ORB - Kalidescope by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8476,7 +8476,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-lava-lamp</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-lava-lamp.png</image:loc>
       <image:title>ORB - Lava Lamp | Stims</image:title>
       <image:caption>ORB - Lava Lamp by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8487,7 +8487,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-liquid-fire</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-liquid-fire.png</image:loc>
       <image:title>ORB - Liquid Fire | Stims</image:title>
       <image:caption>ORB - Liquid Fire by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8498,7 +8498,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-magma-pool</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-magma-pool.png</image:loc>
       <image:title>ORB - Magma Pool | Stims</image:title>
       <image:caption>ORB - Magma Pool by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8509,7 +8509,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-mega-spectrum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-mega-spectrum.png</image:loc>
       <image:title>ORB - Mega Spectrum | Stims</image:title>
       <image:caption>ORB - Mega Spectrum by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8520,7 +8520,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-nova-sunrise</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-nova-sunrise.png</image:loc>
       <image:title>ORB - Nova Sunrise | Stims</image:title>
       <image:caption>ORB - Nova Sunrise by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8531,7 +8531,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-pastel-primer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-pastel-primer.png</image:loc>
       <image:title>ORB - Pastel Primer | Stims</image:title>
       <image:caption>ORB - Pastel Primer by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8542,7 +8542,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-planetary-alignment-acid-burn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-planetary-alignment-acid-burn.png</image:loc>
       <image:title>ORB - Planetary Alignment Acid Burn | Stims</image:title>
       <image:caption>ORB - Planetary Alignment Acid Burn by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8553,7 +8553,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-quicksand-lab</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-quicksand-lab.png</image:loc>
       <image:title>ORB - Quicksand Lab | Stims</image:title>
       <image:caption>ORB - Quicksand Lab by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8564,7 +8564,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-quicksand</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-quicksand.png</image:loc>
       <image:title>ORB - Quicksand | Stims</image:title>
       <image:caption>ORB - Quicksand by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8575,7 +8575,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-sandblade</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-sandblade.png</image:loc>
       <image:title>ORB - Sandblade | Stims</image:title>
       <image:caption>ORB - Sandblade by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8586,7 +8586,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-saturns-rings</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-saturns-rings.png</image:loc>
       <image:title>ORB - Saturns Rings | Stims</image:title>
       <image:caption>ORB - Saturns Rings by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8597,7 +8597,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-slippery-snakes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-slippery-snakes.png</image:loc>
       <image:title>ORB - Slippery Snakes | Stims</image:title>
       <image:caption>ORB - Slippery Snakes by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8608,7 +8608,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-solar-radiation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-solar-radiation.png</image:loc>
       <image:title>ORB - Solar Radiation | Stims</image:title>
       <image:caption>ORB - Solar Radiation by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8619,7 +8619,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-solar-sail</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-solar-sail.png</image:loc>
       <image:title>ORB - Solar Sail | Stims</image:title>
       <image:caption>ORB - Solar Sail by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8630,7 +8630,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-starfish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-starfish.png</image:loc>
       <image:title>ORB - Starfish | Stims</image:title>
       <image:caption>ORB - Starfish by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8641,7 +8641,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-supernova-meltdown</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-supernova-meltdown.png</image:loc>
       <image:title>ORB - Supernova Meltdown | Stims</image:title>
       <image:caption>ORB - Supernova Meltdown by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8652,7 +8652,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-waaa</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-waaa.png</image:loc>
       <image:title>ORB - Waaa | Stims</image:title>
       <image:caption>ORB - Waaa by ORB, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8663,7 +8663,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-data-swimmer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-data-swimmer.png</image:loc>
       <image:title>Phat + Eo.S. - Data_swimmer | Stims</image:title>
       <image:caption>Phat + Eo.S. - Data_swimmer by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8674,7 +8674,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-swim-waveform-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-swim-waveform-mix.png</image:loc>
       <image:title>Phat + Eo.S. - Swim_waveform_mix | Stims</image:title>
       <image:caption>Phat + Eo.S. - Swim_waveform_mix by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8685,7 +8685,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-rainbow-bubble-mid3-f-me-dood</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-rainbow-bubble-mid3-f-me-dood.png</image:loc>
       <image:title>Phat + Eo.S. - rainbow bubble_mid3-f. me dood | Stims</image:title>
       <image:caption>Phat + Eo.S. - rainbow bubble_mid3-f. me dood by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8696,7 +8696,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-rainbow-bubble-mid3-f-me-dood-flash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-rainbow-bubble-mid3-f-me-dood-flash.png</image:loc>
       <image:title>Phat + Zylot + Eo.S. - rainbow bubble_mid3-f. me dood-flash | Stims</image:title>
       <image:caption>Phat + Zylot + Eo.S. - rainbow bubble_mid3-f. me dood-flash by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8707,7 +8707,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-work-with-lines</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-work-with-lines.png</image:loc>
       <image:title>Phat + Zylot + Eo.S. - work with lines | Stims</image:title>
       <image:caption>Phat + Zylot + Eo.S. - work with lines by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8718,7 +8718,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-fishbrain-eo-s-mandala-chasers-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-fishbrain-eo-s-mandala-chasers-remix.png</image:loc>
       <image:title>Phat+fiShbRaiN+Eo.S_Mandala_Chasers_remix | Stims</image:title>
       <image:caption>Phat+fiShbRaiN+Eo.S_Mandala_Chasers_remix by Phat + fiShbRaiN + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8729,7 +8729,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-bluelight-condition-yin-and-eo-s-waveforms-more-flash-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-bluelight-condition-yin-and-eo-s-waveforms-more-flash-mix.png</image:loc>
       <image:title>Phat_BlueLight_Condition (Yin and Eo.S waveforms) More Flash Mix | Stims</image:title>
       <image:caption>Phat_BlueLight_Condition (Yin and Eo.S waveforms) More Flash Mix by Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8740,7 +8740,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-bright-addi-colours-spiral-7-mash0000-denegrating-our-elders-through-wholesome-hard-work</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-bright-addi-colours-spiral-7-mash0000-denegrating-our-elders-through-wholesome-hard-work.png</image:loc>
       <image:title>Phat_Eo.S - bright_addi colours_spiral_7 - mash0000 - denegrating our elders through wholesome hard work | Stims</image:title>
       <image:caption>Phat_Eo.S - bright_addi colours_spiral_7 - mash0000 - denegrating our elders through wholesome hard work by Phat_Eo.S, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8751,7 +8751,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-just-more-trash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-just-more-trash.png</image:loc>
       <image:title>Phat_Eo.S. - Just more trash | Stims</image:title>
       <image:caption>Phat_Eo.S. - Just more trash by Phat_Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8762,7 +8762,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-our-own-personal-demon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-our-own-personal-demon.png</image:loc>
       <image:title>Phat_Eo.S. - our own personal demon | Stims</image:title>
       <image:caption>Phat_Eo.S. - our own personal demon by Phat_Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8773,7 +8773,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-eyes-spiral-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-eyes-spiral-mix.png</image:loc>
       <image:title>Phat_Eo.S. Eyes_spiral_mix | Stims</image:title>
       <image:caption>Phat_Eo.S. Eyes_spiral_mix by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8784,7 +8784,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt.png</image:loc>
       <image:title>Phat_Eo.S. rainbow bubble_mid3-f. me dood | Stims</image:title>
       <image:caption>Phat_Eo.S. rainbow bubble_mid3-f. me dood by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8795,7 +8795,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-rainbow-bubble-mid3-fuck-me-dood</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-rainbow-bubble-mid3-fuck-me-dood.png</image:loc>
       <image:title>Phat_Eo.S. rainbow bubble_mid3-fuck me dood | Stims</image:title>
       <image:caption>Phat_Eo.S. rainbow bubble_mid3-fuck me dood by Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8806,7 +8806,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-rovastar-what-does-your-soul-look-like9</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-rovastar-what-does-your-soul-look-like9.png</image:loc>
       <image:title>Phat_Rovastar - What_does_your_soul_look_like9 | Stims</image:title>
       <image:caption>Phat_Rovastar - What_does_your_soul_look_like9 by Phat_Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8817,7 +8817,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-rovastar-what-does-your-soul-look-like9m</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-rovastar-what-does-your-soul-look-like9m.png</image:loc>
       <image:title>Phat_Rovastar - What_does_your_soul_look_like9m | Stims</image:title>
       <image:caption>Phat_Rovastar - What_does_your_soul_look_like9m by Phat_Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8828,7 +8828,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-rovastar-eo-s-square-faces-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-rovastar-eo-s-square-faces-v2.png</image:loc>
       <image:title>Phat_Rovastar_Eo.S. square_faces_v2 | Stims</image:title>
       <image:caption>Phat_Rovastar_Eo.S. square_faces_v2 by Phat + Rovastar + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8839,7 +8839,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-trippy-rotation-v2-sector-mix-alt-colours</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-trippy-rotation-v2-sector-mix-alt-colours.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. Trippy_rotation_v2_sector_mix_alt_colours | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. Trippy_rotation_v2_sector_mix_alt_colours by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8850,7 +8850,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-trippy-rotation-weird-boxs-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-trippy-rotation-weird-boxs-mix.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. Trippy_rotation_weird_boxs mix | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. Trippy_rotation_weird_boxs mix by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8861,7 +8861,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-rainbow-bubble-mid3-fuck-me-dood-flash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-rainbow-bubble-mid3-fuck-me-dood-flash.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. rainbow bubble_mid3-fuck me dood-flash | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. rainbow bubble_mid3-fuck me dood-flash by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8872,7 +8872,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-rainbow-bubble-mid3-starpoints-spirals-ve-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-rainbow-bubble-mid3-starpoints-spirals-ve-bitcore-tweak.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. rainbow bubble_mid3-starpoints_spirals_VE - Bitcore Tweak | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. rainbow bubble_mid3-starpoints_spirals_VE - Bitcore Tweak by Phat_Zylot_Eo.S. rainbow bubble_mid3-starpoints_spirals_VE, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8883,7 +8883,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-spiral-movements-beatle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-spiral-movements-beatle.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. spiral_Movements_Beatle | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. spiral_Movements_Beatle by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8894,7 +8894,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-spiral-movements-beatle-square-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-spiral-movements-beatle-square-mix.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. spiral_Movements_Beatle_square.mix | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. spiral_Movements_Beatle_square.mix by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8905,7 +8905,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-spiral-faces-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-spiral-faces-v2.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. spiral_faces_v2 | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. spiral_faces_v2 by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8916,7 +8916,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-square-faces-v2-alt-colours</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-square-faces-v2-alt-colours.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. square_faces_v2_alt_colours | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. square_faces_v2_alt_colours by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8927,7 +8927,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-strate-lines</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-strate-lines.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. strate lines | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. strate lines by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8938,7 +8938,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-work-with-lines-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-work-with-lines-alt.png</image:loc>
       <image:title>Phat_Zylot_Eo.S. work with lines | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S. work with lines by Phat + Zylot + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8949,7 +8949,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-zylot-eo-s-krash-i-hope-someone-will-see-this-triping-v2b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-zylot-eo-s-krash-i-hope-someone-will-see-this-triping-v2b.png</image:loc>
       <image:title>Phat_Zylot_Eo.S._Krash I_hope_someone_will_see_this_triping_v2b | Stims</image:title>
       <image:caption>Phat_Zylot_Eo.S._Krash I_hope_someone_will_see_this_triping_v2b by Phat + Zylot + Eo.S. + Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8960,7 +8960,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-remix-eo-s-zion-square-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-remix-eo-s-zion-square-mix.png</image:loc>
       <image:title>Phat_remix_Eo.S. - zion square_mix | Stims</image:title>
       <image:caption>Phat_remix_Eo.S. - zion square_mix by Phat_remix_Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8971,7 +8971,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=pieturp-it-might-be-evil-phat-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/pieturp-it-might-be-evil-phat-remix.png</image:loc>
       <image:title>PieturP - IT_MIGHT_BE_EVIL_phat_remix | Stims</image:title>
       <image:caption>PieturP - IT_MIGHT_BE_EVIL_phat_remix by PieturP, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8982,7 +8982,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=pieturp-triptrap-getting-concrete-visions-through-a-diafragma-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/pieturp-triptrap-getting-concrete-visions-through-a-diafragma-version.png</image:loc>
       <image:title>PieturP - triptrap_(getting_concrete_visions_through_a_diafragma_version) | Stims</image:title>
       <image:caption>PieturP - triptrap_(getting_concrete_visions_through_a_diafragma_version) by PieturP, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8993,7 +8993,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=pieturp-triptrap-ultimate-trip-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/pieturp-triptrap-ultimate-trip-mix.png</image:loc>
       <image:title>PieturP - triptrap_(ultimate-trip-mix) | Stims</image:title>
       <image:caption>PieturP - triptrap_(ultimate-trip-mix) by PieturP, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9004,7 +9004,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-studio-music-shimmering-love</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-studio-music-shimmering-love.png</image:loc>
       <image:title>Redi Jedi + Studio Music - Shimmering Love | Stims</image:title>
       <image:caption>Redi Jedi + Studio Music - Shimmering Love by Redi Jedi + Studio Music, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9015,7 +9015,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-shifter-phat-geiss-flexi-rovastar-120287116022-874-roam3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-shifter-phat-geiss-flexi-rovastar-120287116022-874-roam3.png</image:loc>
       <image:title>Redi Jedi - Shifter - Phat - Geiss - Flexi - Rovastar - 120287116022(874) roam3 | Stims</image:title>
       <image:caption>Redi Jedi - Shifter - Phat - Geiss - Flexi - Rovastar - 120287116022(874) roam3 by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9026,7 +9026,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-acid-on-a-window-pane</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-acid-on-a-window-pane.png</image:loc>
       <image:title>Redi Jedi - acid on a window pane | Stims</image:title>
       <image:caption>Redi Jedi - acid on a window pane by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9037,7 +9037,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-i-dont-think-those-were-portabello-mushrooms</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-i-dont-think-those-were-portabello-mushrooms.png</image:loc>
       <image:title>Redi Jedi - i dont think those were portabello mushrooms | Stims</image:title>
       <image:caption>Redi Jedi - i dont think those were portabello mushrooms by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9048,7 +9048,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-off-the-fadar-no-sweeps-or-bleeps-but-alotta-creeps</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-off-the-fadar-no-sweeps-or-bleeps-but-alotta-creeps.png</image:loc>
       <image:title>Redi Jedi - off the fadar (no sweeps or bleeps, but alotta creeps) | Stims</image:title>
       <image:caption>Redi Jedi - off the fadar (no sweeps or bleeps, but alotta creeps) by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9059,7 +9059,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-off-the-fadar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-off-the-fadar.png</image:loc>
       <image:title>Redi Jedi - off the fadar | Stims</image:title>
       <image:caption>Redi Jedi - off the fadar by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9070,7 +9070,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=redi-jedi-pladman-is-no-more</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/redi-jedi-pladman-is-no-more.png</image:loc>
       <image:title>Redi Jedi - pladman is no more | Stims</image:title>
       <image:caption>Redi Jedi - pladman is no more by Redi Jedi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9081,7 +9081,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=reenen-telek-slow-shift-matrix-bb4-5-dynamic-beat-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/reenen-telek-slow-shift-matrix-bb4-5-dynamic-beat-mix.png</image:loc>
       <image:title>Reenen &amp; Telek - Slow Shift Matrix (bb4.5 (Dynamic Beat) Mix) | Stims</image:title>
       <image:caption>Reenen &amp; Telek - Slow Shift Matrix (bb4.5 (Dynamic Beat) Mix) by Reenen &amp; Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9092,7 +9092,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=reenen-phoenix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/reenen-phoenix.png</image:loc>
       <image:title>Reenen - phoenix | Stims</image:title>
       <image:caption>Reenen - phoenix by Reenen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9103,7 +9103,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=reenen-geiss-soft-triple-feedback</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/reenen-geiss-soft-triple-feedback.png</image:loc>
       <image:title>Reenen Geiss - Soft Triple Feedback | Stims</image:title>
       <image:caption>Reenen Geiss - Soft Triple Feedback by Reenen Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9114,7 +9114,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=reenen-geiss-triple-feedback-phat-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/reenen-geiss-triple-feedback-phat-edit.png</image:loc>
       <image:title>Reenen Geiss - Triple Feedback_phat_edit | Stims</image:title>
       <image:caption>Reenen Geiss - Triple Feedback_phat_edit by Reenen Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9125,7 +9125,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rocke-answer-42-new-mix-1-mash0000-slash-and-char-p-jungle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rocke-answer-42-new-mix-1-mash0000-slash-and-char-p-jungle.png</image:loc>
       <image:title>Rocke - Answer.42 (New Mix 1) - mash0000 - slash and char p. jungle | Stims</image:title>
       <image:caption>Rocke - Answer.42 (New Mix 1) - mash0000 - slash and char p. jungle by Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9136,7 +9136,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rocke-cold-love-tei-zwaa</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rocke-cold-love-tei-zwaa.png</image:loc>
       <image:title>Rocke - Cold Love (Tei Zwaa) | Stims</image:title>
       <image:caption>Rocke - Cold Love (Tei Zwaa) by Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9147,7 +9147,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rocke-loz-tribute</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rocke-loz-tribute.png</image:loc>
       <image:title>Rocke - LoZ Tribute | Stims</image:title>
       <image:caption>Rocke - LoZ Tribute by Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9158,7 +9158,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rocke-personal-comet</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rocke-personal-comet.png</image:loc>
       <image:title>Rocke - Personal Comet | Stims</image:title>
       <image:caption>Rocke - Personal Comet by Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9169,7 +9169,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-aderrasi-airs-of-change</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-aderrasi-airs-of-change.png</image:loc>
       <image:title>Rovastar &amp; Aderrasi - Airs Of Change | Stims</image:title>
       <image:caption>Rovastar &amp; Aderrasi - Airs Of Change by Rovastar &amp; Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9180,7 +9180,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-che-definitly-not-for-the-epileptic-inner-perspective-of-life-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-che-definitly-not-for-the-epileptic-inner-perspective-of-life-mix.png</image:loc>
       <image:title>Rovastar &amp; Che - Definitly Not For The Epileptic (Inner Perspective Of Life Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Che - Definitly Not For The Epileptic (Inner Perspective Of Life Mix) by Rovastar &amp; Che, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9191,7 +9191,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-idiot24-7-balk-acid</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-idiot24-7-balk-acid.png</image:loc>
       <image:title>Rovastar &amp; Idiot24-7 - Balk Acid | Stims</image:title>
       <image:caption>Rovastar &amp; Idiot24-7 - Balk Acid by Rovastar &amp; Idiot24-7, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9202,7 +9202,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-idiot24-7-marphet-s-shrine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-idiot24-7-marphet-s-shrine.png</image:loc>
       <image:title>Rovastar &amp; Idiot24-7 - Marphet′s Shrine | Stims</image:title>
       <image:caption>Rovastar &amp; Idiot24-7 - Marphet′s Shrine by Rovastar &amp; Idiot24-7, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9213,7 +9213,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-krash-rainbow-deflection</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-krash-rainbow-deflection.png</image:loc>
       <image:title>Rovastar &amp; Krash - Rainbow Deflection | Stims</image:title>
       <image:caption>Rovastar &amp; Krash - Rainbow Deflection by Rovastar &amp; Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9224,7 +9224,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-zylot-fractaldrop-spark-machine-v2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-zylot-fractaldrop-spark-machine-v2-0.png</image:loc>
       <image:title>Rovastar &amp; Loadus + Zylot - FractalDrop (Spark Machine v2.0) | Stims</image:title>
       <image:caption>Rovastar &amp; Loadus + Zylot - FractalDrop (Spark Machine v2.0) by Rovastar &amp; Loadus + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9235,7 +9235,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-fractaldrop-active-sparks-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-fractaldrop-active-sparks-mix.png</image:loc>
       <image:title>Rovastar &amp; Loadus - FractalDrop (Active Sparks Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Loadus - FractalDrop (Active Sparks Mix) by Rovastar &amp; Loadus, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9246,7 +9246,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-ambrosia-mystic-dark-heart-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-ambrosia-mystic-dark-heart-mix.png</image:loc>
       <image:title>Rovastar &amp; Unchained - Ambrosia Mystic (Dark Heart Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Unchained - Ambrosia Mystic (Dark Heart Mix) by Rovastar &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9257,7 +9257,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-demonology-vampire-soul-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-demonology-vampire-soul-mix.png</image:loc>
       <image:title>Rovastar &amp; Unchained - Demonology (Vampire Soul Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Unchained - Demonology (Vampire Soul Mix) by Rovastar &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9268,7 +9268,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-unified-drag-2-ghostly-vision-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-unified-drag-2-ghostly-vision-mix.png</image:loc>
       <image:title>Rovastar &amp; Unchained - Unified Drag 2 (Ghostly Vision Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Unchained - Unified Drag 2 (Ghostly Vision Mix) by Rovastar &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9279,7 +9279,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-zylot-crystal-ball-many-visions-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-zylot-crystal-ball-many-visions-mix.png</image:loc>
       <image:title>Rovastar &amp; Zylot - Crystal Ball (Many Visions Mix) | Stims</image:title>
       <image:caption>Rovastar &amp; Zylot - Crystal Ball (Many Visions Mix) by Rovastar &amp; Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9290,7 +9290,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-che-asylum-animations</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-che-asylum-animations.png</image:loc>
       <image:title>Rovastar + Che - Asylum Animations | Stims</image:title>
       <image:caption>Rovastar + Che - Asylum Animations by Rovastar + Che, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9301,7 +9301,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-flexi-loadus-geiss-tone-mapped-fractaldrop-4-moebius-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-flexi-loadus-geiss-tone-mapped-fractaldrop-4-moebius-edit.png</image:loc>
       <image:title>Rovastar + Flexi + Loadus + Geiss - Tone-mapped FractalDrop 4 [moebius edit] | Stims</image:title>
       <image:caption>Rovastar + Flexi + Loadus + Geiss - Tone-mapped FractalDrop 4 [moebius edit] by Rovastar + Flexi + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9312,7 +9312,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-flexi-hurricane-nightmare-moebius-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-flexi-hurricane-nightmare-moebius-mix.png</image:loc>
       <image:title>Rovastar + Flexi - Hurricane Nightmare (Moebius Mix) | Stims</image:title>
       <image:caption>Rovastar + Flexi - Hurricane Nightmare (Moebius Mix) by Rovastar + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9323,7 +9323,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fvese-mosaic-waves</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fvese-mosaic-waves.png</image:loc>
       <image:title>Rovastar + Fvese - Mosaic Waves | Stims</image:title>
       <image:caption>Rovastar + Fvese - Mosaic Waves by Rovastar + Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9334,7 +9334,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fvese-paranormal-static</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fvese-paranormal-static.png</image:loc>
       <image:title>Rovastar + Fvese - Paranormal Static | Stims</image:title>
       <image:caption>Rovastar + Fvese - Paranormal Static by Rovastar + Fvese, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9345,7 +9345,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-approach-vectrip-mix-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-approach-vectrip-mix-painterly.png</image:loc>
       <image:title>Rovastar + Geiss - Approach (Vectrip Mix) - painterly | Stims</image:title>
       <image:caption>Rovastar + Geiss - Approach (Vectrip Mix) - painterly by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9356,7 +9356,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-bipolar-2-vectrip-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-bipolar-2-vectrip-mix.png</image:loc>
       <image:title>Rovastar + Geiss - Bipolar 2 (Vectrip Mix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Bipolar 2 (Vectrip Mix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9367,7 +9367,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-braindance-1-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-braindance-1-reverse-jelly-v3.png</image:loc>
       <image:title>Rovastar + Geiss - Braindance 1 (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Braindance 1 (Reverse Jelly V3) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9378,7 +9378,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-dynamic-swirls-3-voyage-of-twisted-souls-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-dynamic-swirls-3-voyage-of-twisted-souls-mix.png</image:loc>
       <image:title>Rovastar + Geiss - Dynamic Swirls 3 (Voyage Of Twisted Souls Mix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Dynamic Swirls 3 (Voyage Of Twisted Souls Mix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9389,7 +9389,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hurricane-nightmare-gold-chrome-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hurricane-nightmare-gold-chrome-mix.png</image:loc>
       <image:title>Rovastar + Geiss - Hurricane Nightmare (Gold Chrome Mix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hurricane Nightmare (Gold Chrome Mix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9400,7 +9400,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hurricane-nightmare-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hurricane-nightmare-relief-mix.png</image:loc>
       <image:title>Rovastar + Geiss - Hurricane Nightmare (Relief Mix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hurricane Nightmare (Relief Mix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9411,7 +9411,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hurricane-nightmare</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hurricane-nightmare.png</image:loc>
       <image:title>Rovastar + Geiss - Hurricane Nightmare | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hurricane Nightmare by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9422,7 +9422,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hyperkaleidoscope-glow-2-motion-blur-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hyperkaleidoscope-glow-2-motion-blur-jelly.png</image:loc>
       <image:title>Rovastar + Geiss - Hyperkaleidoscope Glow 2 motion blur (Jelly) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hyperkaleidoscope Glow 2 motion blur (Jelly) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9433,7 +9433,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hyperkaleidoscope-glow-2-motion-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hyperkaleidoscope-glow-2-motion-blur.png</image:loc>
       <image:title>Rovastar + Geiss - Hyperkaleidoscope Glow 2 motion blur | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hyperkaleidoscope Glow 2 motion blur by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9444,7 +9444,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hyperspace-kaleidoscope</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hyperspace-kaleidoscope.png</image:loc>
       <image:title>Rovastar + Geiss - Hyperspace - kaleidoscope | Stims</image:title>
       <image:caption>Rovastar + Geiss - Hyperspace - kaleidoscope by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9455,7 +9455,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-snapshot-of-space-lsb-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-snapshot-of-space-lsb-mix.png</image:loc>
       <image:title>Rovastar + Geiss - Snapshot Of Space (LSB mix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Snapshot Of Space (LSB mix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9466,7 +9466,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-tripmaker-square-tiles-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-tripmaker-square-tiles-remix.png</image:loc>
       <image:title>Rovastar + Geiss - Tripmaker (square tiles remix) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Tripmaker (square tiles remix) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9477,7 +9477,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-tripmaker-tiles</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-tripmaker-tiles.png</image:loc>
       <image:title>Rovastar + Geiss - Tripmaker (tiles) | Stims</image:title>
       <image:caption>Rovastar + Geiss - Tripmaker (tiles) by Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9488,7 +9488,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-atmospheric-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-atmospheric-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Atmospheric Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Atmospheric Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9499,7 +9499,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-cauliflower-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-cauliflower-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Cauliflower Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Cauliflower Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9510,7 +9510,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-insanity-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-insanity-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Insanity Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Insanity Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9521,7 +9521,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-relief-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Relief Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Relief Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9532,7 +9532,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-spinning-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-spinning-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Spinning Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Spinning Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9543,7 +9543,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-tone-mapped-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-tone-mapped-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Tone-mapped Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Tone-mapped Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9554,7 +9554,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-triple-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-triple-mix.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - FractalDrop (Triple Mix) | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - FractalDrop (Triple Mix) by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9565,7 +9565,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-tone-mapped-fractaldrop-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-tone-mapped-fractaldrop-4.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 4 | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 4 by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9576,7 +9576,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-tone-mapped-fractaldrop-7b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-tone-mapped-fractaldrop-7b.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7b | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7b by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9587,7 +9587,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-tone-mapped-fractaldrop-7c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-tone-mapped-fractaldrop-7c.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7c | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7c by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9598,7 +9598,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-tone-mapped-fractaldrop-7d</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-tone-mapped-fractaldrop-7d.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7d | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop 7d by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9609,7 +9609,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-tone-mapped-fractaldrop</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-tone-mapped-fractaldrop.png</image:loc>
       <image:title>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop | Stims</image:title>
       <image:caption>Rovastar + Loadus + Geiss - Tone-mapped FractalDrop by Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9620,7 +9620,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-fractaldrop-active-sparks-mix-steady</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-fractaldrop-active-sparks-mix-steady.png</image:loc>
       <image:title>Rovastar + Loadus - FractalDrop (Active Sparks Mix) Steady | Stims</image:title>
       <image:caption>Rovastar + Loadus - FractalDrop (Active Sparks Mix) Steady by Rovastar + Loadus, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9631,7 +9631,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-rocke-sugar-spun-sister-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-rocke-sugar-spun-sister-painterly.png</image:loc>
       <image:title>Rovastar + Rocke - Sugar Spun Sister - Painterly | Stims</image:title>
       <image:caption>Rovastar + Rocke - Sugar Spun Sister - Painterly by Rovastar + Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9642,7 +9642,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-rocke-sugar-spun-sister</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-rocke-sugar-spun-sister.png</image:loc>
       <image:title>Rovastar + Rocke - Sugar Spun Sister | Stims</image:title>
       <image:caption>Rovastar + Rocke - Sugar Spun Sister by Rovastar + Rocke, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9653,7 +9653,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-telek-altars-of-madness-rolling-oceans-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-telek-altars-of-madness-rolling-oceans-mix.png</image:loc>
       <image:title>Rovastar + Telek - Altars of Madness (Rolling Oceans Mix) | Stims</image:title>
       <image:caption>Rovastar + Telek - Altars of Madness (Rolling Oceans Mix) by Rovastar + Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9664,7 +9664,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-life-after-pie-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-life-after-pie-remix.png</image:loc>
       <image:title>Rovastar + Unchained - Life After Pie (Remix) | Stims</image:title>
       <image:caption>Rovastar + Unchained - Life After Pie (Remix) by Rovastar + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9675,7 +9675,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-oddball-world</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-oddball-world.png</image:loc>
       <image:title>Rovastar + Unchained - Oddball World | Stims</image:title>
       <image:caption>Rovastar + Unchained - Oddball World by Rovastar + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9686,7 +9686,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-voodoo-chess-magnet-everglow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-voodoo-chess-magnet-everglow-mix.png</image:loc>
       <image:title>Rovastar + Unchained - Voodoo Chess Magnet (Everglow Mix) | Stims</image:title>
       <image:caption>Rovastar + Unchained - Voodoo Chess Magnet (Everglow Mix) by Rovastar + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9697,7 +9697,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-unchained-xen-traffic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-unchained-xen-traffic.png</image:loc>
       <image:title>Rovastar + Unchained - Xen Traffic | Stims</image:title>
       <image:caption>Rovastar + Unchained - Xen Traffic by Rovastar + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9708,7 +9708,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-zylot-narell-s-fever</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-zylot-narell-s-fever.png</image:loc>
       <image:title>Rovastar + Zylot - Narell′s Fever | Stims</image:title>
       <image:caption>Rovastar + Zylot - Narell′s Fever by Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9719,7 +9719,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-zylot-urza-s-revenge</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-zylot-urza-s-revenge.png</image:loc>
       <image:title>Rovastar + Zylot - Urza′s Revenge | Stims</image:title>
       <image:caption>Rovastar + Zylot - Urza′s Revenge by Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9730,7 +9730,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-a-million-miles-from-earth-wormhole-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-a-million-miles-from-earth-wormhole-mix.png</image:loc>
       <image:title>Rovastar - A Million Miles From Earth (Wormhole Mix) | Stims</image:title>
       <image:caption>Rovastar - A Million Miles From Earth (Wormhole Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9741,7 +9741,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-altars-of-harlequin-s-madness-dark-disorder-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-altars-of-harlequin-s-madness-dark-disorder-mix.png</image:loc>
       <image:title>Rovastar - Altars Of Harlequin′s Madness (Dark Disorder Mix) | Stims</image:title>
       <image:caption>Rovastar - Altars Of Harlequin′s Madness (Dark Disorder Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9752,7 +9752,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-altars-of-harlequin-s-madness</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-altars-of-harlequin-s-madness.png</image:loc>
       <image:title>Rovastar - Altars Of Harlequin′s Madness | Stims</image:title>
       <image:caption>Rovastar - Altars Of Harlequin′s Madness by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9763,7 +9763,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-altars-of-madness-4-spirit-of-twisted-madness-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-altars-of-madness-4-spirit-of-twisted-madness-mix.png</image:loc>
       <image:title>Rovastar - Altars Of Madness 4 (Spirit Of Twisted Madness Mix) | Stims</image:title>
       <image:caption>Rovastar - Altars Of Madness 4 (Spirit Of Twisted Madness Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9774,7 +9774,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-braindance-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-braindance-1.png</image:loc>
       <image:title>Rovastar - Braindance 1 | Stims</image:title>
       <image:caption>Rovastar - Braindance 1 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9785,7 +9785,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-cerebral-parasites-attack-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-cerebral-parasites-attack-mix.png</image:loc>
       <image:title>Rovastar - Cerebral Parasites (Attack Mix) | Stims</image:title>
       <image:caption>Rovastar - Cerebral Parasites (Attack Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9796,7 +9796,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-cosmic-echoes-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-cosmic-echoes-2.png</image:loc>
       <image:title>Rovastar - Cosmic Echoes 2 | Stims</image:title>
       <image:caption>Rovastar - Cosmic Echoes 2 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9807,7 +9807,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-dark-ritual-star-of-destiny-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-dark-ritual-star-of-destiny-mix.png</image:loc>
       <image:title>Rovastar - Dark Ritual (Star Of Destiny Mix) | Stims</image:title>
       <image:caption>Rovastar - Dark Ritual (Star Of Destiny Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9818,7 +9818,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-demon-sunflower-double-resistance-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-demon-sunflower-double-resistance-mix.png</image:loc>
       <image:title>Rovastar - Demon Sunflower (Double Resistance Mix) | Stims</image:title>
       <image:caption>Rovastar - Demon Sunflower (Double Resistance Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9829,7 +9829,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-destiny-star-starbrust-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-destiny-star-starbrust-mix.png</image:loc>
       <image:title>Rovastar - Destiny Star (Starbrust Mix) | Stims</image:title>
       <image:caption>Rovastar - Destiny Star (Starbrust Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9840,7 +9840,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-explosive-minds</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-explosive-minds.png</image:loc>
       <image:title>Rovastar - Explosive Minds | Stims</image:title>
       <image:caption>Rovastar - Explosive Minds by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9851,7 +9851,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-eye-on-reality-mega-3-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-eye-on-reality-mega-3-mix.png</image:loc>
       <image:title>Rovastar - Eye On Reality (Mega 3 Mix) | Stims</image:title>
       <image:caption>Rovastar - Eye On Reality (Mega 3 Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9862,7 +9862,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fractopia-fantic-dancing-lights-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fractopia-fantic-dancing-lights-mix.png</image:loc>
       <image:title>Rovastar - Fractopia (Fantic Dancing Lights Mix) | Stims</image:title>
       <image:caption>Rovastar - Fractopia (Fantic Dancing Lights Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9873,7 +9873,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fractopia-galaxy-swirl-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fractopia-galaxy-swirl-mix.png</image:loc>
       <image:title>Rovastar - Fractopia (Galaxy Swirl Mix) | Stims</image:title>
       <image:caption>Rovastar - Fractopia (Galaxy Swirl Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9884,7 +9884,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fractopia-upspoken-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fractopia-upspoken-mix.png</image:loc>
       <image:title>Rovastar - Fractopia (Upspoken Mix) | Stims</image:title>
       <image:caption>Rovastar - Fractopia (Upspoken Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9895,7 +9895,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-fractopia-upspoken-mix-phat-speak-when-spoken-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-fractopia-upspoken-mix-phat-speak-when-spoken-2.png</image:loc>
       <image:title>Rovastar - Fractopia (Upspoken Mix)_Phat_Speak_When_Spoken_2 | Stims</image:title>
       <image:caption>Rovastar - Fractopia (Upspoken Mix)_Phat_Speak_When_Spoken_2 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9906,7 +9906,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-halcyon-dreams-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-halcyon-dreams-3.png</image:loc>
       <image:title>Rovastar - Halcyon Dreams 3 | Stims</image:title>
       <image:caption>Rovastar - Halcyon Dreams 3 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9917,7 +9917,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-hallucinogenic-pyramids-beat-time-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-hallucinogenic-pyramids-beat-time-mix.png</image:loc>
       <image:title>Rovastar - Hallucinogenic Pyramids (Beat Time Mix) | Stims</image:title>
       <image:caption>Rovastar - Hallucinogenic Pyramids (Beat Time Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9928,7 +9928,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequin-s-jester-s-dual-delight-chaotic-nightmare-mix.png</image:loc>
       <image:title>Rovastar - Harlequin′s &amp; Jester′s Dual Delight (Chaotic Nightmare Mix) | Stims</image:title>
       <image:caption>Rovastar - Harlequin′s &amp; Jester′s Dual Delight (Chaotic Nightmare Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9939,7 +9939,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequin-s-dynamic-fractal-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequin-s-dynamic-fractal-3.png</image:loc>
       <image:title>Rovastar - Harlequin′s Dynamic Fractal 3 | Stims</image:title>
       <image:caption>Rovastar - Harlequin′s Dynamic Fractal 3 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9950,7 +9950,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequin-s-fractal-encounter-cancer-of-saints</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequin-s-fractal-encounter-cancer-of-saints.png</image:loc>
       <image:title>Rovastar - Harlequin′s Fractal Encounter - cancer of saints | Stims</image:title>
       <image:caption>Rovastar - Harlequin′s Fractal Encounter - cancer of saints by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9961,7 +9961,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequin-s-fractal-encounter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequin-s-fractal-encounter.png</image:loc>
       <image:title>Rovastar - Harlequin′s Fractal Encounter | Stims</image:title>
       <image:caption>Rovastar - Harlequin′s Fractal Encounter by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9972,7 +9972,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-harlequin-s-liquid-dragon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-harlequin-s-liquid-dragon.png</image:loc>
       <image:title>Rovastar - Harlequin′s Liquid Dragon | Stims</image:title>
       <image:caption>Rovastar - Harlequin′s Liquid Dragon by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9983,7 +9983,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-hyperspace-hyper-speed-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-hyperspace-hyper-speed-mix.png</image:loc>
       <image:title>Rovastar - Hyperspace (Hyper Speed Mix) | Stims</image:title>
       <image:caption>Rovastar - Hyperspace (Hyper Speed Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -9994,7 +9994,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-hyperspace</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-hyperspace.png</image:loc>
       <image:title>Rovastar - Hyperspace | Stims</image:title>
       <image:caption>Rovastar - Hyperspace by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10005,7 +10005,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-inner-thoughts-distant-memories-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-inner-thoughts-distant-memories-mix.png</image:loc>
       <image:title>Rovastar - Inner Thoughts (Distant Memories Mix) | Stims</image:title>
       <image:caption>Rovastar - Inner Thoughts (Distant Memories Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10016,7 +10016,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-inner-thoughts-frantic-thoughts-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-inner-thoughts-frantic-thoughts-mix.png</image:loc>
       <image:title>Rovastar - Inner Thoughts (Frantic Thoughts Mix) | Stims</image:title>
       <image:caption>Rovastar - Inner Thoughts (Frantic Thoughts Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10027,7 +10027,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-jester-s-calling-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-jester-s-calling-2.png</image:loc>
       <image:title>Rovastar - Jester′s Calling 2 | Stims</image:title>
       <image:caption>Rovastar - Jester′s Calling 2 by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10038,7 +10038,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-jester-s-surreal-tornado-further-vortex-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-jester-s-surreal-tornado-further-vortex-mix.png</image:loc>
       <image:title>Rovastar - Jester′s Surreal Tornado (Further Vortex Mix) | Stims</image:title>
       <image:caption>Rovastar - Jester′s Surreal Tornado (Further Vortex Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10049,7 +10049,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-jester-s-surreal-tornado</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-jester-s-surreal-tornado.png</image:loc>
       <image:title>Rovastar - Jester′s Surreal Tornado | Stims</image:title>
       <image:caption>Rovastar - Jester′s Surreal Tornado by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10060,7 +10060,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-labfunk</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-labfunk.png</image:loc>
       <image:title>Rovastar - LabFunk | Stims</image:title>
       <image:caption>Rovastar - LabFunk by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10071,7 +10071,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-ritual-halostar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-ritual-halostar.png</image:loc>
       <image:title>Rovastar - Ritual Halostar | Stims</image:title>
       <image:caption>Rovastar - Ritual Halostar by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10082,7 +10082,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-snapshot-of-space</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-snapshot-of-space.png</image:loc>
       <image:title>Rovastar - Snapshot Of Space | Stims</image:title>
       <image:caption>Rovastar - Snapshot Of Space by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10093,7 +10093,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-solarized-space</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-solarized-space.png</image:loc>
       <image:title>Rovastar - Solarized Space | Stims</image:title>
       <image:caption>Rovastar - Solarized Space by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10104,7 +10104,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-starquake-sunquake-md2-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-starquake-sunquake-md2-mix.png</image:loc>
       <image:title>Rovastar - Starquake (Sunquake MD2 Mix) | Stims</image:title>
       <image:caption>Rovastar - Starquake (Sunquake MD2 Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10115,7 +10115,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-starquake-sunquake-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-starquake-sunquake-mix.png</image:loc>
       <image:title>Rovastar - Starquake (Sunquake Mix) | Stims</image:title>
       <image:caption>Rovastar - Starquake (Sunquake Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10126,7 +10126,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-sunflower-passion-simple-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-sunflower-passion-simple-mix.png</image:loc>
       <image:title>Rovastar - Sunflower Passion (Simple Mix) | Stims</image:title>
       <image:caption>Rovastar - Sunflower Passion (Simple Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10137,7 +10137,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-sunflower-passion-simple-mix-phat-eo-s-werid-angle-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-sunflower-passion-simple-mix-phat-eo-s-werid-angle-mix.png</image:loc>
       <image:title>Rovastar - Sunflower Passion (Simple Mix)_phat+Eo.S. werid_angle_mix | Stims</image:title>
       <image:caption>Rovastar - Sunflower Passion (Simple Mix)_phat+Eo.S. werid_angle_mix by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10148,7 +10148,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-sunflower-passion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-sunflower-passion.png</image:loc>
       <image:title>Rovastar - Sunflower Passion | Stims</image:title>
       <image:caption>Rovastar - Sunflower Passion by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10159,7 +10159,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-torrid-tales</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-torrid-tales.png</image:loc>
       <image:title>Rovastar - Torrid Tales | Stims</image:title>
       <image:caption>Rovastar - Torrid Tales by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10170,7 +10170,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-tripmaker-space-trip-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-tripmaker-space-trip-mix.png</image:loc>
       <image:title>Rovastar - Tripmaker (Space Trip Mix) | Stims</image:title>
       <image:caption>Rovastar - Tripmaker (Space Trip Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10181,7 +10181,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-tripmaker</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-tripmaker.png</image:loc>
       <image:title>Rovastar - Tripmaker | Stims</image:title>
       <image:caption>Rovastar - Tripmaker by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10192,7 +10192,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-trippy-sperm-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-trippy-sperm-jelly.png</image:loc>
       <image:title>Rovastar - Trippy Sperm (Jelly) | Stims</image:title>
       <image:caption>Rovastar - Trippy Sperm (Jelly) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10203,7 +10203,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-virtual-horizons-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-virtual-horizons-jelly-v3.png</image:loc>
       <image:title>Rovastar - Virtual Horizons (Jelly V3) | Stims</image:title>
       <image:caption>Rovastar - Virtual Horizons (Jelly V3) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10214,7 +10214,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-voov-s-light-pattern</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-voov-s-light-pattern.png</image:loc>
       <image:title>Rovastar - VooV′s Light Pattern | Stims</image:title>
       <image:caption>Rovastar - VooV′s Light Pattern by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10225,7 +10225,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-voov-s-movement-after-dark-mix-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-voov-s-movement-after-dark-mix-painterly.png</image:loc>
       <image:title>Rovastar - VooV′s Movement (After Dark Mix) - Painterly | Stims</image:title>
       <image:caption>Rovastar - VooV′s Movement (After Dark Mix) - Painterly by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10236,7 +10236,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-voov-s-movement-after-dark-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-voov-s-movement-after-dark-mix.png</image:loc>
       <image:title>Rovastar - VooV′s Movement (After Dark Mix) | Stims</image:title>
       <image:caption>Rovastar - VooV′s Movement (After Dark Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10247,7 +10247,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-voov-s-naked-movement-pincushion-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-voov-s-naked-movement-pincushion-mix.png</image:loc>
       <image:title>Rovastar - VooV′s Naked Movement (Pincushion Mix) | Stims</image:title>
       <image:caption>Rovastar - VooV′s Naked Movement (Pincushion Mix) by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10258,7 +10258,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-voov-s-organic-light</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-voov-s-organic-light.png</image:loc>
       <image:title>Rovastar - VooV′s Organic Light | Stims</image:title>
       <image:caption>Rovastar - VooV′s Organic Light by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10269,7 +10269,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-xtal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-xtal.png</image:loc>
       <image:title>Rovastar - Xtal | Stims</image:title>
       <image:caption>Rovastar - Xtal by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10280,7 +10280,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-studiomusic-morecherish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-studiomusic-morecherish.png</image:loc>
       <image:title>Rovastar&amp;StudioMusic-MoreCherish | Stims</image:title>
       <image:caption>Rovastar&amp;StudioMusic-MoreCherish by Rovastar + Studio Music, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10291,7 +10291,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-altarsofmadness-forgottenrea</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-altarsofmadness-forgottenrea.png</image:loc>
       <image:title>Rovastar-altarsofmadness(forgottenrea | Stims</image:title>
       <image:caption>Rovastar-altarsofmadness(forgottenrea by Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10302,7 +10302,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-aderrasi-canon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-aderrasi-canon.png</image:loc>
       <image:title>Rozzor &amp; Aderrasi - Canon | Stims</image:title>
       <image:caption>Rozzor &amp; Aderrasi - Canon by Rozzor &amp; Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10313,7 +10313,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-che-inside-the-house-of-nil</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-che-inside-the-house-of-nil.png</image:loc>
       <image:title>Rozzor &amp; Che - Inside The House Of Nil | Stims</image:title>
       <image:caption>Rozzor &amp; Che - Inside The House Of Nil by Rozzor &amp; Che, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10324,7 +10324,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-esotic-ppl-nwi-mandala-chill-color-reactive-texture-tweaked</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-esotic-ppl-nwi-mandala-chill-color-reactive-texture-tweaked.png</image:loc>
       <image:title>Rozzor &amp; Esotic - PPL (NWI) Mandala Chill Color Reactive Texture Tweaked | Stims</image:title>
       <image:caption>Rozzor &amp; Esotic - PPL (NWI) Mandala Chill Color Reactive Texture Tweaked by Rozzor &amp; Esotic, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10335,7 +10335,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-esotic-ppl-nwi-mandala-chill-color-reactive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-esotic-ppl-nwi-mandala-chill-color-reactive.png</image:loc>
       <image:title>Rozzor &amp; Esotic - PPL (NWI) Mandala Chill Color Reactive | Stims</image:title>
       <image:caption>Rozzor &amp; Esotic - PPL (NWI) Mandala Chill Color Reactive by Rozzor &amp; Esotic, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10346,7 +10346,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-esotic-pixie-party-light-with-liquid-refreshment-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-esotic-pixie-party-light-with-liquid-refreshment-mix.png</image:loc>
       <image:title>Rozzor &amp; Esotic - Pixie Party Light (With Liquid Refreshment Mix) | Stims</image:title>
       <image:caption>Rozzor &amp; Esotic - Pixie Party Light (With Liquid Refreshment Mix) by Rozzor &amp; Esotic, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10357,7 +10357,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-rovastar-shame-turns-into-change</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-rovastar-shame-turns-into-change.png</image:loc>
       <image:title>Rozzor &amp; Rovastar - Shame Turns inTo Change | Stims</image:title>
       <image:caption>Rozzor &amp; Rovastar - Shame Turns inTo Change by Rozzor &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10368,7 +10368,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-shreyas-deeper-aesthetics</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-shreyas-deeper-aesthetics.png</image:loc>
       <image:title>Rozzor &amp; Shreyas - Deeper Aesthetics | Stims</image:title>
       <image:caption>Rozzor &amp; Shreyas - Deeper Aesthetics by Rozzor &amp; Shreyas, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10379,7 +10379,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-studiomusic-vertigyny-geiss-shape-mod</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-studiomusic-vertigyny-geiss-shape-mod.png</image:loc>
       <image:title>Rozzor &amp; StudioMusic - Vertigyny (Geiss Shape Mod) | Stims</image:title>
       <image:caption>Rozzor &amp; StudioMusic - Vertigyny (Geiss Shape Mod) by Rozzor &amp; StudioMusic, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10390,7 +10390,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-unchained-crescat-scientia-vita-excolatur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-unchained-crescat-scientia-vita-excolatur.png</image:loc>
       <image:title>Rozzor &amp; Unchained - Crescat Scientia, Vita Excolatur | Stims</image:title>
       <image:caption>Rozzor &amp; Unchained - Crescat Scientia, Vita Excolatur by Rozzor &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10401,7 +10401,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-unchained-painful-plasma-multi-wave-mirrored-rage-triangle-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-unchained-painful-plasma-multi-wave-mirrored-rage-triangle-tweak.png</image:loc>
       <image:title>Rozzor &amp; Unchained - Painful Plasma (Multi-Wave Mirrored Rage (Triangle Tweak)) | Stims</image:title>
       <image:caption>Rozzor &amp; Unchained - Painful Plasma (Multi-Wave Mirrored Rage (Triangle Tweak)) by Rozzor &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10412,7 +10412,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-unchained-scientifically-shapely</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-unchained-scientifically-shapely.png</image:loc>
       <image:title>Rozzor &amp; Unchained - Scientifically Shapely | Stims</image:title>
       <image:caption>Rozzor &amp; Unchained - Scientifically Shapely by Rozzor &amp; Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10423,7 +10423,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-idiot-any-other-deep-rising</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-idiot-any-other-deep-rising.png</image:loc>
       <image:title>Rozzor + Idiot - Any Other Deep Rising | Stims</image:title>
       <image:caption>Rozzor + Idiot - Any Other Deep Rising by Rozzor + Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10434,7 +10434,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rozzor-learning-curve-invert-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rozzor-learning-curve-invert-tweak.png</image:loc>
       <image:title>Rozzor - Learning Curve (Invert Tweak) | Stims</image:title>
       <image:caption>Rozzor - Learning Curve (Invert Tweak) by Rozzor, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10445,7 +10445,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadowharlequin-fitting-butterfly-v4-loadus-geiss-fractaldrop-22-v2v2v2v2newcolorsv2v2-22v2-newv222v2-bennett</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadowharlequin-fitting-butterfly-v4-loadus-geiss-fractaldrop-22-v2v2v2v2newcolorsv2v2-22v2-newv222v2-bennett.png</image:loc>
       <image:title>ShadowHarlequin - Fitting Butterfly - v4 - [Loadus &amp; Geiss - FractalDrop 22] v2v2v2v2newcolorsv2v2-22v2-NEWv222v2 bennett | Stims</image:title>
       <image:caption>ShadowHarlequin - Fitting Butterfly - v4 - [Loadus &amp; Geiss - FractalDrop 22] v2v2v2v2newcolorsv2v2-22v2-NEWv222v2 bennett by ShadowHarlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10456,7 +10456,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadowharlequin-tunneling-glitch-mix-geiss-3-layers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadowharlequin-tunneling-glitch-mix-geiss-3-layers.png</image:loc>
       <image:title>ShadowHarlequin - Tunneling (glitch mix) - [Geiss - 3 layers] | Stims</image:title>
       <image:caption>ShadowHarlequin - Tunneling (glitch mix) - [Geiss - 3 layers] by ShadowHarlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10467,7 +10467,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadowharlequin-mashup-satin-sunburst-neon-tokyo-megamix-v1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadowharlequin-mashup-satin-sunburst-neon-tokyo-megamix-v1.png</image:loc>
       <image:title>ShadowHarlequin - mashup - Satin Sunburst (Neon Tokyo Megamix) v1 | Stims</image:title>
       <image:caption>ShadowHarlequin - mashup - Satin Sunburst (Neon Tokyo Megamix) v1 by ShadowHarlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10478,7 +10478,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-eo-s-phat-fractical-dancer-inside-the-neural-net</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-eo-s-phat-fractical-dancer-inside-the-neural-net.png</image:loc>
       <image:title>Shifter &amp; Eo.S+Phat - Fractical dancer (inside the neural net) | Stims</image:title>
       <image:caption>Shifter &amp; Eo.S+Phat - Fractical dancer (inside the neural net) by Shifter &amp; Eo.S+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10489,7 +10489,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-eo-s-phat-fractical-dancer-shattered-mind</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-eo-s-phat-fractical-dancer-shattered-mind.png</image:loc>
       <image:title>Shifter &amp; Eo.S+Phat - Fractical dancer (shattered mind) | Stims</image:title>
       <image:caption>Shifter &amp; Eo.S+Phat - Fractical dancer (shattered mind) by Shifter &amp; Eo.S+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10500,7 +10500,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shreyas-carnival</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shreyas-carnival.png</image:loc>
       <image:title>Shreyas - Carnival | Stims</image:title>
       <image:caption>Shreyas - Carnival by Shreyas, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10511,7 +10511,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx-mash0000-closer-to-god-through-bacon.png</image:loc>
       <image:title>Stahlregen &amp; AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack′s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon | Stims</image:title>
       <image:caption>Stahlregen &amp; AdamFX + flexi + Geiss - Dragonfly Wings (MashUp 26 - Jack′s Playful Thumbdrum Planet RMX) - mash0000 - closer to god through bacon by Stahlregen &amp; AdamFX + flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10522,7 +10522,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope-mashup-32-rmx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope-mashup-32-rmx.png</image:loc>
       <image:title>Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot - Fractopia Kaleidoscope (MashUp 32 RMX) | Stims</image:title>
       <image:caption>Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot - Fractopia Kaleidoscope (MashUp 32 RMX) by Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10533,7 +10533,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope.png</image:loc>
       <image:title>Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot - Fractopia Kaleidoscope | Stims</image:title>
       <image:caption>Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot - Fractopia Kaleidoscope by Stahlregen &amp; AdamFx + Eo.S + Flexi + Geiss + Phat + Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10544,7 +10544,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-eo-s-geiss-fishbrain-prickly-abyss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-eo-s-geiss-fishbrain-prickly-abyss.png</image:loc>
       <image:title>Stahlregen &amp; Aderrasi + Eo.S + Geiss + fiShbRaiN - Prickly Abyss | Stims</image:title>
       <image:caption>Stahlregen &amp; Aderrasi + Eo.S + Geiss + fiShbRaiN - Prickly Abyss by Stahlregen &amp; Aderrasi + Eo.S + Geiss + fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10555,7 +10555,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-flexi-rovastar-telek-fractal-twist-a-feat-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-flexi-rovastar-telek-fractal-twist-a-feat-hexcollie.png</image:loc>
       <image:title>Stahlregen &amp; Aderrasi + Flexi + Rovastar + Telek - Fractal Twist (A feat hexcollie) | Stims</image:title>
       <image:caption>Stahlregen &amp; Aderrasi + Flexi + Rovastar + Telek - Fractal Twist (A feat hexcollie) by Stahlregen &amp; Aderrasi + Flexi + Rovastar + Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10566,7 +10566,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-flexi-rovastar-fractal-twist-a-feat-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-flexi-rovastar-fractal-twist-a-feat-hexcollie.png</image:loc>
       <image:title>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (A feat. hexcollie) | Stims</image:title>
       <image:caption>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (A feat. hexcollie) by Stahlregen &amp; Aderrasi + Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10577,7 +10577,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-flexi-rovastar-fractal-twist-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-flexi-rovastar-fractal-twist-b.png</image:loc>
       <image:title>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (B) | Stims</image:title>
       <image:caption>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (B) by Stahlregen &amp; Aderrasi + Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10588,7 +10588,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-flexi-rovastar-fractal-twist-g</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-flexi-rovastar-fractal-twist-g.png</image:loc>
       <image:title>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (G) | Stims</image:title>
       <image:caption>Stahlregen &amp; Aderrasi + Flexi + Rovastar - Fractal Twist (G) by Stahlregen &amp; Aderrasi + Flexi + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10599,7 +10599,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1.png</image:loc>
       <image:title>Stahlregen &amp; Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester′s Smashing Atoms RMX)_1 | Stims</image:title>
       <image:caption>Stahlregen &amp; Benski + Fvese + Geiss + Rovastar - Voyager Spark (Call Jester′s Smashing Atoms RMX)_1 by Stahlregen &amp; Benski + Fvese + Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10610,7 +10610,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-bmelgren-geiss-krash-pieturp-techno-zylot-mashup-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-bmelgren-geiss-krash-pieturp-techno-zylot-mashup-4.png</image:loc>
       <image:title>Stahlregen &amp; Bmelgren + Geiss + Krash + PieturP + TEcHno + Zylot - MashUp 4 | Stims</image:title>
       <image:caption>Stahlregen &amp; Bmelgren + Geiss + Krash + PieturP + TEcHno + Zylot - MashUp 4 by Stahlregen &amp; Bmelgren + Geiss + Krash + PieturP + TEcHno + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10621,7 +10621,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-relief-block-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-relief-block-mix.png</image:loc>
       <image:title>Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot - Machine Code (Relief Block Mix) | Stims</image:title>
       <image:caption>Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot - Machine Code (Relief Block Mix) by Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10632,7 +10632,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-jelly.png</image:loc>
       <image:title>Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot - Machine Code [Jelly] | Stims</image:title>
       <image:caption>Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot - Machine Code [Jelly] by Stahlregen &amp; Boz + Eo.S + Geiss + Phat + Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10643,7 +10643,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-che-geiss-illusion-unchained-shifty-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-che-geiss-illusion-unchained-shifty-jelly-v2.png</image:loc>
       <image:title>Stahlregen &amp; Che + Geiss + Illusion + Unchained - Shifty (Jelly V2) | Stims</image:title>
       <image:caption>Stahlregen &amp; Che + Geiss + Illusion + Unchained - Shifty (Jelly V2) by Stahlregen &amp; Che + Geiss + Illusion + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10654,7 +10654,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-eo-s-flexi-phat-rovastar-zylot-screenspace-fractopia-rmx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-eo-s-flexi-phat-rovastar-zylot-screenspace-fractopia-rmx.png</image:loc>
       <image:title>Stahlregen &amp; Eo.S + Flexi + Phat + Rovastar + Zylot - Screenspace (Fractopia RMX) | Stims</image:title>
       <image:caption>Stahlregen &amp; Eo.S + Flexi + Phat + Rovastar + Zylot - Screenspace (Fractopia RMX) by Stahlregen &amp; Eo.S + Flexi + Phat + Rovastar + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10665,7 +10665,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-eo-s-geiss-orb-phat-fruitsticks-flexi-tex-shader</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-eo-s-geiss-orb-phat-fruitsticks-flexi-tex-shader.png</image:loc>
       <image:title>Stahlregen &amp; Eo.S + Geiss + ORB + Phat - Fruitsticks (Flexi-Tex Shader) | Stims</image:title>
       <image:caption>Stahlregen &amp; Eo.S + Geiss + ORB + Phat - Fruitsticks (Flexi-Tex Shader) by Stahlregen &amp; Eo.S + Geiss + ORB + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10676,7 +10676,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-esotic-idiot24-7-rozzer-zylot-digital-heartbeat-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-esotic-idiot24-7-rozzer-zylot-digital-heartbeat-reverse-jelly-v3.png</image:loc>
       <image:title>Stahlregen &amp; Esotic + Idiot24-7 + Rozzer + Zylot - Digital Heartbeat (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Stahlregen &amp; Esotic + Idiot24-7 + Rozzer + Zylot - Digital Heartbeat (Reverse Jelly V3) by Stahlregen &amp; Esotic + Idiot24-7 + Rozzer + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10687,7 +10687,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-rovastar-unchained-blurred-echoes-reflecto-fucukp</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-rovastar-unchained-blurred-echoes-reflecto-fucukp.png</image:loc>
       <image:title>Stahlregen &amp; Flexi + Geiss + Rovastar + Unchained - Blurred Echoes (reflecto fucukp) | Stims</image:title>
       <image:caption>Stahlregen &amp; Flexi + Geiss + Rovastar + Unchained - Blurred Echoes (reflecto fucukp) by Stahlregen &amp; Flexi + Geiss + Rovastar + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10698,7 +10698,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-liquidity-dynamic-swirls</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-liquidity-dynamic-swirls.png</image:loc>
       <image:title>Stahlregen &amp; Flexi + Geiss - Liquidity (Dynamic Swirls) | Stims</image:title>
       <image:caption>Stahlregen &amp; Flexi + Geiss - Liquidity (Dynamic Swirls) by Stahlregen &amp; Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10709,7 +10709,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-tiger-no-5-random-texture-flow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-tiger-no-5-random-texture-flow.png</image:loc>
       <image:title>Stahlregen &amp; Flexi + Geiss - Tiger No.5 (Random texture flow) | Stims</image:title>
       <image:caption>Stahlregen &amp; Flexi + Geiss - Tiger No.5 (Random texture flow) by Stahlregen &amp; Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10720,7 +10720,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-eo-s-martin-rovastar-halcyon-jelly-skin</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-eo-s-martin-rovastar-halcyon-jelly-skin.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + Eo.S + Martin + Rovastar - Halcyon Jelly Skin | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + Eo.S + Martin + Rovastar - Halcyon Jelly Skin by Stahlregen &amp; Geiss + Eo.S + Martin + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10731,7 +10731,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-phat-studiomusic-rovastar-cataracts-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-phat-studiomusic-rovastar-cataracts-jelly-v2.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + Phat + StudioMusic + Rovastar - Cataracts (Jelly V2) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + Phat + StudioMusic + Rovastar - Cataracts (Jelly V2) by Stahlregen &amp; Geiss + Phat + StudioMusic + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10742,7 +10742,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-rovastar-illusion-krash-rozzor-cyclopean-shift-eyeless-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-rovastar-illusion-krash-rozzor-cyclopean-shift-eyeless-mix.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + Rovastar + Illusion + Krash + Rozzor - Cyclopean Shift (Eyeless Mix) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + Rovastar + Illusion + Krash + Rozzor - Cyclopean Shift (Eyeless Mix) by Stahlregen &amp; Geiss + Rovastar + Illusion + Krash + Rozzor, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10753,7 +10753,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-rovastar-fields-of-flowers-distorted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-rovastar-fields-of-flowers-distorted.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + Rovastar - Fields of Flowers (distorted) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + Rovastar - Fields of Flowers (distorted) by Stahlregen &amp; Geiss + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10764,7 +10764,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-tobiaswolfboi-space-gelatin-color-xplosion-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-tobiaswolfboi-space-gelatin-color-xplosion-2.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + TobiasWolfBoi - Space Gelatin (Color Xplosion 2) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + TobiasWolfBoi - Space Gelatin (Color Xplosion 2) by Stahlregen &amp; Geiss + TobiasWolfBoi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10775,7 +10775,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-tobiaswolfboi-space-gelatin-color-xplosion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-tobiaswolfboi-space-gelatin-color-xplosion.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + TobiasWolfBoi - Space Gelatin (Color Xplosion) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + TobiasWolfBoi - Space Gelatin (Color Xplosion) by Stahlregen &amp; Geiss + TobiasWolfBoi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10786,7 +10786,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-zylot-wall-of-glass-death-by-color-pox-filaments-rmx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-zylot-wall-of-glass-death-by-color-pox-filaments-rmx.png</image:loc>
       <image:title>Stahlregen &amp; Geiss + Zylot - Wall of Glass (Death by Color Pox Filaments RMX) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss + Zylot - Wall of Glass (Death by Color Pox Filaments RMX) by Stahlregen &amp; Geiss + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10797,7 +10797,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx.png</image:loc>
       <image:title>Stahlregen &amp; Geiss - MashUp 16 (Seizure-Inducing Confetti Kaleidoscope RMX) | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss - MashUp 16 (Seizure-Inducing Confetti Kaleidoscope RMX) by Stahlregen &amp; Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10808,7 +10808,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-tiger-no-5-seizure-inducing-confetti-kaleidoscope-rmx-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-tiger-no-5-seizure-inducing-confetti-kaleidoscope-rmx-2.png</image:loc>
       <image:title>Stahlregen &amp; Geiss - Tiger No.5 (Seizure-Inducing Confetti Kaleidoscope RMX)_2 | Stims</image:title>
       <image:caption>Stahlregen &amp; Geiss - Tiger No.5 (Seizure-Inducing Confetti Kaleidoscope RMX)_2 by Stahlregen &amp; Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10819,7 +10819,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-aderrasi-martin-rocke-rovastar-charmed-spun-sugar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-aderrasi-martin-rocke-rovastar-charmed-spun-sugar.png</image:loc>
       <image:title>Stahlregen &amp; aderrasi + martin + rocke + rovastar - Charmed Spun Sugar | Stims</image:title>
       <image:caption>Stahlregen &amp; aderrasi + martin + rocke + rovastar - Charmed Spun Sugar by Stahlregen &amp; aderrasi + martin + rocke + rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10830,7 +10830,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-baked-geiss-krash-washing-machine-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-baked-geiss-krash-washing-machine-v2.png</image:loc>
       <image:title>Stahlregen &amp; baked + Geiss + Krash - Washing Machine (V2) | Stims</image:title>
       <image:caption>Stahlregen &amp; baked + Geiss + Krash - Washing Machine (V2) by Stahlregen &amp; baked + Geiss + Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10841,7 +10841,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-bdrv-fishbrain-flexi-geiss-shifter-starcraft-distorted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-bdrv-fishbrain-flexi-geiss-shifter-starcraft-distorted.png</image:loc>
       <image:title>Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter - Starcraft (Distorted) | Stims</image:title>
       <image:caption>Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter - Starcraft (Distorted) by Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10852,7 +10852,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-bdrv-fishbrain-flexi-geiss-shifter-starcraft-hyperion-rmx-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-bdrv-fishbrain-flexi-geiss-shifter-starcraft-hyperion-rmx-v3.png</image:loc>
       <image:title>Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter - Starcraft (Hyperion RMX V3) | Stims</image:title>
       <image:caption>Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter - Starcraft (Hyperion RMX V3) by Stahlregen &amp; bdrv + fiSHbRAiN + flexi + Geiss + shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10863,7 +10863,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-beetle-relief-mix-reverse-jelly-2c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-beetle-relief-mix-reverse-jelly-2c.png</image:loc>
       <image:title>Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter - Stonecraft (Beetle Relief mix) (Reverse Jelly 2c) | Stims</image:title>
       <image:caption>Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter - Stonecraft (Beetle Relief mix) (Reverse Jelly 2c) by Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10874,7 +10874,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-beetle-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-beetle-relief-mix.png</image:loc>
       <image:title>Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter - Stonecraft (Beetle Relief mix) | Stims</image:title>
       <image:caption>Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter - Stonecraft (Beetle Relief mix) by Stahlregen &amp; fiSHbRaiN + flexi + Geiss + shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10885,7 +10885,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-fishbrain-flexi-geiss-the-machine-that-conquered-the-aether</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-fishbrain-flexi-geiss-the-machine-that-conquered-the-aether.png</image:loc>
       <image:title>Stahlregen &amp; fishbrain + flexi + geiss - The Machine that conquered the Aether | Stims</image:title>
       <image:caption>Stahlregen &amp; fishbrain + flexi + geiss - The Machine that conquered the Aether by Stahlregen &amp; fishbrain + flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10896,7 +10896,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-fishbrain-geiss-martin-flowercraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-fishbrain-geiss-martin-flowercraft.png</image:loc>
       <image:title>Stahlregen &amp; fishbrain + geiss + martin  - Flowercraft | Stims</image:title>
       <image:caption>Stahlregen &amp; fishbrain + geiss + martin  - Flowercraft by Stahlregen &amp; fishbrain + geiss + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10907,7 +10907,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-mashup-25-mash0000-engage-the-mind-in-dissolving-crusts</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-mashup-25-mash0000-engage-the-mind-in-dissolving-crusts.png</image:loc>
       <image:title>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Even More Fractals for Hexcollie (MashUp 25) - mash0000 - engage the mind in dissolving crusts | Stims</image:title>
       <image:caption>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Even More Fractals for Hexcollie (MashUp 25) - mash0000 - engage the mind in dissolving crusts by Stahlregen &amp; flexi + Geiss + Rovastar + Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10918,7 +10918,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-reflecto-fcukup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-reflecto-fcukup.png</image:loc>
       <image:title>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Even More Fractals for Hexcollie (Reflecto Fcukup) | Stims</image:title>
       <image:caption>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Even More Fractals for Hexcollie (Reflecto Fcukup) by Stahlregen &amp; flexi + Geiss + Rovastar + Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10929,7 +10929,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-rovastar-shifter-fractal-feedback-for-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-rovastar-shifter-fractal-feedback-for-hexcollie.png</image:loc>
       <image:title>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Fractal Feedback (for Hexcollie) | Stims</image:title>
       <image:caption>Stahlregen &amp; flexi + Geiss + Rovastar + Shifter - Fractal Feedback (for Hexcollie) by Stahlregen &amp; flexi + Geiss + Rovastar + Shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10940,7 +10940,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics.png</image:loc>
       <image:title>Stahlregen &amp; flexi + Geiss + martin + Rovastar - Tides (martin′s metallics) | Stims</image:title>
       <image:caption>Stahlregen &amp; flexi + Geiss + martin + Rovastar - Tides (martin′s metallics) by Stahlregen &amp; flexi + Geiss + martin + Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10951,7 +10951,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-dots-layered</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-dots-layered.png</image:loc>
       <image:title>Stahlregen + Flexi - dots (layered) | Stims</image:title>
       <image:caption>Stahlregen + Flexi - dots (layered) by Stahlregen + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10962,7 +10962,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-gimme-color-bubble-spinner-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-gimme-color-bubble-spinner-mix.png</image:loc>
       <image:title>Stahlregen + Flexi - gimme color (Bubble Spinner Mix) | Stims</image:title>
       <image:caption>Stahlregen + Flexi - gimme color (Bubble Spinner Mix) by Stahlregen + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10973,7 +10973,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-psychotic-flower-gelatine-burst</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-psychotic-flower-gelatine-burst.png</image:loc>
       <image:title>Stahlregen + Flexi - psychotic flower gelatine burst | Stims</image:title>
       <image:caption>Stahlregen + Flexi - psychotic flower gelatine burst by Stahlregen + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10984,7 +10984,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-martin-ouboros-metal-finish-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-martin-ouboros-metal-finish-2.png</image:loc>
       <image:title>Stahlregen + Geiss + Martin - Ouboros (Metal Finish 2) | Stims</image:title>
       <image:caption>Stahlregen + Geiss + Martin - Ouboros (Metal Finish 2) by Stahlregen + Geiss + Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -10995,7 +10995,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess.png</image:loc>
       <image:title>Stahlregen + Geiss - Old school, baby (Flower V2)_1 - lack-of-torture torture mess | Stims</image:title>
       <image:caption>Stahlregen + Geiss - Old school, baby (Flower V2)_1 - lack-of-torture torture mess by Stahlregen + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>

--- a/public/sitemap-3.xml
+++ b/public/sitemap-3.xml
@@ -6,7 +6,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-old-school-baby-flower-v2-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-old-school-baby-flower-v2-1.png</image:loc>
       <image:title>Stahlregen + Geiss - Old school, baby (Flower V2)_1 | Stims</image:title>
       <image:caption>Stahlregen + Geiss - Old school, baby (Flower V2)_1 by Stahlregen + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -17,7 +17,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-unchained-psychedelic-flower-kung-fu-corrupt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-unchained-psychedelic-flower-kung-fu-corrupt.png</image:loc>
       <image:title>Stahlregen + Unchained - Psychedelic Flower Kung Fu (Corrupt) | Stims</image:title>
       <image:caption>Stahlregen + Unchained - Psychedelic Flower Kung Fu (Corrupt) by Stahlregen + Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -28,7 +28,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-martin-others-psychedelic-metal-flower</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-martin-others-psychedelic-metal-flower.png</image:loc>
       <image:title>Stahlregen + martin + others - Psychedelic Metal Flower | Stims</image:title>
       <image:caption>Stahlregen + martin + others - Psychedelic Metal Flower by Stahlregen + martin + others, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -39,7 +39,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-dots-pixels-blocky-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-dots-pixels-blocky-jelly-v2.png</image:loc>
       <image:title>Stahlregen - Dots (Pixels - Blocky) (Jelly V2) | Stims</image:title>
       <image:caption>Stahlregen - Dots (Pixels - Blocky) (Jelly V2) by Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -50,7 +50,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-dots-pixels-blocky-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-dots-pixels-blocky-reverse-jelly-v3.png</image:loc>
       <image:title>Stahlregen - Dots (Pixels - Blocky) (Reverse Jelly V3) | Stims</image:title>
       <image:caption>Stahlregen - Dots (Pixels - Blocky) (Reverse Jelly V3) by Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -61,7 +61,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-old-school-baby-spiral-ornament-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-old-school-baby-spiral-ornament-1.png</image:loc>
       <image:title>Stahlregen - Old school, baby (Spiral Ornament)_1 | Stims</image:title>
       <image:caption>Stahlregen - Old school, baby (Spiral Ornament)_1 by Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -72,7 +72,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-old-school-baby-spiral-ornament-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-old-school-baby-spiral-ornament-2.png</image:loc>
       <image:title>Stahlregen - Old school, baby (Spiral Ornament)_2 | Stims</image:title>
       <image:caption>Stahlregen - Old school, baby (Spiral Ornament)_2 by Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -83,7 +83,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-spiral-beats-fluctuating-flowers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-spiral-beats-fluctuating-flowers.png</image:loc>
       <image:title>Stahlregen - Spiral Beats (Fluctuating Flowers) | Stims</image:title>
       <image:caption>Stahlregen - Spiral Beats (Fluctuating Flowers) by Stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -94,7 +94,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=studio-music-cherished-desires</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/studio-music-cherished-desires.png</image:loc>
       <image:title>Studio Music - Cherished Desires | Stims</image:title>
       <image:caption>Studio Music - Cherished Desires by Studio Music, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -105,7 +105,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=studio-music-personification</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/studio-music-personification.png</image:loc>
       <image:title>Studio Music - Personification | Stims</image:title>
       <image:caption>Studio Music - Personification by Studio Music, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -116,7 +116,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=studio-music-and-unchained-rapid-alteration</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/studio-music-and-unchained-rapid-alteration.png</image:loc>
       <image:title>Studio Music and Unchained - Rapid Alteration | Stims</image:title>
       <image:caption>Studio Music and Unchained - Rapid Alteration by Studio Music and Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -127,7 +127,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stuttler-lsd-bloom</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stuttler-lsd-bloom.png</image:loc>
       <image:title>Stuttler - LSD Bloom | Stims</image:title>
       <image:caption>Stuttler - LSD Bloom by Stuttler, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -138,7 +138,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=techno-sandstorm-psychodelic-highway</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/techno-sandstorm-psychodelic-highway.png</image:loc>
       <image:title>TEcHNO &amp; SandStorm - Psychodelic Highway | Stims</image:title>
       <image:caption>TEcHNO &amp; SandStorm - Psychodelic Highway by TEcHNO &amp; SandStorm, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -149,7 +149,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tag-cradle-of-life-remix-of-yin-315</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tag-cradle-of-life-remix-of-yin-315.png</image:loc>
       <image:title>Tag - Cradle of Life(remix of yin 315) | Stims</image:title>
       <image:caption>Tag - Cradle of Life(remix of yin 315) by Tag, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -160,7 +160,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=telek-city-helix-lattice</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/telek-city-helix-lattice.png</image:loc>
       <image:title>Telek - City Helix Lattice | Stims</image:title>
       <image:caption>Telek - City Helix Lattice by Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -171,7 +171,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=telek-sine-wave</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/telek-sine-wave.png</image:loc>
       <image:title>Telek - Sine Wave | Stims</image:title>
       <image:caption>Telek - Sine Wave by Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -182,7 +182,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=telek-slow-thing-spiderman-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/telek-slow-thing-spiderman-mix.png</image:loc>
       <image:title>Telek - Slow Thing (Spiderman Mix) | Stims</image:title>
       <image:caption>Telek - Slow Thing (Spiderman Mix) by Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -193,7 +193,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tobiaswolfboi-the-pit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tobiaswolfboi-the-pit.png</image:loc>
       <image:title>TobiasWolfBoi - The Pit | Stims</image:title>
       <image:caption>TobiasWolfBoi - The Pit by TobiasWolfBoi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -204,7 +204,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tokyo-corridor-shifter-tumbling-cubes-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tokyo-corridor-shifter-tumbling-cubes-remix.png</image:loc>
       <image:title>Tokyo corridor (shifter tumbling cubes remix) | Stims</image:title>
       <image:caption>Tokyo corridor (shifter tumbling cubes remix), a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -215,7 +215,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tonymilkdrop-leonardo-da-vinci-s-balloon-flexi-merry-go-round-techstyle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tonymilkdrop-leonardo-da-vinci-s-balloon-flexi-merry-go-round-techstyle.png</image:loc>
       <image:title>TonyMilkdrop - Leonardo Da Vinci&apos;s Balloon [Flexi - merry-go-round + techstyle] | Stims</image:title>
       <image:caption>TonyMilkdrop - Leonardo Da Vinci&apos;s Balloon [Flexi - merry-go-round + techstyle] by TonyMilkdrop, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -226,7 +226,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tonymilkdrop-magellan-s-nebula-flexi-fancy-this-shall-not-retain</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tonymilkdrop-magellan-s-nebula-flexi-fancy-this-shall-not-retain.png</image:loc>
       <image:title>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - fancy + $this shall not retain] | Stims</image:title>
       <image:caption>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - fancy + $this shall not retain] by TonyMilkdrop, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -237,7 +237,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tonymilkdrop-magellan-s-nebula-flexi-grind-this-shall-not-retain</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tonymilkdrop-magellan-s-nebula-flexi-grind-this-shall-not-retain.png</image:loc>
       <image:title>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - grind + $this shall not retain] | Stims</image:title>
       <image:caption>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - grind + $this shall not retain] by TonyMilkdrop, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -248,7 +248,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tonymilkdrop-magellan-s-nebula-flexi-you-enter-first-multiverse</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tonymilkdrop-magellan-s-nebula-flexi-you-enter-first-multiverse.png</image:loc>
       <image:title>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - you enter first + multiverse] | Stims</image:title>
       <image:caption>TonyMilkdrop - Magellan&apos;s Nebula [Flexi - you enter first + multiverse] by TonyMilkdrop, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -259,7 +259,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tripgnosis-antimatter-streams</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tripgnosis-antimatter-streams.png</image:loc>
       <image:title>Tripgnosis - Antimatter Streams | Stims</image:title>
       <image:caption>Tripgnosis - Antimatter Streams by Tripgnosis, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -270,7 +270,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tripgnosis-negative-photon-burn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tripgnosis-negative-photon-burn.png</image:loc>
       <image:title>Tripgnosis - Negative Photon Burn | Stims</image:title>
       <image:caption>Tripgnosis - Negative Photon Burn by Tripgnosis, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -281,7 +281,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tripgnosis-spunn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tripgnosis-spunn.png</image:loc>
       <image:title>Tripgnosis - spunn | Stims</image:title>
       <image:caption>Tripgnosis - spunn by Tripgnosis, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -292,7 +292,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=tschoey-music-flower</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/tschoey-music-flower.png</image:loc>
       <image:title>Tschoey - Music Flower | Stims</image:title>
       <image:caption>Tschoey - Music Flower by Tschoey, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -303,7 +303,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rovastar-luckless</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rovastar-luckless.png</image:loc>
       <image:title>Unchained &amp; Rovastar - Luckless | Stims</image:title>
       <image:caption>Unchained &amp; Rovastar - Luckless by Unchained &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -314,7 +314,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rovastar-rainbow-obscura</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rovastar-rainbow-obscura.png</image:loc>
       <image:title>Unchained &amp; Rovastar - Rainbow Obscura | Stims</image:title>
       <image:caption>Unchained &amp; Rovastar - Rainbow Obscura by Unchained &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -325,7 +325,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rovastar-waves-of-waves</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rovastar-waves-of-waves.png</image:loc>
       <image:title>Unchained &amp; Rovastar - Waves Of Waves | Stims</image:title>
       <image:caption>Unchained &amp; Rovastar - Waves Of Waves by Unchained &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -336,7 +336,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rovastar-wormhole-pillars-hall-of-shadows-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rovastar-wormhole-pillars-hall-of-shadows-mix.png</image:loc>
       <image:title>Unchained &amp; Rovastar - Wormhole Pillars (Hall of Shadows mix) | Stims</image:title>
       <image:caption>Unchained &amp; Rovastar - Wormhole Pillars (Hall of Shadows mix) by Unchained &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -347,7 +347,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rovastar-xen-traffic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rovastar-xen-traffic.png</image:loc>
       <image:title>Unchained &amp; Rovastar - Xen Traffic | Stims</image:title>
       <image:caption>Unchained &amp; Rovastar - Xen Traffic by Unchained &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -358,7 +358,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-geiss-furious-spirals-blur-and-glow-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-geiss-furious-spirals-blur-and-glow-remix.png</image:loc>
       <image:title>Unchained + Geiss - Furious Spirals (Blur and Glow Remix) | Stims</image:title>
       <image:caption>Unchained + Geiss - Furious Spirals (Blur and Glow Remix) by Unchained + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -369,7 +369,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-geiss-furious-spirals-canvas-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-geiss-furious-spirals-canvas-mix.png</image:loc>
       <image:title>Unchained + Geiss - Furious Spirals (Canvas Mix) | Stims</image:title>
       <image:caption>Unchained + Geiss - Furious Spirals (Canvas Mix) by Unchained + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -380,7 +380,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-all-you-can-eat</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-all-you-can-eat.png</image:loc>
       <image:title>Unchained - All You Can Eat | Stims</image:title>
       <image:caption>Unchained - All You Can Eat by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -391,7 +391,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beat-demo-demonology-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beat-demo-demonology-mix.png</image:loc>
       <image:title>Unchained - Beat Demo (Demonology Mix) | Stims</image:title>
       <image:caption>Unchained - Beat Demo (Demonology Mix) by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -402,7 +402,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beat-demo-1-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beat-demo-1-0.png</image:loc>
       <image:title>Unchained - Beat Demo 1.0 | Stims</image:title>
       <image:caption>Unchained - Beat Demo 1.0 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -413,7 +413,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beat-demo-2-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beat-demo-2-1.png</image:loc>
       <image:title>Unchained - Beat Demo 2.1 | Stims</image:title>
       <image:caption>Unchained - Beat Demo 2.1 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -424,7 +424,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beat-demo-2-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beat-demo-2-4.png</image:loc>
       <image:title>Unchained - Beat Demo 2.4 | Stims</image:title>
       <image:caption>Unchained - Beat Demo 2.4 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -435,7 +435,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beat-demo-2-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beat-demo-2-5.png</image:loc>
       <image:title>Unchained - Beat Demo 2.5 | Stims</image:title>
       <image:caption>Unchained - Beat Demo 2.5 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -446,7 +446,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-beyond-the-strife-nexus</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-beyond-the-strife-nexus.png</image:loc>
       <image:title>Unchained - Beyond The Strife Nexus | Stims</image:title>
       <image:caption>Unchained - Beyond The Strife Nexus by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -457,7 +457,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-cartoon-factory</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-cartoon-factory.png</image:loc>
       <image:title>Unchained - Cartoon Factory | Stims</image:title>
       <image:caption>Unchained - Cartoon Factory by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -468,7 +468,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-cranked-on-failure</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-cranked-on-failure.png</image:loc>
       <image:title>Unchained - Cranked On Failure | Stims</image:title>
       <image:caption>Unchained - Cranked On Failure by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -479,7 +479,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-custom-gramatix-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-custom-gramatix-remix.png</image:loc>
       <image:title>Unchained - Custom Gramatix (Remix) | Stims</image:title>
       <image:caption>Unchained - Custom Gramatix (Remix) by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -490,7 +490,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-demonology</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-demonology.png</image:loc>
       <image:title>Unchained - Demonology | Stims</image:title>
       <image:caption>Unchained - Demonology by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -501,7 +501,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-free-to-feel-valium-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-free-to-feel-valium-remix.png</image:loc>
       <image:title>Unchained - Free to Feel (Valium Remix) | Stims</image:title>
       <image:caption>Unchained - Free to Feel (Valium Remix) by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -512,7 +512,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-furious-spirals-remix-radial-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-furious-spirals-remix-radial-blur.png</image:loc>
       <image:title>Unchained - Furious Spirals (Remix) Radial Blur | Stims</image:title>
       <image:caption>Unchained - Furious Spirals (Remix) Radial Blur by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -523,7 +523,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-furious-spirals-remix-steady</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-furious-spirals-remix-steady.png</image:loc>
       <image:title>Unchained - Furious Spirals (Remix) Steady | Stims</image:title>
       <image:caption>Unchained - Furious Spirals (Remix) Steady by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -534,7 +534,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-fuzzy-sciences</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-fuzzy-sciences.png</image:loc>
       <image:title>Unchained - Fuzzy Sciences | Stims</image:title>
       <image:caption>Unchained - Fuzzy Sciences by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -545,7 +545,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-ghostlight-whisper</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-ghostlight-whisper.png</image:loc>
       <image:title>Unchained - Ghostlight Whisper | Stims</image:title>
       <image:caption>Unchained - Ghostlight Whisper by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -556,7 +556,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-goofy-beat-detection</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-goofy-beat-detection.png</image:loc>
       <image:title>Unchained - Goofy Beat Detection | Stims</image:title>
       <image:caption>Unchained - Goofy Beat Detection by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -567,7 +567,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-hard-science</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-hard-science.png</image:loc>
       <image:title>Unchained - Hard Science | Stims</image:title>
       <image:caption>Unchained - Hard Science by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -578,7 +578,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-housed-in-a-childish-mind</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-housed-in-a-childish-mind.png</image:loc>
       <image:title>Unchained - Housed In A Childish Mind | Stims</image:title>
       <image:caption>Unchained - Housed In A Childish Mind by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -589,7 +589,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-in-memory-of-peg</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-in-memory-of-peg.png</image:loc>
       <image:title>Unchained - In Memory Of Peg | Stims</image:title>
       <image:caption>Unchained - In Memory Of Peg by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -600,7 +600,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-jaded-emotion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-jaded-emotion.png</image:loc>
       <image:title>Unchained - Jaded Emotion | Stims</image:title>
       <image:caption>Unchained - Jaded Emotion by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -611,7 +611,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-making-a-science-of-it-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-making-a-science-of-it-2.png</image:loc>
       <image:title>Unchained - Making a Science of It 2 | Stims</image:title>
       <image:caption>Unchained - Making a Science of It 2 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -622,7 +622,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-making-a-science-of-it-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-making-a-science-of-it-3.png</image:loc>
       <image:title>Unchained - Making a Science of It 3 | Stims</image:title>
       <image:caption>Unchained - Making a Science of It 3 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -633,7 +633,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-making-a-science-of-it-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-making-a-science-of-it-4.png</image:loc>
       <image:title>Unchained - Making a Science of It 4 | Stims</image:title>
       <image:caption>Unchained - Making a Science of It 4 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -644,7 +644,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-making-a-science-of-it-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-making-a-science-of-it-7.png</image:loc>
       <image:title>Unchained - Making a Science of It 7 | Stims</image:title>
       <image:caption>Unchained - Making a Science of It 7 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -655,7 +655,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-making-a-science-of-it</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-making-a-science-of-it.png</image:loc>
       <image:title>Unchained - Making a Science of It | Stims</image:title>
       <image:caption>Unchained - Making a Science of It by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -666,7 +666,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-morat-s-final-voyage</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-morat-s-final-voyage.png</image:loc>
       <image:title>Unchained - Morat′s Final Voyage | Stims</image:title>
       <image:caption>Unchained - Morat′s Final Voyage by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -677,7 +677,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-not-as-fun-as-it-looks</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-not-as-fun-as-it-looks.png</image:loc>
       <image:title>Unchained - Not As Fun As It Looks | Stims</image:title>
       <image:caption>Unchained - Not As Fun As It Looks by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -688,7 +688,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-painful-plasma-multi-wave-mirrored-rage-rozzor-triangle-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-painful-plasma-multi-wave-mirrored-rage-rozzor-triangle-tweak.png</image:loc>
       <image:title>Unchained - Painful Plasma (Multi-Wave Mirrored Rage) -- Rozzor triangle tweak | Stims</image:title>
       <image:caption>Unchained - Painful Plasma (Multi-Wave Mirrored Rage) -- Rozzor triangle tweak by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -699,7 +699,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-perverted-dialect</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-perverted-dialect.png</image:loc>
       <image:title>Unchained - Perverted Dialect | Stims</image:title>
       <image:caption>Unchained - Perverted Dialect by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -710,7 +710,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-picture-of-exile</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-picture-of-exile.png</image:loc>
       <image:title>Unchained - Picture Of Exile | Stims</image:title>
       <image:caption>Unchained - Picture Of Exile by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -721,7 +721,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-picture-of-poison</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-picture-of-poison.png</image:loc>
       <image:title>Unchained - Picture Of Poison | Stims</image:title>
       <image:caption>Unchained - Picture Of Poison by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -732,7 +732,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-quine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-quine.png</image:loc>
       <image:title>Unchained - Quine | Stims</image:title>
       <image:caption>Unchained - Quine by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -743,7 +743,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-reawoke</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-reawoke.png</image:loc>
       <image:title>Unchained - ReAwoke | Stims</image:title>
       <image:caption>Unchained - ReAwoke by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -754,7 +754,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-rewop</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-rewop.png</image:loc>
       <image:title>Unchained - Rewop | Stims</image:title>
       <image:caption>Unchained - Rewop by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -765,7 +765,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-ribald-ballad</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-ribald-ballad.png</image:loc>
       <image:title>Unchained - Ribald Ballad | Stims</image:title>
       <image:caption>Unchained - Ribald Ballad by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -776,7 +776,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-scientific-dance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-scientific-dance.png</image:loc>
       <image:title>Unchained - Scientific Dance | Stims</image:title>
       <image:caption>Unchained - Scientific Dance by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -787,7 +787,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-scientific-shapes-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-scientific-shapes-2.png</image:loc>
       <image:title>Unchained - Scientific Shapes 2 | Stims</image:title>
       <image:caption>Unchained - Scientific Shapes 2 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -798,7 +798,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-spinal-mixdown-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-spinal-mixdown-2.png</image:loc>
       <image:title>Unchained - Spinal Mixdown 2 | Stims</image:title>
       <image:caption>Unchained - Spinal Mixdown 2 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -809,7 +809,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-subjective-experience-of-the-manifold</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-subjective-experience-of-the-manifold.png</image:loc>
       <image:title>Unchained - Subjective Experience Of The Manifold | Stims</image:title>
       <image:caption>Unchained - Subjective Experience Of The Manifold by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -820,7 +820,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-those-who-doubted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-those-who-doubted.png</image:loc>
       <image:title>Unchained - Those Who Doubted | Stims</image:title>
       <image:caption>Unchained - Those Who Doubted by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -831,7 +831,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-unclaimed-wreckage-2-hemi-sync</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-unclaimed-wreckage-2-hemi-sync.png</image:loc>
       <image:title>Unchained - Unclaimed Wreckage 2 (Hemi-Sync) | Stims</image:title>
       <image:caption>Unchained - Unclaimed Wreckage 2 (Hemi-Sync) by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -842,7 +842,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-unclaimed-wreckage-2-sub-spinal-daemon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-unclaimed-wreckage-2-sub-spinal-daemon.png</image:loc>
       <image:title>Unchained - Unclaimed Wreckage 2 (Sub-Spinal Daemon) | Stims</image:title>
       <image:caption>Unchained - Unclaimed Wreckage 2 (Sub-Spinal Daemon) by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -853,7 +853,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-unified-drag-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-unified-drag-2.png</image:loc>
       <image:title>Unchained - Unified Drag 2 | Stims</image:title>
       <image:caption>Unchained - Unified Drag 2 by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -864,7 +864,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-unified-drag</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-unified-drag.png</image:loc>
       <image:title>Unchained - Unified Drag | Stims</image:title>
       <image:caption>Unchained - Unified Drag by Unchained, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -875,7 +875,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-vs-rovastar-tripmaker-floral-overload-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-vs-rovastar-tripmaker-floral-overload-2.png</image:loc>
       <image:title>Unchained vs Rovastar - Tripmaker (Floral Overload 2) | Stims</image:title>
       <image:caption>Unchained vs Rovastar - Tripmaker (Floral Overload 2) by Unchained vs Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -886,7 +886,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-vs-rovastar-vs-zylot-tripmaker-trip-machine-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-vs-rovastar-vs-zylot-tripmaker-trip-machine-v3.png</image:loc>
       <image:title>Unchained vs Rovastar vs Zylot - Tripmaker (Trip Machine v3) | Stims</image:title>
       <image:caption>Unchained vs Rovastar vs Zylot - Tripmaker (Trip Machine v3) by Unchained vs Rovastar vs Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -897,7 +897,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=unchained-vs-rovastar-vs-zylot-tripmaker-trip-machine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/unchained-vs-rovastar-vs-zylot-tripmaker-trip-machine.png</image:loc>
       <image:title>Unchained vs Rovastar vs Zylot - Tripmaker (Trip machine) | Stims</image:title>
       <image:caption>Unchained vs Rovastar vs Zylot - Tripmaker (Trip machine) by Unchained vs Rovastar vs Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -908,7 +908,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=valhala-core</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/valhala-core.png</image:loc>
       <image:title>Valhala - Core | Stims</image:title>
       <image:caption>Valhala - Core by Valhala, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -919,7 +919,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=various-fire-and-brimstone</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/various-fire-and-brimstone.png</image:loc>
       <image:title>Various - Fire and Brimstone | Stims</image:title>
       <image:caption>Various - Fire and Brimstone by Various, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -930,7 +930,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=various-artists-goo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/various-artists-goo.png</image:loc>
       <image:title>Various artists - Goo | Stims</image:title>
       <image:caption>Various artists - Goo by Various artists, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -941,7 +941,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=vovan-geiss-bass-with-flover-feedback-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/vovan-geiss-bass-with-flover-feedback-mix.png</image:loc>
       <image:title>Vovan + Geiss - Bass With Flover (Feedback Mix) | Stims</image:title>
       <image:caption>Vovan + Geiss - Bass With Flover (Feedback Mix) by Vovan + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -952,7 +952,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=wulfson-crumple-nth-power-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/wulfson-crumple-nth-power-mix.png</image:loc>
       <image:title>Wulfson - Crumple (Nth Power Mix) | Stims</image:title>
       <image:caption>Wulfson - Crumple (Nth Power Mix) by Wulfson, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -963,7 +963,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-idiot-face-bdrv-et-al-rmx-ketama-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-idiot-face-bdrv-et-al-rmx-ketama-mix.png</image:loc>
       <image:title>Zylot &amp; Idiot - Face BDRV et  AL  rmx ketama mix | Stims</image:title>
       <image:caption>Zylot &amp; Idiot - Face BDRV et  AL  rmx ketama mix by Zylot &amp; Idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -974,7 +974,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-idiot24-7-unknown-power-source</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-idiot24-7-unknown-power-source.png</image:loc>
       <image:title>Zylot &amp; Idiot24-7 - Unknown Power Source | Stims</image:title>
       <image:caption>Zylot &amp; Idiot24-7 - Unknown Power Source by Zylot &amp; Idiot24-7, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -985,7 +985,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-krash-snowflake-halo-ice-cube-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-krash-snowflake-halo-ice-cube-mix.png</image:loc>
       <image:title>Zylot &amp; Krash - Snowflake Halo (Ice Cube mix) | Stims</image:title>
       <image:caption>Zylot &amp; Krash - Snowflake Halo (Ice Cube mix) by Zylot &amp; Krash, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -996,7 +996,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-rovastar-a-million-miles-from-earth-fog-of-time-mix-vessel-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-rovastar-a-million-miles-from-earth-fog-of-time-mix-vessel-remix.png</image:loc>
       <image:title>Zylot &amp; Rovastar - A Million Miles From Earth (Fog Of Time Mix (Vessel reMix) ) | Stims</image:title>
       <image:caption>Zylot &amp; Rovastar - A Million Miles From Earth (Fog Of Time Mix (Vessel reMix) ) by Zylot &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1007,7 +1007,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-rovastar-sully-s-trip-the-worstest-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-rovastar-sully-s-trip-the-worstest-mix.png</image:loc>
       <image:title>Zylot &amp; Rovastar - Sully′s Trip (The Worstest Mix) | Stims</image:title>
       <image:caption>Zylot &amp; Rovastar - Sully′s Trip (The Worstest Mix) by Zylot &amp; Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1018,7 +1018,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-geiss-enlightenment</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-geiss-enlightenment.png</image:loc>
       <image:title>Zylot + Geiss - Enlightenment | Stims</image:title>
       <image:caption>Zylot + Geiss - Enlightenment by Zylot + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1029,7 +1029,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-age-of-science-seeking-truth-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-age-of-science-seeking-truth-mix.png</image:loc>
       <image:title>Zylot - Age of Science (seeking truth mix) | Stims</image:title>
       <image:caption>Zylot - Age of Science (seeking truth mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1040,7 +1040,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-block-of-sound-abstract-architecture-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-block-of-sound-abstract-architecture-mix.png</image:loc>
       <image:title>Zylot - Block Of Sound (Abstract Architecture Mix) | Stims</image:title>
       <image:caption>Zylot - Block Of Sound (Abstract Architecture Mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1051,7 +1051,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-building-block-of-color-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-building-block-of-color-bitcore-tweak.png</image:loc>
       <image:title>Zylot - Building Block of color - Bitcore Tweak | Stims</image:title>
       <image:caption>Zylot - Building Block of color - Bitcore Tweak by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1062,7 +1062,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-crosshair-dimension-light-of-ages</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-crosshair-dimension-light-of-ages.png</image:loc>
       <image:title>Zylot - Crosshair Dimension (Light of Ages) | Stims</image:title>
       <image:caption>Zylot - Crosshair Dimension (Light of Ages) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1073,7 +1073,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-crossing-over-geiss-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-crossing-over-geiss-tweak.png</image:loc>
       <image:title>Zylot - Crossing Over (Geiss Tweak) | Stims</image:title>
       <image:caption>Zylot - Crossing Over (Geiss Tweak) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1084,7 +1084,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-crossing-over-paint-spatter-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-crossing-over-paint-spatter-mix.png</image:loc>
       <image:title>Zylot - Crossing Over (Paint Spatter mix) | Stims</image:title>
       <image:caption>Zylot - Crossing Over (Paint Spatter mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1095,7 +1095,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-digiscape-advanced-processor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-digiscape-advanced-processor.png</image:loc>
       <image:title>Zylot - Digiscape Advanced Processor | Stims</image:title>
       <image:caption>Zylot - Digiscape Advanced Processor by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1106,7 +1106,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-flight-of-harrier-white-world-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-flight-of-harrier-white-world-mix.png</image:loc>
       <image:title>Zylot - Flight Of Harrier (White World Mix) | Stims</image:title>
       <image:caption>Zylot - Flight Of Harrier (White World Mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1117,7 +1117,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-funnels</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-funnels.png</image:loc>
       <image:title>Zylot - Funnels | Stims</image:title>
       <image:caption>Zylot - Funnels by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1128,7 +1128,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-heaven-bloom-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-heaven-bloom-nz.png</image:loc>
       <image:title>Zylot - Heaven Bloom nz+ | Stims</image:title>
       <image:caption>Zylot - Heaven Bloom nz+ by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1139,7 +1139,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-in-death-there-is-life-dancing-lights-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-in-death-there-is-life-dancing-lights-mix.png</image:loc>
       <image:title>Zylot - In death there is life (Dancing Lights mix) | Stims</image:title>
       <image:caption>Zylot - In death there is life (Dancing Lights mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1150,7 +1150,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-in-death-there-is-life-geiss-layered-mix-jelly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-in-death-there-is-life-geiss-layered-mix-jelly.png</image:loc>
       <image:title>Zylot - In death there is life (Geiss Layered Mix) (Jelly) | Stims</image:title>
       <image:caption>Zylot - In death there is life (Geiss Layered Mix) (Jelly) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1161,7 +1161,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-in-death-there-is-life-geiss-layered-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-in-death-there-is-life-geiss-layered-mix.png</image:loc>
       <image:title>Zylot - In death there is life (Geiss Layered Mix) | Stims</image:title>
       <image:caption>Zylot - In death there is life (Geiss Layered Mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1172,7 +1172,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-in-death-there-is-life-surface-reflection-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-in-death-there-is-life-surface-reflection-mix.png</image:loc>
       <image:title>Zylot - In death there is life (surface reflection mix) | Stims</image:title>
       <image:caption>Zylot - In death there is life (surface reflection mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1183,7 +1183,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-magma-crawl</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-magma-crawl.png</image:loc>
       <image:title>Zylot - Magma Crawl | Stims</image:title>
       <image:caption>Zylot - Magma Crawl by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1194,7 +1194,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-paint-spill-music-reactive-paint-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-paint-spill-music-reactive-paint-mix.png</image:loc>
       <image:title>Zylot - Paint Spill (Music Reactive Paint Mix) | Stims</image:title>
       <image:caption>Zylot - Paint Spill (Music Reactive Paint Mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1205,7 +1205,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-rush</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-rush.png</image:loc>
       <image:title>Zylot - Rush | Stims</image:title>
       <image:caption>Zylot - Rush by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1216,7 +1216,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-spiral-hypnotic-phat-double-spiral-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-spiral-hypnotic-phat-double-spiral-mix.png</image:loc>
       <image:title>Zylot - Spiral (Hypnotic)_Phat_Double_Spiral_Mix | Stims</image:title>
       <image:caption>Zylot - Spiral (Hypnotic)_Phat_Double_Spiral_Mix by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1227,7 +1227,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-star-ornament</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-star-ornament.png</image:loc>
       <image:title>Zylot - Star Ornament | Stims</image:title>
       <image:caption>Zylot - Star Ornament by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1238,7 +1238,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-true-visionary-final-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-true-visionary-final-mix.png</image:loc>
       <image:title>Zylot - True Visionary (Final Mix) | Stims</image:title>
       <image:caption>Zylot - True Visionary (Final Mix) by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1249,7 +1249,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-true-visionary</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-true-visionary.png</image:loc>
       <image:title>Zylot - True Visionary | Stims</image:title>
       <image:caption>Zylot - True Visionary by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1260,7 +1260,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=zylot-light-of-the-path</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/zylot-light-of-the-path.png</image:loc>
       <image:title>Zylot - light of the path | Stims</image:title>
       <image:caption>Zylot - light of the path by Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1271,7 +1271,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=ishan-drug-addict-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/ishan-drug-addict-jelly-v3.png</image:loc>
       <image:title>[Ishan] - Drug Addict (Jelly V3) | Stims</image:title>
       <image:caption>[Ishan] - Drug Addict (Jelly V3) by [Ishan], a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1282,7 +1282,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-color-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-color-mix.png</image:loc>
       <image:title>_Aderrasi - Wanderer in Curved Space - mash0000 - faclempt kibitzing meshuggana schmaltz (Geiss color mix) | Stims</image:title>
       <image:caption>_Aderrasi - Wanderer in Curved Space - mash0000 - faclempt kibitzing meshuggana schmaltz (Geiss color mix) by _Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1293,7 +1293,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-greyscale-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-greyscale-mix.png</image:loc>
       <image:title>_Aderrasi - Wanderer in Curved Space - mash0000 - faclempt kibitzing meshuggana schmaltz (Geiss greyscale mix) | Stims</image:title>
       <image:caption>_Aderrasi - Wanderer in Curved Space - mash0000 - faclempt kibitzing meshuggana schmaltz (Geiss greyscale mix) by _Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1304,7 +1304,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=che-geiss-escape-psychedelic-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/che-geiss-escape-psychedelic-mix.png</image:loc>
       <image:title>_Che + Geiss - Escape (Psychedelic Mix) | Stims</image:title>
       <image:caption>_Che + Geiss - Escape (Psychedelic Mix) by _Che + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1315,7 +1315,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-passage-geiss-emboss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-passage-geiss-emboss-mix.png</image:loc>
       <image:title>_Cope - Passage (geiss emboss mix) | Stims</image:title>
       <image:caption>_Cope - Passage (geiss emboss mix) by _Cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1326,7 +1326,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-spectrum-bubble-field-geiss-softened</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-spectrum-bubble-field-geiss-softened.png</image:loc>
       <image:title>_Eo.S. + Phat - spectrum bubble field - Geiss-softened | Stims</image:title>
       <image:caption>_Eo.S. + Phat - spectrum bubble field - Geiss-softened by _Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1337,7 +1337,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-zylot-skylight-stained-glass-majesty-mix-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-zylot-skylight-stained-glass-majesty-mix-alt.png</image:loc>
       <image:title>_Eo.S. + Zylot - skylight (Stained Glass Majesty mix) | Stims</image:title>
       <image:caption>_Eo.S. + Zylot - skylight (Stained Glass Majesty mix) by _Eo.S. + Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1348,7 +1348,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-glowsticks-v2-02-geiss-hpf</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-glowsticks-v2-02-geiss-hpf.png</image:loc>
       <image:title>_Eo.S. - glowsticks v2 02 - Geiss HPF | Stims</image:title>
       <image:caption>_Eo.S. - glowsticks v2 02 - Geiss HPF by _Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1359,7 +1359,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-mindblob-where-it-s-at-now-broth-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-mindblob-where-it-s-at-now-broth-mix.png</image:loc>
       <image:title>_Flexi + Geiss - mindblob [where it′s at now] (broth mix) | Stims</image:title>
       <image:caption>_Flexi + Geiss - mindblob [where it′s at now] (broth mix) by _Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1370,7 +1370,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-mindblob-where-it-s-at-now-emboss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-mindblob-where-it-s-at-now-emboss-mix.png</image:loc>
       <image:title>_Flexi + Geiss - mindblob [where it′s at now] (emboss mix) | Stims</image:title>
       <image:caption>_Flexi + Geiss - mindblob [where it′s at now] (emboss mix) by _Flexi + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1381,7 +1381,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-where-it-s-at-now-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-where-it-s-at-now-2.png</image:loc>
       <image:title>_Flexi - mindblob [where it′s at now] 2 | Stims</image:title>
       <image:caption>_Flexi - mindblob [where it′s at now] 2 by _Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1392,7 +1392,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-where-it-s-at-now-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-where-it-s-at-now-3.png</image:loc>
       <image:title>_Flexi - mindblob [where it′s at now] 3 | Stims</image:title>
       <image:caption>_Flexi - mindblob [where it′s at now] 3 by _Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1403,7 +1403,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-where-it-s-at-now</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-where-it-s-at-now.png</image:loc>
       <image:title>_Flexi - mindblob [where it′s at now] | Stims</image:title>
       <image:caption>_Flexi - mindblob [where it′s at now] by _Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1414,7 +1414,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-geiss-painterly-rogue-wave-strike-color-emboss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-geiss-painterly-rogue-wave-strike-color-emboss-mix.png</image:loc>
       <image:title>_Flexi, martin + geiss - painterly rogue wave strike (color emboss mix) | Stims</image:title>
       <image:caption>_Flexi, martin + geiss - painterly rogue wave strike (color emboss mix) by _Flexi, martin + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1425,7 +1425,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-01</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-01.png</image:loc>
       <image:title>_Geiss - Artifact 01 | Stims</image:title>
       <image:caption>_Geiss - Artifact 01 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1436,7 +1436,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-02</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-02.png</image:loc>
       <image:title>_Geiss - Artifact 02 | Stims</image:title>
       <image:caption>_Geiss - Artifact 02 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1447,7 +1447,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-03</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-03.png</image:loc>
       <image:title>_Geiss - Artifact 03 | Stims</image:title>
       <image:caption>_Geiss - Artifact 03 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1458,7 +1458,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-04</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-04.png</image:loc>
       <image:title>_Geiss - Artifact 04 | Stims</image:title>
       <image:caption>_Geiss - Artifact 04 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1469,7 +1469,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-05</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-05.png</image:loc>
       <image:title>_Geiss - Artifact 05 | Stims</image:title>
       <image:caption>_Geiss - Artifact 05 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1480,7 +1480,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-06</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-06.png</image:loc>
       <image:title>_Geiss - Artifact 06 | Stims</image:title>
       <image:caption>_Geiss - Artifact 06 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1491,7 +1491,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-07</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-07.png</image:loc>
       <image:title>_Geiss - Artifact 07 | Stims</image:title>
       <image:caption>_Geiss - Artifact 07 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1502,7 +1502,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-08</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-08.png</image:loc>
       <image:title>_Geiss - Artifact 08 | Stims</image:title>
       <image:caption>_Geiss - Artifact 08 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1513,7 +1513,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-09</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-09.png</image:loc>
       <image:title>_Geiss - Artifact 09 | Stims</image:title>
       <image:caption>_Geiss - Artifact 09 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1524,7 +1524,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-10</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-10.png</image:loc>
       <image:title>_Geiss - Artifact 10 | Stims</image:title>
       <image:caption>_Geiss - Artifact 10 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1535,7 +1535,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-11</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-11.png</image:loc>
       <image:title>_Geiss - Artifact 11 | Stims</image:title>
       <image:caption>_Geiss - Artifact 11 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1546,7 +1546,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-12</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-12.png</image:loc>
       <image:title>_Geiss - Artifact 12 | Stims</image:title>
       <image:caption>_Geiss - Artifact 12 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1557,7 +1557,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-13-big-waves</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-13-big-waves.png</image:loc>
       <image:title>_Geiss - Artifact 13 (big waves) | Stims</image:title>
       <image:caption>_Geiss - Artifact 13 (big waves) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1568,7 +1568,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-14-emboss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-14-emboss.png</image:loc>
       <image:title>_Geiss - Artifact 14 (emboss) | Stims</image:title>
       <image:caption>_Geiss - Artifact 14 (emboss) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1579,7 +1579,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-artifact-15-emboss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-artifact-15-emboss.png</image:loc>
       <image:title>_Geiss - Artifact 15 (emboss) | Stims</image:title>
       <image:caption>_Geiss - Artifact 15 (emboss) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1590,7 +1590,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom-3-color-emboss-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom-3-color-emboss-mix-2.png</image:loc>
       <image:title>_Geiss - Brain Zoom 3 (Color Emboss Mix 2) | Stims</image:title>
       <image:caption>_Geiss - Brain Zoom 3 (Color Emboss Mix 2) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1601,7 +1601,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-brain-zoom-3-color-emboss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-brain-zoom-3-color-emboss-mix.png</image:loc>
       <image:title>_Geiss - Brain Zoom 3 (Color Emboss Mix) | Stims</image:title>
       <image:caption>_Geiss - Brain Zoom 3 (Color Emboss Mix) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1612,7 +1612,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti-kaleidoscope-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti-kaleidoscope-mix-2.png</image:loc>
       <image:title>_Geiss - Confetti (Kaleidoscope Mix) 2 | Stims</image:title>
       <image:caption>_Geiss - Confetti (Kaleidoscope Mix) 2 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1623,7 +1623,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-confetti-kaleidoscope-mix-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-confetti-kaleidoscope-mix-alt.png</image:loc>
       <image:title>_Geiss - Confetti (Kaleidoscope Mix) | Stims</image:title>
       <image:caption>_Geiss - Confetti (Kaleidoscope Mix) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1634,7 +1634,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-cosmic-dust-2-trails-5z</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-cosmic-dust-2-trails-5z.png</image:loc>
       <image:title>_Geiss - Cosmic Dust 2 - Trails 5z | Stims</image:title>
       <image:caption>_Geiss - Cosmic Dust 2 - Trails 5z by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1645,7 +1645,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-desert-rose-2-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-desert-rose-2-alt.png</image:loc>
       <image:title>_Geiss - Desert Rose 2 | Stims</image:title>
       <image:caption>_Geiss - Desert Rose 2 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1656,7 +1656,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-digitalis</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-digitalis.png</image:loc>
       <image:title>_Geiss - Digitalis | Stims</image:title>
       <image:caption>_Geiss - Digitalis by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1667,7 +1667,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion-mod-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion-mod-1.png</image:loc>
       <image:title>_Geiss - Explosion Mod 1 | Stims</image:title>
       <image:caption>_Geiss - Explosion Mod 1 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1678,7 +1678,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-explosion-mod-2b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-explosion-mod-2b.png</image:loc>
       <image:title>_Geiss - Explosion Mod 2b | Stims</image:title>
       <image:caption>_Geiss - Explosion Mod 2b by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1689,7 +1689,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-kaleidoscope-1-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-kaleidoscope-1-alt.png</image:loc>
       <image:title>_Geiss - Kaleidoscope 1 | Stims</image:title>
       <image:caption>_Geiss - Kaleidoscope 1 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1700,7 +1700,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-microcheckers-3-hpf</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-microcheckers-3-hpf.png</image:loc>
       <image:title>_Geiss - MicroCheckers 3 HPF | Stims</image:title>
       <image:caption>_Geiss - MicroCheckers 3 HPF by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1711,7 +1711,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-relief-mix-c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-relief-mix-c.png</image:loc>
       <image:title>_Geiss - Motion Blur 2 (Relief Mix) c | Stims</image:title>
       <image:caption>_Geiss - Motion Blur 2 (Relief Mix) c by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1722,7 +1722,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-motion-blur-2-color-emboss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-motion-blur-2-color-emboss.png</image:loc>
       <image:title>_Geiss - Motion Blur 2 (color emboss) | Stims</image:title>
       <image:caption>_Geiss - Motion Blur 2 (color emboss) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1733,7 +1733,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-myriad-mosaics-test</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-myriad-mosaics-test.png</image:loc>
       <image:title>_Geiss - Myriad Mosaics --TEST-- | Stims</image:title>
       <image:caption>_Geiss - Myriad Mosaics --TEST-- by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1744,7 +1744,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-relief-mix-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-relief-mix-alt.png</image:loc>
       <image:title>_Geiss - Reaction Diffusion (Relief Mix) | Stims</image:title>
       <image:caption>_Geiss - Reaction Diffusion (Relief Mix) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1755,7 +1755,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-3-lichen-relief-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-3-lichen-relief-mix.png</image:loc>
       <image:title>_Geiss - Reaction Diffusion 3 (Lichen Relief Mix) | Stims</image:title>
       <image:caption>_Geiss - Reaction Diffusion 3 (Lichen Relief Mix) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1766,7 +1766,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reducto-absurdum-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reducto-absurdum-alt.png</image:loc>
       <image:title>_Geiss - Reducto Absurdum | Stims</image:title>
       <image:caption>_Geiss - Reducto Absurdum by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1777,7 +1777,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-3-emboss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-3-emboss.png</image:loc>
       <image:title>_Geiss - Skin Dots Multi-layer 3 (emboss) | Stims</image:title>
       <image:caption>_Geiss - Skin Dots Multi-layer 3 (emboss) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1788,7 +1788,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-3-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-3-mashup-2.png</image:loc>
       <image:title>_Geiss - Skin Dots Multi-layer 3 (mashup 2) | Stims</image:title>
       <image:caption>_Geiss - Skin Dots Multi-layer 3 (mashup 2) by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1799,7 +1799,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-skin-dots-multi-layer-3-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-skin-dots-multi-layer-3-alt.png</image:loc>
       <image:title>_Geiss - Skin Dots Multi-layer 3 | Stims</image:title>
       <image:caption>_Geiss - Skin Dots Multi-layer 3 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1810,7 +1810,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-smoke-trail-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-smoke-trail-2.png</image:loc>
       <image:title>_Geiss - Smoke Trail 2 | Stims</image:title>
       <image:caption>_Geiss - Smoke Trail 2 by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1821,7 +1821,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-spiral-artifact-filament-mix-beat-dots-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-spiral-artifact-filament-mix-beat-dots-mix.png</image:loc>
       <image:title>_Geiss - Spiral Artifact (Filament Mix) - beat dots mix | Stims</image:title>
       <image:caption>_Geiss - Spiral Artifact (Filament Mix) - beat dots mix by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1832,7 +1832,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-spiral-artifact-filament-mix-rad8-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-spiral-artifact-filament-mix-rad8-mix.png</image:loc>
       <image:title>_Geiss - Spiral Artifact (Filament Mix) - rad8 mix | Stims</image:title>
       <image:caption>_Geiss - Spiral Artifact (Filament Mix) - rad8 mix by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1843,7 +1843,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-beetle-bore-color-invert-mirror-animated</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-beetle-bore-color-invert-mirror-animated.png</image:loc>
       <image:title>_Geiss - beetle bore - color invert mirror Animated | Stims</image:title>
       <image:caption>_Geiss - beetle bore - color invert mirror Animated by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1854,7 +1854,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-untitled</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-untitled.png</image:loc>
       <image:title>_Geiss - untitled | Stims</image:title>
       <image:caption>_Geiss - untitled by _Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1865,7 +1865,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=krash-eo-s-photographic-sentinel-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/krash-eo-s-photographic-sentinel-alt.png</image:loc>
       <image:title>_Krash + Eo.S. - Photographic Sentinel | Stims</image:title>
       <image:caption>_Krash + Eo.S. - Photographic Sentinel by _Krash + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1876,7 +1876,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-wire-dance-geiss-warp-shader-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-wire-dance-geiss-warp-shader-mix.png</image:loc>
       <image:title>_Martin - wire dance (geiss warp shader mix) | Stims</image:title>
       <image:caption>_Martin - wire dance (geiss warp shader mix) by _Martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1887,7 +1887,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-004</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-004.png</image:loc>
       <image:title>_Mig_004 | Stims</image:title>
       <image:caption>_Mig_004 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1898,7 +1898,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-004-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-004-version2.png</image:loc>
       <image:title>_Mig_004_version2 | Stims</image:title>
       <image:caption>_Mig_004_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1909,7 +1909,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-008</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-008.png</image:loc>
       <image:title>_Mig_008 | Stims</image:title>
       <image:caption>_Mig_008 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1920,7 +1920,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-009</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-009.png</image:loc>
       <image:title>_Mig_009 | Stims</image:title>
       <image:caption>_Mig_009 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1931,7 +1931,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-010</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-010.png</image:loc>
       <image:title>_Mig_010 | Stims</image:title>
       <image:caption>_Mig_010 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1942,7 +1942,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-014-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-014-version2.png</image:loc>
       <image:title>_Mig_014_version2 | Stims</image:title>
       <image:caption>_Mig_014_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1953,7 +1953,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-017</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-017.png</image:loc>
       <image:title>_Mig_017 | Stims</image:title>
       <image:caption>_Mig_017 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1964,7 +1964,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-022-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-022-version2.png</image:loc>
       <image:title>_Mig_022_version2 | Stims</image:title>
       <image:caption>_Mig_022_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1975,7 +1975,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-022version3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-022version3.png</image:loc>
       <image:title>_Mig_022version3 | Stims</image:title>
       <image:caption>_Mig_022version3 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1986,7 +1986,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-024-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-024-version2.png</image:loc>
       <image:title>_Mig_024_version2 | Stims</image:title>
       <image:caption>_Mig_024_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -1997,7 +1997,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-025</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-025.png</image:loc>
       <image:title>_Mig_025 | Stims</image:title>
       <image:caption>_Mig_025 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2008,7 +2008,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-028</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-028.png</image:loc>
       <image:title>_Mig_028 | Stims</image:title>
       <image:caption>_Mig_028 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2019,7 +2019,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-031</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-031.png</image:loc>
       <image:title>_Mig_031 | Stims</image:title>
       <image:caption>_Mig_031 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2030,7 +2030,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-032-version3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-032-version3.png</image:loc>
       <image:title>_Mig_032_version3 | Stims</image:title>
       <image:caption>_Mig_032_version3 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2041,7 +2041,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-036-version3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-036-version3.png</image:loc>
       <image:title>_Mig_036_version3 | Stims</image:title>
       <image:caption>_Mig_036_version3 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2052,7 +2052,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-036-version5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-036-version5.png</image:loc>
       <image:title>_Mig_036_version5 | Stims</image:title>
       <image:caption>_Mig_036_version5 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2063,7 +2063,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-036version3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-036version3.png</image:loc>
       <image:title>_Mig_036version3 | Stims</image:title>
       <image:caption>_Mig_036version3 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2074,7 +2074,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-039</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-039.png</image:loc>
       <image:title>_Mig_039 | Stims</image:title>
       <image:caption>_Mig_039 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2085,7 +2085,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-049</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-049.png</image:loc>
       <image:title>_Mig_049 | Stims</image:title>
       <image:caption>_Mig_049 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2096,7 +2096,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-049version3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-049version3.png</image:loc>
       <image:title>_Mig_049version3 | Stims</image:title>
       <image:caption>_Mig_049version3 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2107,7 +2107,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-056</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-056.png</image:loc>
       <image:title>_Mig_056 | Stims</image:title>
       <image:caption>_Mig_056 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2118,7 +2118,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-057</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-057.png</image:loc>
       <image:title>_Mig_057 | Stims</image:title>
       <image:caption>_Mig_057 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2129,7 +2129,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-059</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-059.png</image:loc>
       <image:title>_Mig_059 | Stims</image:title>
       <image:caption>_Mig_059 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2140,7 +2140,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-061</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-061.png</image:loc>
       <image:title>_Mig_061 | Stims</image:title>
       <image:caption>_Mig_061 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2151,7 +2151,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-068</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-068.png</image:loc>
       <image:title>_Mig_068 | Stims</image:title>
       <image:caption>_Mig_068 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2162,7 +2162,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-079</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-079.png</image:loc>
       <image:title>_Mig_079 | Stims</image:title>
       <image:caption>_Mig_079 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2173,7 +2173,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-082-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-082-version2.png</image:loc>
       <image:title>_Mig_082_version2 | Stims</image:title>
       <image:caption>_Mig_082_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2184,7 +2184,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-085</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-085.png</image:loc>
       <image:title>_Mig_085 | Stims</image:title>
       <image:caption>_Mig_085 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2195,7 +2195,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-091</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-091.png</image:loc>
       <image:title>_Mig_091 | Stims</image:title>
       <image:caption>_Mig_091 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2206,7 +2206,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-091b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-091b.png</image:loc>
       <image:title>_Mig_091b | Stims</image:title>
       <image:caption>_Mig_091b by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2217,7 +2217,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-095</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-095.png</image:loc>
       <image:title>_Mig_095 | Stims</image:title>
       <image:caption>_Mig_095 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2228,7 +2228,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-101</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-101.png</image:loc>
       <image:title>_Mig_101 | Stims</image:title>
       <image:caption>_Mig_101 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2239,7 +2239,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-120</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-120.png</image:loc>
       <image:title>_Mig_120 | Stims</image:title>
       <image:caption>_Mig_120 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2250,7 +2250,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-145</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-145.png</image:loc>
       <image:title>_Mig_145 | Stims</image:title>
       <image:caption>_Mig_145 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2261,7 +2261,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-146</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-146.png</image:loc>
       <image:title>_Mig_146 | Stims</image:title>
       <image:caption>_Mig_146 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2272,7 +2272,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-171-version2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-171-version2.png</image:loc>
       <image:title>_Mig_171_version2 | Stims</image:title>
       <image:caption>_Mig_171_version2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2283,7 +2283,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-177</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-177.png</image:loc>
       <image:title>_Mig_177 | Stims</image:title>
       <image:caption>_Mig_177 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2294,7 +2294,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-197</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-197.png</image:loc>
       <image:title>_Mig_197 | Stims</image:title>
       <image:caption>_Mig_197 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2305,7 +2305,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-197b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-197b.png</image:loc>
       <image:title>_Mig_197b | Stims</image:title>
       <image:caption>_Mig_197b by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2316,7 +2316,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-199</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-199.png</image:loc>
       <image:title>_Mig_199 | Stims</image:title>
       <image:caption>_Mig_199 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2327,7 +2327,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-208</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-208.png</image:loc>
       <image:title>_Mig_208 | Stims</image:title>
       <image:caption>_Mig_208 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2338,7 +2338,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-211</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-211.png</image:loc>
       <image:title>_Mig_211 | Stims</image:title>
       <image:caption>_Mig_211 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2349,7 +2349,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-304-geiss-remix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-304-geiss-remix-2.png</image:loc>
       <image:title>_Mig_304 - geiss remix 2 | Stims</image:title>
       <image:caption>_Mig_304 - geiss remix 2 by _Mig_304, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2360,7 +2360,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-304-geiss-remix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-304-geiss-remix-3.png</image:loc>
       <image:title>_Mig_304 - geiss remix 3 | Stims</image:title>
       <image:caption>_Mig_304 - geiss remix 3 by _Mig_304, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2371,7 +2371,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-304-geiss-remix-3b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-304-geiss-remix-3b.png</image:loc>
       <image:title>_Mig_304 - geiss remix 3b | Stims</image:title>
       <image:caption>_Mig_304 - geiss remix 3b by _Mig_304, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2382,7 +2382,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-304-geiss-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-304-geiss-remix.png</image:loc>
       <image:title>_Mig_304 - geiss remix | Stims</image:title>
       <image:caption>_Mig_304 - geiss remix by _Mig_304, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2393,7 +2393,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-304</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-304.png</image:loc>
       <image:title>_Mig_304 | Stims</image:title>
       <image:caption>_Mig_304 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2404,7 +2404,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-colorful1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-colorful1.png</image:loc>
       <image:title>_Mig_COLORFUL1 | Stims</image:title>
       <image:caption>_Mig_COLORFUL1 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2415,7 +2415,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-colorful9</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-colorful9.png</image:loc>
       <image:title>_Mig_COLORFUL9 | Stims</image:title>
       <image:caption>_Mig_COLORFUL9 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2426,7 +2426,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope002</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope002.png</image:loc>
       <image:title>_Mig_Oscilloscope002 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope002 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2437,7 +2437,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope003-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope003-v2.png</image:loc>
       <image:title>_Mig_Oscilloscope003_v2 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope003_v2 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2448,7 +2448,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope005</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope005.png</image:loc>
       <image:title>_Mig_Oscilloscope005 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope005 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2459,7 +2459,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope008</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope008.png</image:loc>
       <image:title>_Mig_Oscilloscope008 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope008 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2470,7 +2470,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope021</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope021.png</image:loc>
       <image:title>_Mig_Oscilloscope021 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope021 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2481,7 +2481,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope022-b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope022-b.png</image:loc>
       <image:title>_Mig_Oscilloscope022 b | Stims</image:title>
       <image:caption>_Mig_Oscilloscope022 b by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2492,7 +2492,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope022</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope022.png</image:loc>
       <image:title>_Mig_Oscilloscope022 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope022 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2503,7 +2503,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mig-oscilloscope-010</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mig-oscilloscope-010.png</image:loc>
       <image:title>_Mig_Oscilloscope_010 | Stims</image:title>
       <image:caption>_Mig_Oscilloscope_010 by Mig, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2514,7 +2514,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hurricane-nightmare-posterize-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hurricane-nightmare-posterize-mix.png</image:loc>
       <image:title>_Rovastar + Geiss - Hurricane Nightmare (Posterize Mix) | Stims</image:title>
       <image:caption>_Rovastar + Geiss - Hurricane Nightmare (Posterize Mix) by _Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2525,7 +2525,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-geiss-hyperkaleidoscope-glow-2-multitonal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-geiss-hyperkaleidoscope-glow-2-multitonal.png</image:loc>
       <image:title>_Rovastar + Geiss - Hyperkaleidoscope Glow 2 Multitonal | Stims</image:title>
       <image:caption>_Rovastar + Geiss - Hyperkaleidoscope Glow 2 Multitonal by _Rovastar + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2536,7 +2536,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rovastar-loadus-geiss-fractaldrop-psychedelic-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rovastar-loadus-geiss-fractaldrop-psychedelic-mix.png</image:loc>
       <image:title>_Rovastar + Loadus + Geiss - FractalDrop (Psychedelic Mix) | Stims</image:title>
       <image:caption>_Rovastar + Loadus + Geiss - FractalDrop (Psychedelic Mix) by _Rovastar + Loadus + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2547,7 +2547,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=vovan-geiss-bass-with-flover-feedback-mix-2b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/vovan-geiss-bass-with-flover-feedback-mix-2b.png</image:loc>
       <image:title>_Vovan + Geiss - Bass With Flover (Feedback Mix 2b) | Stims</image:title>
       <image:caption>_Vovan + Geiss - Bass With Flover (Feedback Mix 2b) by _Vovan + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2558,7 +2558,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=vovan-geiss-bass-with-flover-feedback-mix-orig</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/vovan-geiss-bass-with-flover-feedback-mix-orig.png</image:loc>
       <image:title>_Vovan + Geiss - Bass With Flover (Feedback Mix ORIG) | Stims</image:title>
       <image:caption>_Vovan + Geiss - Bass With Flover (Feedback Mix ORIG) by _Vovan + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2569,7 +2569,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=vovan-geiss-bass-with-flover-feedback-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/vovan-geiss-bass-with-flover-feedback-mix-2.png</image:loc>
       <image:title>_Vovan + Geiss - Bass With Flover (Feedback Mix) 2 | Stims</image:title>
       <image:caption>_Vovan + Geiss - Bass With Flover (Feedback Mix) 2 by _Vovan + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2580,7 +2580,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=vovan-geiss-bass-with-flover-feedback-mix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/vovan-geiss-bass-with-flover-feedback-mix-3.png</image:loc>
       <image:title>_Vovan + Geiss - Bass With Flover (Feedback Mix) 3 | Stims</image:title>
       <image:caption>_Vovan + Geiss - Bass With Flover (Feedback Mix) 3 by _Vovan + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2591,7 +2591,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-graffitti-attack-mashmash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-graffitti-attack-mashmash.png</image:loc>
       <image:title>_fishbrain + flexi - witchcraft [graffitti attack] - mashmash | Stims</image:title>
       <image:caption>_fishbrain + flexi - witchcraft [graffitti attack] - mashmash by _fishbrain + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2602,7 +2602,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-emboss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-emboss.png</image:loc>
       <image:title>_geiss + flexi - lorenz chaser [accidental shader-lock mashup] (ripples) (emboss) | Stims</image:title>
       <image:caption>_geiss + flexi - lorenz chaser [accidental shader-lock mashup] (ripples) (emboss) by _geiss + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2613,7 +2613,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix.png</image:loc>
       <image:title>_geiss + mstress - Cleaning a path - Painterly Crossfire (Crisp Emboss Mix) | Stims</image:title>
       <image:caption>_geiss + mstress - Cleaning a path - Painterly Crossfire (Crisp Emboss Mix) by _geiss + mstress, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2624,7 +2624,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-fractal-relief</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-fractal-relief.png</image:loc>
       <image:title>_geiss - fractal relief | Stims</image:title>
       <image:caption>_geiss - fractal relief by _geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2635,7 +2635,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-experimental-aderrasi-kevlar-ore-deposit-geiss-core-stripe-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-experimental-aderrasi-kevlar-ore-deposit-geiss-core-stripe-mix.png</image:loc>
       <image:title>_geiss_experimental__Aderrasi - Kevlar Ore Deposit - geiss core stripe mix | Stims</image:title>
       <image:caption>_geiss_experimental__Aderrasi - Kevlar Ore Deposit - geiss core stripe mix by _geiss_experimental__Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2646,7 +2646,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-experimental-lsb-bass-cubes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-experimental-lsb-bass-cubes.png</image:loc>
       <image:title>_geiss_experimental__LSB Bass Cubes | Stims</image:title>
       <image:caption>_geiss_experimental__LSB Bass Cubes by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2657,7 +2657,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-experimental-spiral-artifact-filament-mix-scallop-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-experimental-spiral-artifact-filament-mix-scallop-mix.png</image:loc>
       <image:title>_geiss_experimental__Spiral Artifact (Filament Mix) - scallop mix | Stims</image:title>
       <image:caption>_geiss_experimental__Spiral Artifact (Filament Mix) - scallop mix by _geiss_experimental__Spiral Artifact, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2668,7 +2668,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-experimental-spiral-artifact-filament-mix-voronoi-circles-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-experimental-spiral-artifact-filament-mix-voronoi-circles-mix.png</image:loc>
       <image:title>_geiss_experimental__Spiral Artifact (Filament Mix) - voronoi circles mix | Stims</image:title>
       <image:caption>_geiss_experimental__Spiral Artifact (Filament Mix) - voronoi circles mix by _geiss_experimental__Spiral Artifact, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2679,7 +2679,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-experimental-wavefronts</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-experimental-wavefronts.png</image:loc>
       <image:title>_geiss_experimental__wavefronts | Stims</image:title>
       <image:caption>_geiss_experimental__wavefronts by Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2690,7 +2690,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=a-crappy-reality-you-did-well</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/a-crappy-reality-you-did-well.png</image:loc>
       <image:title>a crappy reality = you did well | Stims</image:title>
       <image:caption>a crappy reality = you did well, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2701,7 +2701,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=adam-eatit-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-flexi-aderrasi-n-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/adam-eatit-fx-2-martin-disco-mix-lodus-geiss-ludicrous-speed-flexi-aderrasi-n-hexcollie.png</image:loc>
       <image:title>adam eatit fx 2 martin - disco mix, lodus, geiss, ludicrous speed,flexi, aderrasi n hexcollie | Stims</image:title>
       <image:caption>adam eatit fx 2 martin - disco mix, lodus, geiss, ludicrous speed,flexi, aderrasi n hexcollie by adam eatit fx 2 martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2712,7 +2712,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-martin-edit-trick-with-cubes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-martin-edit-trick-with-cubes.png</image:loc>
       <image:title>amandio c - [martin edit] - trick with cubes | Stims</image:title>
       <image:caption>amandio c - [martin edit] - trick with cubes by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2723,7 +2723,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-feeling-well-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-feeling-well-3.png</image:loc>
       <image:title>amandio c - feeling well 3 | Stims</image:title>
       <image:caption>amandio c - feeling well 3 by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2734,7 +2734,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-flashy-thing</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-flashy-thing.png</image:loc>
       <image:title>amandio c - flashy thing | Stims</image:title>
       <image:caption>amandio c - flashy thing by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2745,7 +2745,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-fume</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-fume.png</image:loc>
       <image:title>amandio c - fume | Stims</image:title>
       <image:caption>amandio c - fume by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2756,7 +2756,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-new-life-a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-new-life-a.png</image:loc>
       <image:title>amandio c - new life a | Stims</image:title>
       <image:caption>amandio c - new life a by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2767,7 +2767,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-new-life</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-new-life.png</image:loc>
       <image:title>amandio c - new life | Stims</image:title>
       <image:caption>amandio c - new life by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2778,7 +2778,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-odd-star</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-odd-star.png</image:loc>
       <image:title>amandio c - odd star | Stims</image:title>
       <image:caption>amandio c - odd star by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2789,7 +2789,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-polar-value-shader-pimped</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-polar-value-shader-pimped.png</image:loc>
       <image:title>amandio c - polar value [shader pimped] | Stims</image:title>
       <image:caption>amandio c - polar value [shader pimped] by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2800,7 +2800,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter.png</image:loc>
       <image:title>amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter | Stims</image:title>
       <image:caption>amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2811,7 +2811,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-pole-shf-fab-candiria-pull-ap5-selectro-electronic-afield-asquid</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-pole-shf-fab-candiria-pull-ap5-selectro-electronic-afield-asquid.png</image:loc>
       <image:title>amandio c - pole - shf fab candiria pull ap5+ selectro-electronic afield asquid | Stims</image:title>
       <image:caption>amandio c - pole - shf fab candiria pull ap5+ selectro-electronic afield asquid by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2822,7 +2822,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=amandio-c-salty-beats-spiral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/amandio-c-salty-beats-spiral.png</image:loc>
       <image:title>amandio c - salty beats - spiral | Stims</image:title>
       <image:caption>amandio c - salty beats - spiral by amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2833,7 +2833,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=baked-chinese-fingerbang-cao-ni-ma-pieturp-colors-bitcore-speed-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/baked-chinese-fingerbang-cao-ni-ma-pieturp-colors-bitcore-speed-tweak.png</image:loc>
       <image:title>baked - Chinese Fingerbang (cao ni ma =]) - PieturP colors - Bitcore speed tweak | Stims</image:title>
       <image:caption>baked - Chinese Fingerbang (cao ni ma =]) - PieturP colors - Bitcore speed tweak by baked, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2844,7 +2844,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=baked-river-of-illusion-infected-acid-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/baked-river-of-illusion-infected-acid-mix.png</image:loc>
       <image:title>baked - River of Illusion (InfecteD acid mix) | Stims</image:title>
       <image:caption>baked - River of Illusion (InfecteD acid mix) by baked, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2855,7 +2855,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=baked-river-of-illusion-dillusion-bubble</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/baked-river-of-illusion-dillusion-bubble.png</image:loc>
       <image:title>baked - River of Illusion Dillusion [Bubble] | Stims</image:title>
       <image:caption>baked - River of Illusion Dillusion [Bubble] by baked, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2866,7 +2866,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=baked-mushroom-rainbows-acid-storm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/baked-mushroom-rainbows-acid-storm.png</image:loc>
       <image:title>baked - mushroom rainbows[acid Storm] | Stims</image:title>
       <image:caption>baked - mushroom rainbows[acid Storm] by baked, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2877,7 +2877,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-aderrasi-oracle-bdrv-et-al-rmx-a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-aderrasi-oracle-bdrv-et-al-rmx-a.png</image:loc>
       <image:title>bdrv + al Aderrasi - Oracle BDRV et  AL  rmx A | Stims</image:title>
       <image:caption>bdrv + al Aderrasi - Oracle BDRV et  AL  rmx A by bdrv + al Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2888,7 +2888,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-eo-s-phat-intergalactic-conquest-flag2b</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-eo-s-phat-intergalactic-conquest-flag2b.png</image:loc>
       <image:title>bdrv + al Eo.S.+Phat - intergalactic conquest flag2b | Stims</image:title>
       <image:caption>bdrv + al Eo.S.+Phat - intergalactic conquest flag2b by bdrv + al Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2899,7 +2899,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-eo-s-phat-intergalactic-fuzzball</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-eo-s-phat-intergalactic-fuzzball.png</image:loc>
       <image:title>bdrv + al Eo.S.+Phat - intergalactic fuzzball | Stims</image:title>
       <image:caption>bdrv + al Eo.S.+Phat - intergalactic fuzzball by bdrv + al Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2910,7 +2910,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-eo-s-phat-intergalactic-wtf2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-eo-s-phat-intergalactic-wtf2.png</image:loc>
       <image:title>bdrv + al Eo.S.+Phat - intergalactic wtf2 | Stims</image:title>
       <image:caption>bdrv + al Eo.S.+Phat - intergalactic wtf2 by bdrv + al Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2921,7 +2921,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-eo-s-phat-licence-to-druel2a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-eo-s-phat-licence-to-druel2a.png</image:loc>
       <image:title>bdrv + al Eo.S.+Phat - licence to druel2a | Stims</image:title>
       <image:caption>bdrv + al Eo.S.+Phat - licence to druel2a by bdrv + al Eo.S.+Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2932,7 +2932,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-eo-s-sarc-gbdrv2-mx-phat-redeye-fractalview-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-eo-s-sarc-gbdrv2-mx-phat-redeye-fractalview-v2.png</image:loc>
       <image:title>bdrv + al Eo.s. - Sarc Gbdrv2 mx_Phat_RedEye_FractalView_v2 | Stims</image:title>
       <image:caption>bdrv + al Eo.s. - Sarc Gbdrv2 mx_Phat_RedEye_FractalView_v2 by bdrv + al Eo.s., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2943,7 +2943,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-phat-and-eo-s-shapes-are-cool-slow-colour-melting-edit-bdrv-et-al-rmxmix32</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-phat-and-eo-s-shapes-are-cool-slow-colour-melting-edit-bdrv-et-al-rmxmix32.png</image:loc>
       <image:title>bdrv + al Phat and Eo.S. _ shapes are cool_slow_colour_melting_edit BDRV et  AL  rmxmix32 | Stims</image:title>
       <image:caption>bdrv + al Phat and Eo.S. _ shapes are cool_slow_colour_melting_edit BDRV et  AL  rmxmix32 by BDRV + Phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2954,7 +2954,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-shifter-feathers-angel-wings-phat-remix4-bdrv-et-al-rmx-ii</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-shifter-feathers-angel-wings-phat-remix4-bdrv-et-al-rmx-ii.png</image:loc>
       <image:title>bdrv + al shifter - feathers (angel wings)_phat_remix4 BDRV et  AL  rmx ii | Stims</image:title>
       <image:caption>bdrv + al shifter - feathers (angel wings)_phat_remix4 BDRV et  AL  rmx ii by bdrv + al shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2965,7 +2965,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-shifter-feathers-angel-wings-phat-remix4-bdrv-et-al-rmxmix-bdrv-et-al5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-shifter-feathers-angel-wings-phat-remix4-bdrv-et-al-rmxmix-bdrv-et-al5.png</image:loc>
       <image:title>bdrv + al shifter - feathers (angel wings)_phat_remix4 bdrv et  AL  rmxmix bdrv et.AL5 | Stims</image:title>
       <image:caption>bdrv + al shifter - feathers (angel wings)_phat_remix4 bdrv et  AL  rmxmix bdrv et.AL5 by bdrv + al shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2976,7 +2976,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-ultramix2-43</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-ultramix2-43.png</image:loc>
       <image:title>bdrv - ultramix2 #43 | Stims</image:title>
       <image:caption>bdrv - ultramix2 #43 by bdrv, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2987,7 +2987,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-telek-spirality</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-telek-spirality.png</image:loc>
       <image:title>bdrv al Telek - spirality | Stims</image:title>
       <image:caption>bdrv al Telek - spirality by bdrv al Telek, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -2998,7 +2998,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-al-zylot-pinwheelw</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-al-zylot-pinwheelw.png</image:loc>
       <image:title>bdrv al Zylot - PinWheelw | Stims</image:title>
       <image:caption>bdrv al Zylot - PinWheelw by bdrv al Zylot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3009,7 +3009,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-et-al-eo-s-phat-sentinel-linearitybdrv-et-al-bdrv-plagiarising-shifter3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-et-al-eo-s-phat-sentinel-linearitybdrv-et-al-bdrv-plagiarising-shifter3.png</image:loc>
       <image:title>bdrv et.AL Eo.s. + Phat - Sentinel Linearitybdrv et.AL  bdrv plagiarising SHIFTER3 | Stims</image:title>
       <image:caption>bdrv et.AL Eo.s. + Phat - Sentinel Linearitybdrv et.AL  bdrv plagiarising SHIFTER3 by bdrv et.AL Eo.s. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3020,7 +3020,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=bdrv-flexi-martin-ultramix-380-shiny-tunnel-derivative-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/bdrv-flexi-martin-ultramix-380-shiny-tunnel-derivative-mix.png</image:loc>
       <image:title>bdrv, flexi + martin - ultramix #380 [shiny tunnel derivative mix] | Stims</image:title>
       <image:caption>bdrv, flexi + martin - ultramix #380 [shiny tunnel derivative mix] by bdrv, flexi + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3031,7 +3031,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106-mash0000-defocused-bandwidth-pulsating-log</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106-mash0000-defocused-bandwidth-pulsating-log.png</image:loc>
       <image:title>beta106 - mash0000 - defocused bandwidth pulsating log | Stims</image:title>
       <image:caption>beta106 - mash0000 - defocused bandwidth pulsating log by beta106, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3042,7 +3042,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106-river-of-illusion-dillusion-bubble</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106-river-of-illusion-dillusion-bubble.png</image:loc>
       <image:title>beta106 River of Illusion Dillusion [Bubble] | Stims</image:title>
       <image:caption>beta106 River of Illusion Dillusion [Bubble], a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3053,7 +3053,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106-s-phat-sentinel-linearity-b-nz-mbinistre-ov-mbajiq</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106-s-phat-sentinel-linearity-b-nz-mbinistre-ov-mbajiq.png</image:loc>
       <image:title>beta106.S. + Phat - sentinel linearity b nz+ mbinistre ov mbajiq | Stims</image:title>
       <image:caption>beta106.S. + Phat - sentinel linearity b nz+ mbinistre ov mbajiq by beta106.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3064,7 +3064,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106ain-roto-mix3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106ain-roto-mix3.png</image:loc>
       <image:title>beta106ain-roto-mix3 | Stims</image:title>
       <image:caption>beta106ain-roto-mix3, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3075,7 +3075,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106at-shape-mash0000-hulk-spirit-cum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106at-shape-mash0000-hulk-spirit-cum.png</image:loc>
       <image:title>beta106at shape - mash0000 - hulk spirit cum | Stims</image:title>
       <image:caption>beta106at shape - mash0000 - hulk spirit cum by beta106at shape, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3086,7 +3086,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106at-shape-mash0001-so-sue-me-if-i-voted-against-anti-rape</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106at-shape-mash0001-so-sue-me-if-i-voted-against-anti-rape.png</image:loc>
       <image:title>beta106at shape - mash0001 - so sue me if i voted against anti-rape | Stims</image:title>
       <image:caption>beta106at shape - mash0001 - so sue me if i voted against anti-rape by beta106at shape, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3097,7 +3097,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-airhandler-last-breath-crab-handler</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-airhandler-last-breath-crab-handler.png</image:loc>
       <image:title>beta106i - Airhandler (Last Breath - Crab Handler) | Stims</image:title>
       <image:caption>beta106i - Airhandler (Last Breath - Crab Handler) by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3108,7 +3108,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-airhandler-radial-dreamers-mash0000-unload-stones-into-black-market-torture-houses</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-airhandler-radial-dreamers-mash0000-unload-stones-into-black-market-torture-houses.png</image:loc>
       <image:title>beta106i - Airhandler (Radial Dreamers) - mash0000 - unload stones into black market torture houses | Stims</image:title>
       <image:caption>beta106i - Airhandler (Radial Dreamers) - mash0000 - unload stones into black market torture houses by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3119,7 +3119,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-brilliance-space-time-breaking-mash0000-it-s-2009-and-you-haven-t-replaced-your-analog-tv-with-digital.png</image:loc>
       <image:title>beta106i - Brilliance (Space-Time Breaking) - mash0000 - it′s 2009 and you haven′t replaced your analog tv with digital | Stims</image:title>
       <image:caption>beta106i - Brilliance (Space-Time Breaking) - mash0000 - it′s 2009 and you haven′t replaced your analog tv with digital by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3130,7 +3130,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-burning-form-seething-mass-mash0000-fire-paint-easter-egg-internals</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-burning-form-seething-mass-mash0000-fire-paint-easter-egg-internals.png</image:loc>
       <image:title>beta106i - Burning Form (Seething Mass) - mash0000 - fire paint easter egg internals | Stims</image:title>
       <image:caption>beta106i - Burning Form (Seething Mass) - mash0000 - fire paint easter egg internals by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3141,7 +3141,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-have-at-you-spin-strike-mash0000-more-the-game-of-death-jesus-conway</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-have-at-you-spin-strike-mash0000-more-the-game-of-death-jesus-conway.png</image:loc>
       <image:title>beta106i - Have at You (Spin Strike) - mash0000 - more the game of death, jesus conway | Stims</image:title>
       <image:caption>beta106i - Have at You (Spin Strike) - mash0000 - more the game of death, jesus conway by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3152,7 +3152,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-inhuman-emotion-regret-mash0000-genetic-mutant-incubators-in-the-hands-of-toddlers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-inhuman-emotion-regret-mash0000-genetic-mutant-incubators-in-the-hands-of-toddlers.png</image:loc>
       <image:title>beta106i - Inhuman Emotion (Regret) - mash0000 - genetic mutant incubators in the hands of toddlers | Stims</image:title>
       <image:caption>beta106i - Inhuman Emotion (Regret) - mash0000 - genetic mutant incubators in the hands of toddlers by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3163,7 +3163,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-it-s-the-sun-brotherhood-of-tears-mash0000-vascular-chemical-allergy.png</image:loc>
       <image:title>beta106i - It′s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy | Stims</image:title>
       <image:caption>beta106i - It′s the Sun (Brotherhood of Tears) - mash0000 - vascular chemical allergy by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3174,7 +3174,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-oversizer-modernist-lane-mash0000-noone-ever-helps-you-unless-you-have-something-for-them</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-oversizer-modernist-lane-mash0000-noone-ever-helps-you-unless-you-have-something-for-them.png</image:loc>
       <image:title>beta106i - Oversizer (Modernist Lane) - mash0000 - noone ever helps you unless you have something for them | Stims</image:title>
       <image:caption>beta106i - Oversizer (Modernist Lane) - mash0000 - noone ever helps you unless you have something for them by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3185,7 +3185,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-potion-of-ink-mrt-cope-n777</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-potion-of-ink-mrt-cope-n777.png</image:loc>
       <image:title>beta106i - Potion of Ink - mrt cope n777 | Stims</image:title>
       <image:caption>beta106i - Potion of Ink - mrt cope n777 by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3196,7 +3196,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-potion-of-ink</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-potion-of-ink.png</image:loc>
       <image:title>beta106i - Potion of Ink | Stims</image:title>
       <image:caption>beta106i - Potion of Ink by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3207,7 +3207,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-songflower-orchid-field-mash0000-too-drunk-and-high-at-club</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-songflower-orchid-field-mash0000-too-drunk-and-high-at-club.png</image:loc>
       <image:title>beta106i - Songflower (Orchid Field) - mash0000 - too drunk and high at club | Stims</image:title>
       <image:caption>beta106i - Songflower (Orchid Field) - mash0000 - too drunk and high at club by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3218,7 +3218,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-straight-tropical-coal-hypnotricks-stable-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-straight-tropical-coal-hypnotricks-stable-mix.png</image:loc>
       <image:title>beta106i - Straight Tropical Coal (Hypnotricks Stable Mix) | Stims</image:title>
       <image:caption>beta106i - Straight Tropical Coal (Hypnotricks Stable Mix) by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3229,7 +3229,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106i-transfrontation-crocodile-star</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106i-transfrontation-crocodile-star.png</image:loc>
       <image:title>beta106i - Transfrontation (Crocodile Star) | Stims</image:title>
       <image:caption>beta106i - Transfrontation (Crocodile Star) by beta106i, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3240,7 +3240,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=beta106rd-does-not-bend-like-that-mash0000-symmetric-combustion-monks-not-included</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/beta106rd-does-not-bend-like-that-mash0000-symmetric-combustion-monks-not-included.png</image:loc>
       <image:title>beta106rd does not bend like that - mash0000 - symmetric combustion, monks not included | Stims</image:title>
       <image:caption>beta106rd does not bend like that - mash0000 - symmetric combustion, monks not included by beta106rd does not bend like that, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3251,7 +3251,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-27-super-goats-orbus-maximus-breach-the-egg-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-27-super-goats-orbus-maximus-breach-the-egg-mix.png</image:loc>
       <image:title>cope + 27_super_goats - orbus maximus (breach the egg mix) | Stims</image:title>
       <image:caption>cope + 27_super_goats - orbus maximus (breach the egg mix) by cope + 27_super_goats, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3262,7 +3262,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-cartune-extrusion-machine-mix-inside-the-hive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-cartune-extrusion-machine-mix-inside-the-hive.png</image:loc>
       <image:title>cope + flexi - cartune (extrusion machine mix) [inside the hive] | Stims</image:title>
       <image:caption>cope + flexi - cartune (extrusion machine mix) [inside the hive] by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3273,7 +3273,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-cartune-extrusion-machine-mix-mr-understatement</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-cartune-extrusion-machine-mix-mr-understatement.png</image:loc>
       <image:title>cope + flexi - cartune (extrusion machine mix) [mr understatement] | Stims</image:title>
       <image:caption>cope + flexi - cartune (extrusion machine mix) [mr understatement] by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3284,7 +3284,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-cartune-extrusion-machine-mix-spiral-out</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-cartune-extrusion-machine-mix-spiral-out.png</image:loc>
       <image:title>cope + flexi - cartune (extrusion machine mix) [spiral out] | Stims</image:title>
       <image:caption>cope + flexi - cartune (extrusion machine mix) [spiral out] by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3295,7 +3295,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-colorful-marble-ghost-mix-rand-wave-4-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-colorful-marble-ghost-mix-rand-wave-4-nz.png</image:loc>
       <image:title>cope + flexi - colorful marble (ghost mix) - rand wave 4 nz+ | Stims</image:title>
       <image:caption>cope + flexi - colorful marble (ghost mix) - rand wave 4 nz+ by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3306,7 +3306,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz.png</image:loc>
       <image:title>cope + flexi - mother-of-whirl [composition from fractopia] roam3 nz+ | Stims</image:title>
       <image:caption>cope + flexi - mother-of-whirl [composition from fractopia] roam3 nz+ by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3317,7 +3317,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-mother-of-whirl-composition-from-fractopia</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-mother-of-whirl-composition-from-fractopia.png</image:loc>
       <image:title>cope + flexi - mother-of-whirl [composition from fractopia] | Stims</image:title>
       <image:caption>cope + flexi - mother-of-whirl [composition from fractopia] by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3328,7 +3328,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-mother-of-whirl-no-fnords-were-hurt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-mother-of-whirl-no-fnords-were-hurt.png</image:loc>
       <image:title>cope + flexi - mother-of-whirl [no fnords were hurt] | Stims</image:title>
       <image:caption>cope + flexi - mother-of-whirl [no fnords were hurt] by cope + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3339,7 +3339,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-geiss-stahlregen-cartune-bending-gelatine-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-geiss-stahlregen-cartune-bending-gelatine-mix.png</image:loc>
       <image:title>cope + geiss + stahlregen - cartune (bending gelatine mix) | Stims</image:title>
       <image:caption>cope + geiss + stahlregen - cartune (bending gelatine mix) by cope + geiss + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3350,7 +3350,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-martin-flexi-cartune</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-martin-flexi-cartune.png</image:loc>
       <image:title>cope + martin + flexi - cartune | Stims</image:title>
       <image:caption>cope + martin + flexi - cartune by cope + martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3361,7 +3361,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-martin-mother-of-pearl</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-martin-mother-of-pearl.png</image:loc>
       <image:title>cope + martin - mother-of-pearl | Stims</image:title>
       <image:caption>cope + martin - mother-of-pearl by cope + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3372,7 +3372,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-alternative-energy-antimatter-mod-1-4z</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-alternative-energy-antimatter-mod-1-4z.png</image:loc>
       <image:title>cope - alternative energy (antimatter mod_1)4z | Stims</image:title>
       <image:caption>cope - alternative energy (antimatter mod_1)4z by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3383,7 +3383,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-digital-sea</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-digital-sea.png</image:loc>
       <image:title>cope - digital sea | Stims</image:title>
       <image:caption>cope - digital sea by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3394,7 +3394,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-ferrofluid-flexis-minor-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-ferrofluid-flexis-minor-remix.png</image:loc>
       <image:title>cope - ferrofluid [Flexis minor remix] | Stims</image:title>
       <image:caption>cope - ferrofluid [Flexis minor remix] by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3405,7 +3405,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-ferrofluid</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-ferrofluid.png</image:loc>
       <image:title>cope - ferrofluid | Stims</image:title>
       <image:caption>cope - ferrofluid by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3416,7 +3416,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-matrixcode7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-matrixcode7.png</image:loc>
       <image:title>cope - matrixcode7 | Stims</image:title>
       <image:caption>cope - matrixcode7 by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3427,7 +3427,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-soar-v2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-soar-v2-0.png</image:loc>
       <image:title>cope - soar (v2.0) | Stims</image:title>
       <image:caption>cope - soar (v2.0) by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3438,7 +3438,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-strange-attractor-flexis-let-it-grow-mix-stahlregens-jelly-after-burner</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-strange-attractor-flexis-let-it-grow-mix-stahlregens-jelly-after-burner.png</image:loc>
       <image:title>cope - strange attractor [Flexis let it grow mix] [Stahlregens jelly after-burner] | Stims</image:title>
       <image:caption>cope - strange attractor [Flexis let it grow mix] [Stahlregens jelly after-burner] by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3449,7 +3449,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-strange-attractor-flexis-let-it-grow-mix-jelly-5-56-volume-noise-zoom-in</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-strange-attractor-flexis-let-it-grow-mix-jelly-5-56-volume-noise-zoom-in.png</image:loc>
       <image:title>cope - strange attractor [flexis let it grow mix] (Jelly 5.56 [volume noise zoom-in]) | Stims</image:title>
       <image:caption>cope - strange attractor [flexis let it grow mix] (Jelly 5.56 [volume noise zoom-in]) by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3460,7 +3460,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-the-drain-to-heaven</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-the-drain-to-heaven.png</image:loc>
       <image:title>cope - the drain to heaven | Stims</image:title>
       <image:caption>cope - the drain to heaven by cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3471,7 +3471,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-flexi-martin-cartune-reinventing-the-scene</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-flexi-martin-cartune-reinventing-the-scene.png</image:loc>
       <image:title>cope, flexi + martin - cartune [reinventing the scene] | Stims</image:title>
       <image:caption>cope, flexi + martin - cartune [reinventing the scene] by cope, flexi + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3482,7 +3482,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=cope-martin-flexi-the-slickery-of-alternative-varnish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/cope-martin-flexi-the-slickery-of-alternative-varnish.png</image:loc>
       <image:title>cope, martin + flexi - the slickery of alternative varnish | Stims</image:title>
       <image:caption>cope, martin + flexi - the slickery of alternative varnish by cope, martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3493,7 +3493,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=custom1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/custom1.png</image:loc>
       <image:title>custom1 | Stims</image:title>
       <image:caption>custom1, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3504,7 +3504,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=drasla-simplespectrogram-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/drasla-simplespectrogram-3.png</image:loc>
       <image:title>drasla - simplespectrogram 3 | Stims</image:title>
       <image:caption>drasla - simplespectrogram 3 by drasla, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3515,7 +3515,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=drugsincombat-reactive-molecule-v-05a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/drugsincombat-reactive-molecule-v-05a.png</image:loc>
       <image:title>drugsincombat - reactive molecule v.05a | Stims</image:title>
       <image:caption>drugsincombat - reactive molecule v.05a by drugsincombat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3526,7 +3526,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=ech0-liquid-firesticks-i</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/ech0-liquid-firesticks-i.png</image:loc>
       <image:title>ech0 - liquid firesticks I | Stims</image:title>
       <image:caption>ech0 - liquid firesticks I by ech0, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3537,7 +3537,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=ech0-purp-trip-of-purpose</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/ech0-purp-trip-of-purpose.png</image:loc>
       <image:title>ech0 - purp-trip of purpose | Stims</image:title>
       <image:caption>ech0 - purp-trip of purpose by ech0, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3548,7 +3548,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=eo-s-phat-chasers-11-sentinel-c-jelly-v4-x</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/eo-s-phat-chasers-11-sentinel-c-jelly-v4-x.png</image:loc>
       <image:title>eo.s. + phat - chasers 11 sentinel c (jelly v4.x) | Stims</image:title>
       <image:caption>eo.s. + phat - chasers 11 sentinel c (jelly v4.x) by eo.s. + phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3559,7 +3559,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fed-slowfast-1-1-geiss-composite-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fed-slowfast-1-1-geiss-composite-remix.png</image:loc>
       <image:title>fed - slowfast 1.1 (geiss composite remix) | Stims</image:title>
       <image:caption>fed - slowfast 1.1 (geiss composite remix) by fed, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3570,7 +3570,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fed-slowfast-1-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fed-slowfast-1-1.png</image:loc>
       <image:title>fed - slowfast 1.1 | Stims</image:title>
       <image:caption>fed - slowfast 1.1 by fed, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3581,7 +3581,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=felix-capacitor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/felix-capacitor.png</image:loc>
       <image:title>felix capacitor | Stims</image:title>
       <image:caption>felix capacitor, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3592,7 +3592,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-eo-s-phat-starburst-totem-pole</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-eo-s-phat-starburst-totem-pole.png</image:loc>
       <image:title>fiShbRaiN + Eo.S. + Phat - starburst totem pole | Stims</image:title>
       <image:caption>fiShbRaiN + Eo.S. + Phat - starburst totem pole by fiShbRaiN + Eo.S. + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3603,7 +3603,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-2-0</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-2-0.png</image:loc>
       <image:title>fiShbRaiN + Flexi - witchcraft 2.0 | Stims</image:title>
       <image:caption>fiShbRaiN + Flexi - witchcraft 2.0 by fiShbRaiN + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3614,7 +3614,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-unleashed-00-the-template</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-unleashed-00-the-template.png</image:loc>
       <image:title>fiShbRaiN + Flexi - witchcraft unleashed [00 the template] | Stims</image:title>
       <image:caption>fiShbRaiN + Flexi - witchcraft unleashed [00 the template] by fiShbRaiN + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3625,7 +3625,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-unleashed</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-unleashed.png</image:loc>
       <image:title>fiShbRaiN + Flexi - witchcraft unleashed | Stims</image:title>
       <image:caption>fiShbRaiN + Flexi - witchcraft unleashed by fiShbRaiN + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3636,7 +3636,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-the-adventures-of-prismo-jenkins-tile-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-the-adventures-of-prismo-jenkins-tile-mix.png</image:loc>
       <image:title>fiShbRaiN + Geiss - the adventures of prismo jenkins - tile mix | Stims</image:title>
       <image:caption>fiShbRaiN + Geiss - the adventures of prismo jenkins - tile mix by fiShbRaiN + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3647,7 +3647,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-the-adventures-of-prismo-jenkins-water-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-the-adventures-of-prismo-jenkins-water-mix.png</image:loc>
       <image:title>fiShbRaiN + Geiss - the adventures of prismo jenkins - water mix | Stims</image:title>
       <image:caption>fiShbRaiN + Geiss - the adventures of prismo jenkins - water mix by fiShbRaiN + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3658,7 +3658,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-2-0-mash0000-no-one-cares-about-mi-the-note-major-third</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-2-0-mash0000-no-one-cares-about-mi-the-note-major-third.png</image:loc>
       <image:title>fiShbRaiN + flexi - witchcraft 2.0 - mash0000 - no one cares about mi, the note (major third) | Stims</image:title>
       <image:caption>fiShbRaiN + flexi - witchcraft 2.0 - mash0000 - no one cares about mi, the note (major third) by fiShbRaiN + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3669,7 +3669,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-glow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-glow-mix.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Glow Mix) | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Glow Mix) by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3680,7 +3680,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-grow-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-grow-mix-2.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Grow Mix 2) | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Grow Mix 2) by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3691,7 +3691,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-grow-mix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-grow-mix-3.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Grow Mix 3) | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Grow Mix 3) by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3702,7 +3702,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Grow Mix 3c - finally mirrored) - mash0000 - rituals on water skin | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Grow Mix 3c - finally mirrored) - mash0000 - rituals on water skin by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3713,7 +3713,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-grow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-grow-mix.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Grow Mix) | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Grow Mix) by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3724,7 +3724,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix.png</image:loc>
       <image:title>fiShbRaiN + geiss - witchcraft (Stahl′s Mirror Crossfire Mix) | Stims</image:title>
       <image:caption>fiShbRaiN + geiss - witchcraft (Stahl′s Mirror Crossfire Mix) by fiShbRaiN + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3735,7 +3735,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-a-quiet-death</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-a-quiet-death.png</image:loc>
       <image:title>fiShbRaiN - a quiet death | Stims</image:title>
       <image:caption>fiShbRaiN - a quiet death by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3746,7 +3746,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-breakfast-cruiser</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-breakfast-cruiser.png</image:loc>
       <image:title>fiShbRaiN - breakfast cruiser | Stims</image:title>
       <image:caption>fiShbRaiN - breakfast cruiser by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3757,7 +3757,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-crystal-glasses</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-crystal-glasses.png</image:loc>
       <image:title>fiShbRaiN - crystal glasses | Stims</image:title>
       <image:caption>fiShbRaiN - crystal glasses by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3768,7 +3768,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-gandalf-does-it-best-bccn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-gandalf-does-it-best-bccn-jelly-v4.png</image:loc>
       <image:title>fiShbRaiN - gandalf does it best (bccn Jelly V4) | Stims</image:title>
       <image:caption>fiShbRaiN - gandalf does it best (bccn Jelly V4) by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3779,7 +3779,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-jade-nicotine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-jade-nicotine.png</image:loc>
       <image:title>fiShbRaiN - jade nicotine | Stims</image:title>
       <image:caption>fiShbRaiN - jade nicotine by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3790,7 +3790,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-lost-in-the-bottle</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-lost-in-the-bottle.png</image:loc>
       <image:title>fiShbRaiN - lost in the bottle | Stims</image:title>
       <image:caption>fiShbRaiN - lost in the bottle by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3801,7 +3801,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-one-step-beyond-jelly-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-one-step-beyond-jelly-remix.png</image:loc>
       <image:title>fiShbRaiN - one step beyond (jelly remix) | Stims</image:title>
       <image:caption>fiShbRaiN - one step beyond (jelly remix) by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3812,7 +3812,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-psychotic-meltdown</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-psychotic-meltdown.png</image:loc>
       <image:title>fiShbRaiN - psychotic meltdown | Stims</image:title>
       <image:caption>fiShbRaiN - psychotic meltdown by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3823,7 +3823,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-soft-porn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-soft-porn.png</image:loc>
       <image:title>fiShbRaiN - soft porn | Stims</image:title>
       <image:caption>fiShbRaiN - soft porn by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3834,7 +3834,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-the-adventures-of-prismo-jenkins</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-the-adventures-of-prismo-jenkins.png</image:loc>
       <image:title>fiShbRaiN - the adventures of prismo jenkins | Stims</image:title>
       <image:caption>fiShbRaiN - the adventures of prismo jenkins by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3845,7 +3845,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-the-dark-side-of-the-moon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-the-dark-side-of-the-moon.png</image:loc>
       <image:title>fiShbRaiN - the dark side of the moon | Stims</image:title>
       <image:caption>fiShbRaiN - the dark side of the moon by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3856,7 +3856,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-the-machine-that-conquered-the-world-domination-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-the-machine-that-conquered-the-world-domination-remix.png</image:loc>
       <image:title>fiShbRaiN - the machine that conquered the world (domination remix) | Stims</image:title>
       <image:caption>fiShbRaiN - the machine that conquered the world (domination remix) by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3867,7 +3867,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-toffee-cream-and-icing-sugar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-toffee-cream-and-icing-sugar.png</image:loc>
       <image:title>fiShbRaiN - toffee cream and icing sugar | Stims</image:title>
       <image:caption>fiShbRaiN - toffee cream and icing sugar by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3878,7 +3878,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-when-robots-take-over-the-world</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-when-robots-take-over-the-world.png</image:loc>
       <image:title>fiShbRaiN - when robots take over the world | Stims</image:title>
       <image:caption>fiShbRaiN - when robots take over the world by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3889,7 +3889,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-white-scream-firefly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-white-scream-firefly.png</image:loc>
       <image:title>fiShbRaiN - white scream firefly | Stims</image:title>
       <image:caption>fiShbRaiN - white scream firefly by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3900,7 +3900,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-witchcraft-necromancer-remix-phat-edit-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-witchcraft-necromancer-remix-phat-edit-v3.png</image:loc>
       <image:title>fiShbRaiN - witchcraft (necromancer remix)_phat_edit_v3 | Stims</image:title>
       <image:caption>fiShbRaiN - witchcraft (necromancer remix)_phat_edit_v3 by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3911,7 +3911,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-witchcraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-witchcraft.png</image:loc>
       <image:title>fiShbRaiN - witchcraft | Stims</image:title>
       <image:caption>fiShbRaiN - witchcraft by fiShbRaiN, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3922,7 +3922,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-flexi-witchcraft-grow-mix-moebius-remix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-flexi-witchcraft-grow-mix-moebius-remix.png</image:loc>
       <image:title>fiShbRaiN, geiss + flexi - witchcraft (Grow Mix) (moebius remix) | Stims</image:title>
       <image:caption>fiShbRaiN, geiss + flexi - witchcraft (Grow Mix) (moebius remix) by fiShbRaiN, geiss + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3933,7 +3933,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-geiss-stahlregen-orb-witchcraft-yabm-tiled</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-geiss-stahlregen-orb-witchcraft-yabm-tiled.png</image:loc>
       <image:title>fishbrain + Geiss + Stahlregen + Orb - Witchcraft (yabm - tiled) | Stims</image:title>
       <image:caption>fishbrain + Geiss + Stahlregen + Orb - Witchcraft (yabm - tiled) by fishbrain + Geiss + Stahlregen + Orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3944,7 +3944,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-stitchcraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-stitchcraft.png</image:loc>
       <image:title>fishbrain + flexi - stitchcraft | Stims</image:title>
       <image:caption>fishbrain + flexi - stitchcraft by fishbrain + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3955,7 +3955,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=fishbrain-flexi-witchcraft-graffitti-attack</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/fishbrain-flexi-witchcraft-graffitti-attack.png</image:loc>
       <image:title>fishbrain + flexi - witchcraft [graffitti attack] | Stims</image:title>
       <image:caption>fishbrain + flexi - witchcraft [graffitti attack] by fishbrain + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3966,7 +3966,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic-random-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic-random-mashup-2.png</image:loc>
       <image:title>flexi + amandio c - organic [random mashup 2] | Stims</image:title>
       <image:caption>flexi + amandio c - organic [random mashup 2] by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3977,7 +3977,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic-random-mashup.png</image:loc>
       <image:title>flexi + amandio c - organic [random mashup] | Stims</image:title>
       <image:caption>flexi + amandio c - organic [random mashup] by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3988,7 +3988,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic.png</image:loc>
       <image:title>flexi + amandio c - organic | Stims</image:title>
       <image:caption>flexi + amandio c - organic by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -3999,7 +3999,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic12-3d-2-alt</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic12-3d-2-alt.png</image:loc>
       <image:title>flexi + amandio c - organic12-3d-2 | Stims</image:title>
       <image:caption>flexi + amandio c - organic12-3d-2 by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4010,7 +4010,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic12-3d3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic12-3d3.png</image:loc>
       <image:title>flexi + amandio c - organic12-3d3 | Stims</image:title>
       <image:caption>flexi + amandio c - organic12-3d3 by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4021,7 +4021,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic12-3d4-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic12-3d4-2.png</image:loc>
       <image:title>flexi + amandio c - organic12-3d4-2 | Stims</image:title>
       <image:caption>flexi + amandio c - organic12-3d4-2 by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4032,7 +4032,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic12-3d4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic12-3d4.png</image:loc>
       <image:title>flexi + amandio c - organic12-3d4 | Stims</image:title>
       <image:caption>flexi + amandio c - organic12-3d4 by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4043,7 +4043,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-amandio-c-organic4-columns</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-amandio-c-organic4-columns.png</image:loc>
       <image:title>flexi + amandio c - organic4-columns | Stims</image:title>
       <image:caption>flexi + amandio c - organic4-columns by flexi + amandio c, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4054,7 +4054,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bdrv-acid-etching-jelly-v5-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bdrv-acid-etching-jelly-v5-5.png</image:loc>
       <image:title>flexi + bdrv - acid etching (jelly v5.5) | Stims</image:title>
       <image:caption>flexi + bdrv - acid etching (jelly v5.5) by flexi + bdrv, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4065,7 +4065,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz-wrepwrimindloss-w8</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz-wrepwrimindloss-w8.png</image:loc>
       <image:title>flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ wrepwrimindloss w8 | Stims</image:title>
       <image:caption>flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ wrepwrimindloss w8 by flexi + cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4076,7 +4076,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz.png</image:loc>
       <image:title>flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ | Stims</image:title>
       <image:caption>flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ by flexi + cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4087,7 +4087,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-geiss-unchained-others-plaidcraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-geiss-unchained-others-plaidcraft.png</image:loc>
       <image:title>flexi + fishbrain + geiss + unchained + others - Plaidcraft | Stims</image:title>
       <image:caption>flexi + fishbrain + geiss + unchained + others - Plaidcraft by flexi + fishbrain + geiss + unchained + others, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4098,7 +4098,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-neon-mindblob-grafitti</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-neon-mindblob-grafitti.png</image:loc>
       <image:title>flexi + fishbrain - neon mindblob grafitti | Stims</image:title>
       <image:caption>flexi + fishbrain - neon mindblob grafitti by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4109,7 +4109,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft-random-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft-random-mashup-2.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft [random mashup 2] | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft [random mashup 2] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4120,7 +4120,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft-random-mashup-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft-random-mashup-3.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft [random mashup 3] | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft [random mashup 3] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4131,7 +4131,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft-random-mashup-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft-random-mashup-4.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft [random mashup 4] | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft [random mashup 4] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4142,7 +4142,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft-random-mashup-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft-random-mashup-5.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft [random mashup 5] | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft [random mashup 5] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4153,7 +4153,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft-random-mashup.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft [random mashup] | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft [random mashup] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4164,7 +4164,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-warpcraft</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-warpcraft.png</image:loc>
       <image:title>flexi + fishbrain - warpcraft | Stims</image:title>
       <image:caption>flexi + fishbrain - warpcraft by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4175,7 +4175,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-witchcraft-complex-terraforming-fiddling-twists-in-the-fabric-of-space</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-witchcraft-complex-terraforming-fiddling-twists-in-the-fabric-of-space.png</image:loc>
       <image:title>flexi + fishbrain - witchcraft [complex terraforming - fiddling twists in the fabric of space] | Stims</image:title>
       <image:caption>flexi + fishbrain - witchcraft [complex terraforming - fiddling twists in the fabric of space] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4186,7 +4186,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-witchcraft-complex-terraforming</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-witchcraft-complex-terraforming.png</image:loc>
       <image:title>flexi + fishbrain - witchcraft [complex terraforming] | Stims</image:title>
       <image:caption>flexi + fishbrain - witchcraft [complex terraforming] by flexi + fishbrain, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4197,7 +4197,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-redi-jedi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-redi-jedi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-mashup.png</image:loc>
       <image:title>flexi + geiss + redi jedi + stahlregen - thumbdrum tokamak [crossfiring aftermath mashup] | Stims</image:title>
       <image:caption>flexi + geiss + redi jedi + stahlregen - thumbdrum tokamak [crossfiring aftermath mashup] by flexi + geiss + redi jedi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4208,7 +4208,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-bipolar-vs-reaction-diffusion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-bipolar-vs-reaction-diffusion.png</image:loc>
       <image:title>flexi + geiss - bipolar vs. reaction diffusion | Stims</image:title>
       <image:caption>flexi + geiss - bipolar vs. reaction diffusion by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4219,7 +4219,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery.png</image:loc>
       <image:title>flexi + geiss - infused with the spiral (Heavy Oil Mix) nz+ rapery | Stims</image:title>
       <image:caption>flexi + geiss - infused with the spiral (Heavy Oil Mix) nz+ rapery by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4230,7 +4230,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-vs-tokamak-vs-game-of-life-stahls-jelly-4-5-finish</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-vs-tokamak-vs-game-of-life-stahls-jelly-4-5-finish.png</image:loc>
       <image:title>flexi + geiss - pogo cubes vs. tokamak vs. game of life [stahls jelly 4.5 finish] | Stims</image:title>
       <image:caption>flexi + geiss - pogo cubes vs. tokamak vs. game of life [stahls jelly 4.5 finish] by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4241,7 +4241,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-on-tokamak-matter-bccn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-on-tokamak-matter-bccn-jelly-v4.png</image:loc>
       <image:title>flexi + geiss - pogo-cubes on tokamak matter (bccn Jelly V4) | Stims</image:title>
       <image:caption>flexi + geiss - pogo-cubes on tokamak matter (bccn Jelly V4) by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4252,7 +4252,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2.png</image:loc>
       <image:title>flexi + geiss - pogo-cubes on tokamak matter [mind over matter remix]2 | Stims</image:title>
       <image:caption>flexi + geiss - pogo-cubes on tokamak matter [mind over matter remix]2 by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4263,7 +4263,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-tokamak-fallout-repellor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-tokamak-fallout-repellor.png</image:loc>
       <image:title>flexi + geiss - tokamak fallout repellor | Stims</image:title>
       <image:caption>flexi + geiss - tokamak fallout repellor by flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4274,7 +4274,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-goody-the-prayerwheel-misplaced-prayers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-goody-the-prayerwheel-misplaced-prayers.png</image:loc>
       <image:title>flexi + goody - the prayerwheel - misplaced prayers | Stims</image:title>
       <image:caption>flexi + goody - the prayerwheel - misplaced prayers by flexi + goody, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4285,7 +4285,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-martin-predator-prey-system-versus-fruitmachine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-martin-predator-prey-system-versus-fruitmachine.png</image:loc>
       <image:title>flexi + martin - predator-prey system versus fruitmachine | Stims</image:title>
       <image:caption>flexi + martin - predator-prey system versus fruitmachine by flexi + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4296,7 +4296,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-nitorami-beat-explorer-cn-bc-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-nitorami-beat-explorer-cn-bc-jelly-4.png</image:loc>
       <image:title>flexi + nitorami - beat explorer (cn bc jelly 4) | Stims</image:title>
       <image:caption>flexi + nitorami - beat explorer (cn bc jelly 4) by flexi + nitorami, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4307,7 +4307,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-stupid-visualization-test-bc-cn-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-stupid-visualization-test-bc-cn-jelly-4.png</image:loc>
       <image:title>flexi + stahlregen -  stupid visualization test (bc cn Jelly 4) | Stims</image:title>
       <image:caption>flexi + stahlregen -  stupid visualization test (bc cn Jelly 4) by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4318,7 +4318,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-a-car-crash-you-can-t-defocus-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-a-car-crash-you-can-t-defocus-2.png</image:loc>
       <image:title>flexi + stahlregen - a car crash you can′t defocus_2 | Stims</image:title>
       <image:caption>flexi + stahlregen - a car crash you can′t defocus_2 by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4329,7 +4329,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-gimme-color-spinner-mix-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-gimme-color-spinner-mix-v2.png</image:loc>
       <image:title>flexi + stahlregen - gimme color (spinner mix v2) | Stims</image:title>
       <image:caption>flexi + stahlregen - gimme color (spinner mix v2) by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4340,7 +4340,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-gimme-color-spinner-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-gimme-color-spinner-mix.png</image:loc>
       <image:title>flexi + stahlregen - gimme color (spinner mix) | Stims</image:title>
       <image:caption>flexi + stahlregen - gimme color (spinner mix) by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4351,7 +4351,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-jelly-spin-off</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-jelly-spin-off.png</image:loc>
       <image:title>flexi + stahlregen - jelly spin-off | Stims</image:title>
       <image:caption>flexi + stahlregen - jelly spin-off by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4362,7 +4362,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-jelly-strike</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-jelly-strike.png</image:loc>
       <image:title>flexi + stahlregen - jelly strike | Stims</image:title>
       <image:caption>flexi + stahlregen - jelly strike by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4373,7 +4373,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-jewelry-tiles</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-jewelry-tiles.png</image:loc>
       <image:title>flexi + stahlregen - jewelry tiles | Stims</image:title>
       <image:caption>flexi + stahlregen - jewelry tiles by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4384,7 +4384,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos.png</image:loc>
       <image:title>flexi + stahlregen - julian tiles 3 [mirror-mode=eo.s] (spiral chaos) | Stims</image:title>
       <image:caption>flexi + stahlregen - julian tiles 3 [mirror-mode=eo.s] (spiral chaos) by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4395,7 +4395,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-julian-tiles-mirror-mode-eo-s</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-julian-tiles-mirror-mode-eo-s.png</image:loc>
       <image:title>flexi + stahlregen - julian tiles [mirror-mode=eo.s] | Stims</image:title>
       <image:caption>flexi + stahlregen - julian tiles [mirror-mode=eo.s] by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4406,7 +4406,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-organic-canvas</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-organic-canvas.png</image:loc>
       <image:title>flexi + stahlregen - organic canvas | Stims</image:title>
       <image:caption>flexi + stahlregen - organic canvas by flexi + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4417,7 +4417,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-3d-mosaic-glass-test-mash0000-9d-tuscan-slop-ram</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-3d-mosaic-glass-test-mash0000-9d-tuscan-slop-ram.png</image:loc>
       <image:title>flexi - 3d mosaic glass test - mash0000 - 9d tuscan slop ram | Stims</image:title>
       <image:caption>flexi - 3d mosaic glass test - mash0000 - 9d tuscan slop ram by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4428,7 +4428,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob.png</image:loc>
       <image:title>flexi - Mindblob | Stims</image:title>
       <image:caption>flexi - Mindblob by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4439,7 +4439,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-canvas-learning</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-canvas-learning.png</image:loc>
       <image:title>flexi - alien canvas [learning] | Stims</image:title>
       <image:caption>flexi - alien canvas [learning] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4450,7 +4450,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-canvas-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-canvas-random-mashup.png</image:loc>
       <image:title>flexi - alien canvas [random mashup] | Stims</image:title>
       <image:caption>flexi - alien canvas [random mashup] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4461,7 +4461,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-canvas</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-canvas.png</image:loc>
       <image:title>flexi - alien canvas | Stims</image:title>
       <image:caption>flexi - alien canvas by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4472,7 +4472,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-canvas-001</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-canvas-001.png</image:loc>
       <image:title>flexi - alien canvas_001 | Stims</image:title>
       <image:caption>flexi - alien canvas_001 by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4483,7 +4483,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-web-bouncer-edit-for-hexcollie-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-web-bouncer-edit-for-hexcollie-random-mashup.png</image:loc>
       <image:title>flexi - alien web bouncer [edit for hexcollie] [random mashup] | Stims</image:title>
       <image:caption>flexi - alien web bouncer [edit for hexcollie] [random mashup] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4494,7 +4494,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-alien-web-bouncer-edit-for-hexcollie</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-alien-web-bouncer-edit-for-hexcollie.png</image:loc>
       <image:title>flexi - alien web bouncer [edit for hexcollie] | Stims</image:title>
       <image:caption>flexi - alien web bouncer [edit for hexcollie] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4505,7 +4505,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-black-holes-sucking-fractals-for-breakfast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-black-holes-sucking-fractals-for-breakfast.png</image:loc>
       <image:title>flexi - black holes [sucking fractals for breakfast] | Stims</image:title>
       <image:caption>flexi - black holes [sucking fractals for breakfast] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4516,7 +4516,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-blame-moebius</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-blame-moebius.png</image:loc>
       <image:title>flexi - blame moebius | Stims</image:title>
       <image:caption>flexi - blame moebius by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4527,7 +4527,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-borderline-imagery</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-borderline-imagery.png</image:loc>
       <image:title>flexi - borderline imagery | Stims</image:title>
       <image:caption>flexi - borderline imagery by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4538,7 +4538,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bouncing-balls-double-mindblob-gastrointestinal-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bouncing-balls-double-mindblob-gastrointestinal-mix.png</image:loc>
       <image:title>flexi - bouncing balls [double mindblob gastrointestinal mix] | Stims</image:title>
       <image:caption>flexi - bouncing balls [double mindblob gastrointestinal mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4549,7 +4549,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bouncing-balls-double-mindblob-neon-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bouncing-balls-double-mindblob-neon-mix.png</image:loc>
       <image:title>flexi - bouncing balls [double mindblob neon mix] | Stims</image:title>
       <image:caption>flexi - bouncing balls [double mindblob neon mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4560,7 +4560,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bouncing-balls-grafitti-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bouncing-balls-grafitti-mix.png</image:loc>
       <image:title>flexi - bouncing balls [grafitti mix] | Stims</image:title>
       <image:caption>flexi - bouncing balls [grafitti mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4571,7 +4571,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bouncing-balls-illumination-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bouncing-balls-illumination-mix.png</image:loc>
       <image:title>flexi - bouncing balls [illumination mix] | Stims</image:title>
       <image:caption>flexi - bouncing balls [illumination mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4582,7 +4582,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-bouncing-balls-neon-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-bouncing-balls-neon-mix.png</image:loc>
       <image:title>flexi - bouncing balls [neon mix] | Stims</image:title>
       <image:caption>flexi - bouncing balls [neon mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4593,7 +4593,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-can-t-think-of-mosaic-cages</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-can-t-think-of-mosaic-cages.png</image:loc>
       <image:title>flexi - can′t think of mosaic cages | Stims</image:title>
       <image:caption>flexi - can′t think of mosaic cages by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4604,7 +4604,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-color-strike</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-color-strike.png</image:loc>
       <image:title>flexi - color strike | Stims</image:title>
       <image:caption>flexi - color strike by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4615,7 +4615,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-crank-prototype</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-crank-prototype.png</image:loc>
       <image:title>flexi - crank prototype | Stims</image:title>
       <image:caption>flexi - crank prototype by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4626,7 +4626,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-flow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-flow.png</image:loc>
       <image:title>flexi - flow | Stims</image:title>
       <image:caption>flexi - flow by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4637,7 +4637,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fractal-descent</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fractal-descent.png</image:loc>
       <image:title>flexi - fractal descent | Stims</image:title>
       <image:caption>flexi - fractal descent by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4648,7 +4648,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fractal-seafood</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fractal-seafood.png</image:loc>
       <image:title>flexi - fractal seafood | Stims</image:title>
       <image:caption>flexi - fractal seafood by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4659,7 +4659,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-gimme-color-bc-cn-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-gimme-color-bc-cn-jelly-4.png</image:loc>
       <image:title>flexi - gimme color (bc cn jelly 4) | Stims</image:title>
       <image:caption>flexi - gimme color (bc cn jelly 4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4670,7 +4670,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-gimme-color</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-gimme-color.png</image:loc>
       <image:title>flexi - gimme color | Stims</image:title>
       <image:caption>flexi - gimme color by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4681,7 +4681,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-gravitational-chaos</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-gravitational-chaos.png</image:loc>
       <image:title>flexi - gravitational chaos | Stims</image:title>
       <image:caption>flexi - gravitational chaos by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4692,7 +4692,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-hue-tube</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-hue-tube.png</image:loc>
       <image:title>flexi - hue tube | Stims</image:title>
       <image:caption>flexi - hue tube by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4703,7 +4703,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-hyperspaceflight-bn-cn-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-hyperspaceflight-bn-cn-jelly-4.png</image:loc>
       <image:title>flexi - hyperspaceflight (bn cn Jelly 4) | Stims</image:title>
       <image:caption>flexi - hyperspaceflight (bn cn Jelly 4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4714,7 +4714,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-infused-with-the-spiral-bc-cn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-infused-with-the-spiral-bc-cn-jelly-v4.png</image:loc>
       <image:title>flexi - infused with the spiral (bc cn jelly V4) | Stims</image:title>
       <image:caption>flexi - infused with the spiral (bc cn jelly V4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4725,7 +4725,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-infused-with-the-spiral-jelly-4-x-cn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-infused-with-the-spiral-jelly-4-x-cn.png</image:loc>
       <image:title>flexi - infused with the spiral (jelly 4.x cn) | Stims</image:title>
       <image:caption>flexi - infused with the spiral (jelly 4.x cn) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4736,7 +4736,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-inter-state</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-inter-state.png</image:loc>
       <image:title>flexi - inter state | Stims</image:title>
       <image:caption>flexi - inter state by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4747,7 +4747,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-jelly-fish-mandala</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-jelly-fish-mandala.png</image:loc>
       <image:title>flexi - jelly fish mandala | Stims</image:title>
       <image:caption>flexi - jelly fish mandala by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4758,7 +4758,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-island-output-stage</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-island-output-stage.png</image:loc>
       <image:title>flexi - julia island [output stage] | Stims</image:title>
       <image:caption>flexi - julia island [output stage] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4769,7 +4769,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-illuminating-example-parameter-play</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-illuminating-example-parameter-play.png</image:loc>
       <image:title>flexi - julia set illuminating example [parameter play] | Stims</image:title>
       <image:caption>flexi - julia set illuminating example [parameter play] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4780,7 +4780,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-illuminating-example</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-illuminating-example.png</image:loc>
       <image:title>flexi - julia set illuminating example | Stims</image:title>
       <image:caption>flexi - julia set illuminating example by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4791,7 +4791,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-shader-neocortex-wiretapping</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-shader-neocortex-wiretapping.png</image:loc>
       <image:title>flexi - julia set shader [neocortex wiretapping] | Stims</image:title>
       <image:caption>flexi - julia set shader [neocortex wiretapping] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4802,7 +4802,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-shader-example-2-geiss-sharpen-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-shader-example-2-geiss-sharpen-mix.png</image:loc>
       <image:title>flexi - julia set shader example 2 (geiss sharpen mix) | Stims</image:title>
       <image:caption>flexi - julia set shader example 2 (geiss sharpen mix) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4813,7 +4813,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-shader-example-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-shader-example-2.png</image:loc>
       <image:title>flexi - julia set shader example 2 | Stims</image:title>
       <image:caption>flexi - julia set shader example 2 by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4824,7 +4824,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-set-shader-example</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-set-shader-example.png</image:loc>
       <image:title>flexi - julia set shader example | Stims</image:title>
       <image:caption>flexi - julia set shader example by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4835,7 +4835,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julia-vs-sierpinski</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julia-vs-sierpinski.png</image:loc>
       <image:title>flexi - julia vs. sierpinski | Stims</image:title>
       <image:caption>flexi - julia vs. sierpinski by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4846,7 +4846,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-julian-affairs-bc-cn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-julian-affairs-bc-cn-jelly-v4.png</image:loc>
       <image:title>flexi - julian affairs [bc cn jelly V4) | Stims</image:title>
       <image:caption>flexi - julian affairs [bc cn jelly V4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4857,7 +4857,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-kaleidoscope-template</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-kaleidoscope-template.png</image:loc>
       <image:title>flexi - kaleidoscope template | Stims</image:title>
       <image:caption>flexi - kaleidoscope template by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4868,7 +4868,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lollipop-overkill-bccn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lollipop-overkill-bccn-jelly-v4.png</image:loc>
       <image:title>flexi - lollipop overkill [bccn Jelly V4] | Stims</image:title>
       <image:caption>flexi - lollipop overkill [bccn Jelly V4] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4879,7 +4879,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lorenz-attractor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lorenz-attractor.png</image:loc>
       <image:title>flexi - lorenz attractor | Stims</image:title>
       <image:caption>flexi - lorenz attractor by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4890,7 +4890,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lorenz-chaser-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lorenz-chaser-jelly-v3.png</image:loc>
       <image:title>flexi - lorenz chaser (Jelly V3) | Stims</image:title>
       <image:caption>flexi - lorenz chaser (Jelly V3) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4901,7 +4901,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lorenz-chaser-stahl-s-rainbow-multiply-mix-2-jelly-v2.png</image:loc>
       <image:title>flexi - lorenz chaser (Stahl′s rainbow multiply mix 2 - Jelly V2) | Stims</image:title>
       <image:caption>flexi - lorenz chaser (Stahl′s rainbow multiply mix 2 - Jelly V2) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4912,7 +4912,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples.png</image:loc>
       <image:title>flexi - lorenz chaser [accidental shader-lock mashup] (ripples) | Stims</image:title>
       <image:caption>flexi - lorenz chaser [accidental shader-lock mashup] (ripples) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4923,7 +4923,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-2-nz-discombobule-lose</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-2-nz-discombobule-lose.png</image:loc>
       <image:title>flexi - lorenz chaser [accidental shader-lock mashup] (ripples)2 nz+ discombobule lose | Stims</image:title>
       <image:caption>flexi - lorenz chaser [accidental shader-lock mashup] (ripples)2 nz+ discombobule lose by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4934,7 +4934,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-meta4free</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-meta4free.png</image:loc>
       <image:title>flexi - meta4free | Stims</image:title>
       <image:caption>flexi - meta4free by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4945,7 +4945,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mindblob-2-0-bc-cn-jelly-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mindblob-2-0-bc-cn-jelly-4.png</image:loc>
       <image:title>flexi - mindblob 2.0 (bc cn jelly 4) | Stims</image:title>
       <image:caption>flexi - mindblob 2.0 (bc cn jelly 4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4956,7 +4956,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-moebius-transformation-random-texture-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-moebius-transformation-random-texture-mix.png</image:loc>
       <image:title>flexi - moebius transformation [random texture mix] | Stims</image:title>
       <image:caption>flexi - moebius transformation [random texture mix] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4967,7 +4967,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-mom-why-the-sky-looks-different-today</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-mom-why-the-sky-looks-different-today.png</image:loc>
       <image:title>flexi - mom, why the sky looks different today | Stims</image:title>
       <image:caption>flexi - mom, why the sky looks different today by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4978,7 +4978,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-patternton-district-of-media-capitol-of-the-united-abstractions-of-fractopia</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-patternton-district-of-media-capitol-of-the-united-abstractions-of-fractopia.png</image:loc>
       <image:title>flexi - patternton, district of media, capitol of the united abstractions of fractopia | Stims</image:title>
       <image:caption>flexi - patternton, district of media, capitol of the united abstractions of fractopia by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -4989,7 +4989,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-predator-prey-seminar-paper-visualization-05-mathematical-biology-concepts-reaction-diffusion-on-predator-prey-spirals</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-predator-prey-seminar-paper-visualization-05-mathematical-biology-concepts-reaction-diffusion-on-predator-prey-spirals.png</image:loc>
       <image:title>flexi - predator-prey seminar paper visualization [05 mathematical biology concepts - reaction-diffusion on predator-prey spirals] | Stims</image:title>
       <image:caption>flexi - predator-prey seminar paper visualization [05 mathematical biology concepts - reaction-diffusion on predator-prey spirals] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5000,7 +5000,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-romanesco-fantasies-motion-blurred</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-romanesco-fantasies-motion-blurred.png</image:loc>
       <image:title>flexi - romanesco fantasies [motion blurred] | Stims</image:title>
       <image:caption>flexi - romanesco fantasies [motion blurred] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5011,7 +5011,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-romanesco-fantasies</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-romanesco-fantasies.png</image:loc>
       <image:title>flexi - romanesco fantasies | Stims</image:title>
       <image:caption>flexi - romanesco fantasies by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5022,7 +5022,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-smouldering</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-smouldering.png</image:loc>
       <image:title>flexi - smouldering | Stims</image:title>
       <image:caption>flexi - smouldering by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5033,7 +5033,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-splatter-effects-17-the-wave-a-google-love-story-written-in-decay-roam3-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-splatter-effects-17-the-wave-a-google-love-story-written-in-decay-roam3-2.png</image:loc>
       <image:title>flexi - splatter effects 17 the wave, a google love story written in decay roam3-2  | Stims</image:title>
       <image:caption>flexi - splatter effects 17 the wave, a google love story written in decay roam3-2  by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5044,7 +5044,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-swing-out-on-the-spiral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-swing-out-on-the-spiral.png</image:loc>
       <image:title>flexi - swing out on the spiral | Stims</image:title>
       <image:caption>flexi - swing out on the spiral by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5055,7 +5055,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-target-practice</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-target-practice.png</image:loc>
       <image:title>flexi - target practice | Stims</image:title>
       <image:caption>flexi - target practice by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5066,7 +5066,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-distant-point-between</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-distant-point-between.png</image:loc>
       <image:title>flexi - the distant point between | Stims</image:title>
       <image:caption>flexi - the distant point between by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5077,7 +5077,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-the-prayerwheel</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-the-prayerwheel.png</image:loc>
       <image:title>flexi - the prayerwheel | Stims</image:title>
       <image:caption>flexi - the prayerwheel by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5088,7 +5088,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-trickster-zenarchy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-trickster-zenarchy.png</image:loc>
       <image:title>flexi - trickster zenarchy | Stims</image:title>
       <image:caption>flexi - trickster zenarchy by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5099,7 +5099,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-undercurrents-2-bccn-jelly-v4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-undercurrents-2-bccn-jelly-v4.png</image:loc>
       <image:title>flexi - undercurrents 2 (bccn Jelly V4) | Stims</image:title>
       <image:caption>flexi - undercurrents 2 (bccn Jelly V4) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5110,7 +5110,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-undercurrents-3-geiss-bipolar-1-mix-jelly-5-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-undercurrents-3-geiss-bipolar-1-mix-jelly-5-5.png</image:loc>
       <image:title>flexi - undercurrents 3 [geiss bipolar 1 mix] (Jelly 5.5) | Stims</image:title>
       <image:caption>flexi - undercurrents 3 [geiss bipolar 1 mix] (Jelly 5.5) by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5121,7 +5121,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-undercurrents-3-psychodelic-mix-mash0001-planck-based-dematerializer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-undercurrents-3-psychodelic-mix-mash0001-planck-based-dematerializer.png</image:loc>
       <image:title>flexi - undercurrents 3 [psychodelic mix] - mash0001 - planck based dematerializer | Stims</image:title>
       <image:caption>flexi - undercurrents 3 [psychodelic mix] - mash0001 - planck based dematerializer by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5132,7 +5132,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-what-is-the-matrix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-what-is-the-matrix.png</image:loc>
       <image:title>flexi - what is the matrix | Stims</image:title>
       <image:caption>flexi - what is the matrix by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5143,7 +5143,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template.png</image:loc>
       <image:title>flexi - what to do with the inside of a torus [easily customizable moebius spiral template] | Stims</image:title>
       <image:caption>flexi - what to do with the inside of a torus [easily customizable moebius spiral template] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5154,7 +5154,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-why-random-mashups-should-be-forbidden-meta</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-why-random-mashups-should-be-forbidden-meta.png</image:loc>
       <image:title>flexi - why random mashups should be forbidden [meta] | Stims</image:title>
       <image:caption>flexi - why random mashups should be forbidden [meta] by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5165,7 +5165,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-why-random-mashups-should-be-forbidden</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-why-random-mashups-should-be-forbidden.png</image:loc>
       <image:title>flexi - why random mashups should be forbidden | Stims</image:title>
       <image:caption>flexi - why random mashups should be forbidden by flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5176,7 +5176,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-adamfx-hexcollie-moebius-morbid-vision-crack</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-adamfx-hexcollie-moebius-morbid-vision-crack.png</image:loc>
       <image:title>flexi, adamfx + hexcollie - moebius morbid vision crack | Stims</image:title>
       <image:caption>flexi, adamfx + hexcollie - moebius morbid vision crack by flexi, adamfx + hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5187,7 +5187,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-fishbrain-stahlregen-witchcraft-jelly5-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-fishbrain-stahlregen-witchcraft-jelly5-5.png</image:loc>
       <image:title>flexi, fishbrain + stahlregen - witchcraft [jelly5.5] | Stims</image:title>
       <image:caption>flexi, fishbrain + stahlregen - witchcraft [jelly5.5] by flexi, fishbrain + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5198,7 +5198,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-stahlregen-tokamak-jelly-infusion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-stahlregen-tokamak-jelly-infusion.png</image:loc>
       <image:title>flexi, geiss + stahlregen - tokamak jelly infusion | Stims</image:title>
       <image:caption>flexi, geiss + stahlregen - tokamak jelly infusion by flexi, geiss + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5209,7 +5209,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-geiss-and-rovastar-chaos-layered-sinewsed-tokamak-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-geiss-and-rovastar-chaos-layered-sinewsed-tokamak-2.png</image:loc>
       <image:title>flexi, geiss and rovastar - chaos layered sinewsed tokamak 2 | Stims</image:title>
       <image:caption>flexi, geiss and rovastar - chaos layered sinewsed tokamak 2 by flexi, geiss and rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5220,7 +5220,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-martin-indoctrinutrition</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-martin-indoctrinutrition.png</image:loc>
       <image:title>flexi, stahlregen + martin - indoctrinutrition | Stims</image:title>
       <image:caption>flexi, stahlregen + martin - indoctrinutrition by flexi, stahlregen + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5231,7 +5231,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=flexi-stahlregen-geiss-tobias-wolfboi-space-gelatine-burst-mash0000-chromatidal-pool-mirror-blasphemy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/flexi-stahlregen-geiss-tobias-wolfboi-space-gelatine-burst-mash0000-chromatidal-pool-mirror-blasphemy.png</image:loc>
       <image:title>flexi, stahlregen, geiss + tobias wolfboi - space gelatine burst - mash0000 - chromatidal pool mirror blasphemy | Stims</image:title>
       <image:caption>flexi, stahlregen, geiss + tobias wolfboi - space gelatine burst - mash0000 - chromatidal pool mirror blasphemy by flexi, stahlregen, geiss + tobias wolfboi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5242,7 +5242,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-martin-mandelbox-explorer-high-speed-demo-version-fire-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-martin-mandelbox-explorer-high-speed-demo-version-fire-mix.png</image:loc>
       <image:title>geiss + martin - mandelbox explorer - high speed demo version (fire mix) | Stims</image:title>
       <image:caption>geiss + martin - mandelbox explorer - high speed demo version (fire mix) by geiss + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5253,7 +5253,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-liquid-beats-jelly-v4-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-liquid-beats-jelly-v4-5.png</image:loc>
       <image:title>geiss - liquid beats (jelly v4.5) | Stims</image:title>
       <image:caption>geiss - liquid beats (jelly v4.5) by geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5264,7 +5264,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=geiss-reaction-diffusion-3-rippling-leopard-skin</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/geiss-reaction-diffusion-3-rippling-leopard-skin.png</image:loc>
       <image:title>geiss - reaction diffusion 3 (rippling leopard skin) | Stims</image:title>
       <image:caption>geiss - reaction diffusion 3 (rippling leopard skin) by geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5275,7 +5275,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-eo-s-martin-nematodes-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-eo-s-martin-nematodes-jelly-v3.png</image:loc>
       <image:title>goody + eo.s. + martin - nematodes (Jelly V3) | Stims</image:title>
       <image:caption>goody + eo.s. + martin - nematodes (Jelly V3) by goody + eo.s. + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5286,7 +5286,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-eo-s-martin-nematodes-reverse-jelly-v3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-eo-s-martin-nematodes-reverse-jelly-v3.png</image:loc>
       <image:title>goody + eo.s. + martin - nematodes (Reverse Jelly V3) | Stims</image:title>
       <image:caption>goody + eo.s. + martin - nematodes (Reverse Jelly V3) by goody + eo.s. + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5297,7 +5297,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations.png</image:loc>
       <image:title>goody + martin - crystal palace - schizotoxin - the wild iris bloom - 16 iterations | Stims</image:title>
       <image:caption>goody + martin - crystal palace - schizotoxin - the wild iris bloom - 16 iterations by goody + martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5308,7 +5308,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader-fixed</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader-fixed.png</image:loc>
       <image:title>goody + shadowharlequin - red + blue - chase - megatrip - [geiss - aurora 2 v22 -2222 v2] - shader (fixed) | Stims</image:title>
       <image:caption>goody + shadowharlequin - red + blue - chase - megatrip - [geiss - aurora 2 v22 -2222 v2] - shader (fixed) by goody + shadowharlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5319,7 +5319,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader.png</image:loc>
       <image:title>goody + shadowharlequin - red + blue - chase - megatrip - [geiss - aurora 2 v22 -2222 v2] - shader | Stims</image:title>
       <image:caption>goody + shadowharlequin - red + blue - chase - megatrip - [geiss - aurora 2 v22 -2222 v2] - shader by goody + shadowharlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5330,7 +5330,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=had-to-cum-that-jaben</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/had-to-cum-that-jaben.png</image:loc>
       <image:title>had to cum that - jaben | Stims</image:title>
       <image:caption>had to cum that - jaben by had to cum that, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5341,7 +5341,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-alex2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-alex2.png</image:loc>
       <image:title>hexcollie - Alex2 | Stims</image:title>
       <image:caption>hexcollie - Alex2 by hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5352,7 +5352,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=hexcollie-1-goody-3-stahlregen-3-fed-1-2nd-collaboration-ps2-0-8</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/hexcollie-1-goody-3-stahlregen-3-fed-1-2nd-collaboration-ps2-0-8.png</image:loc>
       <image:title>hexcollie(1), goody(3), stahlregen(3), fed(1) - 2nd collaboration(ps2.0) - 8 | Stims</image:title>
       <image:caption>hexcollie(1), goody(3), stahlregen(3), fed(1) - 2nd collaboration(ps2.0) - 8 by hexcollie, goody, stahlregen, fed, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5363,7 +5363,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=high-altitude-basket-unraveling-singh-grooves-nitrogen-argon-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/high-altitude-basket-unraveling-singh-grooves-nitrogen-argon-nz.png</image:loc>
       <image:title>high-altitude basket unraveling - singh grooves nitrogen argon nz+ | Stims</image:title>
       <image:caption>high-altitude basket unraveling - singh grooves nitrogen argon nz+ by high-altitude basket unraveling, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5374,7 +5374,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=imus-and-rovastar-the-shroomery-psilobellum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/imus-and-rovastar-the-shroomery-psilobellum.png</image:loc>
       <image:title>iMuS and  Rovastar - The Shroomery (psilobellum) | Stims</image:title>
       <image:caption>iMuS and  Rovastar - The Shroomery (psilobellum) by iMuS and  Rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5385,7 +5385,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=idiot-spectrum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/idiot-spectrum.png</image:loc>
       <image:title>idiot - Spectrum | Stims</image:title>
       <image:caption>idiot - Spectrum by idiot, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5396,7 +5396,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch.png</image:loc>
       <image:title>lit claw (explorers grid) - i don′t have either a belfry or bats bitch | Stims</image:title>
       <image:caption>lit claw (explorers grid) - i don′t have either a belfry or bats bitch by lit claw, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5407,7 +5407,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbox-explorer-high-speed-demo-flexi-s-complex-polynomial-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbox-explorer-high-speed-demo-flexi-s-complex-polynomial-version.png</image:loc>
       <image:title>martin  - mandelbox explorer - high speed demo  [flexi&apos;s complex polynomial version] | Stims</image:title>
       <image:caption>martin  - mandelbox explorer - high speed demo  [flexi&apos;s complex polynomial version] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5418,7 +5418,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-bombyx-mori-mix2-in-the-beehive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-bombyx-mori-mix2-in-the-beehive.png</image:loc>
       <image:title>martin + flexi - bombyx mori mix2 in the beehive | Stims</image:title>
       <image:caption>martin + flexi - bombyx mori mix2 in the beehive by martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5429,7 +5429,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-diamond-cutter-prismaticvortex-com-camille-i-wish-i-wish-i-wish-i-was-constrained</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-diamond-cutter-prismaticvortex-com-camille-i-wish-i-wish-i-wish-i-was-constrained.png</image:loc>
       <image:title>martin + flexi - diamond cutter [prismaticvortex.com] - camille - i wish i wish i wish i was constrained | Stims</image:title>
       <image:caption>martin + flexi - diamond cutter [prismaticvortex.com] - camille - i wish i wish i wish i was constrained by martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5440,7 +5440,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-mandelbox-explorer-high-speed-oversustained-bipolar</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-mandelbox-explorer-high-speed-oversustained-bipolar.png</image:loc>
       <image:title>martin + flexi - mandelbox explorer - high speed oversustained bipolar | Stims</image:title>
       <image:caption>martin + flexi - mandelbox explorer - high speed oversustained bipolar by martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5451,7 +5451,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix.png</image:loc>
       <image:title>martin + flexi - mandelbox stepper mix [kinetic triangles gossip matrix] | Stims</image:title>
       <image:caption>martin + flexi - mandelbox stepper mix [kinetic triangles gossip matrix] by martin + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5462,7 +5462,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-1.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 1 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 1 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5473,7 +5473,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-10-infinity-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-10-infinity-mix.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 10 (infinity mix) | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 10 (infinity mix) by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5484,7 +5484,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-11</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-11.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 11 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 11 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5495,7 +5495,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-12</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-12.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 12 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 12 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5506,7 +5506,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-12a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-12a.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 12a | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 12a by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5517,7 +5517,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-14</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-14.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 14 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 14 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5528,7 +5528,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-16</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-16.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 16 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 16 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5539,7 +5539,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-18</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-18.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 18 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 18 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5550,7 +5550,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-3.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 3 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 3 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5561,7 +5561,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stahlregen-martin-in-da-mash-7</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stahlregen-martin-in-da-mash-7.png</image:loc>
       <image:title>martin + stahlregen - martin in da mash 7 | Stims</image:title>
       <image:caption>martin + stahlregen - martin in da mash 7 by martin + stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5572,7 +5572,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-suksma-fed-goody-and-others-blarfff-zebra-puke-mash-up-by-stahlregen</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-suksma-fed-goody-and-others-blarfff-zebra-puke-mash-up-by-stahlregen.png</image:loc>
       <image:title>martin + suksma + fed + goody and others - blarfff [Zebra puke mash-up by Stahlregen] | Stims</image:title>
       <image:caption>martin + suksma + fed + goody and others - blarfff [Zebra puke mash-up by Stahlregen] by martin + suksma + fed + goody and others, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5583,7 +5583,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexis-swarm-in-martins-pond-not-yet-a-boid-implementation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexis-swarm-in-martins-pond-not-yet-a-boid-implementation.png</image:loc>
       <image:title>martin - Flexis swarm in Martins pond [not yet a boid implementation]  | Stims</image:title>
       <image:caption>martin - Flexis swarm in Martins pond [not yet a boid implementation]  by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5594,7 +5594,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-geiss-psychotic-roulette</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-geiss-psychotic-roulette.png</image:loc>
       <image:title>martin - Geiss - Psychotic Roulette | Stims</image:title>
       <image:caption>martin - Geiss - Psychotic Roulette by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5605,7 +5605,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-bridge-of-khazad-dum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-bridge-of-khazad-dum.png</image:loc>
       <image:title>martin - The Bridge of Khazad-Dum | Stims</image:title>
       <image:caption>martin - The Bridge of Khazad-Dum by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5616,7 +5616,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-thinking-about-you</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-thinking-about-you.png</image:loc>
       <image:title>martin - Thinking about you | Stims</image:title>
       <image:caption>martin - Thinking about you by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5627,7 +5627,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-adrift-on-a-dead-planet-lard-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-adrift-on-a-dead-planet-lard-mix.png</image:loc>
       <image:title>martin - adrift on a dead planet - lard mix | Stims</image:title>
       <image:caption>martin - adrift on a dead planet - lard mix by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5638,7 +5638,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-adrift-on-a-dead-planet-lite</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-adrift-on-a-dead-planet-lite.png</image:loc>
       <image:title>martin - adrift on a dead planet - lite | Stims</image:title>
       <image:caption>martin - adrift on a dead planet - lite by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5649,7 +5649,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-alien-grand-theft-water</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-alien-grand-theft-water.png</image:loc>
       <image:title>martin - alien grand theft water | Stims</image:title>
       <image:caption>martin - alien grand theft water by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5660,7 +5660,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-amandio-c-a-different-view-of-the-green-machine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-amandio-c-a-different-view-of-the-green-machine.png</image:loc>
       <image:title>martin - amandio c - a different view of the green machine | Stims</image:title>
       <image:caption>martin - amandio c - a different view of the green machine by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5671,7 +5671,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-angel-flight</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-angel-flight.png</image:loc>
       <image:title>martin - angel flight | Stims</image:title>
       <image:caption>martin - angel flight by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5682,7 +5682,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-another-kind-of-groove-ati-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-another-kind-of-groove-ati-fix.png</image:loc>
       <image:title>martin - another kind of groove (Ati Fix) | Stims</image:title>
       <image:caption>martin - another kind of groove (Ati Fix) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5693,7 +5693,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-another-kind-of-groove</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-another-kind-of-groove.png</image:loc>
       <image:title>martin - another kind of groove | Stims</image:title>
       <image:caption>martin - another kind of groove by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5704,7 +5704,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-attack-of-the-beast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-attack-of-the-beast.png</image:loc>
       <image:title>martin - attack of the beast | Stims</image:title>
       <image:caption>martin - attack of the beast by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5715,7 +5715,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-axon3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-axon3.png</image:loc>
       <image:title>martin - axon3 | Stims</image:title>
       <image:caption>martin - axon3 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5726,7 +5726,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-baby-one-more-time</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-baby-one-more-time.png</image:loc>
       <image:title>martin - baby one more time | Stims</image:title>
       <image:caption>martin - baby one more time by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5737,7 +5737,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-basal-ganglion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-basal-ganglion.png</image:loc>
       <image:title>martin - basal ganglion | Stims</image:title>
       <image:caption>martin - basal ganglion by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5748,7 +5748,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-blue-mountains</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-blue-mountains.png</image:loc>
       <image:title>martin - blue mountains | Stims</image:title>
       <image:caption>martin - blue mountains by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5759,7 +5759,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-bombyx-mori-flexi-s-logarithmic-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-bombyx-mori-flexi-s-logarithmic-edit.png</image:loc>
       <image:title>martin - bombyx mori [flexi′s logarithmic edit] | Stims</image:title>
       <image:caption>martin - bombyx mori [flexi′s logarithmic edit] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5770,7 +5770,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-bombyx-mori</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-bombyx-mori.png</image:loc>
       <image:title>martin - bombyx mori | Stims</image:title>
       <image:caption>martin - bombyx mori by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5781,7 +5781,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-bring-up-the-big-guns</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-bring-up-the-big-guns.png</image:loc>
       <image:title>martin - bring up the big guns | Stims</image:title>
       <image:caption>martin - bring up the big guns by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5792,7 +5792,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-butterflies</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-butterflies.png</image:loc>
       <image:title>martin - butterflies | Stims</image:title>
       <image:caption>martin - butterflies by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5803,7 +5803,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-carpet-weaver</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-carpet-weaver.png</image:loc>
       <image:title>martin - carpet weaver | Stims</image:title>
       <image:caption>martin - carpet weaver by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5814,7 +5814,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-castle-in-the-air</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-castle-in-the-air.png</image:loc>
       <image:title>martin - castle in the air | Stims</image:title>
       <image:caption>martin - castle in the air by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5825,7 +5825,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-chain-breaker-xxx</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-chain-breaker-xxx.png</image:loc>
       <image:title>martin - chain breaker xxx | Stims</image:title>
       <image:caption>martin - chain breaker xxx by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5836,7 +5836,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-chain-breaker</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-chain-breaker.png</image:loc>
       <image:title>martin - chain breaker | Stims</image:title>
       <image:caption>martin - chain breaker by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5847,7 +5847,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-cherry-brain-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-cherry-brain-2.png</image:loc>
       <image:title>martin - cherry brain 2 | Stims</image:title>
       <image:caption>martin - cherry brain 2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5858,7 +5858,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-cherry-brain-wall-mod</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-cherry-brain-wall-mod.png</image:loc>
       <image:title>martin - cherry brain wall mod | Stims</image:title>
       <image:caption>martin - cherry brain wall mod by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5869,7 +5869,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-city-of-shadows</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-city-of-shadows.png</image:loc>
       <image:title>martin - city of shadows | Stims</image:title>
       <image:caption>martin - city of shadows by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5880,7 +5880,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-coloured-metal</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-coloured-metal.png</image:loc>
       <image:title>martin - coloured metal | Stims</image:title>
       <image:caption>martin - coloured metal by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5891,7 +5891,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-cope-laser-dome</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-cope-laser-dome.png</image:loc>
       <image:title>martin - cope - laser dome | Stims</image:title>
       <image:caption>martin - cope - laser dome by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5902,7 +5902,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-crystal-alley</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-crystal-alley.png</image:loc>
       <image:title>martin - crystal alley | Stims</image:title>
       <image:caption>martin - crystal alley by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5913,7 +5913,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-crystal-palace-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-crystal-palace-nz.png</image:loc>
       <image:title>martin - crystal palace nz+ | Stims</image:title>
       <image:caption>martin - crystal palace nz+ by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5924,7 +5924,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-crystal-palace</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-crystal-palace.png</image:loc>
       <image:title>martin - crystal palace | Stims</image:title>
       <image:caption>martin - crystal palace by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5935,7 +5935,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-dark-galaxy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-dark-galaxy.png</image:loc>
       <image:title>martin - dark galaxy | Stims</image:title>
       <image:caption>martin - dark galaxy by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5946,7 +5946,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-deep-blue</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-deep-blue.png</image:loc>
       <image:title>martin - deep blue | Stims</image:title>
       <image:caption>martin - deep blue by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5957,7 +5957,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-diamond-cutter</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-diamond-cutter.png</image:loc>
       <image:title>martin - diamond cutter | Stims</image:title>
       <image:caption>martin - diamond cutter by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5968,7 +5968,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-1.png</image:loc>
       <image:title>martin - disco mix 1 | Stims</image:title>
       <image:caption>martin - disco mix 1 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5979,7 +5979,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-2.png</image:loc>
       <image:title>martin - disco mix 2 | Stims</image:title>
       <image:caption>martin - disco mix 2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -5990,7 +5990,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-2a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-2a.png</image:loc>
       <image:title>martin - disco mix 2a | Stims</image:title>
       <image:caption>martin - disco mix 2a by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6001,7 +6001,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-4.png</image:loc>
       <image:title>martin - disco mix 4 | Stims</image:title>
       <image:caption>martin - disco mix 4 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6012,7 +6012,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-disco-mix-5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-disco-mix-5.png</image:loc>
       <image:title>martin - disco mix 5 | Stims</image:title>
       <image:caption>martin - disco mix 5 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6023,7 +6023,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-dont-drink-and-drive-police-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-dont-drink-and-drive-police-mix.png</image:loc>
       <image:title>martin - dont drink and drive (police mix) | Stims</image:title>
       <image:caption>martin - dont drink and drive (police mix) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6034,7 +6034,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-dune-racer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-dune-racer.png</image:loc>
       <image:title>martin - dune racer | Stims</image:title>
       <image:caption>martin - dune racer by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6045,7 +6045,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-electric-pool</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-electric-pool.png</image:loc>
       <image:title>martin - electric pool | Stims</image:title>
       <image:caption>martin - electric pool by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6056,7 +6056,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-elusive-impressions-mix1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-elusive-impressions-mix1.png</image:loc>
       <image:title>martin - elusive impressions mix1 | Stims</image:title>
       <image:caption>martin - elusive impressions mix1 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6067,7 +6067,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-elusive-impressions-mix2-flacc-mess-proph-nz-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-elusive-impressions-mix2-flacc-mess-proph-nz-2.png</image:loc>
       <image:title>martin - elusive impressions mix2 - flacc mess proph nz+2 | Stims</image:title>
       <image:caption>martin - elusive impressions mix2 - flacc mess proph nz+2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6078,7 +6078,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-elusive-impressions-mix2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-elusive-impressions-mix2.png</image:loc>
       <image:title>martin - elusive impressions mix2 | Stims</image:title>
       <image:caption>martin - elusive impressions mix2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6089,7 +6089,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-extreme-heat</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-extreme-heat.png</image:loc>
       <image:title>martin - extreme heat | Stims</image:title>
       <image:caption>martin - extreme heat by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6100,7 +6100,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-first-try</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-first-try.png</image:loc>
       <image:title>martin - first try | Stims</image:title>
       <image:caption>martin - first try by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6111,7 +6111,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-laser-dome-bipolar-focus-intent</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-laser-dome-bipolar-focus-intent.png</image:loc>
       <image:title>martin - flexi - laser dome [bipolar focus intent] | Stims</image:title>
       <image:caption>martin - flexi - laser dome [bipolar focus intent] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6122,7 +6122,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-foggy-notion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-foggy-notion.png</image:loc>
       <image:title>martin - foggy notion | Stims</image:title>
       <image:caption>martin - foggy notion by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6133,7 +6133,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-frosty-caves-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-frosty-caves-2.png</image:loc>
       <image:title>martin - frosty caves 2 | Stims</image:title>
       <image:caption>martin - frosty caves 2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6144,7 +6144,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fruit-machine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fruit-machine.png</image:loc>
       <image:title>martin - fruit machine | Stims</image:title>
       <image:caption>martin - fruit machine by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6155,7 +6155,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-gate-to-moria</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-gate-to-moria.png</image:loc>
       <image:title>martin - gate to moria | Stims</image:title>
       <image:caption>martin - gate to moria by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6166,7 +6166,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-gentle-happiness-2a</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-gentle-happiness-2a.png</image:loc>
       <image:title>martin - gentle happiness 2a | Stims</image:title>
       <image:caption>martin - gentle happiness 2a by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6177,7 +6177,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-ghost-city</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-ghost-city.png</image:loc>
       <image:title>martin - ghost city | Stims</image:title>
       <image:caption>martin - ghost city by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6188,7 +6188,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-girlie-affairs</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-girlie-affairs.png</image:loc>
       <image:title>martin - girlie affairs | Stims</image:title>
       <image:caption>martin - girlie affairs by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6199,7 +6199,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-glass-corridor</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-glass-corridor.png</image:loc>
       <image:title>martin - glass corridor | Stims</image:title>
       <image:caption>martin - glass corridor by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6210,7 +6210,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-glassball-dance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-glassball-dance.png</image:loc>
       <image:title>martin - glassball dance | Stims</image:title>
       <image:caption>martin - glassball dance by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6221,7 +6221,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-golden-mirror</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-golden-mirror.png</image:loc>
       <image:title>martin - golden mirror | Stims</image:title>
       <image:caption>martin - golden mirror by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6232,7 +6232,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-hardcore-mix-1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-hardcore-mix-1.png</image:loc>
       <image:title>martin - hardcore mix 1 | Stims</image:title>
       <image:caption>martin - hardcore mix 1 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6243,7 +6243,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-hardcore-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-hardcore-mix-2.png</image:loc>
       <image:title>martin - hardcore mix 2 | Stims</image:title>
       <image:caption>martin - hardcore mix 2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6254,7 +6254,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-ice-flames</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-ice-flames.png</image:loc>
       <image:title>martin - ice flames | Stims</image:title>
       <image:caption>martin - ice flames by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6265,7 +6265,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-infinity-2008</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-infinity-2008.png</image:loc>
       <image:title>martin - infinity (2008) | Stims</image:title>
       <image:caption>martin - infinity (2008) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6276,7 +6276,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-infinity-2010-update</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-infinity-2010-update.png</image:loc>
       <image:title>martin - infinity (2010 update) | Stims</image:title>
       <image:caption>martin - infinity (2010 update) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6287,7 +6287,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-infinity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-infinity.png</image:loc>
       <image:title>martin - infinity | Stims</image:title>
       <image:caption>martin - infinity by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6298,7 +6298,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-into-the-fireworks</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-into-the-fireworks.png</image:loc>
       <image:title>martin - into the fireworks | Stims</image:title>
       <image:caption>martin - into the fireworks by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6309,7 +6309,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-invasion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-invasion.png</image:loc>
       <image:title>martin - invasion | Stims</image:title>
       <image:caption>martin - invasion by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6320,7 +6320,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-jellyfish-dance</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-jellyfish-dance.png</image:loc>
       <image:title>martin - jellyfish dance | Stims</image:title>
       <image:caption>martin - jellyfish dance by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6331,7 +6331,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-liquid-gold</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-liquid-gold.png</image:loc>
       <image:title>martin - liquid gold | Stims</image:title>
       <image:caption>martin - liquid gold by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6342,7 +6342,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-lock-and-release-ss</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-lock-and-release-ss.png</image:loc>
       <image:title>martin - lock and release ss | Stims</image:title>
       <image:caption>martin - lock and release ss by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6353,7 +6353,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-lock-and-release</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-lock-and-release.png</image:loc>
       <image:title>martin - lock and release | Stims</image:title>
       <image:caption>martin - lock and release by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6364,7 +6364,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-ludicrous-speed</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-ludicrous-speed.png</image:loc>
       <image:title>martin - ludicrous speed | Stims</image:title>
       <image:caption>martin - ludicrous speed by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6375,7 +6375,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave-random-mashup.png</image:loc>
       <image:title>martin - mandelbox explorer - high speed demo version [Flexi&apos;s diffuse wave] [random mashup] | Stims</image:title>
       <image:caption>martin - mandelbox explorer - high speed demo version [Flexi&apos;s diffuse wave] [random mashup] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6386,7 +6386,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave.png</image:loc>
       <image:title>martin - mandelbox explorer - high speed demo version [Flexi&apos;s diffuse wave] | Stims</image:title>
       <image:caption>martin - mandelbox explorer - high speed demo version [Flexi&apos;s diffuse wave] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6397,7 +6397,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbox-explorer-high-speed-demo-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbox-explorer-high-speed-demo-version.png</image:loc>
       <image:title>martin - mandelbox explorer - high speed demo version | Stims</image:title>
       <image:caption>martin - mandelbox explorer - high speed demo version by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6408,7 +6408,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbox-stepper</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbox-stepper.png</image:loc>
       <image:title>martin - mandelbox stepper | Stims</image:title>
       <image:caption>martin - mandelbox stepper by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6419,7 +6419,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mandelbulb-slideshow</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mandelbulb-slideshow.png</image:loc>
       <image:title>martin - mandelbulb slideshow | Stims</image:title>
       <image:caption>martin - mandelbulb slideshow by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6430,7 +6430,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-moonlight-splash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-moonlight-splash.png</image:loc>
       <image:title>martin - moonlight splash | Stims</image:title>
       <image:caption>martin - moonlight splash by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6441,7 +6441,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-move-this-body</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-move-this-body.png</image:loc>
       <image:title>martin - move this body | Stims</image:title>
       <image:caption>martin - move this body by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6452,7 +6452,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-mucus-cervix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-mucus-cervix.png</image:loc>
       <image:title>martin - mucus cervix | Stims</image:title>
       <image:caption>martin - mucus cervix by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6463,7 +6463,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-musicogenic-epilepsy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-musicogenic-epilepsy.png</image:loc>
       <image:title>martin - musicogenic epilepsy | Stims</image:title>
       <image:caption>martin - musicogenic epilepsy by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6474,7 +6474,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-neon-space-ps2-ati-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-neon-space-ps2-ati-fix.png</image:loc>
       <image:title>martin - neon space ps2 (ati fix) | Stims</image:title>
       <image:caption>martin - neon space ps2 (ati fix) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6485,7 +6485,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-neon-space-ps2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-neon-space-ps2.png</image:loc>
       <image:title>martin - neon space ps2 | Stims</image:title>
       <image:caption>martin - neon space ps2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6496,7 +6496,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-neon-space-ps3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-neon-space-ps3.png</image:loc>
       <image:title>martin - neon space ps3 | Stims</image:title>
       <image:caption>martin - neon space ps3 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6507,7 +6507,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-night-cathedral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-night-cathedral.png</image:loc>
       <image:title>martin - night cathedral | Stims</image:title>
       <image:caption>martin - night cathedral by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6518,7 +6518,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-night-in-the-forest</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-night-in-the-forest.png</image:loc>
       <image:title>martin - night in the forest | Stims</image:title>
       <image:caption>martin - night in the forest by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6529,7 +6529,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-on-silent-paths</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-on-silent-paths.png</image:loc>
       <image:title>martin - on silent paths | Stims</image:title>
       <image:caption>martin - on silent paths by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6540,7 +6540,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-orbit-trap-playground</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-orbit-trap-playground.png</image:loc>
       <image:title>martin - orbit trap playground | Stims</image:title>
       <image:caption>martin - orbit trap playground by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6551,7 +6551,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-organic-light</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-organic-light.png</image:loc>
       <image:title>martin - organic light | Stims</image:title>
       <image:caption>martin - organic light by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6562,7 +6562,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-pendulum-in-brass-ps3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-pendulum-in-brass-ps3.png</image:loc>
       <image:title>martin - pendulum in brass ps3 | Stims</image:title>
       <image:caption>martin - pendulum in brass ps3 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6573,7 +6573,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-purple-pulsator</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-purple-pulsator.png</image:loc>
       <image:title>martin - purple pulsator | Stims</image:title>
       <image:caption>martin - purple pulsator by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6584,7 +6584,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-reflections-on-black-tiles</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-reflections-on-black-tiles.png</image:loc>
       <image:title>martin - reflections on black tiles | Stims</image:title>
       <image:caption>martin - reflections on black tiles by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6595,7 +6595,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-resonant-twister-steel-spring</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-resonant-twister-steel-spring.png</image:loc>
       <image:title>martin - resonant twister - steel spring | Stims</image:title>
       <image:caption>martin - resonant twister - steel spring by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6606,7 +6606,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-resonant-twister</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-resonant-twister.png</image:loc>
       <image:title>martin - resonant twister | Stims</image:title>
       <image:caption>martin - resonant twister by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6617,7 +6617,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-rogue-wave-ps2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-rogue-wave-ps2.png</image:loc>
       <image:title>martin - rogue wave -ps2 | Stims</image:title>
       <image:caption>martin - rogue wave -ps2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6628,7 +6628,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-rogue-wave-ps3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-rogue-wave-ps3.png</image:loc>
       <image:title>martin - rogue wave -ps3 | Stims</image:title>
       <image:caption>martin - rogue wave -ps3 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6639,7 +6639,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-royal-waterfall</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-royal-waterfall.png</image:loc>
       <image:title>martin - royal waterfall | Stims</image:title>
       <image:caption>martin - royal waterfall by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6650,7 +6650,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-satellite-view</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-satellite-view.png</image:loc>
       <image:title>martin - satellite view | Stims</image:title>
       <image:caption>martin - satellite view by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6661,7 +6661,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-shifter-armorial-bearings-of-robotopia</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-shifter-armorial-bearings-of-robotopia.png</image:loc>
       <image:title>martin - shifter - armorial bearings of robotopia | Stims</image:title>
       <image:caption>martin - shifter - armorial bearings of robotopia by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6672,7 +6672,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-silversmith</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-silversmith.png</image:loc>
       <image:title>martin - silversmith | Stims</image:title>
       <image:caption>martin - silversmith by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6683,7 +6683,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-skywards</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-skywards.png</image:loc>
       <image:title>martin - skywards | Stims</image:title>
       <image:caption>martin - skywards by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6694,7 +6694,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-soma-in-pink-ati-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-soma-in-pink-ati-fix.png</image:loc>
       <image:title>martin - soma in pink (Ati Fix) | Stims</image:title>
       <image:caption>martin - soma in pink (Ati Fix) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6705,7 +6705,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-soma-in-pink</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-soma-in-pink.png</image:loc>
       <image:title>martin - soma in pink | Stims</image:title>
       <image:caption>martin - soma in pink by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6716,7 +6716,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-sparky-caleidoscope</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-sparky-caleidoscope.png</image:loc>
       <image:title>martin - sparky caleidoscope | Stims</image:title>
       <image:caption>martin - sparky caleidoscope by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6727,7 +6727,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-sphery-tales-slow-version</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-sphery-tales-slow-version.png</image:loc>
       <image:title>martin - sphery tales slow version | Stims</image:title>
       <image:caption>martin - sphery tales slow version by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6738,7 +6738,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-sphery-tales</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-sphery-tales.png</image:loc>
       <image:title>martin - sphery tales | Stims</image:title>
       <image:caption>martin - sphery tales by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6749,7 +6749,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-starfield-sectors-ati-fix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-starfield-sectors-ati-fix.png</image:loc>
       <image:title>martin - starfield sectors (Ati fix) | Stims</image:title>
       <image:caption>martin - starfield sectors (Ati fix) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6760,7 +6760,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-starfield-sectors</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-starfield-sectors.png</image:loc>
       <image:title>martin - starfield sectors | Stims</image:title>
       <image:caption>martin - starfield sectors by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6771,7 +6771,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stormy-sea-2009</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stormy-sea-2009.png</image:loc>
       <image:title>martin - stormy sea (2009) | Stims</image:title>
       <image:caption>martin - stormy sea (2009) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6782,7 +6782,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stormy-sea-2010-update</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stormy-sea-2010-update.png</image:loc>
       <image:title>martin - stormy sea (2010 update) | Stims</image:title>
       <image:caption>martin - stormy sea (2010 update) by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6793,7 +6793,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-stormy-sea</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-stormy-sea.png</image:loc>
       <image:title>martin - stormy sea | Stims</image:title>
       <image:caption>martin - stormy sea by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6804,7 +6804,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-sunset-over-the-river</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-sunset-over-the-river.png</image:loc>
       <image:title>martin - sunset over the river | Stims</image:title>
       <image:caption>martin - sunset over the river by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6815,7 +6815,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-test</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-test.png</image:loc>
       <image:title>martin - test | Stims</image:title>
       <image:caption>martin - test by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6826,7 +6826,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-dome-ps2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-dome-ps2.png</image:loc>
       <image:title>martin - the Dome ps2 | Stims</image:title>
       <image:caption>martin - the Dome ps2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6837,7 +6837,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-dome-ps3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-dome-ps3.png</image:loc>
       <image:title>martin - the Dome ps3 | Stims</image:title>
       <image:caption>martin - the Dome ps3 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6848,7 +6848,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-beast</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-beast.png</image:loc>
       <image:title>martin - the beast | Stims</image:title>
       <image:caption>martin - the beast by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6859,7 +6859,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-forge-of-isengard</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-forge-of-isengard.png</image:loc>
       <image:title>martin - the forge of Isengard | Stims</image:title>
       <image:caption>martin - the forge of Isengard by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6870,7 +6870,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix.png</image:loc>
       <image:title>martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix] | Stims</image:title>
       <image:caption>martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix] by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6881,7 +6881,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-this-beautiful-planet</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-this-beautiful-planet.png</image:loc>
       <image:title>martin - this beautiful planet | Stims</image:title>
       <image:caption>martin - this beautiful planet by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6892,7 +6892,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-tiling-the-tube</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-tiling-the-tube.png</image:loc>
       <image:title>martin - tiling the tube | Stims</image:title>
       <image:caption>martin - tiling the tube by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6903,7 +6903,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-time-machine</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-time-machine.png</image:loc>
       <image:title>martin - time machine | Stims</image:title>
       <image:caption>martin - time machine by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6914,7 +6914,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-timeless</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-timeless.png</image:loc>
       <image:title>martin - timeless | Stims</image:title>
       <image:caption>martin - timeless by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6925,7 +6925,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-tunnel-race</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-tunnel-race.png</image:loc>
       <image:title>martin - tunnel race | Stims</image:title>
       <image:caption>martin - tunnel race by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6936,7 +6936,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-unholy-amulet-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-unholy-amulet-2.png</image:loc>
       <image:title>martin - unholy amulet 2 | Stims</image:title>
       <image:caption>martin - unholy amulet 2 by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6947,7 +6947,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-unholy-amulet</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-unholy-amulet.png</image:loc>
       <image:title>martin - unholy amulet | Stims</image:title>
       <image:caption>martin - unholy amulet by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6958,7 +6958,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-violet-flash</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-violet-flash.png</image:loc>
       <image:title>martin - violet flash | Stims</image:title>
       <image:caption>martin - violet flash by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6969,7 +6969,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-volcano</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-volcano.png</image:loc>
       <image:title>martin - volcano | Stims</image:title>
       <image:caption>martin - volcano by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6980,7 +6980,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-witchcraft-reloaded</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-witchcraft-reloaded.png</image:loc>
       <image:title>martin - witchcraft reloaded | Stims</image:title>
       <image:caption>martin - witchcraft reloaded by martin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -6991,7 +6991,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-shadow-harlequins-shape-code-fata-morgana</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-shadow-harlequins-shape-code-fata-morgana.png</image:loc>
       <image:title>martin [shadow harlequins shape code] - fata morgana | Stims</image:title>
       <image:caption>martin [shadow harlequins shape code] - fata morgana by martin [shadow harlequins shape code], a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7002,7 +7002,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-fishbrain-flexi-mandelbox-explorer-v1-eo-s-optimize-bipolar-witchcraft-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-fishbrain-flexi-mandelbox-explorer-v1-eo-s-optimize-bipolar-witchcraft-mix.png</image:loc>
       <image:title>martin, fishbrain + flexi - mandelbox explorer v1 Eo.S. optimize [bipolar witchcraft mix] | Stims</image:title>
       <image:caption>martin, fishbrain + flexi - mandelbox explorer v1 Eo.S. optimize [bipolar witchcraft mix] by martin, fishbrain + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7013,7 +7013,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-sto-traumflug</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-sto-traumflug.png</image:loc>
       <image:title>martin, flexi + sto - traumflug | Stims</image:title>
       <image:caption>martin, flexi + sto - traumflug by martin, flexi + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7024,7 +7024,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-fishbrain-sto-enterstate-random-mashup-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-fishbrain-sto-enterstate-random-mashup-2.png</image:loc>
       <image:title>martin, flexi, fishbrain + sto - enterstate [random mashup 2] | Stims</image:title>
       <image:caption>martin, flexi, fishbrain + sto - enterstate [random mashup 2] by martin, flexi, fishbrain + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7035,7 +7035,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-fishbrain-sto-enterstate-random-mashup-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-fishbrain-sto-enterstate-random-mashup-3.png</image:loc>
       <image:title>martin, flexi, fishbrain + sto - enterstate [random mashup 3] | Stims</image:title>
       <image:caption>martin, flexi, fishbrain + sto - enterstate [random mashup 3] by martin, flexi, fishbrain + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7046,7 +7046,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-fishbrain-sto-enterstate-random-mashup</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-fishbrain-sto-enterstate-random-mashup.png</image:loc>
       <image:title>martin, flexi, fishbrain + sto - enterstate [random mashup] | Stims</image:title>
       <image:caption>martin, flexi, fishbrain + sto - enterstate [random mashup] by martin, flexi, fishbrain + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7057,7 +7057,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=martin-flexi-fishbrain-sto-enterstate</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/martin-flexi-fishbrain-sto-enterstate.png</image:loc>
       <image:title>martin, flexi, fishbrain + sto - enterstate | Stims</image:title>
       <image:caption>martin, flexi, fishbrain + sto - enterstate by martin, flexi, fishbrain + sto, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7068,7 +7068,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=massive-crack-hit-maggot-trace</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/massive-crack-hit-maggot-trace.png</image:loc>
       <image:title>massive crack hit maggot trace | Stims</image:title>
       <image:caption>massive crack hit maggot trace, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7079,7 +7079,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz.png</image:loc>
       <image:title>menstruating in reverse in reverse time max out crap roam3 nz+ | Stims</image:title>
       <image:caption>menstruating in reverse in reverse time max out crap roam3 nz+, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7090,7 +7090,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mstress-cleaning-a-path-painterly-crossfire</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mstress-cleaning-a-path-painterly-crossfire.png</image:loc>
       <image:title>mstress - Cleaning a path - Painterly Crossfire | Stims</image:title>
       <image:caption>mstress - Cleaning a path - Painterly Crossfire by mstress, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7101,7 +7101,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=mstress-scattered-gravity-smoked-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/mstress-scattered-gravity-smoked-mix.png</image:loc>
       <image:title>mstress - Scattered gravity (Smoked mix) | Stims</image:title>
       <image:caption>mstress - Scattered gravity (Smoked mix) by mstress, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7112,7 +7112,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/niko-radiative-bunchess-i-m-gonna-break-my-rusty-cage-and-run-the-fuck-grunge-isn-t-the-source-of-anarchy.png</image:loc>
       <image:title>niko radiative bunchess - i′m gonna break my rusty cage, and run (the fuck grunge isn′t the source of anarchy) | Stims</image:title>
       <image:caption>niko radiative bunchess - i′m gonna break my rusty cage, and run (the fuck grunge isn′t the source of anarchy) by niko radiative bunchess, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7123,7 +7123,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=nil-did-you-speak-with-the-orb</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/nil-did-you-speak-with-the-orb.png</image:loc>
       <image:title>nil - Did You Speak with the Orb | Stims</image:title>
       <image:caption>nil - Did You Speak with the Orb by nil, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7134,7 +7134,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=nil-vortex-of-vortices</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/nil-vortex-of-vortices.png</image:loc>
       <image:title>nil - Vortex of Vortices | Stims</image:title>
       <image:caption>nil - Vortex of Vortices by nil, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7145,7 +7145,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=no-good-rnz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/no-good-rnz.png</image:loc>
       <image:title>no good rnz | Stims</image:title>
       <image:caption>no good rnz, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7156,7 +7156,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-fireworks-fusion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-fireworks-fusion.png</image:loc>
       <image:title>orb - fireworks - fusion | Stims</image:title>
       <image:caption>orb - fireworks - fusion by orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7167,7 +7167,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=orb-toxic-goo</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/orb-toxic-goo.png</image:loc>
       <image:title>orb - toxic goo | Stims</image:title>
       <image:caption>orb - toxic goo by orb, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7178,7 +7178,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-2ct2v5</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-2ct2v5.png</image:loc>
       <image:title>phat + Eo.S. - 2ct2V5 | Stims</image:title>
       <image:caption>phat + Eo.S. - 2ct2V5 by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7189,7 +7189,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-2ct2v6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-2ct2v6.png</image:loc>
       <image:title>phat + Eo.S. - 2ct2V6 | Stims</image:title>
       <image:caption>phat + Eo.S. - 2ct2V6 by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7200,7 +7200,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-bass-responce-red-movements-disorienting-nebula3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-bass-responce-red-movements-disorienting-nebula3.png</image:loc>
       <image:title>phat + Eo.S. - Bass_responce_Red_Movements_Disorienting nebula3 | Stims</image:title>
       <image:caption>phat + Eo.S. - Bass_responce_Red_Movements_Disorienting nebula3 by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7211,7 +7211,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-bass-responce-red-spiral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-bass-responce-red-spiral.png</image:loc>
       <image:title>phat + Eo.S. - Bass_responce_Red_spiral | Stims</image:title>
       <image:caption>phat + Eo.S. - Bass_responce_Red_spiral by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7222,7 +7222,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-follow-me</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-follow-me.png</image:loc>
       <image:title>phat + Eo.S. - Follow Me | Stims</image:title>
       <image:caption>phat + Eo.S. - Follow Me by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7233,7 +7233,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-peoplewhoeatacid-phatcoloursv2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-peoplewhoeatacid-phatcoloursv2.png</image:loc>
       <image:title>phat + Eo.S. - PeopleWhoEatAcid_phatColoursV2 | Stims</image:title>
       <image:caption>phat + Eo.S. - PeopleWhoEatAcid_phatColoursV2 by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7244,7 +7244,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-tesellatingfractal-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-tesellatingfractal-mix.png</image:loc>
       <image:title>phat + Eo.S. - TesellatingFractal_Mix | Stims</image:title>
       <image:caption>phat + Eo.S. - TesellatingFractal_Mix by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7255,7 +7255,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-tesellatingfractal-mix3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-tesellatingfractal-mix3.png</image:loc>
       <image:title>phat + Eo.S. - TesellatingFractal_Mix3 | Stims</image:title>
       <image:caption>phat + Eo.S. - TesellatingFractal_Mix3 by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7266,7 +7266,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-single-cel-angel-birth</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-single-cel-angel-birth.png</image:loc>
       <image:title>phat + Eo.S. - single cel angel birth | Stims</image:title>
       <image:caption>phat + Eo.S. - single cel angel birth by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7277,7 +7277,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-eo-s-single-cel-angel-birthpoints</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-eo-s-single-cel-angel-birthpoints.png</image:loc>
       <image:title>phat + Eo.S. - single cel angel birthpoints | Stims</image:title>
       <image:caption>phat + Eo.S. - single cel angel birthpoints by phat + Eo.S., a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7288,7 +7288,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-2c-b6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-2c-b6.png</image:loc>
       <image:title>phat_2C-B6 | Stims</image:title>
       <image:caption>phat_2C-B6 by Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7299,7 +7299,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-closeincounetersv5-plus-some-fucking-shaders-somebody-worked-hard-on-within-reach-of-absolute-hate</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-closeincounetersv5-plus-some-fucking-shaders-somebody-worked-hard-on-within-reach-of-absolute-hate.png</image:loc>
       <image:title>phat_CloseIncounetersV5 plus some fucking shaders somebody worked hard on - within reach of absolute hate | Stims</image:title>
       <image:caption>phat_CloseIncounetersV5 plus some fucking shaders somebody worked hard on - within reach of absolute hate by phat_CloseIncounetersV5 plus some fucking shaders somebody worked hard on, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7310,7 +7310,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-it-sjustnumbers</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-it-sjustnumbers.png</image:loc>
       <image:title>phat_It′sJustNumbers=) | Stims</image:title>
       <image:caption>phat_It′sJustNumbers=) by Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7321,7 +7321,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-it-sjustnumbers-remix3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-it-sjustnumbers-remix3.png</image:loc>
       <image:title>phat_It′sJustNumbers_remix3 | Stims</image:title>
       <image:caption>phat_It′sJustNumbers_remix3 by Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7332,7 +7332,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-ripplenebula99h-eo-s-mod-mod6</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-ripplenebula99h-eo-s-mod-mod6.png</image:loc>
       <image:title>phat_RippleNebula99h-eo.s. mod_mod6 | Stims</image:title>
       <image:caption>phat_RippleNebula99h-eo.s. mod_mod6 by Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7343,7 +7343,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=phat-ripplenebula-update-mash0000-the-colors-of-autumn-invoke-dumpster-dives</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/phat-ripplenebula-update-mash0000-the-colors-of-autumn-invoke-dumpster-dives.png</image:loc>
       <image:title>phat_RippleNebula_update - mash0000 - the colors of autumn invoke dumpster dives | Stims</image:title>
       <image:caption>phat_RippleNebula_update - mash0000 - the colors of autumn invoke dumpster dives by phat_RippleNebula_update, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7354,7 +7354,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=pork-blouse-lafertion</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/pork-blouse-lafertion.png</image:loc>
       <image:title>pork blouse lafertion | Stims</image:title>
       <image:caption>pork blouse lafertion, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7365,7 +7365,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=random-mash-up-round-47</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/random-mash-up-round-47.png</image:loc>
       <image:title>random mash-up round 47 | Stims</image:title>
       <image:caption>random mash-up round 47, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7376,7 +7376,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=raron-flexi-milkdrop-fibers-on-fire</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/raron-flexi-milkdrop-fibers-on-fire.png</image:loc>
       <image:title>raron + flexi - milkdrop fibers on fire | Stims</image:title>
       <image:caption>raron + flexi - milkdrop fibers on fire by raron + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7387,7 +7387,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=raron-a-grayish-blob-mash0000-pungent-gastric-automata-cloud-fumes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/raron-a-grayish-blob-mash0000-pungent-gastric-automata-cloud-fumes.png</image:loc>
       <image:title>raron - a grayish blob - mash0000 - pungent gastric automata cloud fumes | Stims</image:title>
       <image:caption>raron - a grayish blob - mash0000 - pungent gastric automata cloud fumes by raron, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7398,7 +7398,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=raron-fourth-state-of-milkdrop-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/raron-fourth-state-of-milkdrop-2.png</image:loc>
       <image:title>raron - fourth state of Milkdrop 2 | Stims</image:title>
       <image:caption>raron - fourth state of Milkdrop 2 by raron, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7409,7 +7409,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rce-ordinary-flexi-far-away-distance-custom-beat-detection-bipolar-colour-ghost-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rce-ordinary-flexi-far-away-distance-custom-beat-detection-bipolar-colour-ghost-mix.png</image:loc>
       <image:title>rce-ordinary + flexi - far away distance (custom beat detection + bipolar colour ghost mix) | Stims</image:title>
       <image:caption>rce-ordinary + flexi - far away distance (custom beat detection + bipolar colour ghost mix) by rce-ordinary + flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7420,7 +7420,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=rediculator-qrem-glob</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/rediculator-qrem-glob.png</image:loc>
       <image:title>rediculator qrem glob | Stims</image:title>
       <image:caption>rediculator qrem glob, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7431,7 +7431,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=sawtooth-grin-roam</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/sawtooth-grin-roam.png</image:loc>
       <image:title>sawtooth grin roam | Stims</image:title>
       <image:caption>sawtooth grin roam, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7442,7 +7442,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=schglasmia-danqueer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/schglasmia-danqueer.png</image:loc>
       <image:title>schglasmia - danqueer | Stims</image:title>
       <image:caption>schglasmia - danqueer by schglasmia, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7453,7 +7453,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=sckephthaeck-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/sckephthaeck-nz.png</image:loc>
       <image:title>sckephthaeck nz | Stims</image:title>
       <image:caption>sckephthaeck nz, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7464,7 +7464,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=sexually-repressed-americans-mess-roam</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/sexually-repressed-americans-mess-roam.png</image:loc>
       <image:title>sexually repressed americans - mess roam | Stims</image:title>
       <image:caption>sexually repressed americans - mess roam by sexually repressed americans, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7475,7 +7475,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadow-harlequin-babylon-warp-drive-resurrection-call-flexi-s-insertion-of-martin-s-ripple-on-water-shader.png</image:loc>
       <image:title>shadow harlequin - babylon warp drive resurrection call [Flexi′s insertion of Martin′s ripple on water shader] | Stims</image:title>
       <image:caption>shadow harlequin - babylon warp drive resurrection call [Flexi′s insertion of Martin′s ripple on water shader] by shadow harlequin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7486,7 +7486,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadowharlequin-cope-alternative-energy-antimatter-mod-1-rave-dreams</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadowharlequin-cope-alternative-energy-antimatter-mod-1-rave-dreams.png</image:loc>
       <image:title>shadowharlequin, cope - alternative energy (antimatter mod_1) - [rave dreams] | Stims</image:title>
       <image:caption>shadowharlequin, cope - alternative energy (antimatter mod_1) - [rave dreams] by shadowharlequin, cope, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7497,7 +7497,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shadowharlequin-loadus-fishbrain-geiss-fitting-butterfly-v-many-times-2.png</image:loc>
       <image:title>shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v′many times′2 | Stims</image:title>
       <image:caption>shadowharlequin, loadus, fishbrain + geiss - fitting butterfly - v′many times′2 by shadowharlequin, loadus, fishbrain + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7508,7 +7508,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-aderrasi-airhandler-sadako</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-aderrasi-airhandler-sadako.png</image:loc>
       <image:title>shifter + Aderrasi - Airhandler (Sadako) | Stims</image:title>
       <image:caption>shifter + Aderrasi - Airhandler (Sadako) by shifter + Aderrasi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7519,7 +7519,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-eo-s-phat-blob</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-eo-s-phat-blob.png</image:loc>
       <image:title>shifter + Eo.S + Phat - Blob | Stims</image:title>
       <image:caption>shifter + Eo.S + Phat - Blob by shifter + Eo.S + Phat, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7530,7 +7530,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-geiss-molten-glass-crystal-glass-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-geiss-molten-glass-crystal-glass-mix.png</image:loc>
       <image:title>shifter + Geiss - molten glass (crystal glass mix) | Stims</image:title>
       <image:caption>shifter + Geiss - molten glass (crystal glass mix) by shifter + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7541,7 +7541,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-geiss-molten-glass-wrap</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-geiss-molten-glass-wrap.png</image:loc>
       <image:title>shifter + Geiss - molten glass wrap | Stims</image:title>
       <image:caption>shifter + Geiss - molten glass wrap by shifter + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7552,7 +7552,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-geiss-neon-pulse-glow-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-geiss-neon-pulse-glow-mix.png</image:loc>
       <image:title>shifter + geiss - neon pulse (glow mix) | Stims</image:title>
       <image:caption>shifter + geiss - neon pulse (glow mix) by shifter + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7563,7 +7563,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-a-thousand-monkeys-phat-edit-subliminal-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-a-thousand-monkeys-phat-edit-subliminal-mix.png</image:loc>
       <image:title>shifter - a thousand monkeys_phat_edit (subliminal mix) | Stims</image:title>
       <image:caption>shifter - a thousand monkeys_phat_edit (subliminal mix) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7574,7 +7574,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-brain-coral-left-brained</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-brain-coral-left-brained.png</image:loc>
       <image:title>shifter - brain coral (left brained) | Stims</image:title>
       <image:caption>shifter - brain coral (left brained) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7585,7 +7585,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-brain-coral-non-inverted</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-brain-coral-non-inverted.png</image:loc>
       <image:title>shifter - brain coral (non-inverted) | Stims</image:title>
       <image:caption>shifter - brain coral (non-inverted) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7596,7 +7596,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-brain-coral</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-brain-coral.png</image:loc>
       <image:title>shifter - brain coral | Stims</image:title>
       <image:caption>shifter - brain coral by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7607,7 +7607,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-cellular-phat-yak-infusion-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-cellular-phat-yak-infusion-v2.png</image:loc>
       <image:title>shifter - cellular_Phat_YAK_Infusion_v2 | Stims</image:title>
       <image:caption>shifter - cellular_Phat_YAK_Infusion_v2 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7618,7 +7618,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-dark-tides-eo-s-phat-whisps-of-doom-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-dark-tides-eo-s-phat-whisps-of-doom-mix.png</image:loc>
       <image:title>shifter - dark tides (eo.s+phat_whisps of doom mix) | Stims</image:title>
       <image:caption>shifter - dark tides (eo.s+phat_whisps of doom mix) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7629,7 +7629,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-dark-tides-bdrv-mix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-dark-tides-bdrv-mix-2.png</image:loc>
       <image:title>shifter - dark tides bdrv mix 2 | Stims</image:title>
       <image:caption>shifter - dark tides bdrv mix 2 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7640,7 +7640,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-dark-tides-bdrv-mix-2c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-dark-tides-bdrv-mix-2c.png</image:loc>
       <image:title>shifter - dark tides bdrv mix 2c | Stims</image:title>
       <image:caption>shifter - dark tides bdrv mix 2c by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7651,7 +7651,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-dark-tides-bdrv-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-dark-tides-bdrv-mix.png</image:loc>
       <image:title>shifter - dark tides bdrv mix | Stims</image:title>
       <image:caption>shifter - dark tides bdrv mix by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7662,7 +7662,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-digi</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-digi.png</image:loc>
       <image:title>shifter - digi | Stims</image:title>
       <image:caption>shifter - digi by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7673,7 +7673,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-escape-the-worm-eo-s-phat-before-it-eats-your-brain-mix-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-escape-the-worm-eo-s-phat-before-it-eats-your-brain-mix-v2.png</image:loc>
       <image:title>shifter - escape the worm - Eo.S. + Phat - Before_It_Eats_Your_Brain_Mix_v2 | Stims</image:title>
       <image:caption>shifter - escape the worm - Eo.S. + Phat - Before_It_Eats_Your_Brain_Mix_v2 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7684,7 +7684,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-escape-the-worm-eo-s-phat-5362</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-escape-the-worm-eo-s-phat-5362.png</image:loc>
       <image:title>shifter - escape the worm - Eo.S. + Phat 5362 | Stims</image:title>
       <image:caption>shifter - escape the worm - Eo.S. + Phat 5362 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7695,7 +7695,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-feathers-angel-wings</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-feathers-angel-wings.png</image:loc>
       <image:title>shifter - feathers (angel wings) | Stims</image:title>
       <image:caption>shifter - feathers (angel wings) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7706,7 +7706,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-feathers-angel-wings-phat-remix-relief-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-feathers-angel-wings-phat-remix-relief-2.png</image:loc>
       <image:title>shifter - feathers (angel wings)_phat_remix relief 2 | Stims</image:title>
       <image:caption>shifter - feathers (angel wings)_phat_remix relief 2 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7717,7 +7717,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-fractal-grinder</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-fractal-grinder.png</image:loc>
       <image:title>shifter - fractal grinder | Stims</image:title>
       <image:caption>shifter - fractal grinder by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7728,7 +7728,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-lattice-eclipse-phat-eo-s-more-color-mix-v2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-lattice-eclipse-phat-eo-s-more-color-mix-v2.png</image:loc>
       <image:title>shifter - lattice (eclipse) Phat + Eo.S. more color mix_v2 | Stims</image:title>
       <image:caption>shifter - lattice (eclipse) Phat + Eo.S. more color mix_v2 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7739,7 +7739,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-lattice</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-lattice.png</image:loc>
       <image:title>shifter - lattice | Stims</image:title>
       <image:caption>shifter - lattice by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7750,7 +7750,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-lazerspecs-phat-edit</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-lazerspecs-phat-edit.png</image:loc>
       <image:title>shifter - lazerspecs_phat_edit | Stims</image:title>
       <image:caption>shifter - lazerspecs_phat_edit by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7761,7 +7761,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-liquid-circuitry</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-liquid-circuitry.png</image:loc>
       <image:title>shifter - liquid circuitry | Stims</image:title>
       <image:caption>shifter - liquid circuitry by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7772,7 +7772,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-mandala</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-mandala.png</image:loc>
       <image:title>shifter - mandala | Stims</image:title>
       <image:caption>shifter - mandala by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7783,7 +7783,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-molten-glass</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-molten-glass.png</image:loc>
       <image:title>shifter - molten glass | Stims</image:title>
       <image:caption>shifter - molten glass by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7794,7 +7794,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-morphid</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-morphid.png</image:loc>
       <image:title>shifter - morphid | Stims</image:title>
       <image:caption>shifter - morphid by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7805,7 +7805,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-neon-pulse-reactive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-neon-pulse-reactive.png</image:loc>
       <image:title>shifter - neon pulse (reactive) | Stims</image:title>
       <image:caption>shifter - neon pulse (reactive) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7816,7 +7816,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-robotopia</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-robotopia.png</image:loc>
       <image:title>shifter - robotopia | Stims</image:title>
       <image:caption>shifter - robotopia by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7827,7 +7827,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-spills-blender-krash-beatdetect-mash0000-here-comb-your-hair-with-this-planet</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-spills-blender-krash-beatdetect-mash0000-here-comb-your-hair-with-this-planet.png</image:loc>
       <image:title>shifter - spills blender + krash beatdetect - mash0000 - here comb your hair with this planet | Stims</image:title>
       <image:caption>shifter - spills blender + krash beatdetect - mash0000 - here comb your hair with this planet by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7838,7 +7838,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-spincycle-c</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-spincycle-c.png</image:loc>
       <image:title>shifter - spincycle c | Stims</image:title>
       <image:caption>shifter - spincycle c by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7849,7 +7849,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-spincycle-remix-love-at-home-electroplasmic-pissbowel-roam3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-spincycle-remix-love-at-home-electroplasmic-pissbowel-roam3.png</image:loc>
       <image:title>shifter - spincycle(remix) - love at home - electroplasmic pissbowel roam3- | Stims</image:title>
       <image:caption>shifter - spincycle(remix) - love at home - electroplasmic pissbowel roam3- by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7860,7 +7860,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tadpole-evolution-static-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tadpole-evolution-static-mix.png</image:loc>
       <image:title>shifter - tadpole evolution (static mix) | Stims</image:title>
       <image:caption>shifter - tadpole evolution (static mix) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7871,7 +7871,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tumbling-cubes-endless-radial-blur</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tumbling-cubes-endless-radial-blur.png</image:loc>
       <image:title>shifter - tumbling cubes (endless) radial blur | Stims</image:title>
       <image:caption>shifter - tumbling cubes (endless) radial blur by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7882,7 +7882,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tumbling-cubes-ripples-eo-s-remix1</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tumbling-cubes-ripples-eo-s-remix1.png</image:loc>
       <image:title>shifter - tumbling cubes (ripples) Eo.S. remix1 | Stims</image:title>
       <image:caption>shifter - tumbling cubes (ripples) Eo.S. remix1 by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7893,7 +7893,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tumbling-cubes-ripples-phat-parallel-planes-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tumbling-cubes-ripples-phat-parallel-planes-mix.png</image:loc>
       <image:title>shifter - tumbling cubes (ripples) Phat_parallel_planes_mix | Stims</image:title>
       <image:caption>shifter - tumbling cubes (ripples) Phat_parallel_planes_mix by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7904,7 +7904,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tumbling-cubes-ripples</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tumbling-cubes-ripples.png</image:loc>
       <image:title>shifter - tumbling cubes (ripples) | Stims</image:title>
       <image:caption>shifter - tumbling cubes (ripples) by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7915,7 +7915,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-tumbling-cubes</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-tumbling-cubes.png</image:loc>
       <image:title>shifter - tumbling cubes | Stims</image:title>
       <image:caption>shifter - tumbling cubes by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7926,7 +7926,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=shifter-urchin-mod</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/shifter-urchin-mod.png</image:loc>
       <image:title>shifter - urchin mod | Stims</image:title>
       <image:caption>shifter - urchin mod by shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7937,7 +7937,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful.png</image:loc>
       <image:title>skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful | Stims</image:title>
       <image:caption>skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful by skipper skipper kiss me hard, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7948,7 +7948,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn.png</image:loc>
       <image:title>skipper skipper kiss me hard - thank god for martin nitorami - tgfmn | Stims</image:title>
       <image:caption>skipper skipper kiss me hard - thank god for martin nitorami - tgfmn by skipper skipper kiss me hard, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7959,7 +7959,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-nz.png</image:loc>
       <image:title>skipper skipper kiss me hard - thank god for martin nitorami nz | Stims</image:title>
       <image:caption>skipper skipper kiss me hard - thank god for martin nitorami nz by skipper skipper kiss me hard, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7970,7 +7970,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-flexi-geiss-tiger-no-5-mashup-16-random-texture-flow-inf-fin-bnd</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-flexi-geiss-tiger-no-5-mashup-16-random-texture-flow-inf-fin-bnd.png</image:loc>
       <image:title>stahlregen &amp; flexi + geiss - tiger no.5 (mashup 16 - random texture flow) - inf fin bnd | Stims</image:title>
       <image:caption>stahlregen &amp; flexi + geiss - tiger no.5 (mashup 16 - random texture flow) - inf fin bnd by stahlregen &amp; flexi + geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7981,7 +7981,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-rovastar-fields-of-flowers-mashup-9-space-flower-rmx-mash0001-pack-em-in-we-got-a-long-haul-flashlight</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-rovastar-fields-of-flowers-mashup-9-space-flower-rmx-mash0001-pack-em-in-we-got-a-long-haul-flashlight.png</image:loc>
       <image:title>stahlregen &amp; geiss + rovastar - fields of flowers (mashup 9 - space flower rmx) - mash0001 - pack em in, we got a long haul + flashlight | Stims</image:title>
       <image:caption>stahlregen &amp; geiss + rovastar - fields of flowers (mashup 9 - space flower rmx) - mash0001 - pack em in, we got a long haul + flashlight by stahlregen &amp; geiss + rovastar, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -7992,7 +7992,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-geiss-shifter-babylon</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-geiss-shifter-babylon.png</image:loc>
       <image:title>stahlregen + geiss + shifter - babylon | Stims</image:title>
       <image:caption>stahlregen + geiss + shifter - babylon by stahlregen + geiss + shifter, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8003,7 +8003,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-old-school-baby-spiral-ornament</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-old-school-baby-spiral-ornament.png</image:loc>
       <image:title>stahlregen - old school, baby (spiral ornament) | Stims</image:title>
       <image:caption>stahlregen - old school, baby (spiral ornament) by stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8014,7 +8014,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=stahlregen-spiral-hundertwasser-2-painterly</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/stahlregen-spiral-hundertwasser-2-painterly.png</image:loc>
       <image:title>stahlregen - spiral (hundertwasser 2 - painterly) | Stims</image:title>
       <image:caption>stahlregen - spiral (hundertwasser 2 - painterly) by stahlregen, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8025,7 +8025,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/studio-music-unchained-phat-and-e-o-s-how-it-feel-s-to-be-alive.png</image:loc>
       <image:title>studio music &amp; unchained + phat and e.o.s - how it feel′s to be alive | Stims</image:title>
       <image:caption>studio music &amp; unchained + phat and e.o.s - how it feel′s to be alive by studio music &amp; unchained + phat and e.o.s, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8036,7 +8036,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-flexi-full-tilt-fsaa-demo-dither-color-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-flexi-full-tilt-fsaa-demo-dither-color-tweak.png</image:loc>
       <image:title>suksma + Flexi - full tilt FSAA demo - dither color tweak | Stims</image:title>
       <image:caption>suksma + Flexi - full tilt FSAA demo - dither color tweak by suksma + Flexi, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8047,7 +8047,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz.png</image:loc>
       <image:title>suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+ | Stims</image:title>
       <image:caption>suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+ by suksma + aderassi geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8058,7 +8058,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-aderassi-orb-hexcollie-status-quo-burial-at-sea</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-aderassi-orb-hexcollie-status-quo-burial-at-sea.png</image:loc>
       <image:title>suksma + aderassi orb hexcollie - status quo burial at sea | Stims</image:title>
       <image:caption>suksma + aderassi orb hexcollie - status quo burial at sea by suksma + aderassi orb hexcollie, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8069,7 +8069,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-aderrasi-martin-raron-geiss-are-you-mad-at-me</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-aderrasi-martin-raron-geiss-are-you-mad-at-me.png</image:loc>
       <image:title>suksma + aderrasi martin raron geiss - are you mad at me | Stims</image:title>
       <image:caption>suksma + aderrasi martin raron geiss - are you mad at me by suksma + aderrasi martin raron geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8080,7 +8080,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-raron-satanizer-kissing-chickens-multi-beak-mash0002</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-raron-satanizer-kissing-chickens-multi-beak-mash0002.png</image:loc>
       <image:title>suksma + raron - satanizer - kissing chickens (multi-beak) - mash0002 | Stims</image:title>
       <image:caption>suksma + raron - satanizer - kissing chickens (multi-beak) - mash0002 by suksma + raron, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8091,7 +8091,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-redi-unchained-adamfx-nobility-obscured-through-isolation</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-redi-unchained-adamfx-nobility-obscured-through-isolation.png</image:loc>
       <image:title>suksma + redi unchained adamfx - nobility obscured through isolation | Stims</image:title>
       <image:caption>suksma + redi unchained adamfx - nobility obscured through isolation by suksma + redi unchained adamfx, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8102,7 +8102,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall.png</image:loc>
       <image:title>suksma + rovaster eos phat gastly geiss stahlgren - copper mine shaft fall | Stims</image:title>
       <image:caption>suksma + rovaster eos phat gastly geiss stahlgren - copper mine shaft fall by suksma + rovaster eos phat gastly geiss stahlgren, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8113,7 +8113,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-rovastar-sunflower-passion-enlightment-mix-phat-edit-flexi-und-martin-shaders-circumflex-in-character-classes-in-regular-expression</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-rovastar-sunflower-passion-enlightment-mix-phat-edit-flexi-und-martin-shaders-circumflex-in-character-classes-in-regular-expression.png</image:loc>
       <image:title>suksma - Rovastar - Sunflower Passion (Enlightment Mix)_Phat_edit + flexi und martin shaders - circumflex in character classes in regular expression | Stims</image:title>
       <image:caption>suksma - Rovastar - Sunflower Passion (Enlightment Mix)_Phat_edit + flexi und martin shaders - circumflex in character classes in regular expression by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8124,7 +8124,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-blatantic-emissarial-crotch</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-blatantic-emissarial-crotch.png</image:loc>
       <image:title>suksma - blatantic emissarial crotch | Stims</image:title>
       <image:caption>suksma - blatantic emissarial crotch by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8135,7 +8135,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-bubble-gum-pop-gore</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-bubble-gum-pop-gore.png</image:loc>
       <image:title>suksma - bubble gum pop gore | Stims</image:title>
       <image:caption>suksma - bubble gum pop gore by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8146,7 +8146,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-creepy-children-steal-your-identity</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-creepy-children-steal-your-identity.png</image:loc>
       <image:title>suksma - creepy children steal your identity | Stims</image:title>
       <image:caption>suksma - creepy children steal your identity by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8157,7 +8157,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-ctp-log-smell</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-ctp-log-smell.png</image:loc>
       <image:title>suksma - ctp log smell | Stims</image:title>
       <image:caption>suksma - ctp log smell by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8168,7 +8168,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-dinner-stalk-the-stalker-with-satanic-telepathy-j4</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-dinner-stalk-the-stalker-with-satanic-telepathy-j4.png</image:loc>
       <image:title>suksma - dinner - stalk the stalker with satanic telepathy - j4+ | Stims</image:title>
       <image:caption>suksma - dinner - stalk the stalker with satanic telepathy - j4+ by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8179,7 +8179,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-diploautomatic-autoimmunity-vs-passivematic-aggpressive-float-dev</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-diploautomatic-autoimmunity-vs-passivematic-aggpressive-float-dev.png</image:loc>
       <image:title>suksma - diploautomatic autoimmunity vs passivematic aggpressive - float dev | Stims</image:title>
       <image:caption>suksma - diploautomatic autoimmunity vs passivematic aggpressive - float dev by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8190,7 +8190,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored.png</image:loc>
       <image:title>suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored | Stims</image:title>
       <image:caption>suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8201,7 +8201,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-feign-shoulder-concern-when-i-should-be-executed-everything-is-eternally-shrinking</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-feign-shoulder-concern-when-i-should-be-executed-everything-is-eternally-shrinking.png</image:loc>
       <image:title>suksma - feign shoulder concern when i should be executed - everything is eternally shrinking | Stims</image:title>
       <image:caption>suksma - feign shoulder concern when i should be executed - everything is eternally shrinking by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8212,7 +8212,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-fishbrain-white-sceam-firefly-mash0000-liquid-oxygen-jet-fuel-and-maybe-some-plutonium-too</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-fishbrain-white-sceam-firefly-mash0000-liquid-oxygen-jet-fuel-and-maybe-some-plutonium-too.png</image:loc>
       <image:title>suksma - fiShbRaiN - white sceam firefly - mash0000 - liquid oxygen, jet fuel, and maybe some plutonium too | Stims</image:title>
       <image:caption>suksma - fiShbRaiN - white sceam firefly - mash0000 - liquid oxygen, jet fuel, and maybe some plutonium too by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8223,7 +8223,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-flexi-lorenz-chaser-heretical-tribal-necklace</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-flexi-lorenz-chaser-heretical-tribal-necklace.png</image:loc>
       <image:title>suksma - flexi - lorenz chaser - heretical tribal necklace | Stims</image:title>
       <image:caption>suksma - flexi - lorenz chaser - heretical tribal necklace by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8234,7 +8234,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-gaeomaentaec-log-smell-2-steaming-wienies2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-gaeomaentaec-log-smell-2-steaming-wienies2.png</image:loc>
       <image:title>suksma - gaeomaentaec - log smell 2 - steaming wienies2 | Stims</image:title>
       <image:caption>suksma - gaeomaentaec - log smell 2 - steaming wienies2 by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8245,7 +8245,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-greaezequescent-red-eyed-black-goatz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-greaezequescent-red-eyed-black-goatz.png</image:loc>
       <image:title>suksma - greaezequescent red-eyed black goatz | Stims</image:title>
       <image:caption>suksma - greaezequescent red-eyed black goatz by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8256,7 +8256,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-heretical-crosscut-playpen</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-heretical-crosscut-playpen.png</image:loc>
       <image:title>suksma - heretical crosscut playpen | Stims</image:title>
       <image:caption>suksma - heretical crosscut playpen by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8267,7 +8267,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-in-madness-i-purposely-convince-myself-of-all-your-lies-then-slice-you-open-and-eat-your-lungs-only-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-in-madness-i-purposely-convince-myself-of-all-your-lies-then-slice-you-open-and-eat-your-lungs-only-nz.png</image:loc>
       <image:title>suksma - in madness i purposely convince myself of all your lies, then slice you open and eat your lungs only nz+ | Stims</image:title>
       <image:caption>suksma - in madness i purposely convince myself of all your lies, then slice you open and eat your lungs only nz+ by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8278,7 +8278,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-more-pathetic-attempts-justifying-my-ignominious-end-waning-anti-tunneled</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-more-pathetic-attempts-justifying-my-ignominious-end-waning-anti-tunneled.png</image:loc>
       <image:title>suksma - more pathetic attempts justifying my ignominious end - waning anti-tunneled | Stims</image:title>
       <image:caption>suksma - more pathetic attempts justifying my ignominious end - waning anti-tunneled by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8289,7 +8289,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-nip-tuck</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-nip-tuck.png</image:loc>
       <image:title>suksma - nip tuck | Stims</image:title>
       <image:caption>suksma - nip tuck by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8300,7 +8300,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-penattrition</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-penattrition.png</image:loc>
       <image:title>suksma - penattrition | Stims</image:title>
       <image:caption>suksma - penattrition by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8311,7 +8311,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-question-authority-take-what-you-want-be-a-nihilist</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-question-authority-take-what-you-want-be-a-nihilist.png</image:loc>
       <image:title>suksma - question authority, take what you want, be a nihilist | Stims</image:title>
       <image:caption>suksma - question authority, take what you want, be a nihilist by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8322,7 +8322,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-sick-star-bloat</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-sick-star-bloat.png</image:loc>
       <image:title>suksma - sick star bloat | Stims</image:title>
       <image:caption>suksma - sick star bloat by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8333,7 +8333,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-squasm-minor-plot-frugal-koonut-kalifee</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-squasm-minor-plot-frugal-koonut-kalifee.png</image:loc>
       <image:title>suksma - squasm minor plot frugal koonut kalifee | Stims</image:title>
       <image:caption>suksma - squasm minor plot frugal koonut kalifee by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8344,7 +8344,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-sun-pod-gambit-couch-nz-2-satangastriq</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-sun-pod-gambit-couch-nz-2-satangastriq.png</image:loc>
       <image:title>suksma - sun pod gambit couch nz+2 satangastriq | Stims</image:title>
       <image:caption>suksma - sun pod gambit couch nz+2 satangastriq by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8355,7 +8355,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-tech-support-for-the-dead</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-tech-support-for-the-dead.png</image:loc>
       <image:title>suksma - tech support for the dead | Stims</image:title>
       <image:caption>suksma - tech support for the dead by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8366,7 +8366,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-the-placebo-unlicensed-rip-off-whore</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-the-placebo-unlicensed-rip-off-whore.png</image:loc>
       <image:title>suksma - the placebo unlicensed rip off whore | Stims</image:title>
       <image:caption>suksma - the placebo unlicensed rip off whore by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8377,7 +8377,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-uninitialized-variabowl-hydroponic-chronic</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-uninitialized-variabowl-hydroponic-chronic.png</image:loc>
       <image:title>suksma - uninitialized variabowl (hydroponic chronic) | Stims</image:title>
       <image:caption>suksma - uninitialized variabowl (hydroponic chronic) by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8388,7 +8388,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-vector-exp-1-couldn-t-not</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-vector-exp-1-couldn-t-not.png</image:loc>
       <image:title>suksma - vector exp 1 - couldn′t not | Stims</image:title>
       <image:caption>suksma - vector exp 1 - couldn′t not by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8399,7 +8399,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-water-cooled-red-uranium-vs-dotes-freeenergynow-net</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-water-cooled-red-uranium-vs-dotes-freeenergynow-net.png</image:loc>
       <image:title>suksma - water cooled red uranium vs dotes - freeenergynow.net | Stims</image:title>
       <image:caption>suksma - water cooled red uranium vs dotes - freeenergynow.net by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8410,7 +8410,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=suksma-yin-100-through-the-ether-bitcore-tweak-mash0000-dmt-eye-rub-spher-nz</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/suksma-yin-100-through-the-ether-bitcore-tweak-mash0000-dmt-eye-rub-spher-nz.png</image:loc>
       <image:title>suksma - yin - 100 - Through the ether - Bitcore Tweak - mash0000 - dmt eye rub spher nz+ | Stims</image:title>
       <image:caption>suksma - yin - 100 - Through the ether - Bitcore Tweak - mash0000 - dmt eye rub spher nz+ by suksma, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8421,7 +8421,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=undulate-harque-calm-ling</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/undulate-harque-calm-ling.png</image:loc>
       <image:title>undulate harque - calm ling | Stims</image:title>
       <image:caption>undulate harque - calm ling by undulate harque, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8432,7 +8432,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/various-artists-1200774354134-mash0000-what-the-writer-s-guild-is-doing-with-the-extra-money.png</image:loc>
       <image:title>various artists - 1200774354134 - mash0000 - what the writer′s guild is doing with the extra money | Stims</image:title>
       <image:caption>various artists - 1200774354134 - mash0000 - what the writer′s guild is doing with the extra money by various artists, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8443,7 +8443,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-geiss-240-electric-universe-bkg-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-geiss-240-electric-universe-bkg-mix.png</image:loc>
       <image:title>yin + Geiss - 240 - Electric universe (Bkg Mix) | Stims</image:title>
       <image:caption>yin + Geiss - 240 - Electric universe (Bkg Mix) by yin + Geiss, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8454,7 +8454,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-030-dance-with-the-ocean</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-030-dance-with-the-ocean.png</image:loc>
       <image:title>yin - 030 - Dance with the ocean | Stims</image:title>
       <image:caption>yin - 030 - Dance with the ocean by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8465,7 +8465,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-051-van-gogh-s-nightmare-in-depth-bitcore-tweak.png</image:loc>
       <image:title>yin - 051 - Van Gogh′s nightmare (in depth) - bitcore tweak | Stims</image:title>
       <image:caption>yin - 051 - Van Gogh′s nightmare (in depth) - bitcore tweak by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8476,7 +8476,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-100-through-the-ether-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-100-through-the-ether-bitcore-tweak.png</image:loc>
       <image:title>yin - 100 - Through the ether - Bitcore Tweak | Stims</image:title>
       <image:caption>yin - 100 - Through the ether - Bitcore Tweak by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8487,7 +8487,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-102-through-the-ether-the-separation-bitcore-tweak</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-102-through-the-ether-the-separation-bitcore-tweak.png</image:loc>
       <image:title>yin - 102 - Through the ether (The separation) - Bitcore Tweak | Stims</image:title>
       <image:caption>yin - 102 - Through the ether (The separation) - Bitcore Tweak by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8498,7 +8498,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-140-ohm-to-the-stars</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-140-ohm-to-the-stars.png</image:loc>
       <image:title>yin - 140 - Ohm to the stars | Stims</image:title>
       <image:caption>yin - 140 - Ohm to the stars by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8509,7 +8509,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-160-controversial</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-160-controversial.png</image:loc>
       <image:title>yin - 160 - Controversial | Stims</image:title>
       <image:caption>yin - 160 - Controversial by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8520,7 +8520,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-190-temporal-fluctuations</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-190-temporal-fluctuations.png</image:loc>
       <image:title>yin - 190 - Temporal fluctuations | Stims</image:title>
       <image:caption>yin - 190 - Temporal fluctuations by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8531,7 +8531,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-191-temporal-singularities</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-191-temporal-singularities.png</image:loc>
       <image:title>yin - 191 - Temporal singularities | Stims</image:title>
       <image:caption>yin - 191 - Temporal singularities by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8542,7 +8542,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-250-artificial-poles-of-the-continuum</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-250-artificial-poles-of-the-continuum.png</image:loc>
       <image:title>yin - 250 - Artificial poles of the continuum | Stims</image:title>
       <image:caption>yin - 250 - Artificial poles of the continuum by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8553,7 +8553,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-250-artificial-poles-of-the-continuum-phat-s-orbit-mix.png</image:loc>
       <image:title>yin - 250 - Artificial poles of the continuum_Phat′s_Orbit_mix | Stims</image:title>
       <image:caption>yin - 250 - Artificial poles of the continuum_Phat′s_Orbit_mix by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8564,7 +8564,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-253-artificial-poles-of-the-continuum-remix-3</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-253-artificial-poles-of-the-continuum-remix-3.png</image:loc>
       <image:title>yin - 253 - Artificial poles of the continuum (remix #3) | Stims</image:title>
       <image:caption>yin - 253 - Artificial poles of the continuum (remix #3) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8575,7 +8575,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-280-coming-home</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-280-coming-home.png</image:loc>
       <image:title>yin - 280 - Coming home | Stims</image:title>
       <image:caption>yin - 280 - Coming home by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8586,7 +8586,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-290-sonic-brainstorm</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-290-sonic-brainstorm.png</image:loc>
       <image:title>yin - 290 - Sonic brainstorm | Stims</image:title>
       <image:caption>yin - 290 - Sonic brainstorm by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8597,7 +8597,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-293-sonic-brainstorm-inner-state-group-experience-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-293-sonic-brainstorm-inner-state-group-experience-mix.png</image:loc>
       <image:title>yin - 293 - Sonic brainstorm (inner state - group experience mix) | Stims</image:title>
       <image:caption>yin - 293 - Sonic brainstorm (inner state - group experience mix) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8608,7 +8608,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-300-daydreamer</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-300-daydreamer.png</image:loc>
       <image:title>yin - 300 - Daydreamer | Stims</image:title>
       <image:caption>yin - 300 - Daydreamer by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8619,7 +8619,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-302-daydreamer-remix-2</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-302-daydreamer-remix-2.png</image:loc>
       <image:title>yin - 302 - Daydreamer (remix 2) | Stims</image:title>
       <image:caption>yin - 302 - Daydreamer (remix 2) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8630,7 +8630,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-311-ocean-of-light-bouncing-off-mix</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-311-ocean-of-light-bouncing-off-mix.png</image:loc>
       <image:title>yin - 311 - Ocean of Light (bouncing off mix) | Stims</image:title>
       <image:caption>yin - 311 - Ocean of Light (bouncing off mix) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8641,7 +8641,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-315-ocean-of-light-yo-im-peakin-yo-eo-s-phat</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-315-ocean-of-light-yo-im-peakin-yo-eo-s-phat.png</image:loc>
       <image:title>yin - 315 - Ocean of Light (yo im peakin yo Eo.S.-Phat) | Stims</image:title>
       <image:caption>yin - 315 - Ocean of Light (yo im peakin yo Eo.S.-Phat) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>
@@ -8652,7 +8652,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
-      <image:loc>https://toil.fyi/api/og-preset?id=yin-385-magic-ride-distance-based-hue</image:loc>
+      <image:loc>https://toil.fyi/milkdrop-presets/previews/yin-385-magic-ride-distance-based-hue.png</image:loc>
       <image:title>yin - 385 - Magic ride (distance based hue) | Stims</image:title>
       <image:caption>yin - 385 - Magic ride (distance based hue) by yin, a MilkDrop preset running live in the browser on Stims.</image:caption>
     </image:image>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://toil.fyi/sitemap-1.xml</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-21</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://toil.fyi/sitemap-2.xml</loc>

--- a/scripts/generate-seo.ts
+++ b/scripts/generate-seo.ts
@@ -33,6 +33,7 @@ export const PRESET_CATALOG_PATH = 'public/milkdrop-presets/catalog.json';
 // parsing the full catalog on every cold isolate.
 export const GENERATED_PRESET_META_PATH = 'public/preset-meta.json';
 export const PRESET_PREVIEW_DIR = 'public/milkdrop-presets/previews';
+export const PRESET_LIBRARIES_DIR = 'public/milkdrop-presets/libraries';
 // Presets start at chunk 2; chunk 1 stays reserved for the hand-written app
 // routes so their priorities and lastmods are not buried under 1,791 entries.
 export const PRESET_SITEMAP_FIRST_CHUNK = 2;
@@ -590,18 +591,38 @@ export async function buildPresetSitemapEntries(
 }
 
 export async function buildPresetMetaMap(rootDir = repoRoot) {
-  const catalogRaw = await readFile(
-    path.join(rootDir, PRESET_CATALOG_PATH),
-    'utf8',
-  );
-  const catalog = JSON.parse(catalogRaw) as { presets?: PresetCatalogEntry[] };
+  // Root catalog plus the bundled libraries, discovered by directory the same
+  // way generate-thumbnails does. The libraries are ~a third of the browsable
+  // catalog, and reading only the root left 932 presets — the whole
+  // cream-of-the-crop set among them — with no title or author here. Sharing
+  // one of those produced a card that guessed both from the slug, crediting
+  // "ORB - Fire and Fumes 2" to an author named "Cotc".
+  const libraryDir = path.join(rootDir, PRESET_LIBRARIES_DIR);
+  const libraryCatalogs = (
+    await readdir(libraryDir, { withFileTypes: true }).catch(() => [])
+  )
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(libraryDir, entry.name, 'catalog.json'));
 
-  return Object.fromEntries(
-    (catalog.presets ?? []).map((preset) => [
-      preset.id,
-      [preset.title, isNamedAuthor(preset.author) ? preset.author : ''],
-    ]),
-  );
+  const meta: Record<string, [string, string]> = {};
+  for (const catalogPath of [
+    path.join(rootDir, PRESET_CATALOG_PATH),
+    ...libraryCatalogs,
+  ]) {
+    const raw = await readFile(catalogPath, 'utf8').catch(() => null);
+    if (!raw) continue;
+    const catalog = JSON.parse(raw) as { presets?: PresetCatalogEntry[] };
+    for (const preset of catalog.presets ?? []) {
+      // First catalog wins, matching the runtime's own precedence.
+      if (meta[preset.id]) continue;
+      const author = preset.author;
+      meta[preset.id] = [
+        preset.title,
+        author && isNamedAuthor(author) ? author : '',
+      ];
+    }
+  }
+  return meta;
 }
 
 export const chunkSitemapEntries = (

--- a/scripts/generate-thumbnails.ts
+++ b/scripts/generate-thumbnails.ts
@@ -20,6 +20,8 @@
  *   bun run scripts/generate-thumbnails.ts --ids-file=path/to/ids.txt
  *   bun run scripts/generate-thumbnails.ts --all         # all presets
  *   bun run scripts/generate-thumbnails.ts --force       # overwrite existing
+ *   bun run scripts/generate-thumbnails.ts --force --keep-best  # re-sweep, keep the better frame
+ *   bun run scripts/generate-thumbnails.ts --beat-pulse  # 2Hz beats in the synthetic signal
  *   bun run scripts/generate-thumbnails.ts --workers=8   # concurrency
  *   bun run scripts/generate-thumbnails.ts --port=5178   # dedicated dev server
  *   bun run scripts/generate-thumbnails.ts --no-headless # visible windows (debugging)
@@ -94,6 +96,7 @@ function parseArgs() {
     workers?: number;
     port?: number;
     beatPulse?: boolean;
+    keepBest?: boolean;
     // Headless by default: launched via the 'chromium' channel
     // (--headless=new), captures still render on the real GPU, and the
     // whole window-occlusion problem class disappears. --no-headless
@@ -118,6 +121,9 @@ function parseArgs() {
     // Overlay deterministic 2Hz beats on the synthetic audio — lights up
     // beat-gated presets that stay dark under the smooth idle signal.
     if (arg === '--beat-pulse') args.beatPulse = true;
+    // Only replace an existing preview when the fresh capture scores better.
+    // Makes a corpus-wide --force re-sweep monotonic (see the write site).
+    if (arg === '--keep-best') args.keepBest = true;
   }
   return args;
 }
@@ -205,6 +211,8 @@ type FrameStats = {
   meanLuma: number;
   maxLuma: number;
   stdLuma: number;
+  /** Fraction of pixels clipped to white — high std is worthless if clipped. */
+  blownFraction: number;
 };
 
 async function analyzeFrame(buffer: Buffer): Promise<FrameStats> {
@@ -215,6 +223,7 @@ async function analyzeFrame(buffer: Buffer): Promise<FrameStats> {
   let sum = 0;
   let sumSq = 0;
   let max = 0;
+  let blown = 0;
   const pixels = info.width * info.height;
   for (let i = 0; i < data.length; i += info.channels) {
     const luma =
@@ -222,10 +231,18 @@ async function analyzeFrame(buffer: Buffer): Promise<FrameStats> {
     sum += luma;
     sumSq += luma * luma;
     if (luma > max) max = luma;
+    if (
+      data[i] >= 250 &&
+      (data[i + 1] ?? 0) >= 250 &&
+      (data[i + 2] ?? 0) >= 250
+    ) {
+      blown += 1;
+    }
   }
   const mean = sum / pixels;
   return {
     hash: createHash('sha256').update(data).digest('hex'),
+    blownFraction: blown / pixels,
     meanLuma: mean,
     maxLuma: max,
     stdLuma: Math.sqrt(Math.max(0, sumSq / pixels - mean * mean)),
@@ -238,6 +255,19 @@ async function analyzeFrame(buffer: Buffer): Promise<FrameStats> {
  * presets (a few glowing shapes on black) are legitimate, so a low mean is
  * only fatal when nothing bright exists either.
  */
+// The same score the in-page checkpoint search maximizes. Structure (std) is
+// what makes a thumbnail readable, scaled down for frames that are technically
+// lit but almost empty, penalized for clipping (a white blob on black scores
+// enormous std while showing nothing), and zeroed at both failure ends.
+function frameScore(stats: FrameStats): number {
+  if (stats.maxLuma < 32 || stats.meanLuma > 240) return 0;
+  return (
+    stats.stdLuma *
+    Math.min(1, stats.meanLuma / 8) *
+    (1 - Math.min(1, stats.blownFraction)) ** 2
+  );
+}
+
 function badFrameReason(stats: FrameStats): string | null {
   if (stats.maxLuma < 32 || stats.meanLuma < 0.4) {
     return `black frame (mean=${stats.meanLuma.toFixed(1)}, max=${stats.maxLuma.toFixed(0)})`;
@@ -278,6 +308,8 @@ class RenderSession {
     /** All catalog ids, used to pick a sacrificial boot preset. */
     private catalogIds: string[],
     private beatPulse: boolean,
+    private keepBest: boolean,
+    private tally: { kept: number; improved: number },
   ) {}
 
   private async boot(firstTargetId: string) {
@@ -402,15 +434,17 @@ class RenderSession {
             let sum = 0;
             let sumSq = 0;
             let max = 0;
+            let blown = 0;
             for (let i = 0; i < d.length; i += 4) {
               const l = 0.299 * d[i] + 0.587 * d[i + 1] + 0.114 * d[i + 2];
               sum += l;
               sumSq += l * l;
               if (l > max) max = l;
+              if (d[i] >= 250 && d[i + 1] >= 250 && d[i + 2] >= 250) blown += 1;
             }
             const mean = sum / (96 * 54);
             const std = Math.sqrt(Math.max(0, sumSq / (96 * 54) - mean * mean));
-            return { mean, max, std };
+            return { mean, max, std, blown: blown / (96 * 54) };
           };
 
           // A good preview frame has visible structure and isn't blown out.
@@ -427,9 +461,21 @@ class RenderSession {
           // technically lit but almost empty, and zeroed at both failure ends.
           const acceptable = (s: { mean: number; max: number; std: number }) =>
             s.max >= 32 && s.mean >= 0.4 && s.mean <= 240 && s.std >= 2.5;
-          const score = (s: { mean: number; max: number; std: number }) => {
+          // A clipped white region has enormous std, so an unpenalized score
+          // ranks "black rectangle with a white blob burned into it" above the
+          // structured frame a second earlier. Squaring the unclipped fraction
+          // makes a frame that is half blown out worth a quarter of the same
+          // structure drawn in tones the viewer can actually see.
+          const score = (s: {
+            mean: number;
+            max: number;
+            std: number;
+            blown: number;
+          }) => {
             if (s.max < 32 || s.mean > 240) return 0;
-            return s.std * Math.min(1, s.mean / 8);
+            return (
+              s.std * Math.min(1, s.mean / 8) * (1 - Math.min(1, s.blown)) ** 2
+            );
           };
 
           let rendered = 0;
@@ -518,8 +564,25 @@ class RenderSession {
           // not actually advance to this preset.
           failure = `duplicate of ${collidesWith}`;
         } else {
+          const outPath = join(OUTPUT_DIR, `${preset.id}.png`);
+          // A re-sweep is not uniformly an upgrade: the capture search is a
+          // plateau search over a moving image, so a preset that happened to
+          // land on a good frame last time can land on a worse one now.
+          // Under --keep-best a fresh capture has to beat what is already on
+          // disk before it replaces it, which makes a corpus-wide re-run
+          // monotonic instead of a coin flip per preset.
+          if (this.keepBest && existsSync(outPath)) {
+            const previous = await analyzeFrame(readFileSync(outPath));
+            if (frameScore(stats) <= frameScore(previous)) {
+              this.seenHashes.set(previous.hash, preset.id);
+              this.tally.kept++;
+              this.rendered++;
+              return;
+            }
+          }
           this.seenHashes.set(stats.hash, preset.id);
-          await writePreview(buffer, join(OUTPUT_DIR, `${preset.id}.png`));
+          await writePreview(buffer, outPath);
+          this.tally.improved++;
           this.rendered++;
           return;
         }
@@ -535,13 +598,20 @@ async function worker(
   browser: Awaited<ReturnType<typeof chromium.launch>>,
   id: number,
   queue: PresetEntry[],
-  counters: { success: number; fail: number; done: number },
+  counters: {
+    success: number;
+    fail: number;
+    done: number;
+    kept: number;
+    improved: number;
+  },
   failures: CaptureFailure[],
   total: number,
   devServer: string,
   seenHashes: Map<string, string>,
   catalogIds: string[],
   beatPulse: boolean,
+  keepBest: boolean,
 ) {
   let ctx: BrowserContext | null = null;
   let session: RenderSession | null = null;
@@ -579,6 +649,8 @@ async function worker(
           seenHashes,
           catalogIds,
           beatPulse,
+          keepBest,
+          counters,
         );
 
       await Promise.race([
@@ -660,7 +732,7 @@ async function main() {
     ],
   });
   const startTime = Date.now();
-  const counters = { success: 0, fail: 0, done: 0 };
+  const counters = { success: 0, fail: 0, done: 0, kept: 0, improved: 0 };
   const failures: CaptureFailure[] = [];
   const seenHashes = new Map<string, string>();
 
@@ -680,6 +752,7 @@ async function main() {
       seenHashes,
       catalogIds,
       args.beatPulse ?? false,
+      args.keepBest ?? false,
     ),
   );
   await Promise.all(workers);
@@ -689,11 +762,17 @@ async function main() {
   console.log('=== Done ===');
   console.log(`Total: ${(totalTime / 60).toFixed(1)}m`);
   console.log(`Success: ${counters.success}  Failed: ${counters.fail}`);
+  if (args.keepBest)
+    console.log(
+      `Replaced: ${counters.improved}  Kept existing (not an improvement): ${counters.kept}`,
+    );
   if (counters.success > 0)
     console.log(`Avg: ${(totalTime / counters.success).toFixed(1)}s/preset`);
   if (failures.length > 0) {
     const reportPath = join(OUTPUT_DIR, '..', 'preview-failures.json');
-    writeFileSync(reportPath, JSON.stringify(failures, null, 2));
+    // Trailing newline: this file is committed, and the repo's own formatter
+    // check fails on it otherwise.
+    writeFileSync(reportPath, `${JSON.stringify(failures, null, 2)}\n`);
     console.log(
       `${failures.length} presets failed — no file written; details in ${reportPath}`,
     );

--- a/scripts/generate-thumbnails.ts
+++ b/scripts/generate-thumbnails.ts
@@ -770,11 +770,22 @@ async function main() {
     console.log(`Avg: ${(totalTime / counters.success).toFixed(1)}s/preset`);
   if (failures.length > 0) {
     const reportPath = join(OUTPUT_DIR, '..', 'preview-failures.json');
+    // check-catalog-integrity reads this file as "these presets have no usable
+    // preview" and forbids `preview: true` for anything on it. On a --force
+    // re-sweep that is not the same set as "this capture attempt failed": a
+    // preset whose recapture came back black keeps the good preview it already
+    // had, and listing it here would strip the preview flag off an image that
+    // renders fine. Only presets actually left without a file belong on the
+    // list.
+    const unusable = failures.filter(
+      (failure) => !existsSync(join(OUTPUT_DIR, `${failure.presetId}.png`)),
+    );
+    const keptPrevious = failures.length - unusable.length;
     // Trailing newline: this file is committed, and the repo's own formatter
     // check fails on it otherwise.
-    writeFileSync(reportPath, `${JSON.stringify(failures, null, 2)}\n`);
+    writeFileSync(reportPath, `${JSON.stringify(unusable, null, 2)}\n`);
     console.log(
-      `${failures.length} presets failed — no file written; details in ${reportPath}`,
+      `${failures.length} presets failed to capture (${keptPrevious} kept the preview they already had); ${unusable.length} left with no preview — details in ${reportPath}`,
     );
   }
 

--- a/tests/unit/preset-sharing.test.ts
+++ b/tests/unit/preset-sharing.test.ts
@@ -4,10 +4,12 @@ import { join } from 'node:path';
 import { onRequest as middlewareRequest } from '../../functions/_middleware.ts';
 import {
   buildPresetOgSvg,
+  fitTitle,
   normalizePresetId,
   onRequest as ogPresetRequest,
   type RenderAssets,
 } from '../../functions/api/og-preset.ts';
+import { presentTitle } from '../../functions/shared/preset-title.ts';
 import {
   buildPresetLink,
   formatPresetShareCopy,
@@ -63,8 +65,75 @@ describe('preset social sharing', () => {
       expect(svg).toContain('<svg');
       expect(svg).toContain('Parallel Universe');
       expect(svg).toContain('Rovastar');
-      expect(svg).toContain('STIMS • SOUND REACTIVE VISUALIZER');
+      expect(svg).toContain('STIMS');
       expect(svg).toContain('toil.fyi');
+      expect(svg).toContain('CREAM OF THE CROP');
+    });
+
+    test('drops the author prefix the corpus stores in the title', () => {
+      const svg = buildPresetOgSvg({
+        id: 'rovastar-parallel-universe',
+        title: 'Rovastar - Parallel Universe',
+        author: 'Rovastar',
+      });
+
+      expect(svg).toContain('>Parallel Universe<');
+      expect(svg).not.toContain('>Rovastar - Parallel Universe<');
+      expect(svg).toContain('by Rovastar');
+    });
+
+    test('collapses slug-derived delimiter chains in the title', () => {
+      expect(
+        presentTitle('Eos - Ether - Posession - Phat - Edit', 'Eo.S.'),
+      ).toBe('Eos Ether Posession Phat Edit');
+    });
+
+    test('wraps a long title onto two lines rather than shrinking it flat', () => {
+      const short = fitTitle('Parallel Universe');
+      expect(short.lines).toHaveLength(1);
+
+      const long = fitTitle(
+        'crystal palace schizotoxin the wild iris bloom 16 iterations',
+      );
+      expect(long.lines).toHaveLength(2);
+      expect(long.size).toBeGreaterThanOrEqual(40);
+      expect(long.lines.join(' ')).toBe(
+        'crystal palace schizotoxin the wild iris bloom 16 iterations',
+      );
+    });
+
+    test('renders the preset frame full-bleed when a preview exists', () => {
+      const svg = buildPresetOgSvg({
+        id: 'rovastar-parallel-universe',
+        title: 'Parallel Universe',
+        previewImageUri: 'data:image/png;base64,AAAA',
+      });
+
+      expect(svg).toContain(
+        '<image href="data:image/png;base64,AAAA" x="0" y="0" width="1200" height="630"',
+      );
+    });
+
+    test('carries no animation the rasterizer cannot draw', () => {
+      const svg = buildPresetOgSvg({
+        id: 'rovastar-parallel-universe',
+        title: 'Parallel Universe',
+      });
+
+      expect(svg).not.toContain('@keyframes');
+      expect(svg).not.toContain('animation:');
+    });
+
+    // Space Mono has no U+25B6; the previous card shipped a literal tofu box
+    // in its call to action.
+    test('uses only glyphs the bundled fonts can shape', () => {
+      const svg = buildPresetOgSvg({
+        id: 'rovastar-parallel-universe',
+        title: 'Parallel Universe',
+        author: 'Rovastar',
+      });
+      const text = svg.replace(/<[^>]*>/g, '');
+      expect(text).not.toMatch(/[\u25a0-\u25ff\u2190-\u21ff]/);
     });
 
     test('og-preset function returns SVG when format=svg is requested', async () => {
@@ -129,6 +198,57 @@ describe('preset social sharing', () => {
       const view = new DataView(bytes.buffer, bytes.byteOffset);
       expect(view.getUint32(16)).toBe(1200);
       expect(view.getUint32(20)).toBe(630);
+    });
+
+    // Regression: previews are excluded from the deploy bundle and served
+    // from R2 by functions/milkdrop-presets/previews. Reading them back
+    // through ASSETS returned the SPA shell at status 200, so production
+    // rendered the no-preview branch for every shared preset.
+    test('reads the preset frame from the R2 bucket, not the assets binding', async () => {
+      const previewPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+      const requestedKeys: string[] = [];
+      const request = new Request(
+        'https://toil.fyi/api/og-preset?id=rovastar-parallel-universe&format=svg',
+      );
+      const response = await ogPresetRequest({
+        request,
+        env: {
+          STATIC_R2: {
+            get: async (key: string) => {
+              requestedKeys.push(key);
+              return {
+                arrayBuffer: async () => previewPng.buffer as ArrayBuffer,
+              };
+            },
+          },
+        },
+      });
+
+      expect(requestedKeys).toEqual([
+        'milkdrop-presets/previews/rovastar-parallel-universe.png',
+      ]);
+      expect(await response.text()).toContain(
+        '<image href="data:image/png;base64,',
+      );
+    });
+
+    test('ignores an assets response that is not an image', async () => {
+      const request = new Request(
+        'https://toil.fyi/api/og-preset?id=rovastar-parallel-universe&format=svg',
+      );
+      const response = await ogPresetRequest({
+        request,
+        env: {
+          ASSETS: {
+            fetch: async () =>
+              new Response('<!doctype html><html>app shell</html>', {
+                headers: { 'Content-Type': 'text/html' },
+              }),
+          },
+        },
+      });
+
+      expect(await response.text()).not.toContain('<image href=');
     });
 
     test('falls back to the static card when rendering is impossible', async () => {

--- a/tests/unit/preset-sharing.test.ts
+++ b/tests/unit/preset-sharing.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { onRequest as middlewareRequest } from '../../functions/_middleware.ts';
 import {
   buildPresetOgSvg,
+  fitByline,
   fitTitle,
   normalizePresetId,
   onRequest as ogPresetRequest,
@@ -100,6 +101,48 @@ describe('preset social sharing', () => {
       expect(long.lines.join(' ')).toBe(
         'crystal palace schizotoxin the wild iris bloom 16 iterations',
       );
+    });
+
+    // Corpus names carry underscore- and paren-delimited runs with no spaces,
+    // which word wrapping alone cannot fit.
+    test('hard-breaks a single word too long for one line', () => {
+      const { size, lines } = fitTitle(
+        'triptrap_(getting_concrete_visions_through_a_diafragma_version)',
+      );
+      const maxChars = Math.floor(1072 / (size * 0.55));
+
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(maxChars);
+      }
+      expect(lines.join('')).toContain('triptrap_(getting');
+    });
+
+    test('ellipsizes a title that cannot fit in two lines', () => {
+      const { lines } = fitTitle('x'.repeat(400));
+
+      expect(lines).toHaveLength(2);
+      expect(lines[1].endsWith('…')).toBe(true);
+    });
+
+    // 60 corpus authors run past 40 characters; the longest is 94, and the
+    // brand lockup sits on the byline's own baseline.
+    test('truncates a byline before it reaches the brand lockup', () => {
+      const long =
+        'The NG + Stahlregen & Boz + EoS + Geiss + Phat + Rovastar + Zylot + Flexi + martin + Fishbrain';
+      const fitted = fitByline(long);
+
+      expect(fitted.length).toBeLessThan(long.length);
+      expect(fitted.endsWith('…')).toBe(true);
+      // "by " + the byline must clear the right-aligned "STIMS · toil.fyi".
+      const bylineWidth = `by ${fitted}`.length * 25 * 0.52;
+      expect(bylineWidth).toBeLessThanOrEqual(
+        1200 - 64 * 2 - 16 * 19 * 0.6 - 40,
+      );
+    });
+
+    test('leaves a byline that already fits untouched', () => {
+      expect(fitByline('Rovastar')).toBe('Rovastar');
     });
 
     test('renders the preset frame full-bleed when a preview exists', () => {


### PR DESCRIPTION
## Summary

Shared links to a Stims preset have never contained the preset.

`og-preset` loaded the rendered frame through `env.ASSETS`, but previews were moved out of the deploy bundle and are served from the `stims-static` R2 bucket by `functions/milkdrop-presets/previews`. The lookup always missed, so every shared preset URL on the internet unfurled to the "no preview" HUD fallback — verified against production before changing anything. It now reads R2 first, keeping the assets binding for local dev behind a content-type check, since ASSETS answers a miss with the SPA shell at status 200 and that would otherwise be embedded as a bogus PNG data URI.

Fixing the plumbing exposed how little of the card was the product, so the layout changed too, and then how bad the frames behind it were, so the corpus was regenerated.

### The card

It spent a 1200×630 unfurl on invented chrome — a play button that cannot be clicked, a `LIVE 60FPS` pill, a decorative waveform — around a 506×430 box that cropped 34% off a 16:9 frame. It is now preview-forward: the frame full-bleed, all chrome in one bottom caption band with its own scrim so bright frames are not greyed out and dark ones stay readable. Long names wrap to two lines instead of shrinking flat.

Also removed: the `@keyframes` blocks (resvg rasterizes a static PNG, so they never drew anything) and the U+25B6 in `LAUNCH VISUALIZER ▶`, which Space Mono has no glyph for and shipped as a literal tofu box.

### The names

Names were guessed from the slug while `preset-meta.json` held the real values, and 92% of those titles store the author as a prefix, so the middleware emitted `Rovastar - Parallel Universe by Rovastar`. `presentTitle` (new, shared by the middleware and the renderer) strips it.

`preset-meta` itself was built from the root catalog only, leaving 932 library presets — the whole cream-of-the-crop set — with no title or author at all, and no per-preset `<title>` from the middleware either. Their cards credited `ORB - Fire and Fumes 2` to an author named "Cotc". `buildPresetMetaMap` now reads the library catalogs the way `generate-thumbnails` does.

The unfurl text led with an emoji `▶ Play` and claimed "live in 60FPS WebGPU … zero install required"; rewritten.

### The frames

The best-frame scorer landed 08-19, but only 32 of 2,364 preview files were generated after it — the code was fixed and the artifacts never caught up, leaving a median frame luminance of 14/255 and 40% of the corpus effectively black.

A plain `--force` re-sweep is not an upgrade: the capture is a plateau search over a moving image, so a preset that landed well last time can land worse now (a 39-preset pilot improved 19 and **regressed 7**). New `--keep-best` makes a fresh capture beat what is on disk before replacing it, which makes a corpus-wide re-run monotonic. `--beat-pulse` already existed and was off for every preview ever shipped, so beat-gated presets were captured on a flat idle signal.

Then the scorer's own trap: `std * min(1, mean/8)` ranks "black rectangle with a clipped white blob burned into it" above the structured frame a second earlier, and the first sweep duly traded black frames for blown-out ones (>20%-clipped share 6.5% → 8.8%). Both scorers now multiply by `(1 - blownFraction)²`; re-running the 132 affected presets put clipping *below* baseline.

Over the 2,364 existing previews: **1,084 better, 1 marginally worse** (11.1 → 10.3, noise). Median quality 17.5 → 28.2, effectively-black 40% → 29%, clipped 6.5% → 6.0%, plus 77 presets that had no preview at all.

## Testing

- `bun run check` — pass (includes the 8 new cases in `tests/unit/preset-sharing.test.ts`)
- `bun run build` — pass
- `curl https://toil.fyi/api/og-preset?id=rovastar-parallel-universe` — confirmed production serves the HUD fallback today, which is the bug this fixes
- Cards rendered locally through `renderPresetOgPng` and inspected across a near-black frame, a mid frame, and a near-white frame for caption legibility
- Preview sweep measured before/after on every file against a pre-sweep backup, on both axes (black *and* clipped), since they trade against each other

New tests cover the R2 read path, the HTML-not-image guard on the ASSETS fallback, the author-prefix and delimiter-chain title rules, two-line wrapping, the full-bleed frame, absence of animation, and a guard that the card uses no glyph the bundled fonts cannot shape.

## Docs touched

None. `scripts/generate-thumbnails.ts`'s docblock gained the two new flags, which `bun run help` reads.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

The card SVG is rasterized in a Worker and cannot read CSS, so its colors are literals; they are the existing brand coral `#f47a54` and ink `#f7f4eb` rather than new values.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [x] `bun run build` (if build/runtime output changed)

## Notes for the reviewer

**The regenerated PNGs are not in this PR.** Previews are gitignored and reach production through `scripts/sync-previews-r2.ts`, which needs `BACKFILL_TOKEN`. Until someone runs it, merging ships the new card design against the *old* frames. The card fix stands on its own — it is what makes the frame appear at all — but the quality numbers above only land after the sync.

**Still open, not addressed here:** 451 presets capture a pure-black framebuffer (mean=0, max=0), 402 of them `cotc-` — 45% of the cream-of-the-crop library drawing literally nothing under `?renderer=webgl`. That is a rendering gap rather than dark presets, and it is not the GetBlur/GetPixel fix from 08-19 since these still fail after it. It could not be A/B'd against WebGPU through this harness: the capture path reads back through a WebGL context.

**Also unchanged:** the homepage card still contains no visualizer output. Ranking the improved corpus for a hero frame yields either blown-out black-and-white blobs or full-rainbow kaleidoscopes, which cuts against the design direction for Stims chrome, so picking one was left as a taste call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
