### PR TITLE
fix(transitions): one decision per preset switch, and say why it cut

### DIFF
--- a/src/js/frontend/shortcut-registry.ts
+++ b/src/js/frontend/shortcut-registry.ts
@@ -173,11 +173,16 @@ export const SHORTCUT_REGISTRY: ShortcutDefinition[] = [
     dispatchViaPalette: true,
   },
   {
-    // Shift+L: L alone is close enough to the preset-navigation keys that a
-    // mis-hit during a set would be costly, and this is a mode you set once.
+    // Shift+D, for "display" — the mode is about driving one.
+    //
+    // Not the obvious Shift+L: the MilkDrop overlay handles both 'l' and 'L'
+    // for preset lock and calls preventDefault, so an L binding never
+    // reaches the shell at all. Across the three key layers exactly two
+    // letters were unclaimed when this shipped (d and y), which is worth
+    // knowing before adding the next binding.
     id: 'live-performance',
     label: 'Toggle live performance mode',
-    defaultKeys: ['Shift+L'],
+    defaultKeys: ['Shift+D'],
     paletteActionId: 'toggle-live-performance',
     dispatchViaPalette: true,
   },

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -656,6 +656,25 @@ export function createMilkdropExperience({
    * decision over the same frame state. Each used to derive it separately,
    * down to a second copy of the workload threshold in the controller.
    */
+  /**
+   * The frame state the last transition decision was made against, and the
+   * decision itself.
+   *
+   * A single preset switch reaches this function TWICE — once from the
+   * navigation controller, once from the editor-session subscriber, about
+   * 2ms apart. Each call re-evaluated the gate independently against live
+   * frame timings that move in between, so the two regularly disagreed and
+   * the second silently overwrote the first: the same switch would cut or
+   * blend depending on which won. Coalescing on frame-state identity makes
+   * one switch produce one decision, because `currentFrameState` is
+   * replaced per rendered frame and both calls land inside the same one.
+   */
+  let lastTransitionFrameState: MilkdropFrameState | null | undefined;
+  let lastTransitionDecision: {
+    mode: 'blend' | 'cut';
+    durationSeconds: number;
+  } | null = null;
+
   const beginPresetTransition = () => {
     // A hand-driven crossfade is a gesture, not a persisted mode: it applies
     // to the one switch that armed it and then clears. Making it a third
@@ -664,6 +683,14 @@ export function createMilkdropExperience({
     // completes a preset change on its own.
     const manual = pendingManualCrossfade;
     pendingManualCrossfade = false;
+
+    if (
+      !manual &&
+      lastTransitionDecision !== null &&
+      lastTransitionFrameState === currentFrameState
+    ) {
+      return lastTransitionDecision;
+    }
 
     const quality = adaptiveQualityController?.getState() ?? null;
     const gate = evaluateBlendGate(
@@ -688,7 +715,11 @@ export function createMilkdropExperience({
         // different remedies (simpler preset / close something / let it cool).
         setOverlayStatus(BLEND_REFUSAL_STATUS[gate.refusal]);
       }
-      transitionController.begin(nextBlendState, blendDuration);
+      transitionController.begin(
+        nextBlendState,
+        blendDuration,
+        wantsBlend ? (gate.refusal ?? undefined) : 'transition mode: cut',
+      );
     }
     if (nextBlendState) {
       adapter?.saveFeedbackFrame?.();
@@ -699,10 +730,13 @@ export function createMilkdropExperience({
     // stale pressure evidence and, on constrained devices, pre-pays the
     // warm-up with one quality step instead of dropped frames.
     adaptiveQualityController?.notePresetApplied();
-    return {
+    const decision = {
       mode: canBlend ? ('blend' as const) : ('cut' as const),
       durationSeconds: blendDuration,
     };
+    lastTransitionFrameState = currentFrameState;
+    lastTransitionDecision = decision;
+    return decision;
   };
 
   const navigation = createMilkdropPresetNavigationController({

--- a/src/js/milkdrop/runtime/session.ts
+++ b/src/js/milkdrop/runtime/session.ts
@@ -134,8 +134,16 @@ export const MAX_BLEND_WORKLOAD = 6000;
  * geometry submission for its duration, so the headroom check is the honest
  * gate: a machine hitting budget can afford it, one already dropping frames
  * cannot.
+ *
+ * 2x, not something tighter. Against a 60Hz budget this refuses below about
+ * 30fps and allows everything above it. An earlier 1.25x looked defensible
+ * on paper and refused a machine running a perfectly serviceable 45fps —
+ * which is most laptops driving a projector, i.e. exactly the case the
+ * blend exists for. A gate this one has to earn its refusals: a crossfade
+ * that silently does not happen is the failure mode this whole path is
+ * being repaired for.
  */
-const BLEND_FRAME_BUDGET_TOLERANCE = 1.25;
+const BLEND_FRAME_BUDGET_TOLERANCE = 2;
 
 export type BlendPressureSnapshot = {
   rollingAverageFrameMs: number | null;

--- a/src/js/milkdrop/runtime/transition-controller.ts
+++ b/src/js/milkdrop/runtime/transition-controller.ts
@@ -92,7 +92,11 @@ export function createMilkdropTransitionController() {
      * cut is `begin(null, ...)`, which settles immediately — one entry
      * point for both so the event log sees every switch.
      */
-    begin(nextBlendState: MilkdropBlendState | null, seconds: number) {
+    begin(
+      nextBlendState: MilkdropBlendState | null,
+      seconds: number,
+      cutReason?: string,
+    ) {
       if (phase === 'manual') {
         // A preset switch reaches this controller twice — once from the
         // navigation controller and once from the editor-session subscriber
@@ -112,7 +116,10 @@ export function createMilkdropTransitionController() {
         lastTickAt = null;
         record('blend-started', `${seconds.toFixed(2)}s`);
       } else {
-        record('cut');
+        // The detail is the whole point of the log here: "why did that
+        // switch cut instead of blending" needs an answer that distinguishes
+        // "you asked for a cut" from "a gate refused you a blend".
+        record('cut', cutReason);
         settle('cut');
       }
     },

--- a/tests/e2e/preset-crossfade.test.ts
+++ b/tests/e2e/preset-crossfade.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Crossfades actually happen.
+ *
+ * The blend path shipped, had a workload gate, and was unreachable: the
+ * threshold (900) sat below the corpus MINIMUM frame workload (1323 — the
+ * warp mesh alone contributes ~992), so every preset switch in the product
+ * silently became a hard cut and the blend-duration control did nothing.
+ * `milkdrop-blend-gate.test.ts` pins the threshold against measured corpus
+ * numbers; this test pins the thing that actually matters, end to end, in a
+ * browser that is really rendering.
+ *
+ * It has to be an e2e test. `beginPresetTransition` clones the CURRENT
+ * frame state to blend out of, and a hidden tab has none — the browser
+ * stops scheduling rAF entirely — so any harness whose page is not visibly
+ * rendering records a cut no matter how the gate is configured. That is
+ * exactly the trap that made the original bug look like it might be a
+ * measurement artifact.
+ */
+import { afterAll, beforeAll, expect } from 'bun:test';
+import { chromium } from 'playwright';
+import { hasChromium, requiredBrowserTest } from './browser-availability.ts';
+import { closeQuietly } from './deadline.ts';
+import { type DevServerHandle, startDevServer } from './dev-server.ts';
+import { HEADLESS, SOFTWARE_RENDERER_ARGS } from './webgl-launch.ts';
+
+const browserTest = requiredBrowserTest;
+const TEST_PORT = 5188;
+/** Light, always-bundled, and already used as the first-run preset. */
+const TARGET_PRESET_ID = 'geiss-experimental-lsb-bass-cubes';
+const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+let devServer: DevServerHandle | null = null;
+
+type TransitionEvent = { at: number; event: string; detail?: string };
+type AgentWindow = typeof window & {
+  __milkdropRuntimeDebug?: {
+    getTransition: () => {
+      phase: string;
+      crossfade: number | null;
+      events: ReadonlyArray<TransitionEvent>;
+    };
+  };
+  __stims_agent?: {
+    run: (
+      actionId: string,
+      params?: Record<string, unknown>,
+    ) => Promise<{ ok: boolean; error?: string }>;
+  };
+};
+
+beforeAll(
+  async () => {
+    if (!hasChromium) return;
+    devServer = await startDevServer({ port: TEST_PORT });
+  },
+  { timeout: 60000 },
+);
+
+afterAll(async () => {
+  const server = devServer;
+  devServer = null;
+  await server?.stop();
+});
+
+browserTest(
+  'a preset switch in blend mode crossfades instead of cutting',
+  async () => {
+    const browser = await chromium.launch({
+      headless: HEADLESS,
+      args: SOFTWARE_RENDERER_ARGS,
+    });
+    const ctx = await browser.newContext({
+      viewport: { width: 1280, height: 720 },
+      deviceScaleFactor: 1,
+    });
+    const page = await ctx.newPage();
+
+    try {
+      await page.goto(`${SERVER_URL}/?agent=true&renderer=webgl`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.waitForSelector('body[data-engine-state="ready"]', {
+        timeout: 30000,
+      });
+      await page.evaluate(() =>
+        (window as AgentWindow).__stims_agent?.run('audio-demo'),
+      );
+      await page.waitForSelector('body[data-engine-state="live"]', {
+        timeout: 20000,
+      });
+
+      // Frames must have been rendered before the switch: the outgoing
+      // frame state is what a crossfade blends FROM, and under a software
+      // renderer the first few frames take a while to arrive.
+      await page.waitForFunction(
+        () =>
+          ((window as AgentWindow).__milkdropRuntimeDebug?.getTransition()
+            ?.phase ?? null) !== null,
+        undefined,
+        { timeout: 10000 },
+      );
+      await page.waitForTimeout(3000);
+
+      await page.evaluate(() =>
+        (window as AgentWindow).__stims_agent?.run('transition-2s'),
+      );
+
+      const before = await page.evaluate(
+        () =>
+          (window as AgentWindow).__milkdropRuntimeDebug?.getTransition().events
+            .length ?? 0,
+      );
+
+      // A named target, not `next-preset`: which preset the shuffle lands
+      // on is random, and a heavy one can spend longer compiling under a
+      // software renderer than this test is willing to wait — a flaky
+      // failure that would say nothing about the gate.
+      const advance = await page.evaluate(
+        (presetId) =>
+          (window as AgentWindow).__stims_agent?.run('select-preset', {
+            id: presetId,
+          }),
+        TARGET_PRESET_ID,
+      );
+      expect(advance?.ok).toBe(true);
+
+      await page.waitForFunction(
+        (seen) => {
+          const events =
+            (window as AgentWindow).__milkdropRuntimeDebug?.getTransition()
+              .events ?? [];
+          return events.length > (seen as number);
+        },
+        before,
+        // Generous: under a software renderer a preset switch has to compile
+        // shaders before it can transition at all.
+        { timeout: 30000 },
+      );
+      await page.waitForTimeout(500);
+
+      const events: TransitionEvent[] = await page.evaluate(
+        (seen) =>
+          ((window as AgentWindow).__milkdropRuntimeDebug
+            ?.getTransition()
+            .events.slice(seen as number) ?? []) as TransitionEvent[],
+        before,
+      );
+
+      expect(events.length).toBeGreaterThan(0);
+
+      // What this pins is that the WORKLOAD gate never refuses a normal
+      // preset — the regression that made the whole blend path dead code.
+      //
+      // It deliberately does not demand a blend outright. CI renders through
+      // SwiftShader at a handful of frames per second, where the frame-
+      // pressure and thermal gates refuse crossfades for entirely correct
+      // reasons; asserting `blend-started` there would pin the renderer's
+      // speed, not the gate's logic. Each cut now carries its reason, so the
+      // one refusal that must never appear can be named exactly.
+      const workloadRefusals = events.filter(
+        (entry) => entry.event === 'cut' && entry.detail === 'workload',
+      );
+      expect(workloadRefusals).toEqual([]);
+
+      // And whatever did happen has to be an outcome the controller can
+      // account for, rather than silence.
+      const kinds = new Set(events.map((entry) => entry.event));
+      expect(
+        ['blend-started', 'cut', 'begin-ignored'].some((kind) =>
+          kinds.has(kind),
+        ),
+      ).toBe(true);
+    } finally {
+      await closeQuietly(page, ctx, browser);
+    }
+  },
+  { timeout: 120000 },
+);

--- a/tests/unit/milkdrop-blend-gate.test.ts
+++ b/tests/unit/milkdrop-blend-gate.test.ts
@@ -88,16 +88,19 @@ describe('blend gate', () => {
     expect(
       evaluateBlendGate(CORPUS_MEDIAN, {
         ...HEALTHY,
-        rollingAverageFrameMs: 30,
+        // ~14fps against a 60Hz budget.
+        rollingAverageFrameMs: 70,
       }),
     ).toEqual({ canBlend: false, refusal: 'frame-pressure' });
   });
 
-  test('mild overrun stays inside tolerance', () => {
+  test('a serviceable frame rate still crossfades', () => {
+    // 45fps on a laptop driving a projector is the normal case the blend
+    // exists for, not a machine in trouble. A tighter tolerance refused it.
     expect(
       evaluateBlendGate(CORPUS_MEDIAN, {
         ...HEALTHY,
-        rollingAverageFrameMs: 18,
+        rollingAverageFrameMs: 22,
       }).canBlend,
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

Follow-up to the blend-gate repair in 5bf81fce, from watching it run in a browser that was really rendering rather than trusting the unit tests. Two defects, both making preset transitions unreliable for anyone driving a screen with them.

**A preset switch made two independent transition decisions.** `beginPresetTransition` is reached twice per switch — once from the navigation controller, once from the editor-session subscriber, about 2ms apart. Each call re-evaluated the blend gate against live frame timings that move in between, so the two regularly disagreed and the second silently overwrote the first: the same switch would cut or blend depending on which won. Now coalesced on frame-state identity (`currentFrameState` is replaced per rendered frame, so both calls land inside the same one) — one switch, one decision. Verified: repeated live runs went from a random `cut`/`blend-started` pair to a single consistent event.

**Cuts didn't say why.** The transition event log exists to answer "why did that switch cut instead of blending", and couldn't. Each cut now carries its reason: `workload`, `frame-pressure`, `thermal`, or `transition mode: cut`.

Also widens the frame-pressure tolerance from 1.25x to 2x frame budget. The tighter value looked defensible on paper and refused a machine running 45fps against a 60Hz budget — which is most laptops driving a projector, i.e. exactly the case a crossfade exists for. 2x refuses below ~30fps.

Last commit fixes a dead keybinding: `Shift+L` for the live performance mode added in f3e065fd never reached the shell, because the MilkDrop overlay handles both `l` and `L` for preset lock and calls `preventDefault`. The registry guard test caught it. Rebound to `Shift+D`. Worth flagging for reviewers: across the three key layers exactly **two** letters were unclaimed (`d` and `y`) — the keyboard namespace is close to exhausted.

## Testing

- `bun run check` — passes except `promoteProjectMReference`, which is **pre-existing and unrelated**: it arrives with 001a5b21 (already on `main`) and reproduces identically with this branch's changes stashed. Nothing in this diff touches that path.
- `bun test tests/unit/milkdrop-blend-gate.test.ts tests/unit/milkdrop-transition-controller.test.ts tests/e2e/preset-crossfade.test.ts` — 23 pass.
- `bun run lab:blend-gate -- --count 120` — corpus sweep; floor 1323, median 1615, p90 3445, max 10523; 5.8% would cut on workload.
- **Negative control:** reinstated the old `MAX_BLEND_WORKLOAD = 900` and confirmed both the unit suite (6 failures) and the new e2e test fail, then restored it. The tests genuinely catch the original bug.

New `tests/e2e/preset-crossfade.test.ts` pins the gate end to end (~23s, stable across 3 runs). Two things a reviewer should know about how it is written:

- It asserts **no `workload` refusal** rather than demanding a blend. CI renders through SwiftShader at a few frames per second, where the frame-pressure and thermal gates refuse crossfades for entirely correct reasons; asserting `blend-started` there would pin the renderer's speed, not the gate's logic.
- It has to be an e2e test at all because a hidden tab receives **zero** rAF callbacks, so `currentFrameState` is null and every switch records a cut no matter how the gate is configured. Any harness whose page is not visibly rendering silently reports the bug as present — which is the trap that made the original finding look like it might be a measurement artifact.

## Docs touched

None. Rationale lives in module docblocks (`runtime/session.ts`, `runtime.ts`) and the new script's docblock, which `check:script-docs` enforces and `bun run help` indexes.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic — the coalescing key is deliberately `currentFrameState` identity including `null === null`, which correctly collapses the pair when no frame has rendered
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic — removed a redundant guard added to `transition-controller.ts` once the runtime-level coalescing made it dead
- [x] New visual literals use existing design tokens (or include a new named token) — n/a, no visual literals
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes) — see the pre-existing failure noted above
- [ ] `bun run build` (if build/runtime output changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
