### PR TITLE
fix(milkdrop): keep a preset's declared vector type in emitted GLSL

### DIFF
--- a/performance/glsl-corpus-scan-baseline.json
+++ b/performance/glsl-corpus-scan-baseline.json
@@ -1,3647 +1,2857 @@
 {
   "version": 1,
-  "capturedAt": "2026-08-19T19:13:39.245Z",
+  "capturedAt": "2026-08-21T19:49:38.045Z",
   "validatorVersion": "Glslang Version: 11:16.5.0",
   "failures": [
     {
       "id": "amandio-c-fume",
       "stage": "warp",
-      "detail": "ERROR: 0:285: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
+      "detail": "ERROR: 0:297: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
     },
     {
       "id": "flexi-can-t-think-of-mosaic-cages",
       "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
     },
     {
       "id": "lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch",
       "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
     },
     {
       "id": "martin-adrift-on-a-dead-planet-lard-mix",
       "stage": "warp",
-      "detail": "ERROR: 0:523: 'dot' : no matching overloaded function found"
+      "detail": "ERROR: 0:535: 'dot' : no matching overloaded function found"
     },
     {
       "id": "martin-adrift-on-a-dead-planet-lite",
       "stage": "warp",
-      "detail": "ERROR: 0:523: 'dot' : no matching overloaded function found"
+      "detail": "ERROR: 0:535: 'dot' : no matching overloaded function found"
     },
     {
       "id": "martin-alien-grand-theft-water",
       "stage": "composite",
-      "detail": "ERROR: 0:412: 'dFdx' : required extension not requested: GL_OES_standard_derivatives"
+      "detail": "ERROR: 0:424: 'dFdx' : required extension not requested: GL_OES_standard_derivatives"
     },
     {
       "id": "martin-elusive-impressions-mix1",
       "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
+      "detail": "ERROR: 0:362: 'assign' :  cannot convert from ' const int' to ' global mediump float'"
     },
     {
       "id": "martin-invasion",
       "stage": "composite",
-      "detail": "ERROR: 0:386: 'dFdx' : required extension not requested: GL_OES_standard_derivatives"
+      "detail": "ERROR: 0:398: 'dFdx' : required extension not requested: GL_OES_standard_derivatives"
     },
     {
       "id": "cotc-suksma-passive-probabilistic-roaming-coin-gods",
       "stage": "warp",
-      "detail": "ERROR: 0:273: 'sampleUv' : no matching overloaded function found"
+      "detail": "ERROR: 0:284: 'sampleUv' : no matching overloaded function found"
     },
     {
       "id": "cotc-suksma-passive-probabilistic-roaming-coin-gods",
       "stage": "composite",
-      "detail": "ERROR: 0:340: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 4-component vector of float' and a right operand of type ' temp mediump 3-compon"
+      "detail": "ERROR: 0:351: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 4-component vector of float' and a right operand of type ' temp mediump 3-compon"
     },
     {
       "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-phat-zyl",
       "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-royal-mashup-291",
       "stage": "warp",
-      "detail": "ERROR: 0:285: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:290: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-geiss-skin-dots-10b",
       "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-royal-mashup-131",
       "stage": "warp",
-      "detail": "ERROR: 0:274: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:285: 'colorScale' : undeclared identifier"
     },
     {
       "id": "cotc-stahlregen-geiss-martin-tiger-no5-random-color-metal",
       "stage": "warp",
-      "detail": "ERROR: 0:283: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-martin-tiger-no5-random-color-metal",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:291: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-eos-angels-of-decay-19-hexocollie-6",
       "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-eos-angels-of-decay-19-hexocollie-6",
       "stage": "composite",
-      "detail": "ERROR: 0:341: 'max' : no matching overloaded function found"
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
     },
     {
       "id": "cotc-isosceles-mashup25",
       "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-hexocollie-flexi-adamfx-",
       "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-hexocollie-flexi-adamfx-",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-5-5",
       "stage": "warp",
-      "detail": "ERROR: 0:277: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:285: 'colorScale' : undeclared identifier"
     },
     {
       "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-5-5",
       "stage": "composite",
-      "detail": "ERROR: 0:345: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:361: 'pow' : no matching overloaded function found"
     },
     {
       "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-geiss-and-zylot-aurora-industrialis",
       "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
     },
     {
       "id": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
       "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
     },
     {
       "id": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
       "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
     },
     {
       "id": "cotc-suksma-daryl-feels-my-hellish-lonliness",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'tex2D' : can't use function syntax on variable"
-    },
-    {
-      "id": "cotc-mashup-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-flexi-and",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-zylot-visionarie-geiss-aspect-ratio-fix-mash0000-infinitely-dense-massless-particle",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-isosceles-mashup24",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2-amazing-mas",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-three-kinds-of-amphetamines-mash0000-jester-od-s-on-back-alley-clown-juice",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot6",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-jim-geiss-inverse-bass-zoom-mash0000-aim-your-scream-toward-the-avalanche",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-diffusion-effect-warp",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-10c",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-halfbreak-caramelize-serpentine",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-halfbreak-caramelize-serpentine",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-suksma-bmelgren-hungry-orbits-mash0000-sir-i-can-t-help-you-over-here-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-11b",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-luxxx-geiss-game-of-life-4",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-130",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-royal-mashup-130",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples-warp",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'assign' :  cannot convert from ' temp lowp 3-component vector of float' to ' temp mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-halfbreak-last-in-nebula",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-halfbreak-last-in-nebula",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'mix' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-isosceles-mashup02",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-bit-storm-effected-by-adamfx-2-shadowharlequin-bit-storm-ft-dancing-petals",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-157",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-acid-astralmatics",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-tripgnosis-acid-astralmatics",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-hypnocinagenic-drift",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-fishbrain-geiss-witchcraft-glow-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-234",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-fig-leaves-can-t-cover-that-much",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-tripgnosis-diffused-mana-pattern-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-diffused-mana-pattern-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-suksma-cuneinformal-basilihistrionix",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-zylot-and-fishbrain-i-am-the-witch",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tripgnosis-astral-calculations-5",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-tripgnosis-astral-calculations-5",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-indecision-about-how-to-die-decision-made",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tripgnosis-neon-algebra",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-neon-algebra",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'z' : undeclared identifier"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-01",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-03",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-05",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-02",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-04",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-on",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-amandio-c-sierpinsky-s-triangle",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-flexi-wolfram-s-rule-110-rise-of-the-log-attack",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-110-so-call-the-police",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-wolfram-s-rule-90-rise-of-the-log-attack",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-disruptor-wolfram-s-rule-110-satanic-teleprompter-05",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors2",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-enough-strange-candles-to-lay",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy2",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-squasm-minor-plot-frugal-koonut-kalifee",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-camden-defib-lancaster-tucker-s-neck",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-frustratingly-incomplete-wasteland",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-estrangedaholic-grandfather-cloques",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-gapes-to-spelunkcide-dada-hate-art-isn-t-art",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
-    },
-    {
-      "id": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-fishbrain-submarine-exp-ame-med",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-movement-within-the-trout-i-love-you-i-thank-you-it-meant-everything-don-t-forget",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-",
-      "stage": "composite",
-      "detail": "ERROR: 0:363: 'assign' :  cannot convert from ' temp mediump 4-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-esotic-krash-rolly-poly",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-nicklepenultim-roam",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-nicklepenultim-roam",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-nicklepenultim",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-nicklepenultim",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-nicklepenultim-the-skuzzmuppet",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-nicklepenultim-the-skuzzmuppet",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-camel-llama",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-at-the-root-of-open-the-graves",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-at-the-root-of-open-the-graves",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-truth-rarity-isosceles-edit08",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-truth-rarity-isosceles-edit09",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-eos-multisphere-01-b-phat-ra-mix-nexus-roams-falling-through-9-time",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-foldrinymicull",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova",
-      "stage": "composite",
-      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-162",
-      "stage": "composite",
-      "detail": "ERROR: 0:337: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-truth-raritys-isosceles-edit-11",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-waterrgate",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-evet-waterrgate",
-      "stage": "composite",
-      "detail": "ERROR: 0:368: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-29",
-      "stage": "warp",
-      "detail": "ERROR: 0:270: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-plasma",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tripgnosis-flameorb",
-      "stage": "warp",
-      "detail": "ERROR: 0:270: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-flameorb",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-380",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-betelguese3",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'mix' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-foolish-mash",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-royal-mashup-395",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-royal-mashup-377",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-lights-in-the-sky",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-lights-in-the-sky",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-farming-equipment-ice-shower",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-farming-equipment-ice-shower",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
-      "stage": "warp",
-      "detail": "ERROR: 0:293: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
-      "stage": "composite",
-      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-phairess-weale-mrt-flx",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-40",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-undulate-harque-auto-thef",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-undulate-harque-zing",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-undulate-harque-zing",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-circle-of-the-taeyrunts-phairess-imbularse-deign-offal",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' const float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-geite-spooksville-roams",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geite-spooksville-roams",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-undulate-harque-pain-tthe",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-undulate-harque-pain-tthe",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-accredited-omniversidioty",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-bass-spectre-ps2",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-downpour-x-spectre-ps2b",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-geiss-witchcraft-grow-mix-2-a-a",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-geiss-electric-storm-half-digital-2-fiesta-mix",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-electric-storm-half-digital-2-fiesta-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-race-for-hot-dog-log-smell-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-race-for-hot-dog-log-smell-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-orb-etheral-waves-mashup-20",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-vertigo-revisited",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-tokamak-plus-painterly",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-cepia-dither",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'mix' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-downpour-x-spectre-ps2-contact-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-cosmic-dust-2-laplacian-mix-maalol-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-luxxx-broken-beat-machina-i",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-luxxx-broken-beat-machina-i",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-cosmic-dust-2-laplacian-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-downpour-x-spectre-ps2",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-14",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-jewelsmoke",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-deconstrue-orbaet",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-deconstrue-orbaet",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-another-kind-of-groove",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-another-kind-of-groove",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 4-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-xtramartin-3",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-xtramartin-3",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-trapstract",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-never-churchmouth",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-water-your-pet-goldfish-i",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-flaring-squamoid-mode-placement",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-absinthe-with-mc-escher",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-absinthe-with-mc-escher",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-badballz",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-never-throck",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-when-the-first-aliens-came-b",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-when-the-first-aliens-came-b",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-flexi-orb-others-i-ve-had-it-with-this-g-tree",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-circles007b",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-serge-circles007b",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace000",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace000",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-158-002",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-serge-158-002",
-      "stage": "composite",
-      "detail": "ERROR: 0:368: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-pendulum-in-brass-ps2",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-martin-pendulum-in-brass-ps2",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-pendulum-in-brass-ps3",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-martin-pendulum-in-brass-ps3",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001b",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001b",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001c",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-serge-martin-crystal-palace001c",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-uhnfareknesce-roosta-conflarian",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-jc-lovely-bones",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-288",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-288",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-x-warp-harsh-klive",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-hexcollie-x-warp-harsh-klive",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-flexi-heartbleeding-emocore-will-get-the-rest-of-you",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-as-for-me-i-take-medicines2",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' const float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-goody-need-desire-remix",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-aurora-totalis",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-101",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-316",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-215",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'assign' :  cannot convert from ' global mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-215",
-      "stage": "composite",
-      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-orb-blade",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' global mediump 3"
-    },
-    {
-      "id": "cotc-orb-blade",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-hexcollie-shifter-martin-anime-vs-the-stalion-mang",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire-geiss-a",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-cantstop-adamfx-2-flexi-geiss-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-hex",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-shifter-etw",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-julian-shader-wars4",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-julian-shader-wars4",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-mig-colorful9",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-isosceles-mashup01",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-dark-tides-eos-phat-whisps-of-doom-mix-mash0000-salt-dunes-time-lapse",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-aderrasi-airhandler-last-breath-angel-evolution-mash0000-your-mints-have-arrived-sir",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-10",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-127",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-simple-squamous-mix",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-geiss-reaction-diffusion-simple-squamous-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot4-isosceles-e",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-9",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-lackstastique-j4",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-molten-glass",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-11-crossfire-composite",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-eos-particle-daemon-forge-mash0000-the-itchy-and-scratchy-show-meets-the-adam-s-family",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-bmelgren-unchained-ambrosia-myth-spinning-rain-mix-mash0000-fucked-up-dreams-about-a",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-hexcollie-julian-shader-wars3",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-julian-shader-wars3",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-orb-acid-cycle",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-geiss-skin-dots-multi-layer-3-pig-jembe-acid-wretch",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-luxxx-my-soul-i",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-rce-ordinary-want-nevermore-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-flexi-leaving-colors-crazy-cogitations-centrifuge-collapsing-cosmos-creation-oh-thats-still",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-stahlregen-flexi-geiss-shifter-swirlz-hue-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-youtube-pqswlhvukk8-something-else-dumb",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-no-grip-chute-reinvents-terror",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-loading-doctor",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-loading-doctor",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-moistened-gills-in-latent-galaxy-raggy",
-      "stage": "warp",
-      "detail": "ERROR: 0:3: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-suksma-moistened-gills-in-latent-galaxy-raggy",
-      "stage": "composite",
-      "detail": "ERROR: 0:3: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-feeling-ignore",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-414",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-flexi-fishbrain-geiss-unchained-others-plaidcraft",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-feeling-retry",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-flexi-witchcraft-unleashed-01-stepping-into-it",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-flexi-witchcraft-unleashed-01-stepping-into-it",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-423",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type8",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type8",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-fishbrain-flexi-geiss-martin-shifter-stonecraft-martin-s-metallics",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-rechivalrizing-tents",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-flexi-witchcraft-unleashed-00-the-template",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-flexi-stitchcraft-n",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-flexi-stitchcraft-n",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-circular-unlogic",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-429",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type9",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type9",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-feeling-abort",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
-    },
-    {
-      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-astralacid",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' global mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-astralacid",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-dense",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'lum' : can't use function syntax on variable"
-    },
-    {
-      "id": "cotc-serge-adam-eatit-mashup-fx-2-martin001",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-serge-adam-eatit-mashup-fx-2-martin001",
-      "stage": "composite",
-      "detail": "ERROR: 0:362: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-witchcraft-metropolish-remix-motor-up-pre-air-filter-cyclone-argon-tweecer",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-halfbreak-tonymilkdrop-beautiful-sepia-mashmash",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-her-sideways-crawl-through-your-bank-accounts",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-midgitstraights-of-majillaen-gunthree-spher",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-midgitstraights-of-majillaen-gunthree-spher",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swellin1",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-glowing",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-twist-fiber-wrap-cut-circulation",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-twist-fiber-wrap-cut-circulation",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-fishbrain-geiss-martin-flowercraft-reflecto-upfcku-yaqui-graph",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-fishbrain-witchcraft-phugly-megalopolish-remix",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
-    },
-    {
-      "id": "cotc-goody-s-portfolio-acid-angel",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-waltra-monodream",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-true-meaning-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-true-meaning-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit",
       "stage": "warp",
       "detail": "ERROR: 0:288: 'scalar swizzle' : not supported with this profile: es"
     },
     {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit",
+      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness",
       "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:356: 'tex2D' : can't use function syntax on variable"
     },
     {
-      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-flexi-geiss-tokamak-fractal-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:292: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-evet-flexi-geiss-tokamak-fractal-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:355: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-salutatorian-s-teat",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-fickle-will-dive-fed-shd",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-fickle-will-dive-fed-shd",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-fed-shd",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-fed-shd",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-this-pain-was-saved-for-you-maggot-filigree-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-distort-crops-of-horror-torture-blackode",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-distort-crops-of-horror-torture-blackode",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-flaming-bag-of-wisconsin-i-being-the-last-thing-you-remember-is-the-last-thing-i-rem",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-distort-crops-of-horror-torture",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-distort-crops-of-horror-torture",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' const float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-stahlregen-downpour",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 3-component vector of float'"
-    },
-    {
-      "id": "cotc-stahlregen-downpour",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' const float' to ' temp mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-the-ng-stahlregen-boz-eos-geiss-phat-rovastar-zylot-flexi-martin-fishbrain-machine-code-in-",
-      "stage": "composite",
-      "detail": "ERROR: 0:363: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-shifter-geiss-neon-pulse-glow-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-flexi-stahlregen-jewelry-tiles",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-flexi-stahlregen-jewelry-tiles",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'constructor' : too many arguments"
-    },
-    {
-      "id": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-cope-flexi-julia-set-strange-days-bdrv2",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-cope-flexi-julia-set-strange-days-bdrv2",
-      "stage": "composite",
-      "detail": "ERROR: 0:349: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
-      "stage": "warp",
-      "detail": "ERROR: 0:298: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
-      "stage": "composite",
-      "detail": "ERROR: 0:367: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
-      "stage": "warp",
-      "detail": "ERROR: 0:304: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
-      "stage": "composite",
-      "detail": "ERROR: 0:371: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
-      "stage": "warp",
-      "detail": "ERROR: 0:298: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
-      "stage": "composite",
-      "detail": "ERROR: 0:367: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-tunnel-race-meta-mash-for-rats",
-      "stage": "warp",
-      "detail": "ERROR: 0:302: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-martin-tunnel-race-meta-mash-for-rats",
-      "stage": "composite",
-      "detail": "ERROR: 0:369: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-xtramartin-459",
-      "stage": "warp",
-      "detail": "ERROR: 0:298: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
-    },
-    {
-      "id": "cotc-xtramartin-459",
-      "stage": "composite",
-      "detail": "ERROR: 0:365: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-hardcore-mix-2-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:298: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
-    },
-    {
-      "id": "cotc-martin-hardcore-mix-2-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:365: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen-aderrasi-geiss-unchained-zyl",
-      "stage": "composite",
-      "detail": "ERROR: 0:366: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-tunnel-race-meta-mash-disciple",
-      "stage": "warp",
-      "detail": "ERROR: 0:307: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-tunnel-race-meta-mash-disciple",
-      "stage": "composite",
-      "detail": "ERROR: 0:371: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-hardcore-mix-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:298: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
-    },
-    {
-      "id": "cotc-martin-hardcore-mix-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:365: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
-      "stage": "warp",
-      "detail": "ERROR: 0:295: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
-      "stage": "composite",
-      "detail": "ERROR: 0:364: 'float2x2' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-sewn-to-slavish-memes",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-sewn-to-slavish-memes",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
-    },
-    {
-      "id": "cotc-suksma-mundane-side-of-eden",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-goody-ego-decontructor",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' const float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-goody-woven-beads-ps2-0",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'x' : undeclared identifier"
-    },
-    {
-      "id": "cotc-goody-woven-beads",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'x' : undeclared identifier"
-    },
-    {
-      "id": "cotc-amandio-c-moving-ripple-reproducing-the-end-feeling-of-doing-anything-in-the-mind",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-524",
-      "stage": "composite",
-      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' global mediump float' to ' global mediump 3-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-505",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-505",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-509",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-509",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-evet-mindmelt-responsive-mix",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-276",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-orb-cloud-burst",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' global mediump 3"
-    },
-    {
-      "id": "cotc-orb-cloud-burst",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-444",
-      "stage": "composite",
-      "detail": "ERROR: 0:358: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-evet-fishbrain-betelguese-hyperdrive-remix",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-time-is-a-prison",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-apparitions-tear-at-your-b",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-276-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:281: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-tripgnosis-firestar",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-betelguese3-aa",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'mix' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-fishbrain-hexcollie-martin-bioluminescent-aerodynamic-poltergeist",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-fishbrain-david-bowie-cpe",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' global mediump 3-component vector of float' and a right operand of type ' smooth in mediump 2"
-    },
-    {
-      "id": "cotc-orb-waaa-jelly-5-55",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-59",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-85",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-405",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-83",
-      "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-83",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-58",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-96",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-surge",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-waltra-furry-synthesis-isosceles-edit2",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-last-thing-i-remember-was-reading-tombstones",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-rovastar-geiss-hyperkaleidoscope-glow-2-multitonal",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
-      "stage": "warp",
-      "detail": "ERROR: 0:289: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
-      "stage": "composite",
-      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-as-for-me-i-take-medicines",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' const float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-undulate-harque-amaz-inge",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-undulate-harque-amaz-inge",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-circle-of-the-taeyrunts",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' const float' to ' temp unknown type'"
-    },
-    {
-      "id": "cotc-undulate-harque-brit-tlee",
-      "stage": "warp",
-      "detail": "ERROR: 0:8: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-undulate-harque-brit-tlee",
-      "stage": "composite",
-      "detail": "ERROR: 0:8: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-extreme-paranoia-and-fear-unleash-in-spontaneous-suicide-flails-slapping-the-elite-roam3",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-extreme-paranoia-and-fear-unleash-in-spontaneous-suicide-flails-slapping-the-elite",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-confetti-manslut",
-      "stage": "composite",
-      "detail": "ERROR: 0:338: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-flukerication-machinist",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-actually-i-didn-t-eat-last-night",
-      "stage": "warp",
-      "detail": "ERROR: 0:3: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-suksma-actually-i-didn-t-eat-last-night",
-      "stage": "composite",
-      "detail": "ERROR: 0:3: 'output' : Reserved word."
-    },
-    {
-      "id": "cotc-suksma-and-i-will-have-salmon-for-dinner",
-      "stage": "composite",
-      "detail": "ERROR: 0:339: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-barnacle-coated-hemoclubbin",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies2",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-eos-pointfield-07-insek-mash0000-shiny-bladed-homicide-machine-at-dusk",
-      "stage": "warp",
-      "detail": "ERROR: 0:278: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-waltra-galactic-super-perspective",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-waltra-galactic-super-perspective",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: '-' :  wrong operand types: no operation '-' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
-    },
-    {
-      "id": "cotc-martin-soma-in-pink",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-soma-in-pink",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-passive-probabilistic-roaming",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-220",
-      "stage": "warp",
-      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-220",
-      "stage": "composite",
-      "detail": "ERROR: 0:363: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-beta106i-burning-form-seething-mass-mash0000-fire-paint-easter-egg-internals-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-103",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-174",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-104",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-suksma-ritually-invoking-the-irrational-slaves",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'sampleUv' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-102",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-62",
-      "stage": "warp",
-      "detail": "ERROR: 0:294: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-62",
-      "stage": "composite",
-      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-flexi-space-voyage-organic-aftermath-1",
-      "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-waltra-time-travel",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: '-' :  wrong operand types: no operation '-' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
-    },
-    {
-      "id": "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'max' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-isosceles-mashup23",
-      "stage": "composite",
-      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-317",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-need-transcendance-remix",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-141",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-19",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-146",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-310",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-367",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-170",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-170",
-      "stage": "composite",
-      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-370",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-13",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-307",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-312",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-345",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-308",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-372",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-368",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-313",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-318",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-16",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-goody-need",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-314",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-338",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-103",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-102",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-99",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-315",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-rovastar-stahlregen-touchdown-on-jelly-planet-bccn-v4",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-zylot-the-collective-unconcious-jelly-5-5",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-bass-pulsing-ps2",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 3-component vector of float'"
-    },
-    {
-      "id": "cotc-stahlregen-sparkling",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-eckshack-s-eyeball-floater-mix-plastic",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-rovastar-goody-geiss-rism-1982-gremlin-pinto-hybrid-440-block-2000-watts-obscura-bla",
-      "stage": "warp",
-      "detail": "ERROR: 0:276: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-stahlregen-hypnotron-v-0-5",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-484",
-      "stage": "warp",
-      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-484",
-      "stage": "composite",
-      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-270",
-      "stage": "warp",
-      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-270",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
-      "stage": "warp",
-      "detail": "ERROR: 0:282: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-orb-lazer-ride",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' global mediump 3"
-    },
-    {
-      "id": "cotc-orb-lazer-ride",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-160",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-183",
-      "stage": "warp",
-      "detail": "ERROR: 0:285: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-183",
-      "stage": "composite",
-      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-martin-sphery-tales-slow-version",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-sphery-tales-slow-version",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-sphery-tales",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-sphery-tales",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-martin-lock-and-release",
-      "stage": "warp",
-      "detail": "ERROR: 0:283: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
-    },
-    {
-      "id": "cotc-martin-lock-and-release",
-      "stage": "composite",
-      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-shifter-glassworms-flare-jelly-5-5",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1-isosceles-edit1",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1-isosceles-edit1",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-diabolo-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-diabolo-isosceles-edit",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-martin-diabolo",
-      "stage": "warp",
-      "detail": "ERROR: 0:273: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-martin-diabolo",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
-      "stage": "warp",
-      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
-      "stage": "composite",
-      "detail": "ERROR: 0:361: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
-      "stage": "warp",
-      "detail": "ERROR: 0:287: 'ofs' :  left of '[' is not of type array, matrix, or vector"
-    },
-    {
-      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
-      "stage": "composite",
-      "detail": "ERROR: 0:359: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1-isosceles-edit2",
-      "stage": "warp",
-      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-evet-ball-lightning-1-isosceles-edit2",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2e-feat-martin-flexi-phat",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 4-component vector of float' and a right operand of type ' smooth in mediump 2-c"
-    },
-    {
-      "id": "cotc-royal-mashup-115",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2-border-mix",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-190",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-190",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-189",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-189",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-tripgnosis-firesticks-isosceles-edit04",
-      "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' global mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-455",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-228",
-      "stage": "warp",
-      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-228",
-      "stage": "composite",
-      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-192",
-      "stage": "warp",
-      "detail": "ERROR: 0:274: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
-    },
-    {
-      "id": "cotc-royal-mashup-192",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-22",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-flexi-s-reflections-phat-s-r",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-34",
-      "stage": "composite",
-      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-royal-mashup-21",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'GetPixel' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-royal-mashup-21",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff-isosceles-edit",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-water-cooled-red-uranium-vs-dotes-here-have-a-hoho-flacc-grey-budget-never-ending-ba",
-      "stage": "warp",
-      "detail": "ERROR: 0:272: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killphreqs-mix4-flacc",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killphreqs-mix4-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-you-can-buy-hate-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis",
-      "stage": "warp",
-      "detail": "ERROR: 0:291: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis",
-      "stage": "composite",
-      "detail": "ERROR: 0:357: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-bleeding-like-a-horsey",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
-      "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-offx-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:342: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
-    },
-    {
-      "id": "cotc-suksma-mtn-flx-flacc-roam3",
+      "id": "cotc-mashup-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-flexi-and",
       "stage": "warp",
-      "detail": "ERROR: 0:277: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-mtn-flx-flacc-roam3",
-      "stage": "composite",
-      "detail": "ERROR: 0:350: 'scalar swizzle' : not supported with this profile: es"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills",
+      "id": "cotc-zylot-visionarie-geiss-aspect-ratio-fix-mash0000-infinitely-dense-massless-particle",
       "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-gss-sth-hogwoman-style-starin-at-sports-carscryin-schnig-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-thinkin-bout-u",
-      "stage": "composite",
-      "detail": "ERROR: 0:344: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff",
+      "id": "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot",
       "stage": "warp",
-      "detail": "ERROR: 0:272: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+      "detail": "ERROR: 0:291: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-geiss-dotes-orb",
+      "id": "cotc-suksma-adam-martin-geiss-come-into-my-closet-of-rot",
       "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:354: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
+      "id": "cotc-isosceles-mashup24",
       "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-and-zylot-reaction-diffusion-3-overload-mix-2-amazing-mas",
       "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:287: 'colorScale' : undeclared identifier"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
+      "id": "cotc-jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue",
       "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
-    },
-    {
-      "id": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire",
+      "id": "cotc-geiss-three-kinds-of-amphetamines-mash0000-jester-od-s-on-back-alley-clown-juice",
       "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+      "detail": "ERROR: 0:291: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
+      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot6",
       "stage": "warp",
-      "detail": "ERROR: 0:277: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
-    },
-    {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
-      "stage": "composite",
-      "detail": "ERROR: 0:348: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-j4-2",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire-isosceles-edit",
+      "id": "cotc-suksma-jim-geiss-inverse-bass-zoom-mash0000-aim-your-scream-toward-the-avalanche",
       "stage": "warp",
-      "detail": "ERROR: 0:277: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-bleeding-like-a-horsey-roams-i-just-got-through-watching-planet-bboy-and-boy-do-i-feel-emba",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam",
+      "id": "cotc-geiss-reaction-diffusion-3-janky-diffusion-effect-warp",
       "stage": "warp",
-      "detail": "ERROR: 0:271: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'max' : no matching overloaded function found"
+      "detail": "ERROR: 0:291: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher",
+      "id": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
       "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:292: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher",
+      "id": "cotc-geiss-tadpole-hunter-mash0000-humiliate-the-god-with-spencer",
       "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' global mediump float' to ' global mediump 3-component vector of float'"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
+      "id": "cotc-geiss-skin-dots-10c",
       "stage": "warp",
-      "detail": "ERROR: 0:279: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
-      "stage": "composite",
-      "detail": "ERROR: 0:346: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-collapsar",
+      "id": "cotc-halfbreak-caramelize-serpentine",
       "stage": "warp",
-      "detail": "ERROR: 0:285: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:292: 'colorScale' : undeclared identifier"
     },
     {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-collapsar",
+      "id": "cotc-halfbreak-caramelize-serpentine",
       "stage": "composite",
       "detail": "ERROR: 0:352: 'scalar swizzle' : not supported with this profile: es"
     },
     {
-      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted",
+      "id": "cotc-stahlregen-geiss-tiger-no5-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
       "stage": "warp",
-      "detail": "ERROR: 0:275: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:294: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted",
-      "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-drugsincombat-reactive-molecule-v-05a",
-      "stage": "composite",
-      "detail": "ERROR: 0:340: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-pacific-heights-flacc-roams-higher-self-lower-self-battles",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore",
+      "id": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
       "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:292: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore",
+      "id": "cotc-halfbreak-flexi-and-goody-geiss-benski-sparkly-lsb-feedback",
       "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:360: 'constructor' : too many arguments"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid",
+      "id": "cotc-suksma-bmelgren-hungry-orbits-mash0000-sir-i-can-t-help-you-over-here-isosceles-edit",
       "stage": "warp",
-      "detail": "ERROR: 0:276: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'sin' : undeclared identifier"
-    },
-    {
-      "id": "cotc-fleekus-flokus-violent-and-insane-homicidal-air-molecules-beat-code-experiment2-gss",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher",
+      "id": "cotc-geiss-skin-dots-11b",
       "stage": "warp",
-      "detail": "ERROR: 0:279: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher",
-      "stage": "composite",
-      "detail": "ERROR: 0:347: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killgaia-mix2",
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral",
       "stage": "warp",
-      "detail": "ERROR: 0:275: 'assign' :  cannot convert from ' global mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-stahlregen-dots-layered-suksma-world-humanvirus-replication-killgaia-mix2",
-      "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
-    },
-    {
-      "id": "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist",
+      "id": "cotc-luxxx-geiss-game-of-life-4",
       "stage": "warp",
-      "detail": "ERROR: 0:275: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist",
-      "stage": "composite",
-      "detail": "ERROR: 0:343: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-mtn-flx-flacc",
+      "id": "cotc-royal-mashup-130",
       "stage": "warp",
-      "detail": "ERROR: 0:277: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
     },
     {
-      "id": "cotc-suksma-mtn-flx-flacc",
+      "id": "cotc-royal-mashup-130",
       "stage": "composite",
-      "detail": "ERROR: 0:350: 'scalar swizzle' : not supported with this profile: es"
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-one-too-many-days-under-the-iron-flacc",
+      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples-warp",
       "stage": "warp",
-      "detail": "ERROR: 0:275: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:284: 'assign' :  cannot convert from ' temp lowp 3-component vector of float' to ' temp mediump 2-component vector of float'"
     },
     {
-      "id": "cotc-suksma-dotes-hostile-undertake-one-too-many-days-under-the-iron-flacc",
+      "id": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-geiss-eos-martin-rovastar-halcyon-jelly-skin",
       "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:360: 'pow' : no matching overloaded function found"
     },
     {
-      "id": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
+      "id": "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill",
       "stage": "warp",
-      "detail": "ERROR: 0:286: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:283: 'scalar swizzle' : not supported with this profile: es"
     },
     {
-      "id": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
+      "id": "cotc-hexcollie-flexi-n-geiss-caught-in-the-vortex-of-the-mystery-pill",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'assign' :  cannot convert from ' global mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-halfbreak-last-in-nebula",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-halfbreak-last-in-nebula",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' global mediump float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-isosceles-mashup02",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-melodic-pulsing-leds-mash0000-vegas-doesn-t-make-life-less-pointless",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-a-bit-storm-effected-by-adamfx-2-shadowharlequin-bit-storm-ft-dancing-petals",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-157",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' smooth in mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tripgnosis-acid-astralmatics",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-tripgnosis-acid-astralmatics",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-hypnocinagenic-drift",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-fishbrain-geiss-witchcraft-glow-mix",
       "stage": "composite",
       "detail": "ERROR: 0:352: 'constructor' : too many arguments"
     },
     {
-      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam2",
+      "id": "cotc-234",
       "stage": "warp",
-      "detail": "ERROR: 0:275: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:290: 'z' : undeclared identifier"
     },
     {
-      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam2",
+      "id": "cotc-suksma-fig-leaves-can-t-cover-that-much",
       "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+      "detail": "ERROR: 0:356: 'constructor' : too many arguments"
     },
     {
-      "id": "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed",
+      "id": "cotc-tripgnosis-diffused-mana-pattern-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-zylot-and-fishbrain-i-am-the-witch",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-tripgnosis-astral-calculations-5",
       "stage": "warp",
-      "detail": "ERROR: 0:286: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
     },
     {
-      "id": "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed",
+      "id": "cotc-tripgnosis-astral-calculations-5",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-indecision-about-how-to-die-decision-made",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-including-adam-fx-2-flexi-fishbrain-operation-fatcap-fishbrain-and-witchcraft",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-tripgnosis-neon-algebra",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-tripgnosis-neon-algebra",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-aderassi-bdrv-adamfx-n-flexi-it-s-a-start",
+      "stage": "composite",
+      "detail": "ERROR: 0:363: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-01",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-03",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-05",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-02",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-04",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter-on",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-amandio-c-sierpinsky-s-triangle",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-wolfram-s-rule-110-rise-of-the-log-attack",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-110-so-call-the-police",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-90-satanic-teleprompter",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-wolfram-s-rule-90-rise-of-the-log-attack",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-flexi-disruptor-wolfram-s-rule-110-satanic-teleprompter-05",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '>' :  wrong operand types: no operation '>' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' const float' (or ther"
+    },
+    {
+      "id": "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors2",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-enough-strange-candles-to-lay",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-now-for-only-19-95-you-can-pray-to-a-whole-array-of-saviors",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy2",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-squasm-minor-plot-frugal-koonut-kalifee",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-camden-defib-lancaster-tucker-s-neck",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-aaron-funcking-god-and-his-mod-file-savvy",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-estrangedaholic-grandfather-cloques",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-bdrv-al-eos-pulsecubebdrv-etal-rmxmix-25-qabalistic-space-invading-homo-nutrient-mouth-swis",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-gapes-to-spelunkcide-dada-hate-art-isn-t-art",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
+    },
+    {
+      "id": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-rovastar-loadus-geiss-tone-mapped-fractaldrop-4-jelly-v5",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-fishbrain-submarine-exp-ame-med",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' global mediump 3-component vector of float' and a right operand of type ' smooth in mediump 2"
+    },
+    {
+      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-j",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-movement-within-the-trout-i-love-you-i-thank-you-it-meant-everything-don-t-forget",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-new-creation-sensation-adamfx-flexi-amandio-c-n-martin-star-to-another-world-ft-hexocollie-",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-evet-esotic-krash-rolly-poly",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-nicklepenultim-roam",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-nicklepenultim-roam",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-nicklepenultim",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-nicklepenultim",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-nicklepenultim-the-skuzzmuppet",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-nicklepenultim-the-skuzzmuppet",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-camel-llama",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-at-the-root-of-open-the-graves",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-at-the-root-of-open-the-graves",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-truth-rarity-isosceles-edit09",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-eos-multisphere-01-b-phat-ra-mix-nexus-roams-falling-through-9-time",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-foldrinymicull",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-cope-flexi-strange-attractor-jewellery-tile-mix-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rova",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-royal-mashup-162",
+      "stage": "composite",
+      "detail": "ERROR: 0:349: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-evet-waterrgate",
+      "stage": "warp",
+      "detail": "ERROR: 0:298: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-royal-mashup-29",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-plasma",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-tripgnosis-flameorb",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-fishbrain-betelguese3",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' global mediump float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-suksma-foolish-mash",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-royal-mashup-395",
+      "stage": "composite",
+      "detail": "ERROR: 0:368: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-royal-mashup-377",
+      "stage": "composite",
+      "detail": "ERROR: 0:367: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
+      "stage": "warp",
+      "detail": "ERROR: 0:283: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 2-compon"
+    },
+    {
+      "id": "cotc-suksma-dark-one-clouds-das-yi-hyper-phosphene-ejaculate",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-yin-314-ocean-of-light-ascending-nadi-mix-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-goody-lights-in-the-sky",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-goody-lights-in-the-sky",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
+      "stage": "warp",
+      "detail": "ERROR: 0:299: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell-roams-saucy",
+      "stage": "composite",
+      "detail": "ERROR: 0:367: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-slut-warm-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
+      "stage": "warp",
+      "detail": "ERROR: 0:299: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-maps-of-hell",
+      "stage": "composite",
+      "detail": "ERROR: 0:369: 'assign' :  cannot convert from ' global mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-suksma-farming-equipment-ice-shower",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-farming-equipment-ice-shower",
       "stage": "composite",
       "detail": "ERROR: 0:351: 'scalar swizzle' : not supported with this profile: es"
     },
     {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami",
+      "stage": "composite",
+      "detail": "ERROR: 0:373: 'mod' : undeclared identifier"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear",
+      "stage": "composite",
+      "detail": "ERROR: 0:366: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-phairess-weale-mrt-flx",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-40",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-undulate-harque-auto-thef",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-undulate-harque-zing",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-undulate-harque-zing",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-circle-of-the-taeyrunts-phairess-imbularse-deign-offal",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geite-spooksville-roams",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-geite-spooksville-roams",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-undulate-harque-pain-tthe",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-undulate-harque-pain-tthe",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-hypra-a-astral-hypra-a-plane-fairlly-amazing-bullshit",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
+      "stage": "warp",
+      "detail": "ERROR: 0:300: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-gentlekid-cosmic-dust-2-digital-data-loss",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-fishbrain-geiss-witchcraft-grow-mix-2-a-a",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-geiss-electric-storm-half-digital-2-fiesta-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-this-is-a-painting-flexi-let-s-trade-techstyle-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
+      "stage": "warp",
+      "detail": "ERROR: 0:300: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-race-for-hot-dog-log-smell-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-race-for-hot-dog-log-smell-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-geiss-orb-etheral-waves-mashup-20",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-goody-vertigo-revisited",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-cepia-dither",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' global mediump float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-geiss-cosmic-dust-2-laplacian-mix-maalol-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-geiss-cosmic-dust-2-laplacian-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-deconstrue-orbaet",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-another-kind-of-groove",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-g-martin-m-m-w-mu-wp-m-c-m-getting-beat-isn-t-embarrassing-it-s-no-one-cares",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-xtramartin-3",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-shifter-flashburn-roams-use-fishing-line-to-keep-the-spiral-plates-from-touching",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-luxxx-absinthe-with-mc-escher",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-luxxx-badballz",
+      "stage": "warp",
+      "detail": "ERROR: 0:300: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-never-throck",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'milkdropIntMod' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-serge-circles007b",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-serge-martin-crystal-palace000",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-serge-martin-crystal-palace001",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-serge-158-002",
+      "stage": "warp",
+      "detail": "ERROR: 0:297: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-martin-pendulum-in-brass-ps2",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-martin-pendulum-in-brass-ps3",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-serge-martin-crystal-palace001b",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-starz-in-milkhdfx-stahlregen-aderrasi-eos-geiss-unchained-zylot-flexi-martin-adamfx-e",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-serge-martin-crystal-palace001c",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-jc-lovely-bones",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-288",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-288",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-x-warp-harsh-klive",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-hexcollie-x-warp-harsh-klive",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-as-for-me-i-take-medicines2",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-goody-aurora-totalis",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-215",
+      "stage": "warp",
+      "detail": "ERROR: 0:299: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-royal-mashup-215",
+      "stage": "composite",
+      "detail": "ERROR: 0:362: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-orb-blade",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-swelling-spiral-liquid-fire-geiss-a",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-janky-ripple-effect-again",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-cantstop-adamfx-2-flexi-geiss-fishbrain-swelling-spiral-work-with-lines-deamon-lord-eos-hex",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-3",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-stahlregen-adamfx-flexi-geiss-dragonfly-wings-mashup-26-jack-s-playful-thumbdrum-planet-rmx",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-rippling-leopard-skin",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-shifter-etw",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-julian-shader-wars4",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-mig-colorful9",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-flexi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-jelly-mashup-yay3",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-isosceles-mashup01",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-bdrv-flexi-geiss-shifter-hypno-swirl-mashup-38-coral-trance-rmx",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-luxxx-inhale-this-golden-rate-tax-stamp-for-025-credits-off",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-shifter-dark-tides-eos-phat-whisps-of-doom-mix-mash0000-salt-dunes-time-lapse",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-aderrasi-airhandler-last-breath-angel-evolution-mash0000-your-mints-have-arrived-sir",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-3-janky-ripples",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-bitstorm-intune-with-ada",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-skin-dots-10",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-127",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-simple-squamous-mix",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-geiss-reaction-diffusion-simple-squamous-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-aderassi-phat-zylot4-isosceles-e",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-skin-dots-9",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-lackstastique-j4",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-shifter-crosshatch-colony-beta6-gaseous-lives",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-molten-glass",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-skin-dots-11-crossfire-composite",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-eos-particle-daemon-forge-mash0000-the-itchy-and-scratchy-show-meets-the-adam-s-family",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-bmelgren-unchained-ambrosia-myth-spinning-rain-mix-mash0000-fucked-up-dreams-about-a",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-hexcollie-julian-shader-wars3",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-new-adam-master-mashup-fx-2-geiss-reaction-diffusion-34-aurora-industrialis-orb-acid-cycle",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-shifter-crosshatch-colony-beta6-loved-to-death-by-nymphs-and-hentai-succubi",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-a-feature-preset-master-exclusive-orb-planetary-alignment-acidburn-eso-demon-released-by-ad",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-geiss-and-zylot-reaction-diffusion-3-overload-mix-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-a-hd-adamfx-creation-ft-martin-flexi-rovastar-mdropfx-collaboration-e-adam-hd-infectionfx-a",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-g-thea-ceo-m-zylo-v-w-27su-om-wp-xxx-c-stah-j5-heiyin-taiyang",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-stahlregen-geiss-rovastar-fields-of-flowers-jelly-zen-gardens",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-geiss-skin-dots-multi-layer-3-pig-jembe-acid-wretch",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-luxxx-my-soul-i",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-rce-ordinary-want-nevermore-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-leaving-colors-crazy-cogitations-centrifuge-collapsing-cosmos-creation-oh-thats-still",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-no-grip-chute-reinvents-terror",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-loading-doctor",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-loading-doctor",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-moistened-gills-in-latent-galaxy-raggy",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'output' : Reserved word."
+    },
+    {
+      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-daryl-feels-my-hellish-lonliness-creamy-layers-of-junk-mail-drips-with-soul",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-men-in-reverse-in-reverse-time-born-to-breath-not-much-else",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-feeling-ignore",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-414",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-414",
+      "stage": "composite",
+      "detail": "ERROR: 0:365: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-fishbrain-geiss-unchained-others-plaidcraft",
+      "stage": "composite",
+      "detail": "ERROR: 0:362: 'assign' :  cannot convert from ' temp mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-like-me-who-indulge-in-crying-wo",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-423",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type8",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type8",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-suksma-rechivalrizing-tents",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'milkdropIntMod' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-fishbrain-flexi-stitchcraft-n",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'assign' :  cannot convert from ' temp mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-tripgnosis-circular-unlogic",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-429",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-morons-who-don-t-think-things-are-going",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-g-martin-m-m-w-fishbrain-wp-m-c-m-tanked-on-pure-neoepinephrine",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-flexi-identity-killing-petting-colon-gonad-type9",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp mediump 2-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-414-bowel-rebranding-pr-skinned-to-the-teeth-loadus-veracruz",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-tripgnosis-astralacid",
+      "stage": "warp",
+      "detail": "ERROR: 0:288: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-stahlregen-fishbrain-flexi-geiss-shifter-stonecraft-dense",
+      "stage": "composite",
+      "detail": "ERROR: 0:367: 'assign' :  cannot convert from ' global mediump float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-serge-adam-eatit-mashup-fx-2-martin001",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-her-sideways-crawl-through-your-bank-accounts",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-midgitstraights-of-majillaen-gunthree-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-midgitstraights-of-majillaen-gunthree-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-best-of-adamfx-2-flexi-geiss-bipolar-vs-reaction-diffusion-another-flexi-fishbrain-swellin1",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-twist-fiber-wrap-cut-circulation",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-fishbrain-witchcraft-phugly-megalopolish-remix",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
+    },
+    {
+      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-true-meaning-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-the-touch-and-the-tough-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-the-psyched-out-about-loop-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:300: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-don-t-play-with-those-kids-multiverse-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-an-excuse-taken-back-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit2",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-flexi-bdrv-ultramix-05-alien-complex-mix-not-roaring-at-all",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-have-you-listened-anyway-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex-isosceles-edit1",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-priming-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-rhythm-of-my-life-flexi-multiverse",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
+      "stage": "warp",
+      "detail": "ERROR: 0:298: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-the-ng-flexi-bdrv-ultramix-05-alien-complex-mix-underground",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-pump-up-the-jam-multiverse-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:299: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-tricolors-flexi-gettogether-multiverse-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:363: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-evet-flexi-geiss-tokamak-fractal-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:301: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-evet-flexi-geiss-tokamak-fractal-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:365: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-multiverse-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-nuclear-flexi-why-even-bother-alien-complex",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-tonymilkdrop-angels-of-glory-flexi-safer-sex-alien-complex-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-fickle-will-dive-fed-shd",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-fickle-will-dive-fed-shd",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-nothing-to-remember-you-by-logsmeltitdealtit2",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-fed-shd",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-fed-shd",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-this-pain-was-saved-for-you-maggot-filigree-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-distort-crops-of-horror-torture-blackode",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-distort-crops-of-horror-torture-blackode",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'lum' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-flaming-bag-of-wisconsin-i-being-the-last-thing-you-remember-is-the-last-thing-i-rem",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-this-pain-was-saved-for-you-roams-stephen-hill-hos",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-distort-crops-of-horror-torture",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-distort-crops-of-horror-torture",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-downpour",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'assign' :  cannot convert from ' const float' to ' temp mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-shifter-geiss-neon-pulse-glow-mix",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-flexi-stahlregen-jewelry-tiles",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-flexi-stahlregen-jewelry-tiles",
+      "stage": "composite",
+      "detail": "ERROR: 0:365: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar-orb-mstress-mash0000-prismatic-spec",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-flexi-geiss-bipolar-vs-reaction-diffusion-mirror-scoped-phat-s-reflecto",
+      "stage": "composite",
+      "detail": "ERROR: 0:365: 'assign' :  cannot convert from ' temp mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-by-adam-fx-2-shifter-geiss-neon-pulse-glow-mix-rovastar",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-bdrv-aderrasi-accelerator-orbital-migraine-bdrv-et-al-rmx8-sorry-to-hear-you-re-not-liking-",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-cope-flexi-julia-set-strange-days-bdrv2",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
+      "stage": "warp",
+      "detail": "ERROR: 0:309: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself",
+      "stage": "composite",
+      "detail": "ERROR: 0:378: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
+      "stage": "warp",
+      "detail": "ERROR: 0:311: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-flexi-shifter-n-fishbrain",
+      "stage": "composite",
+      "detail": "ERROR: 0:378: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
+      "stage": "warp",
+      "detail": "ERROR: 0:310: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-ac",
+      "stage": "composite",
+      "detail": "ERROR: 0:379: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-tunnel-race-meta-mash-for-rats",
+      "stage": "warp",
+      "detail": "ERROR: 0:313: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-martin-tunnel-race-meta-mash-for-rats",
+      "stage": "composite",
+      "detail": "ERROR: 0:380: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-xtramartin-459",
+      "stage": "warp",
+      "detail": "ERROR: 0:310: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
+    },
+    {
+      "id": "cotc-xtramartin-459",
+      "stage": "composite",
+      "detail": "ERROR: 0:377: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-hardcore-mix-2-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:310: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
+    },
+    {
+      "id": "cotc-martin-hardcore-mix-2-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:377: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen-aderrasi-geiss-unchained-zyl",
+      "stage": "composite",
+      "detail": "ERROR: 0:377: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-tunnel-race-meta-mash-disciple",
+      "stage": "warp",
+      "detail": "ERROR: 0:318: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-martin-tunnel-race-meta-mash-disciple",
+      "stage": "composite",
+      "detail": "ERROR: 0:382: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-martin-hardcore-mix-2",
+      "stage": "warp",
+      "detail": "ERROR: 0:310: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump float' and a right operand of type ' const int' (or there is no acceptable conve"
+    },
+    {
+      "id": "cotc-martin-hardcore-mix-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:377: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
+      "stage": "warp",
+      "detail": "ERROR: 0:307: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-martin-n-adamfx-hardcore-mix-collision-in-myself-ft-stahlregen",
+      "stage": "composite",
+      "detail": "ERROR: 0:376: 'float2x2' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-sewn-to-slavish-memes",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-sewn-to-slavish-memes",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
+    },
+    {
+      "id": "cotc-suksma-mundane-side-of-eden",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-goody-ego-decontructor",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-goody-woven-beads-ps2-0",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'x' : undeclared identifier"
+    },
+    {
+      "id": "cotc-goody-woven-beads",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'x' : undeclared identifier"
+    },
+    {
+      "id": "cotc-amandio-c-moving-ripple-reproducing-the-end-feeling-of-doing-anything-in-the-mind",
+      "stage": "composite",
+      "detail": "ERROR: 0:367: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 4-component vector of float' and a right operand of type ' temp mediump 3-compon"
+    },
+    {
+      "id": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-amandio-c-typhoon-season-inside-eid-sdi",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-524",
+      "stage": "composite",
+      "detail": "ERROR: 0:366: 'assign' :  cannot convert from ' global mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-505",
+      "stage": "warp",
+      "detail": "ERROR: 0:298: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-505",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-509",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-509",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-evet-mindmelt-responsive-mix",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-royal-mashup-276",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-orb-cloud-burst",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
+    },
+    {
+      "id": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-rovaster-eos-phat-gastly-geiss-stahlgren-copper-mine-shaft-fall",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-goody-amandio-c-final-hour-eclipse-shader-rmx-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-444",
+      "stage": "composite",
+      "detail": "ERROR: 0:369: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-evet-fishbrain-betelguese-hyperdrive-remix",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-time-is-a-prison",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-apparitions-tear-at-your-b",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-var-eos-geiss-goody-god-parasite-dissonance-palms-your-soul",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-royal-mashup-276-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-dark-one-clouds-i-forcibly-shoved-the-crowbar-down-my-skeletal-remain",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-fishbrain-betelguese3-aa",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' global mediump float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-fishbrain-david-bowie-cpe",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' global mediump 3-component vector of float' and a right operand of type ' smooth in mediump 2"
+    },
+    {
+      "id": "cotc-orb-waaa-jelly-5-55",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-59",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-85",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-405",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-83",
+      "stage": "warp",
+      "detail": "ERROR: 0:283: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-83",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-58",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-96",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-waltra-furry-synthesis-isosceles-edit2",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-last-thing-i-remember-was-reading-tombstones",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-rovastar-geiss-hyperkaleidoscope-glow-2-multitonal",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'assign' :  cannot convert from ' global mediump float' to ' temp mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-a-rip-in-mommy-s-underwear-roams",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-suksma-as-for-me-i-take-medicines",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-undulate-harque-amaz-inge",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-undulate-harque-amaz-inge",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-circle-of-the-taeyrunts",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-undulate-harque-brit-tlee",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-undulate-harque-brit-tlee",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'output' : Reserved word."
+    },
+    {
+      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-flukerication-machinist",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' global mediump 3-component vector of float' and a right operand of type ' smooth in mediump 2"
+    },
+    {
+      "id": "cotc-suksma-actually-i-didn-t-eat-last-night",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'output' : Reserved word."
+    },
+    {
+      "id": "cotc-suksma-and-i-will-have-salmon-for-dinner",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-barnacle-coated-hemoclubbin",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp unknown type'"
+    },
+    {
+      "id": "cotc-suksma-log-smell-via-gandalf-pipeweed-taint-flashies2",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-eos-pointfield-07-insek-mash0000-shiny-bladed-homicide-machine-at-dusk",
+      "stage": "warp",
+      "detail": "ERROR: 0:290: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-waltra-galactic-super-perspective",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-waltra-galactic-super-perspective",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: '-' :  wrong operand types: no operation '-' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
+    },
+    {
+      "id": "cotc-martin-soma-in-pink",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-passive-probabilistic-roaming",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-220",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-royal-mashup-103",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-104",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-suksma-ritually-invoking-the-irrational-slaves",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-102",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-62",
+      "stage": "warp",
+      "detail": "ERROR: 0:303: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-62",
+      "stage": "composite",
+      "detail": "ERROR: 0:367: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-flexi-space-voyage-organic-aftermath-1",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-waltra-time-travel",
+      "stage": "composite",
+      "detail": "ERROR: 0:350: '-' :  wrong operand types: no operation '-' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
+    },
+    {
+      "id": "cotc-stahlregen-eos-geiss-krash-pieturp-zylot-dandelion-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-170",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-rovastar-stahlregen-touchdown-on-jelly-planet-bccn-v4",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-zylot-the-collective-unconcious-jelly-5-5",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-sparkling",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-eckshack-s-eyeball-floater-mix-plastic",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-rovastar-goody-geiss-rism-1982-gremlin-pinto-hybrid-440-block-2000-watts-obscura-bla",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-stahlregen-hypnotron-v-0-5",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'mix' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-484",
+      "stage": "warp",
+      "detail": "ERROR: 0:294: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-484",
+      "stage": "composite",
+      "detail": "ERROR: 0:362: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-270",
+      "stage": "warp",
+      "detail": "ERROR: 0:299: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-royal-mashup-270",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-shifter-flexi-american-pie-artifactory-never-contribute-given-7-inches-to-bath-with",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-orb-lazer-ride",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' smooth in mediump 2-component vector of float' and a right operand of type ' temp mediump 3-c"
+    },
+    {
+      "id": "cotc-orb-lazer-ride",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-160",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-183",
+      "stage": "warp",
+      "detail": "ERROR: 0:293: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-183",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-martin-sphery-tales-slow-version",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-martin-sphery-tales-slow-version",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-martin-sphery-tales",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-martin-sphery-tales",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-martin-lock-and-release",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: '' :  syntax error, unexpected IDENTIFIER, expecting COMMA or SEMICOLON"
+    },
+    {
+      "id": "cotc-martin-lock-and-release",
+      "stage": "composite",
+      "detail": "ERROR: 0:363: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-shifter-glassworms-flare-jelly-5-5",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1-isosceles-edit1",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1-isosceles-edit1",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-diabolo-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-martin-diabolo-isosceles-edit",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-martin-diabolo",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-martin-diabolo",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
+      "stage": "warp",
+      "detail": "ERROR: 0:297: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk",
+      "stage": "composite",
+      "detail": "ERROR: 0:370: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'ofs' :  left of '[' is not of type array, matrix, or vector"
+    },
+    {
+      "id": "cotc-mrt-ei-cynical-engineers-working-for-a-backward-system-unite-in-circle-jerk-oink",
+      "stage": "composite",
+      "detail": "ERROR: 0:368: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1-isosceles-edit2",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-evet-ball-lightning-1-isosceles-edit2",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-v2e-feat-martin-flexi-phat",
+      "stage": "composite",
+      "detail": "ERROR: 0:353: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 4-component vector of float' and a right operand of type ' smooth in mediump 2-c"
+    },
+    {
+      "id": "cotc-royal-mashup-190",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-eos-glowsticks-v2-04-music-minimal-oscilloscope-vomit-mix-keylontic",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-royal-mashup-189",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-tripgnosis-firesticks-isosceles-edit04",
+      "stage": "warp",
+      "detail": "ERROR: 0:289: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-455",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: 'sampleUv' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-228",
+      "stage": "warp",
+      "detail": "ERROR: 0:297: 'z' : undeclared identifier"
+    },
+    {
+      "id": "cotc-228",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-royal-mashup-192",
+      "stage": "warp",
+      "detail": "ERROR: 0:282: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump 4-component vector of float'"
+    },
+    {
+      "id": "cotc-eos-glowsticks-v2-03-music-shifter-edit-b-stahl-s-reactive-rmx-flexi-s-reflections-phat-s-r",
+      "stage": "composite",
+      "detail": "ERROR: 0:360: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-royal-mashup-21",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'GetPixel' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-water-cooled-red-uranium-vs-dotes-here-have-a-hoho-flacc-grey-budget-never-ending-ba",
+      "stage": "warp",
+      "detail": "ERROR: 0:283: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-ed-geining-hateops-flx-if-it-is-selfish-to-have-your-focus-then-i-am-an-ever-unsatis",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-bleeding-like-a-horsey",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'lum' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-offx-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:352: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' uniform mediump 4-component vector of float' and a right operand of type ' temp mediump 2-com"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-roam3",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-roam3",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-gss-sth-hogwoman-style-starin-at-sports-carscryin-schnig-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-ti-n-suksma-n-zylot-blarffff",
+      "stage": "warp",
+      "detail": "ERROR: 0:284: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-geiss-dotes-orb",
+      "stage": "composite",
+      "detail": "ERROR: 0:355: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
+      "stage": "warp",
+      "detail": "ERROR: 0:283: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 2-compon"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-dying-visions2-flacc-roams-thee-big-rip-of-wills-rce-beats",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-suksma-geiss-dotes-orb-extreme-elegance",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
+      "stage": "warp",
+      "detail": "ERROR: 0:285: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-stenter-phi",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-j4-2",
+      "stage": "composite",
+      "detail": "ERROR: 0:356: 'pow' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-hexcollie-ti-n-suksma-zylot-n-orb-blarffff-fire-isosceles-edit",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'assign' :  cannot convert from ' temp mediump 3-component vector of float' to ' temp mediump 2-component vector of float'"
+    },
+    {
+      "id": "cotc-bleeding-like-a-horsey-roams-i-just-got-through-watching-planet-bboy-and-boy-do-i-feel-emba",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam",
+      "stage": "warp",
+      "detail": "ERROR: 0:283: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 2-compon"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-autoclayve-flacc-das-yi-roam",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-yada-yaka-yada-flacc-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-finished-breathing-sir-flacc-roam",
+      "stage": "composite",
+      "detail": "ERROR: 0:364: 'lum' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-collapsar",
+      "stage": "warp",
+      "detail": "ERROR: 0:292: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-collapsar",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-pacific-heights-flacc-roams-higher-self-lower-self-battles",
+      "stage": "composite",
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc-choilan-duncan-dodo-boid-dna-kodak-whore",
+      "stage": "composite",
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-j4-flacc-bryan-fnord-kool-aid",
+      "stage": "composite",
+      "detail": "ERROR: 0:351: 'sin' : undeclared identifier"
+    },
+    {
+      "id": "cotc-fleekus-flokus-violent-and-insane-homicidal-air-molecules-beat-code-experiment2-gss",
+      "stage": "composite",
+      "detail": "ERROR: 0:358: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher",
+      "stage": "warp",
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-dotes-hostile-undertake-painterly-oil-reflection-flacc-spher",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
+    },
+    {
+      "id": "cotc-suksma-question-authority-take-what-you-want-be-a-nihilist",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc",
+      "stage": "warp",
+      "detail": "ERROR: 0:286: '=' :  cannot convert from ' temp mediump 2-component vector of float' to ' temp mediump float'"
+    },
+    {
+      "id": "cotc-suksma-mtn-flx-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:359: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
+      "id": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
+      "stage": "warp",
+      "detail": "ERROR: 0:295: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-suksma-ed-geining-hateops-flx-maggotillion-flacc",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'constructor' : too many arguments"
+    },
+    {
+      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam2",
+      "stage": "warp",
+      "detail": "ERROR: 0:287: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 4-compon"
+    },
+    {
+      "id": "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed",
+      "stage": "warp",
+      "detail": "ERROR: 0:296: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
+    },
+    {
+      "id": "cotc-stahlregen-flexi-geiss-liquidity-dynamic-swirls-mess-flout-tessed",
+      "stage": "composite",
+      "detail": "ERROR: 0:361: 'scalar swizzle' : not supported with this profile: es"
+    },
+    {
       "id": "cotc-undermines-him-in-the-subtlest-ways-mega-schoob-1d-serial-flashline-projection-creator",
       "stage": "warp",
-      "detail": "ERROR: 0:278: 'colorScale' : undeclared identifier"
+      "detail": "ERROR: 0:286: 'colorScale' : undeclared identifier"
     },
     {
       "id": "cotc-undermines-him-in-the-subtlest-ways-mega-schoob-1d-serial-flashline-projection-creator",
       "stage": "composite",
-      "detail": "ERROR: 0:348: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:357: 'max' : no matching overloaded function found"
     },
     {
       "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam3",
-      "stage": "warp",
-      "detail": "ERROR: 0:275: 'lum' : no matching overloaded function found"
-    },
-    {
-      "id": "cotc-suksma-dotes-var-eyes-built-to-fuck-flacc-when-we-touch-i-get-disgusted-roam3",
       "stage": "composite",
-      "detail": "ERROR: 0:341: 'assign' :  cannot convert from ' temp mediump 2-component vector of float' to ' global mediump float'"
-    },
-    {
-      "id": "cotc-suksma-gss-sth-hogwoman-style-incantation-onward-to-golgotha-christening-the-afterbirth-fla",
-      "stage": "warp",
-      "detail": "ERROR: 0:4: 'output' : Reserved word."
+      "detail": "ERROR: 0:353: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp mediump 3-component vector of float' and a right operand of type ' temp mediump 4-compon"
     },
     {
       "id": "cotc-suksma-gss-sth-hogwoman-style-incantation-onward-to-golgotha-christening-the-afterbirth-fla",
       "stage": "composite",
-      "detail": "ERROR: 0:4: 'output' : Reserved word."
+      "detail": "ERROR: 0:351: 'output' : Reserved word."
     },
     {
       "id": "cotc-orb-inferno-burnt-to-a-crisp-ngdbthzs-avoid-homozoidne",
       "stage": "warp",
-      "detail": "ERROR: 0:280: 'lum' : no matching overloaded function found"
+      "detail": "ERROR: 0:291: 'assign' :  cannot convert from ' temp mediump float' to ' global mediump 3-component vector of float'"
     },
     {
       "id": "cotc-hexcollie-ti-n-suksma-zylot-orb-martin-n-flexi-blarffff-roams-drugs-stretch-time-wave-packe",
       "stage": "composite",
-      "detail": "ERROR: 0:345: 'scalar swizzle' : not supported with this profile: es"
+      "detail": "ERROR: 0:354: 'scalar swizzle' : not supported with this profile: es"
     }
   ]
 }

--- a/scripts/check-cache-bounds.ts
+++ b/scripts/check-cache-bounds.ts
@@ -39,6 +39,8 @@ const ALLOWED: Record<string, string> = {
     'PINNABLE_BY_TARGET is a lookup index over the fixed PINNABLE_FIELDS literal, built once at module load — it is a table, not a cache.',
   'src/js/frontend/PerformSurface.tsx':
     'The only container is a Set derived inside a render/poll callback to de-duplicate the current modulator targets; it is rebuilt from scratch each time and never accumulates.',
+  'src/js/milkdrop/compiler/shader-analysis-glsl.ts':
+    'TEMPLATE_OWNED_TARGETS is a two-element literal fixed at module load, and declaredLocals is a per-call Set scoped to one shader program — both are bounded by the source they read, not by runtime accumulation.',
 };
 
 type DiffLine = { kind: 'file' | 'hunk' | 'added' | 'other'; text: string };

--- a/src/js/milkdrop/compiler/shader-analysis-glsl.ts
+++ b/src/js/milkdrop/compiler/shader-analysis-glsl.ts
@@ -90,10 +90,25 @@ function emitExpression(
 /**
  * Creates a GLSL emitter that maps MilkDrop sampler/texture names to GLSL
  * functions in the composite shader.
+ *
+ * `shadowedIdentifiers` are names the preset declares for itself. The alias
+ * table below would otherwise rewrite every read of such a name to a shader
+ * uniform: a preset writing `float3 b = …; ret = b;` would assign its own
+ * local and then read `colorScale.b`, which is not a compile error — it is a
+ * silently wrong picture. A declaration in the preset wins over the alias, the
+ * same way it would in HLSL.
+ *
+ * No bundled preset currently reaches this (measured: zero declare a local
+ * whose name collides with an alias), so it guards authored presets and the
+ * editor rather than fixing a corpus failure. It is here because the
+ * alternative failure mode is invisible.
  */
-export function createCompositeGlslEmitter(): GlslEmitter {
+export function createCompositeGlslEmitter(
+  shadowedIdentifiers: ReadonlySet<string> = new Set(),
+): GlslEmitter {
   return {
     emitIdentifier(name: string): string {
+      if (shadowedIdentifiers.has(name)) return name;
       const lower = name.toLowerCase();
       // Signal aliases come from the shared table; only the non-signal
       // composite uniforms and literal constants live in this map.
@@ -768,7 +783,17 @@ export function generateGlslFromShaderStatements(
 ): string | null {
   if (statements.length === 0) return null;
 
-  const emitter = createCompositeGlslEmitter();
+  // Collected before emission, not during: a preset may read one of its own
+  // locals on a line the emitter has not walked yet, and the declaration has
+  // to beat the alias on every line rather than only later ones. Every
+  // declared name counts, not just the vector ones emitted below — `float b`
+  // collides with the alias table exactly as `float3 b` does.
+  const presetDeclaredNames = new Set(
+    statements
+      .filter((statement) => statement.declaration !== null)
+      .map((statement) => statement.target),
+  );
+  const emitter = createCompositeGlslEmitter(presetDeclaredNames);
   const lines: string[] = [];
   const declaredLocals = new Set<string>();
 

--- a/src/js/milkdrop/compiler/shader-analysis-glsl.ts
+++ b/src/js/milkdrop/compiler/shader-analysis-glsl.ts
@@ -727,6 +727,41 @@ function getAuxTextureSourceId(name: string): string {
  * Generates a GLSL function body from a list of shader statements.
  * Returns GLSL code that can be embedded in a fragment shader.
  */
+// Targets the stage templates declare and read back themselves. `ret` is the
+// shader's output and `uv` its coordinate: re-declaring either inside main()
+// would shadow the template's copy, so the value the template reads after the
+// body would never be written — a black frame rather than a compile error.
+const TEMPLATE_OWNED_TARGETS = new Set(['ret', 'uv']);
+
+/**
+ * Carries a preset's own `float2 uv_y = …` through as `vec2 uv_y = …`.
+ *
+ * The declared type was parsed into the statement and then dropped here, which
+ * left the assembled shader to infer it from the assignment text downstream —
+ * and that inference only recognises a bare `vecN(` constructor, so
+ * `float2 uv_y = uv - 0.25 * float2(a, b);` was declared `float uv_y;` and
+ * every later use failed to compile. Vector and matrix declarations are the
+ * only ones emitted: `float` already matches what the fallback infers, so
+ * restating it would add shadowing risk for no gain.
+ */
+function localDeclarationType(
+  statement: MilkdropShaderStatement,
+  target: string,
+  declaredLocals: Set<string>,
+): string | null {
+  const declaration = statement.declaration;
+  if (
+    !declaration ||
+    !/^(?:vec[234]|mat[234])$/u.test(declaration) ||
+    TEMPLATE_OWNED_TARGETS.has(target) ||
+    declaredLocals.has(target)
+  ) {
+    return null;
+  }
+  declaredLocals.add(target);
+  return declaration;
+}
+
 export function generateGlslFromShaderStatements(
   statements: MilkdropShaderStatement[],
   _stage: 'warp' | 'comp',
@@ -735,6 +770,7 @@ export function generateGlslFromShaderStatements(
 
   const emitter = createCompositeGlslEmitter();
   const lines: string[] = [];
+  const declaredLocals = new Set<string>();
 
   for (const statement of statements) {
     const expressionGlsl = emitExpression(statement.expression, emitter);
@@ -755,12 +791,26 @@ export function generateGlslFromShaderStatements(
       // broadcast for a scalar one, so wrapping restores HLSL's meaning for
       // both. Compound operators need no help: GLSL already defines
       // vector-op-scalar component-wise.
-      const needsBroadcast = target === 'ret';
-      lines.push(
-        needsBroadcast
-          ? `  ${target} = vec3(${expressionGlsl});`
-          : `  ${target} = ${expressionGlsl};`,
+      const declaration = localDeclarationType(
+        statement,
+        target,
+        declaredLocals,
       );
+      if (target === 'ret') {
+        lines.push(`  ${target} = vec3(${expressionGlsl});`);
+      } else if (declaration) {
+        // Same HLSL promotion `ret` needs, at the declaration: `float3 dots =
+        // <scalar>;` splats there, and vecN(...) is both a broadcast for a
+        // scalar RHS and a copy constructor for a matching one. Matrices are
+        // left alone — matN(scalar) is a diagonal in GLSL but a full splat in
+        // HLSL, so wrapping would quietly change the value.
+        const wrapped = declaration.startsWith('vec')
+          ? `${declaration}(${expressionGlsl})`
+          : expressionGlsl;
+        lines.push(`  ${declaration} ${target} = ${wrapped};`);
+      } else {
+        lines.push(`  ${target} = ${expressionGlsl};`);
+      }
     } else if (operator === '+=') {
       lines.push(`  ${target} += ${expressionGlsl};`);
     } else if (operator === '-=') {

--- a/tests/unit/milkdrop-compiler-shader-glsl-emitter.test.ts
+++ b/tests/unit/milkdrop-compiler-shader-glsl-emitter.test.ts
@@ -839,3 +839,66 @@ describe('milkdrop compiler shader GLSL emitter — texsize', () => {
     );
   });
 });
+
+// ─── Preset-declared locals ─────────────────────────────────────────
+
+describe('preset-declared locals', () => {
+  function emitProgram(sources: string[]): string {
+    const glsl = generateGlslFromShaderStatements(
+      sources.map(glslStatement),
+      'comp',
+    );
+    if (glsl === null) throw new Error('Failed to emit GLSL');
+    return glsl;
+  }
+
+  test("carries a preset's declared vector type into the emitted GLSL", () => {
+    const glsl = emitProgram(['float2 uv_y = uv - 0.25']);
+
+    // Without the declaration the assembled shader infers the type from the
+    // assignment text, which only recognises a bare vecN( constructor — so a
+    // parenthesised or arithmetic RHS became `float uv_y;` and every later use
+    // failed to compile.
+    expect(glsl).toContain('vec2 uv_y =');
+  });
+
+  test('broadcasts a scalar into a declared vector, as HLSL does', () => {
+    const glsl = emitProgram(['float3 dots = 0.5']);
+
+    expect(glsl).toContain('vec3 dots = vec3(');
+  });
+
+  test('declares a name once, however many times it is assigned', () => {
+    const glsl = emitProgram(['float3 acc = 0.5', 'acc = 0.25']);
+
+    expect(glsl.match(/vec3 acc =/g)).toHaveLength(1);
+    expect(glsl).toContain('acc = 0.25');
+  });
+
+  // `ret` and `uv` are declared by the stage templates and read back after the
+  // body. Shadowing either with a local means the template reads a value the
+  // body never wrote — a black frame rather than a compile error.
+  test('never re-declares a target the stage template owns', () => {
+    const glsl = emitProgram(['float3 ret = 0.5', 'float2 uv = 0.25']);
+
+    expect(glsl).not.toContain('vec3 ret =');
+    expect(glsl).not.toContain('vec2 uv =');
+  });
+
+  // A preset may name a local after a shader control (`b`, `mix`, `sat`, …).
+  // Rewriting reads of it to the uniform is not a compile error, it is a
+  // silently wrong picture, so the declaration has to win.
+  test('a declared local wins over the uniform alias of the same name', () => {
+    const glsl = emitProgram(['float3 b = 0.5', 'ret = b']);
+
+    expect(glsl).toContain('vec3 b = vec3(');
+    expect(glsl).toContain('ret = vec3(b)');
+    expect(glsl).not.toContain('colorScale.b');
+  });
+
+  test('still aliases a control the preset did not declare', () => {
+    const glsl = emitProgram(['ret = b']);
+
+    expect(glsl).toContain('colorScale.b');
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #1137 (`fix/glsl-lum-and-scan-coverage`) — review that one first; this branch adds one commit.

A preset's `float2 uv_y = uv - 0.25 * float2(a, b);` reached GLSL as a bare `uv_y = …`. The parsed statement carried the declared type all along and the emitter dropped it, leaving the assembled shader to infer the type from the assignment text downstream — an inference that only recognises a bare `vecN(` constructor, so a parenthesised or arithmetic right-hand side fell through to `float uv_y;` and every later use of that variable failed to compile.

It is the single largest cause of shader compile failure in the corpus, and it is why 150 of the 152 presets whose previews captured a pure-black framebuffer failed to compile at all.

## What the fix does, and what it deliberately does not

Vector and matrix declarations are emitted. `float` is left to the existing inference, which already agrees — restating it would add shadowing risk for no gain.

`ret` and `uv` are excluded: the stage templates declare and read those back themselves, so re-declaring either inside `main()` shadows the template's copy and the value it reads after the body is never written. That trades a compile error for a **black frame**, which is strictly worse.

Declarations broadcast the same way `ret` assignments already do — `float3 dots = <scalar>;` splats in HLSL, and `vecN(…)` is both a broadcast for a scalar and a copy constructor for a matching vector. This was not theoretical: without it the first run produced exactly one new failure, `vec3 dots = clamp(0.04 / length(uv1), 0.0, 1.0)`.

Matrices are left unwrapped. `matN(scalar)` is a diagonal in GLSL but a full splat in HLSL, so wrapping would quietly change the value.

## Testing

- `bun run lab:glsl-corpus-scan` — **721 → 570** shader compile errors, **505 → 418** failing presets, **0 regressions**
- `bun run check` — pass
- Baseline re-tightened (728 → 570) so the 139 fixed entries are protected rather than left as permitted failures

Verified past the validator, since a shader that compiles can still draw nothing: of the 152 presets whose previews captured a pure-black framebuffer, 27 now compile and **17 render real frames**. Re-running the full no-preview set, **45 of 238 presets recovered a preview they never had**.

## What this leaves open

570 errors across 418 presets remain, and the classes are now well separated:

| Count | Class | Notes |
|-|-|-|
| 203 | `no matching overloaded function` | `mix` 70, `max` 56, `pow` 18 — HLSL promotes a scalar argument against a vector one; GLSL does not. Needs argument-width inference in the emitter. |
| 107 | vec2 conversion | the tail of this same class, via paths that do not carry a declaration |
| 70 | `scalar swizzle` | HLSL allows `f.x` / `f.xxx` on a scalar; GLSL ES rejects it |
| 38 | `undeclared identifier` | 27 are one bug: a preset declaring its own `float3 b` has that line dropped by the statement parser while its *uses* survive and get aliased to the `colorScale.b` uniform. A parser gap, not an emitter one. |
| 13 | `float2x2` | deliberately untouched — HLSL matrices are row-major and GLSL column-major, so renaming to `mat2` transposes them and silently rotates the wrong way |

I stopped short of the argument-width inference. It is the right next step and worth the most, but getting it wrong yields silently wrong visuals rather than a loud compile error — the trade this codebase explicitly refuses elsewhere — so it deserves its own change with its own verification rather than being bolted onto this one.

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

Covered by the corpus scan and its baseline gate, which is the instrument this class of change is verified with — 2,679 presets compiled through the real emitter and validated by `glslangValidator`, plus browser capture on the affected presets. One allowlist entry added to `check-cache-bounds.ts` for a two-element literal `Set` and a per-call `Set`, with the reason recorded inline.

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — shader emission only, no build output change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
