### PR TITLE
Give the e2e browser calls that can hang a deadline

### DIFF
--- a/tests/e2e/agent-api.ts
+++ b/tests/e2e/agent-api.ts
@@ -321,15 +321,28 @@ export async function writeAgentFailureArtifact(
     const diagnosticsPath = path.join(dir, 'diagnostics.json');
     fs.writeFileSync(diagnosticsPath, JSON.stringify(diagnostics, null, 2));
 
+    // Bounded like the probes above, and for the same reason: this dump runs
+    // *because* something already went wrong, so the page it is pointed at is
+    // exactly the kind that does not answer. An unbounded screenshot() here
+    // silently ate the rest of the test budget — a click that had already
+    // failed fast at 30s still reported as a 240s timeout naming no cause,
+    // because the dump, not the test, was hanging. The try/catch below never
+    // saw it: a hang is not a throw.
     let screenshotPath: string | null = null;
-    try {
-      const candidate = path.join(dir, 'screenshot.png');
-      await page.screenshot({ path: candidate });
-      screenshotPath = candidate;
-    } catch {
-      // Page may already be mid-teardown or the backend (WebGPU) canvas may
-      // not be screenshot-able in this state — diagnostics.json still lands.
-    }
+    const candidate = path.join(dir, 'screenshot.png');
+    const captured = await withProbeTimeout(
+      page
+        .screenshot({
+          path: candidate,
+          timeout: FAILURE_ARTIFACT_PROBE_TIMEOUT_MS,
+        })
+        .then(() => true)
+        // Page may already be mid-teardown or the backend (WebGPU) canvas may
+        // not be screenshot-able in this state — diagnostics.json still lands.
+        .catch(() => false),
+      false,
+    );
+    if (captured) screenshotPath = candidate;
 
     return { dir, diagnosticsPath, screenshotPath };
   } catch {

--- a/tests/e2e/agent-boot-smoke.test.ts
+++ b/tests/e2e/agent-boot-smoke.test.ts
@@ -21,6 +21,7 @@ import {
   localOnlyBrowserTest,
   requiredBrowserTest,
 } from './browser-availability.ts';
+import { closeQuietly } from './deadline.ts';
 import { type DevServerHandle, startDevServer } from './dev-server.ts';
 import {
   HEADLESS,
@@ -67,16 +68,6 @@ type AgentWindow = typeof window & {
     } | null;
   };
 };
-
-async function closeQuietly(
-  ...closeables: Array<{ close: () => Promise<unknown> }>
-) {
-  for (const c of closeables) {
-    try {
-      await c.close();
-    } catch {}
-  }
-}
 
 beforeAll(
   async () => {

--- a/tests/e2e/agent-integration.test.ts
+++ b/tests/e2e/agent-integration.test.ts
@@ -172,7 +172,24 @@ integrationTest(
     try {
       await mobile.page.goto(`http://127.0.0.1:${TEST_PORT}/?agent=true`);
       await mobile.page.waitForSelector('#use-demo-audio');
-      await mobile.page.click('#use-demo-audio');
+      // waitForSelector resolves on *attached*, but this CTA renders
+      // `disabled={!isEngineReady || isStarting}` and engineReady is just
+      // `catalogError === null` (workspace-shell-hooks.ts). click() then
+      // auto-waits for enabled with no deadline of its own, so a failed
+      // catalog fetch turned this into a silent hang that ate the whole test
+      // budget and reported a timeout naming no cause. Wait for enabled
+      // explicitly, and bound the click, so each failure says which it was.
+      await mobile.page.waitForFunction(
+        () => {
+          const btn = document.querySelector(
+            '#use-demo-audio',
+          ) as HTMLButtonElement | null;
+          return Boolean(btn) && !btn?.disabled;
+        },
+        undefined,
+        { timeout: 60000 },
+      );
+      await mobile.page.click('#use-demo-audio', { timeout: 30000 });
 
       await mobile.page.waitForFunction(
         () => window.stimState?.getState().audioActive === true,

--- a/tests/e2e/deadline.ts
+++ b/tests/e2e/deadline.ts
@@ -1,0 +1,78 @@
+/**
+ * Deadlines for the browser calls that do not carry one.
+ *
+ * A browser test that is failing has usually already wedged the page or the
+ * browser process, and that is exactly when the teardown and diagnostic calls
+ * pointed at it stop answering. Playwright's `evaluate()` takes no timeout at
+ * all, and `close()`/`click()` take one only if you pass it, so an unbounded
+ * call in that state does not fail — it absorbs whatever is left of the test
+ * budget and the runner reports `timed out after 240000ms` naming no step.
+ *
+ * That is what made #1123 so hard to place. The hang appeared to move between
+ * runs and between tests, because whichever unbounded call happened to be
+ * reached first swallowed the clock; the visible symptom (which test "hung")
+ * was an artifact of ordering, not a clue about the cause. A `try/catch`
+ * around such a call is no protection either: a hang is not a throw.
+ *
+ * So the rule these helpers encode is that every call which can wait on a
+ * wedged page gets a deadline, and blowing it produces a message naming what
+ * was being attempted.
+ */
+
+/** Rejects with a named error if `work` outlives `ms`. */
+export async function withDeadline<T>(
+  work: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Timed out after ${ms}ms while ${label}. The page stopped ` +
+                  'answering — usually a blocked main thread rather than a ' +
+                  'missing element.',
+              ),
+            ),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** How long a single close() gets before we give up and move on. */
+const CLOSE_TIMEOUT_MS = 15_000;
+
+/**
+ * Closes each resource, tolerating both throws and hangs.
+ *
+ * This runs in `finally`, so anything it fails to bound is charged to the
+ * test that was already failing. Closing a wedged browser can block forever;
+ * when it does, the process is left for the runner to reap (`killed 1
+ * dangling process` in the log) and the real failure is buried under a budget
+ * timeout. Giving up on a close leaks a browser for the rest of the run,
+ * which is the cheaper of the two problems by a wide margin.
+ */
+export async function closeQuietly(
+  ...closeables: Array<{ close: () => Promise<unknown> }>
+): Promise<void> {
+  for (const closeable of closeables) {
+    try {
+      await withDeadline(
+        Promise.resolve(closeable.close()),
+        CLOSE_TIMEOUT_MS,
+        'closing a browser or context during teardown',
+      );
+    } catch {
+      // Deliberately swallowed: teardown must not replace the real failure.
+    }
+  }
+}

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -10,6 +10,7 @@ import {
   localOnlyBrowserTest,
   requiredBrowserTest,
 } from './browser-availability.ts';
+import { closeQuietly, withDeadline } from './deadline.ts';
 import {
   type DevServerHandle,
   isResponsive,
@@ -29,6 +30,21 @@ const baseBrowserTest = requiredBrowserTest;
 
 const TEST_PORT = 5181;
 const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+
+/**
+ * Pins the adaptive-quality controller to its cheapest step for these tests.
+ *
+ * Not a fidelity choice — a latency one. CI renders WebGL through SwiftShader
+ * on a small runner, and measured on this box the home page ran at a median
+ * frame of 495ms with `setTimeout(0)` taking 407ms to be serviced: the main
+ * thread is blocked in ~400ms slabs. Playwright's click() needs that thread
+ * several times over (hit-test, dispatch, acknowledge), so clicks queued
+ * behind those slabs and blew whatever deadline they were given. Locking the
+ * step roughly halves it (median 240ms), which buys the input path enough
+ * room without changing the viewport, and so without moving any responsive
+ * breakpoint these tests assert against.
+ */
+const CHEAP_RENDER_PARAMS = 'lockQualityStep=6';
 let devServer: DevServerHandle | null = null;
 
 // A single preset navigation used to fan out into several redundant compile
@@ -48,15 +64,6 @@ let devServer: DevServerHandle | null = null;
 const GPU_PROBE_TIMEOUT_MS = 120000;
 
 /** Never let teardown mask the assertion failure that got us here. */
-async function closeQuietly(
-  ...closeables: Array<{ close: () => Promise<unknown> }>
-) {
-  for (const c of closeables) {
-    try {
-      await c.close();
-    } catch {}
-  }
-}
 
 /**
  * Waits for the GPU to produce non-zero output anywhere on the stage canvas.
@@ -372,19 +379,63 @@ async function openAudioSourceDisclosure(page: import('playwright').Page) {
   // `domcontentloaded`, and the home page is a lazy chunk, so an immediate
   // count() returns 0 and the disclosure silently stays shut — which then
   // fails much later as "element is not visible" on the button inside it.
+  //
+  // 15s was not enough on CI, and the `catch { return }` below used to hide
+  // that: the helper returned having opened nothing, the caller's click()
+  // found a card that would never exist, and — with no timeout of its own —
+  // auto-waited until the whole 240s test budget expired. The log showed a
+  // hung test with no error. Two things went wrong and both are fixed here.
+  //
+  // The wait is longer because `.stims-shell__stage-hero`, which callers
+  // wait on first, is rendered by the *shell* (workspace-ui.tsx) while this
+  // disclosure comes from the lazily-imported NewHomePage. Reaching the hero
+  // says nothing about that chunk having arrived, and a cold vite dev server
+  // on a 2-vCPU runner can take a while to transform it.
   try {
-    await details.first().waitFor({ state: 'attached', timeout: 15000 });
+    await details.first().waitFor({ state: 'attached', timeout: 90000 });
   } catch {
-    return; // Surfaces without the disclosure (e.g. the Settings panel).
+    throw new Error(
+      'The audio-source disclosure never appeared. It lives inside the lazy ' +
+        'NewHomePage chunk, so this usually means that chunk failed or was ' +
+        'still loading — not that the disclosure is missing from the markup. ' +
+        'Waiting on .stims-shell__stage-hero does not cover it: the shell ' +
+        'renders the hero before the chunk resolves.',
+    );
   }
   const first = details.first();
-  const alreadyOpen = await first.evaluate(
-    (el) => (el as HTMLDetailsElement).open,
+  // evaluate() has no timeout in Playwright at all, and click() has none of
+  // its own — so if the page's main thread is wedged (which is precisely the
+  // state a failing visualizer test is in), either call waits forever and the
+  // test reports a bare budget timeout naming no step. Give both a deadline
+  // so the failure says which call stopped and what that implies.
+  // Opened by setting the property rather than clicking <summary>, because
+  // opening it is *setup* — no test here asserts that the disclosure is
+  // clickable; they assert what the controls inside it do.
+  //
+  // The click was the single worst offender in #1123. Playwright reported
+  // the element visible, enabled, stable and scrolled, then hung on
+  // "performing click action": dispatching a real input event needs the
+  // page's main thread, and these tests deliberately run a WebGL visualizer
+  // that saturates it under software rendering on a small CI runner. So the
+  // suite was gambling the whole test budget on input latency in order to
+  // toggle a <details>. Setting .open does the same thing without the wager,
+  // and the interactions a test is actually about stay real clicks.
+  const opened = await withDeadline(
+    first.evaluate((el) => {
+      const details = el as HTMLDetailsElement;
+      if (!details.open) details.open = true;
+      return details.open;
+    }),
+    15000,
+    'opening the audio-source disclosure',
   );
-  if (!alreadyOpen) {
-    await first.locator('summary').click();
-    await page.waitForTimeout(150);
+  if (!opened) {
+    throw new Error(
+      'The audio-source disclosure would not open. It is attached, so this ' +
+        'is not the lazy-chunk case above.',
+    );
   }
+  await page.waitForTimeout(150);
 }
 
 async function verifySmartphoneMicrophoneAccess({
@@ -608,9 +659,12 @@ browserTest(
 
     try {
       step('goto');
-      await page.goto(`${SERVER_URL}/?agent=true&renderer=webgl`, {
-        waitUntil: 'domcontentloaded',
-      });
+      await page.goto(
+        `${SERVER_URL}/?agent=true&renderer=webgl&${CHEAP_RENDER_PARAMS}`,
+        {
+          waitUntil: 'domcontentloaded',
+        },
+      );
       step('await #stims-main');
       await page.waitForSelector('#stims-main', { timeout: 30000 });
       step('await stage-frame[data-mode=home]');
@@ -627,9 +681,16 @@ browserTest(
       step('open audio disclosure');
       await openAudioSourceDisclosure(page);
       step('click demo-audio');
+      // click() carries no deadline of its own, so a card that never becomes
+      // actionable used to consume the whole test budget and report a timeout
+      // naming no cause. 30s, not more: raising this to 90s was tried and
+      // changed nothing, which is itself the useful result — when this fails
+      // the card is absent rather than slow (Playwright's call log stops at
+      // "waiting for locator", never resolving it), so waiting longer only
+      // buys a later identical failure. See #1123.
       await page
         .locator('.stims-shell__source-card[data-demo-audio-btn]')
-        .click();
+        .click({ timeout: 30000 });
 
       step('await audioActive=true');
       await page.waitForFunction(
@@ -720,14 +781,24 @@ browserTest(
     const page = await ctx.newPage();
 
     try {
-      await page.goto(`${SERVER_URL}/?agent=true&renderer=webgl`, {
-        waitUntil: 'domcontentloaded',
-      });
+      await page.goto(
+        `${SERVER_URL}/?agent=true&renderer=webgl&${CHEAP_RENDER_PARAMS}`,
+        {
+          waitUntil: 'domcontentloaded',
+        },
+      );
       await page.waitForSelector('#stims-main', { timeout: 30000 });
       await openAudioSourceDisclosure(page);
+      // click() carries no deadline of its own, so a card that never becomes
+      // actionable used to consume the whole test budget and report a timeout
+      // naming no cause. 30s, not more: raising this to 90s was tried and
+      // changed nothing, which is itself the useful result — when this fails
+      // the card is absent rather than slow (Playwright's call log stops at
+      // "waiting for locator", never resolving it), so waiting longer only
+      // buys a later identical failure. See #1123.
       await page
         .locator('.stims-shell__source-card[data-demo-audio-btn]')
-        .click();
+        .click({ timeout: 30000 });
 
       await page.waitForFunction(
         () => document.body.dataset.audioActive === 'true',


### PR DESCRIPTION
## Summary

**This does not make `e2e-engine-mount` pass.** It makes it fail in a way somebody can act on, and it records what the newly-legible logs revealed. I want that clear up front, because #1123 is the "CI is red" issue and this only closes half of it.

#1123 reported one e2e test per file eating its whole timeout budget, with the affected test appearing to move between runs. **The moving target was an artifact.** A browser test that is already failing has usually wedged the page or the browser, and that is exactly when the calls pointed at it stop answering. Playwright's `evaluate()` takes no timeout *at all*; `close()` and `click()` take one only if asked. So whichever unbounded call happened to be reached first absorbed the remaining budget, and the runner reported `timed out after 240000ms` naming no step. Which test "hung" was a fact about ordering, not about the bug. A `try/catch` never helped either — a hang is not a throw.

### What is bounded now

`tests/e2e/deadline.ts` adds `withDeadline()` and a bounded `closeQuietly()` — the latter replacing **two identical unbounded copies**. Its hanging `close()` is the source of the `killed 1 dangling process` line that preceded every one of these timeouts.

Also bounded:
- **The failure-dump screenshot** (`agent-api.ts`). Its two sibling probes were already bounded; `page.screenshot()` was not. An unbounded screenshot of a wedged page ate the rest of the budget *after* the real error had been raised — so a click that had already failed fast still surfaced as a bare 240s timeout.
- The disclosure's `evaluate`/`click`, and the source-card clicks.

### Two smaller fixes found on the way

- **`openAudioSourceDisclosure()` swallowed its own timeout.** `catch { return }` meant it carried on having opened nothing, and the caller's click then waited on a card that would never exist. It now throws — and waits longer, because callers wait on `.stims-shell__stage-hero`, which the *shell* renders, while the disclosure comes from the lazily imported `NewHomePage`. Reaching the hero says nothing about that chunk having arrived.
- **`agent-integration` waited for `#use-demo-audio` to be *attached*.** That CTA renders `disabled` until `engineReady` (just `catalogError === null`), and `click()` then waits for enabled with no deadline — so a failed catalog fetch became a silent hang. It now waits for enabled explicitly.

## Testing

- `bun run check` — **2292 pass / 0 fail**
- `tests/e2e/e2e-engine-mount.test.ts` run repeatedly under `xvfb`, `CI=1`: **275s → 99–115s**, and the failure now prints the call that stopped plus Playwright's action log.
- `tests/e2e/chrome-visual-contract.test.ts` — unchanged, passes.
- Typecheck and Biome clean.

## Findings for the follow-up (also on #1123)

Now that the logs name things, three things are measurable that were not before:

| Measurement | Value |
| --- | --- |
| Home-page median frame under SwiftShader | **495ms** (~2fps) |
| `setTimeout(0)` service latency | **407ms** — main thread blocked in ~400ms slabs |
| Same with `lockQualityStep=6` | 240ms / 240ms |
| Same, plus an 800×450 viewport | 102ms / 106ms |

`lockQualityStep=6` is applied to this suite's two `goto`s — a latency change, not a fidelity one, and chosen over shrinking the viewport so no responsive breakpoint these tests assert against moves.

**The remaining failure is not what any of us assumed, including me — twice.** With everything bounded, the surviving error is:

```
TimeoutError: click: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('.stims-shell__source-card[data-demo-audio-btn]')
```

That call log is one line. The locator **never resolved** — the card is absent, not slow. (Contrast the `<summary>` click, which resolved and then stuck on "performing click action", which is what sent me down the blocked-main-thread path.) Raising that deadline to 90s changed nothing, which is the confirming evidence; I put it back to 30s and recorded why in the comment.

A probe against a healthy home page finds the card present (`sourceCards: 4`, `demoCard: true`) even with the disclosure closed, so the markup is right and the disclosure state is not the cause. Something puts that page into a state where the source grid is absent. That is the next thing to chase, and it is a product question rather than a harness one.

## Docs touched

None. The reasoning is in `tests/e2e/deadline.ts`'s module docblock, which `check:module-docs` and `bun run help` surface.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic — `withDeadline` rejects rather than resolving a sentinel; `closeQuietly` swallows both throws and timeouts by design so teardown cannot replace the real failure
- [x] Async/lifecycle state transitions reviewed — this is entirely about teardown and wedged-page lifecycles; `closeQuietly` giving up leaks a browser for the rest of the run, which is deliberate and far cheaper than blocking `finally` forever
- [x] Existing shared helper/module checked before introducing duplicate logic — this *removes* two duplicated `closeQuietly` copies; `withProbeTimeout` in `agent-api.ts` was left alone as it returns a fallback rather than failing
- [x] New visual literals use existing design tokens — n/a
- [x] Behavior change is covered by tests — these *are* the tests; verified by running the suite and reading the failure mode, not by a meta-test

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [ ] `bun run build` — not applicable, test harness only

Refs #1123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7wixhXoRvPMSbJKdMhUkp)_