### PR TITLE
fix(milkdrop): define lum() in the shader preamble

### DIFF
--- a/scripts/preset-lab-glsl-corpus-scan.ts
+++ b/scripts/preset-lab-glsl-corpus-scan.ts
@@ -175,11 +175,18 @@ function main() {
 
   const args = process.argv.slice(2);
   const updateBaseline = args.includes('--update-baseline');
+  // `--only <id> [...]` takes every id up to the next flag, as the usage above
+  // advertises. Reading just the one argument after the flag silently scanned
+  // a single preset when handed a list, and reported success for the rest.
   const only: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
-    if (args[index] === '--only' && args[index + 1]) {
-      only.push(args[index + 1] as string);
+    if (args[index] !== '--only') continue;
+    let cursor = index + 1;
+    while (cursor < args.length && !args[cursor]?.startsWith('--')) {
+      only.push(args[cursor] as string);
+      cursor += 1;
     }
+    index = cursor - 1;
   }
 
   const entries = [...loadCatalogEntries(repoRoot).values()].filter(
@@ -191,7 +198,7 @@ function main() {
   }
 
   const failures: PresetFinding[] = [];
-  let shaderPresetCount = 0;
+  let failedPresetCount = 0;
   const startedAt = Date.now();
 
   for (const [index, entry] of entries.entries()) {
@@ -213,7 +220,7 @@ function main() {
     }
     const findings = scanPreset(raw, entry.id);
     if (findings.length > 0) {
-      shaderPresetCount += 1;
+      failedPresetCount += 1;
       failures.push(...findings);
     }
     if ((index + 1) % 200 === 0) {
@@ -228,7 +235,7 @@ function main() {
   console.log(
     `\nScanned ${entries.length} presets in ${elapsedSeconds}s ` +
       `(glslangValidator ${validatorVersion}): ` +
-      `${failures.length} shader compile error(s) across ${shaderPresetCount} preset(s).`,
+      `${failures.length} shader compile error(s) across ${failedPresetCount} preset(s).`,
   );
   for (const failure of failures) {
     console.log(`  ✗ ${failure.id} [${failure.stage}] ${failure.detail}`);

--- a/src/js/milkdrop/feedback-manager-shared.ts
+++ b/src/js/milkdrop/feedback-manager-shared.ts
@@ -439,6 +439,18 @@ const MILKDROP_NOISE_VOLUME_HELPERS = `
 // the composite pass (overlay/comp-body sampling), so they live in one
 // shared chunk instead of drifting apart as duplicates.
 const MILKDROP_AUX_SAMPLING_HELPERS = `
+        // MilkDrop 2's shader preamble ships lum(), so preset bodies call it
+        // without ever declaring it — the same gap that made GetPixel/GetBlur
+        // blank the cream-of-the-crop library. Its weights are MilkDrop's own,
+        // confirmed against the vendored butterchurn corpus, where the same
+        // expression appears inlined as dot(rgb, vec3(0.32, 0.49, 0.29)).
+        //
+        // The scalar overload matches HLSL, not intuition: there a float
+        // argument promotes to float3 before the dot, so lum(x) is x * 1.10.
+        float lum(vec3 v) { return dot(v, vec3(0.32, 0.49, 0.29)); }
+        float lum(vec4 v) { return lum(v.xyz); }
+        float lum(float v) { return v * 1.10; }
+
         vec2 sampleUv(vec2 uv, float wrapMode) {
           return wrapMode > 0.5 ? fract(uv) : clamp(uv, 0.0, 1.0);
         }


### PR DESCRIPTION
## Summary

Chasing why 152 preset previews capture a pure-black framebuffer. This does not fix them — it fixes one real gap found on the way, and two bugs in the instrument that were hiding the truth.

**`lum()` was undefined.** MilkDrop 2's shader preamble ships it, so preset bodies call it without ever declaring it — the same class of gap that had `GetPixel`/`GetBlur` blanking the cream-of-the-crop library. It was the single most common undefined symbol in the corpus: 122 of 728 shader compile errors named it. The weights are MilkDrop's own, confirmed against the vendored butterchurn corpus, where the same expression appears inlined as `dot(rgb, vec3(0.32, 0.49, 0.29))`. The scalar overload follows HLSL rather than intuition: a float argument promotes to `float3` before the dot, so `lum(x)` is `x * 1.10`.

**`--only <id> [...]` read exactly one id per flag.** Passing a list silently scanned the first preset and reported success for the rest — a 152-preset run came back claiming a single failure, which is how I nearly concluded these presets had no shaders at all. It now consumes every id up to the next flag.

**`shaderPresetCount` counted presets that FAILED**, not presets scanned, while printing as "across N preset(s)" beside the error total. Renamed to say what it holds.

## Testing

- `bun run lab:glsl-corpus-scan` — `lum` errors 122 → 3, failing presets 507 → 505, **0 regressions**, gate clean vs baseline
- `bun run check` — pass
- Browser probe on `cotc-waltra-monodream` (one of the two fixed): shader compile errors gone, engine live

The honest numbers, since the headline could mislead: **the preset delta is 2, not 122.** glslang reports the first error per shader, so most of those 122 were masking a further problem in the same shader rather than being the only one — `mix` errors surface 4 → 64 once `lum` stops shadowing them.

**This does not fix the 152 black previews.** Verified rather than assumed: re-captured 25 of them with the fix in place, 0 recovered. Neither of the two newly-compiling presets was in the black set.

## Docs touched

None.

## What this leaves open

The black previews are 150 presets already sitting in the 728-entry `glsl-corpus-scan-baseline.json` — a known, tracked backlog, not an undiscovered bug. Fixing them is an emitter project, not a symbol-by-symbol job. Error classes across the corpus:

| Count | Class |
|-|-|
| 128 | `cannot convert from X to Y` (HLSL implicit conversion: `float3 = float`, `1-q25`) |
| 52 | `no matching overloaded function` (`max`, `float2x2`, `GetPixel` arity) |
| 25 | `scalar swizzle not supported with this profile: es` |
| 10 | `undeclared identifier` |
| 8 | wrong operand types |

The largest class is HLSL's implicit conversion and splat rules, which needs type inference in the emitter rather than more builtins.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

`lum()` goes in `MILKDROP_AUX_SAMPLING_HELPERS`, the existing shared chunk both passes already include, rather than a second copy per pass. Covered by the corpus scan and its baseline gate, which is the instrument this class of change is verified with.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — shader source only, no build output change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
