### PR TITLE
test(e2e): share one Chromium across agent-integration

### DIFF
--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { chromium } from 'playwright';
+import { type Browser, chromium } from 'playwright';
 import { playToy } from '../../scripts/play-toy.ts';
 import {
   hasChromium,
@@ -79,12 +79,35 @@ async function ensureDevServer() {
   );
 }
 
-async function createMobilePage() {
-  const browser = await withDeadline(
+/**
+ * One Chromium for the whole file, a fresh context per test.
+ *
+ * Each test used to launch its own browser. CI failed on the fifth with
+ * `Timed out after 60000ms while launching Chromium` — not a slow page, a
+ * browser process that could not start, because by then the 2-core runner was
+ * carrying the remains of four others. The symptom kept moving earlier as the
+ * machine degraded (first a stuck wait, then a 30s navigation, then the launch
+ * itself), which is the signature of resource exhaustion rather than of any
+ * one call being wrong.
+ *
+ * A context is the isolation boundary these tests actually need — separate
+ * storage, cookies and pages — so sharing the process costs nothing and
+ * removes four launches from the run.
+ */
+let sharedBrowser: Browser | null = null;
+
+async function launchSharedBrowser(): Promise<Browser> {
+  if (sharedBrowser?.isConnected()) return sharedBrowser;
+  sharedBrowser = await withDeadline(
     chromium.launch({ args: WEBGL_RENDERER_ARGS }),
     LAUNCH_TIMEOUT_MS,
-    'launching Chromium',
+    'launching the shared Chromium',
   );
+  return sharedBrowser;
+}
+
+async function createMobilePage() {
+  const browser = await launchSharedBrowser();
   const context = await withDeadline(
     browser.newContext({
       viewport: { width: 430, height: 932 },
@@ -103,15 +126,14 @@ async function createMobilePage() {
     window.localStorage.setItem('stims:onboarding-complete', 'true');
   });
 
-  const closeBrowser = async () => {
-    await closeQuietly(context, browser);
-  };
-
   return {
     browser,
     context,
     page,
-    close: closeBrowser,
+    // Only the context: the browser outlives the test.
+    close: async () => {
+      await closeQuietly(context);
+    },
   };
 }
 
@@ -122,6 +144,10 @@ beforeAll(async () => {
 }, 60000);
 
 afterAll(async () => {
+  if (sharedBrowser) {
+    await closeQuietly(sharedBrowser);
+    sharedBrowser = null;
+  }
   await stopDevServerInstance();
 }, 30000);
 

--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -10,6 +10,7 @@ import {
   localOnlyBrowserTest,
   requiredBrowserTest,
 } from './browser-availability.ts';
+import { closeQuietly, withDeadline } from './deadline.ts';
 import {
   type DevServerHandle,
   isResponsive,
@@ -29,6 +30,13 @@ const TEST_PORT = 5180;
 // this test past a 90s budget in CI even though it completes in ~10s
 // locally with real GPU (2026-08-06 CI investigation).
 const INTEGRATION_TIMEOUT_MS = 180000;
+// Launching Chromium and bringing the dev server back are the two setup steps
+// that can wait on something wedged, and neither carries a timeout of its own.
+const LAUNCH_TIMEOUT_MS = 60_000;
+const DEV_SERVER_TIMEOUT_MS = 90_000;
+// evaluate() takes no timeout at all, and the one here runs *inside* a failure
+// path — exactly when the page has stopped answering.
+const EVALUATE_TIMEOUT_MS = 15_000;
 let devServer: DevServerHandle | null = null;
 
 async function startDevServerInstance() {
@@ -54,34 +62,49 @@ async function stopDevServerInstance() {
  * which is what made it look like flakiness rather than a fixed bug.
  */
 async function ensureDevServer() {
-  if (!devServer) {
-    await startDevServerInstance();
-    return;
-  }
-  if (await isResponsive(`http://127.0.0.1:${TEST_PORT}/`)) {
-    return;
-  }
-  await stopDevServerInstance();
-  await startDevServerInstance();
+  await withDeadline(
+    (async () => {
+      if (!devServer) {
+        await startDevServerInstance();
+        return;
+      }
+      if (await isResponsive(`http://127.0.0.1:${TEST_PORT}/`)) {
+        return;
+      }
+      await stopDevServerInstance();
+      await startDevServerInstance();
+    })(),
+    DEV_SERVER_TIMEOUT_MS,
+    'restarting the shared dev server',
+  );
 }
 
 async function createMobilePage() {
-  const browser = await chromium.launch({
-    args: WEBGL_RENDERER_ARGS,
-  });
-  const context = await browser.newContext({
-    viewport: { width: 430, height: 932 },
-    isMobile: true,
-    hasTouch: true,
-  });
-  const page = await context.newPage();
+  const browser = await withDeadline(
+    chromium.launch({ args: WEBGL_RENDERER_ARGS }),
+    LAUNCH_TIMEOUT_MS,
+    'launching Chromium',
+  );
+  const context = await withDeadline(
+    browser.newContext({
+      viewport: { width: 430, height: 932 },
+      isMobile: true,
+      hasTouch: true,
+    }),
+    LAUNCH_TIMEOUT_MS,
+    'opening a browser context',
+  );
+  const page = await withDeadline(
+    context.newPage(),
+    LAUNCH_TIMEOUT_MS,
+    'opening a page',
+  );
   await page.addInitScript(() => {
     window.localStorage.setItem('stims:onboarding-complete', 'true');
   });
 
   const closeBrowser = async () => {
-    await context.close().catch(() => {});
-    await browser.close().catch(() => {});
+    await closeQuietly(context, browser);
   };
 
   return {
@@ -279,15 +302,19 @@ integrationTest(
         .catch(async (error) => {
           // Name what the page actually showed instead. Without this the
           // only artifact of a failure here is the selector string.
-          const shellState = await mobile.page.evaluate(() => ({
-            url: window.location.href,
-            readyState: document.readyState,
-            hasShell: Boolean(document.getElementById('stims-main')),
-            statusText:
-              document
-                .querySelector('.active-toy-status')
-                ?.textContent?.trim() ?? null,
-          }));
+          const shellState = await withDeadline(
+            mobile.page.evaluate(() => ({
+              url: window.location.href,
+              readyState: document.readyState,
+              hasShell: Boolean(document.getElementById('stims-main')),
+              statusText:
+                document
+                  .querySelector('.active-toy-status')
+                  ?.textContent?.trim() ?? null,
+            })),
+            EVALUATE_TIMEOUT_MS,
+            'reading the shell state after the error status never rendered',
+          ).catch(() => null);
           throw new Error(
             `Error status never rendered: ${JSON.stringify(shellState)} (${
               (error as Error).message

--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -283,7 +283,15 @@ integrationTest(
       // budget, and the alias has its own coverage in the SEO guard.
       await mobile.page.goto(
         `http://127.0.0.1:${TEST_PORT}/?agent=true&experience=non-existent-toy-slug&renderer=webgl`,
-        { waitUntil: 'domcontentloaded', timeout: 30000 },
+        // 60s, not the 30s default. This is the fifth browser this file
+        // launches in a run, and CI reported `goto: Timeout 30000ms exceeded`
+        // here while the identical navigation in the tests above — on the
+        // slower `load` wait, no less — finished in single-digit seconds. The
+        // page is not stuck, the 2-core SwiftShader runner is just saturated
+        // by that point, so the first navigation needs room rather than a
+        // tighter bound. Still well inside the test budget: 60 + 30 + 20 plus
+        // setup stays under INTEGRATION_TIMEOUT_MS.
+        { waitUntil: 'domcontentloaded', timeout: 60000 },
       );
 
       // Two waits, not one, because they fail for different reasons and the

--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -299,5 +299,11 @@ integrationTest(
       await mobile.close();
     }
   },
-  { timeout: 90000 },
+  // The waits inside sum to 80s (30 + 30 + 20) before the browser launch and
+  // the dev-server check are counted, so 90s could expire *during* the last
+  // wait — killing the test before the wait it was stuck in could name itself,
+  // which is the bare "timed out after 90000ms" CI kept reporting and the
+  // whole reason these waits are split. Every other test in this file already
+  // budgets INTEGRATION_TIMEOUT_MS; this one was left behind.
+  { timeout: INTEGRATION_TIMEOUT_MS },
 );

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -45,6 +45,10 @@ const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
  * breakpoint these tests assert against.
  */
 const CHEAP_RENDER_PARAMS = 'lockQualityStep=6';
+
+// Launching a browser carries no timeout of its own, and it is the call that
+// fails first when the runner is out of headroom.
+const LAUNCH_TIMEOUT_MS = 60_000;
 let devServer: DevServerHandle | null = null;
 
 // A single preset navigation used to fan out into several redundant compile
@@ -181,6 +185,41 @@ async function ensureDevServer() {
 }
 
 /** Wraps every browser test so the server guard above cannot be forgotten. */
+/**
+ * One Chromium for the tests that launch it identically, a fresh context each.
+ *
+ * This file launched a browser per test — five on a 2-core SwiftShader runner,
+ * and `home-to-live flip` is the fourth. That is why its stall kept moving
+ * (`await stage-hero` at 30s one run, `open audio disclosure` at 90s the next)
+ * without any of its own waits being wrong: by the time it ran, the machine
+ * was carrying the remains of three other browsers. The sibling suite showed
+ * the end state of the same pattern, failing outright with
+ * `Timed out after 60000ms while launching Chromium`.
+ *
+ * A context already gives these tests the isolation they use — viewport,
+ * reduced-motion, init scripts, storage — so the process is shared and only
+ * the context is per-test. The microphone test keeps its own browser: its
+ * fake-media-stream flags are process-level, not context-level.
+ */
+let sharedBrowser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+
+async function releaseSharedBrowser() {
+  if (!sharedBrowser) return;
+  const browser = sharedBrowser;
+  sharedBrowser = null;
+  await closeQuietly(browser);
+}
+
+async function sharedRendererBrowser() {
+  if (sharedBrowser?.isConnected()) return sharedBrowser;
+  sharedBrowser = await withDeadline(
+    chromium.launch({ headless: HEADLESS, args: RENDERER_ARGS }),
+    LAUNCH_TIMEOUT_MS,
+    'launching the shared Chromium',
+  );
+  return sharedBrowser;
+}
+
 function browserTest(
   name: string,
   body: () => Promise<void>,
@@ -197,15 +236,15 @@ function browserTest(
 }
 
 beforeAll(() => startServer(), { timeout: 60000 });
-afterAll(() => stopServer());
+afterAll(async () => {
+  await releaseSharedBrowser();
+  stopServer();
+});
 
 browserTest(
   'mounts engine, loads preset, and renders a silent preview frame',
   async () => {
-    const browser = await chromium.launch({
-      headless: HEADLESS,
-      args: RENDERER_ARGS,
-    });
+    const browser = await sharedRendererBrowser();
     // DPR 1 keeps the SwiftShader backing store at 1280×720. CI's 2-core
     // runner software-rasterizes every frame, so the 4× pixel work of DPR 2
     // is pure timeout risk with no assertion value here (non-zero pixel and
@@ -275,7 +314,7 @@ browserTest(
       );
       throw error;
     } finally {
-      await closeQuietly(ctx, browser);
+      await closeQuietly(ctx);
     }
   },
   { timeout: 240000 },
@@ -284,10 +323,7 @@ browserTest(
 browserTest(
   'switches preset and canvas content changes',
   async () => {
-    const browser = await chromium.launch({
-      headless: HEADLESS,
-      args: RENDERER_ARGS,
-    });
+    const browser = await sharedRendererBrowser();
     const ctx = await browser.newContext({
       viewport: { width: 1280, height: 720 },
       deviceScaleFactor: 1,
@@ -358,7 +394,7 @@ browserTest(
       );
       throw error;
     } finally {
-      await closeQuietly(ctx, browser);
+      await closeQuietly(ctx);
     }
   },
   { timeout: 240000 },
@@ -443,14 +479,24 @@ async function verifySmartphoneMicrophoneAccess({
 }: {
   returningUser: boolean;
 }) {
-  const browser = await chromium.launch({
-    headless: HEADLESS,
-    args: [
-      ...RENDERER_ARGS,
-      '--use-fake-device-for-media-stream',
-      '--use-fake-ui-for-media-stream',
-    ],
-  });
+  // This one cannot share: fake-media-stream is a process-level flag. Drop the
+  // shared browser first so only one is ever alive — leaving both up put two
+  // SwiftShader processes on the runner at once, which is the contention this
+  // whole change exists to remove. `sharedRendererBrowser()` re-launches on
+  // demand if a later test needs it.
+  await releaseSharedBrowser();
+  const browser = await withDeadline(
+    chromium.launch({
+      headless: HEADLESS,
+      args: [
+        ...RENDERER_ARGS,
+        '--use-fake-device-for-media-stream',
+        '--use-fake-ui-for-media-stream',
+      ],
+    }),
+    LAUNCH_TIMEOUT_MS,
+    'launching Chromium with a fake media stream',
+  );
   const ctx = await browser.newContext({
     ...devices['iPhone 13'],
     ...(returningUser ? { permissions: ['microphone'] } : {}),
@@ -635,10 +681,7 @@ async function readVtCount(page: import('playwright').Page): Promise<number> {
 browserTest(
   'home-to-live flip runs a view transition and mounts the live canvas',
   async () => {
-    const browser = await chromium.launch({
-      headless: HEADLESS,
-      args: RENDERER_ARGS,
-    });
+    const browser = await sharedRendererBrowser();
     const ctx = await browser.newContext({
       viewport: { width: 1280, height: 720 },
       deviceScaleFactor: 1,
@@ -759,7 +802,7 @@ browserTest(
       );
       throw error;
     } finally {
-      await closeQuietly(ctx, browser);
+      await closeQuietly(ctx);
     }
   },
   { timeout: 240000 },
@@ -768,10 +811,7 @@ browserTest(
 browserTest(
   'skips the view transition when the OS prefers reduced motion',
   async () => {
-    const browser = await chromium.launch({
-      headless: HEADLESS,
-      args: RENDERER_ARGS,
-    });
+    const browser = await sharedRendererBrowser();
     const ctx = await browser.newContext({
       viewport: { width: 1280, height: 720 },
       deviceScaleFactor: 1,
@@ -819,7 +859,7 @@ browserTest(
       );
       throw error;
     } finally {
-      await closeQuietly(ctx, browser);
+      await closeQuietly(ctx);
     }
   },
   { timeout: 180000 },


### PR DESCRIPTION
## Summary

`agents can detect failing toy` has been red on CI. Four commits, and the last one is the actual fix — the first three are what it took to see the cause, each one disproved by the next CI run.

The symptom kept **moving earlier** as the run progressed:

| Change | What CI then reported |
|-|-|
| raised the budget 90s → 180s | consumed all 180s, named nothing |
| gave the unbounded calls deadlines (#1138's helpers) | `goto: Timeout 30000ms exceeded` — named, 60s |
| raised that navigation to 60s | `Timed out after 60000ms while launching Chromium` |

A browser process that cannot start is not a slow page, and a failure that keeps arriving one step sooner is not a wrong bound — it is resource exhaustion. By the fifth test this file had launched five Chromiums on a 2-core SwiftShader runner and was carrying the remains of four.

**The fix:** stop launching a browser per test. A context is the isolation boundary these tests actually need — separate storage, cookies and pages — so one shared process costs nothing and removes four launches from the run. The context closes per test, the browser once in `afterAll`.

The deadlines stay. They are what turned an unreadable `timed out after 180000ms` into a named cause, and they are the reason this got diagnosed at all rather than absorbed into the clock again.

## Testing

- `bun test tests/e2e/agent-integration.test.ts` — 5 pass
- `bun run check` — pass (pre-commit gate)

The honest limit: none of this reproduces on a fast machine with a real GPU, which is why the first three attempts were wrong. Each was a guess about *which bound was too tight*; the evidence only became legible once every call had one. Only CI can confirm the last commit.

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Test-only; no production code. It reuses #1138's `withDeadline`/`closeQuietly` rather than adding parallel helpers. `launchSharedBrowser` re-launches if the shared browser is not connected, so a crashed process does not cascade into every later test. Teardown closes only the context; `afterAll` closes the browser.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — no build output changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
