### PR TITLE
fix(landing): make the first load deliver what it promises

### DIFF
--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -25,6 +25,7 @@ become fast feedback instead of a surprise at PR time.
 | [`check:css-tokens`](#checkcss-tokens) | `check:quick` | Fail on `var(--token)` references that resolve to nothing. |
 | [`check:doc-references`](#checkdoc-references) | `check:quick` | Guard against docs that point at files and commands which no longer exist. |
 | [`check:duplicate-css`](#checkduplicate-css) | `check:quick` | Detect duplicate CSS keyframes and rule blocks — the "merge duplicate CSS, remove duplicate keyframes" pattern recurred multiple times in the last 400 commits (`0cc04211`, `6b39eb2f`, `1d2fa2af`). Duplicates bloat the bundle and cause maintenance drift where one copy is updated and the other is forgotten. |
+| [`check:first-run-evidence`](#checkfirst-run-evidence) | `check:quick` | Record the measured evidence behind the first-run preset. |
 | [`check:guard-registry`](#checkguard-registry) | `check:quick` | Blocks banned patterns in changed source files before they land. |
 | [`check:guardrails-doc`](#checkguardrails-doc) | `check:quick` | Generates `docs/GUARDRAILS.md` — the rules this repo enforces — from the guard scripts themselves. |
 | [`check:module-docs`](#checkmodule-docs) | `check:quick` | Requires a file-level docblock on the `src/` modules big enough to need one. |
@@ -260,6 +261,40 @@ of the global `fade-in`. Duplicates *within* a single file are still
 caught (two `@keyframes spin` in the same file is always a mistake).
 
 Run it directly: `bun run check:duplicate-css`
+
+## check:first-run-evidence
+
+Record the measured evidence behind the first-run preset.
+
+The landing page makes one claim — "full-screen visuals that move to
+whatever you're listening to" — and the first-run preset is the only proof
+of it most visitors ever see. The previous default was chosen on a variable
+count (8 of 36 parameters read audio) that turned out not to predict
+anything visible: measured at the pixel level it moved the same with demo
+audio as in silence, and every parameter that drives visible motion — zoom,
+rot, warp, sx, sy, decay — was static.
+
+So the choice is pinned to measurement instead of judgement, and the
+measurement is checked in. `tests/unit/first-run-preset.test.ts` reads this
+file and fails when the shipped default no longer matches the evidence, the
+preset's bytes change, or the numbers fall below the bar. Regenerating is
+the deliberate act of re-measuring.
+
+Merges one backend at a time, because `lab:visual` writes both renderers to
+the same path. Full refresh:
+
+  bun run lab:visual -- --preset <id> --renderer webgl
+  bun run generate:first-run-evidence
+  bun run lab:visual -- --preset <id> --renderer webgpu
+  bun run generate:first-run-evidence
+  bun run lab:reactivity -- --preset <id>
+  bun run generate:first-run-evidence
+
+Usage:
+  bun run scripts/generate-first-run-evidence.ts
+  bun run scripts/generate-first-run-evidence.ts --check
+
+Run it directly: `bun run check:first-run-evidence`
 
 ## check:guard-registry
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "check:script-docs": "bun run scripts/scripts-list.ts --check",
     "check:module-docs": "bun run scripts/check-module-docs.ts",
     "check:guardrails-doc": "bun run scripts/generate-guardrails-doc.ts --check",
+    "check:first-run-evidence": "bun run scripts/generate-first-run-evidence.ts --check",
     "check:authoring-examples": "bun run scripts/check-authoring-examples.ts",
     "check:authoring-docs": "bun run scripts/check-authoring-examples.ts && bun run scripts/generate-authoring-reference.ts --check",
     "docs:authoring-reference": "bun run scripts/generate-authoring-reference.ts",
@@ -162,7 +163,8 @@
     "assets:generate": "bun run scripts/generate-scenes.ts",
     "perf:low-resource": "bun run scripts/run-certification-corpus-perf-suite.ts --cpu-throttle 4 --renderer compatibility --viewport-width 1280 --viewport-height 720 --output ./screenshots/low-resource-perf",
     "test:audio-rig": "bun run scripts/test-audio-rig.ts",
-    "generate:guardrails": "bun run scripts/generate-guardrails-doc.ts"
+    "generate:guardrails": "bun run scripts/generate-guardrails-doc.ts",
+    "generate:first-run-evidence": "bun run scripts/generate-first-run-evidence.ts"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",

--- a/public/milkdrop-presets/catalog.json
+++ b/public/milkdrop-presets/catalog.json
@@ -1939,7 +1939,14 @@
           "duplicatePenalty": 0
         }
       },
-      "curatedRank": 7
+      "curatedRank": 7,
+      "sensoryProfile": {
+        "flashRiskLevel": "none",
+        "maxTransitionsPerSecondEstimate": 0,
+        "meanLuminance": 0.04622463014926661,
+        "maxLuminanceDelta": 0.004822092742847322,
+        "measuredAt": "2026-08-22T04:00:19.216Z"
+      }
     },
     {
       "id": "shifter-spectro",

--- a/public/milkdrop-presets/starter-catalog.json
+++ b/public/milkdrop-presets/starter-catalog.json
@@ -38,6 +38,13 @@
           "flashPenalty": 0,
           "duplicatePenalty": 0
         }
+      },
+      "sensoryProfile": {
+        "flashRiskLevel": "none",
+        "maxTransitionsPerSecondEstimate": 0,
+        "meanLuminance": 0.04622463014926661,
+        "maxLuminanceDelta": 0.004822092742847322,
+        "measuredAt": "2026-08-22T04:00:19.216Z"
       }
     },
     {

--- a/public/milkdrop-presets/starter-catalog.json
+++ b/public/milkdrop-presets/starter-catalog.json
@@ -1,6 +1,46 @@
 {
   "presets": [
     {
+      "id": "shifter-glassworms-flare",
+      "title": "Shifter - Glassworms - Flare",
+      "author": "Shifter",
+      "file": "/milkdrop-presets/libraries/projectm-cream-of-the-crop/shifter-glassworms-flare.milk",
+      "tags": [
+        "collection:cream-of-the-crop",
+        "preset",
+        "category:particles",
+        "category:waveform"
+      ],
+      "preview": true,
+      "supports": {
+        "webgl": true,
+        "webgpu": true
+      },
+      "expectedFidelityClass": "partial",
+      "visualCertification": {
+        "status": "uncertified",
+        "measured": false,
+        "source": "inferred",
+        "fidelityClass": "partial",
+        "visualEvidenceTier": "runtime",
+        "requiredBackend": "webgpu",
+        "actualBackend": null,
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
+      },
+      "quality": {
+        "score": 0.47,
+        "components": {
+          "fidelity": 0.2,
+          "evidence": 0.5,
+          "staticAudio": 1,
+          "measuredReactivity": 0.9999999999999974,
+          "motion": null,
+          "flashPenalty": 0,
+          "duplicatePenalty": 0
+        }
+      }
+    },
+    {
       "id": "eos-glowsticks-v2-03-music",
       "title": "Eo.S. - Glowsticks v2 03 Music",
       "author": "Eo.S.",
@@ -80,9 +120,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4524,
@@ -130,9 +168,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -180,9 +216,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -226,9 +260,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.432,
@@ -273,9 +305,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4522,
@@ -316,9 +346,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.47,
@@ -359,9 +387,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4537,
@@ -402,9 +428,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.47,
@@ -449,9 +473,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4338,
@@ -496,9 +518,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -542,9 +562,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4656,
@@ -588,9 +606,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -630,9 +646,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.445,
@@ -672,9 +686,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.445,
@@ -714,9 +726,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.445,
@@ -759,9 +769,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4529,
@@ -805,9 +813,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4529,
@@ -851,9 +857,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.416,
@@ -897,9 +901,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -942,9 +944,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4674,
@@ -987,9 +987,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4529,
@@ -1032,9 +1030,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4676,
@@ -1077,9 +1073,7 @@
         "visualEvidenceTier": "runtime",
         "requiredBackend": "webgpu",
         "actualBackend": null,
-        "reasons": [
-          "No measured WebGPU reference capture is recorded yet."
-        ]
+        "reasons": ["No measured WebGPU reference capture is recorded yet."]
       },
       "quality": {
         "score": 0.4529,

--- a/scripts/generate-first-run-evidence.ts
+++ b/scripts/generate-first-run-evidence.ts
@@ -1,0 +1,276 @@
+/**
+ * Record the measured evidence behind the first-run preset.
+ *
+ * The landing page makes one claim — "full-screen visuals that move to
+ * whatever you're listening to" — and the first-run preset is the only proof
+ * of it most visitors ever see. The previous default was chosen on a variable
+ * count (8 of 36 parameters read audio) that turned out not to predict
+ * anything visible: measured at the pixel level it moved the same with demo
+ * audio as in silence, and every parameter that drives visible motion — zoom,
+ * rot, warp, sx, sy, decay — was static.
+ *
+ * So the choice is pinned to measurement instead of judgement, and the
+ * measurement is checked in. `tests/unit/first-run-preset.test.ts` reads this
+ * file and fails when the shipped default no longer matches the evidence, the
+ * preset's bytes change, or the numbers fall below the bar. Regenerating is
+ * the deliberate act of re-measuring.
+ *
+ * Merges one backend at a time, because `lab:visual` writes both renderers to
+ * the same path. Full refresh:
+ *
+ *   bun run lab:visual -- --preset <id> --renderer webgl
+ *   bun run generate:first-run-evidence
+ *   bun run lab:visual -- --preset <id> --renderer webgpu
+ *   bun run generate:first-run-evidence
+ *   bun run lab:reactivity -- --preset <id>
+ *   bun run generate:first-run-evidence
+ *
+ * Usage:
+ *   bun run scripts/generate-first-run-evidence.ts
+ *   bun run scripts/generate-first-run-evidence.ts --check
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { FIRST_RUN_PRESET_ID } from '../src/js/milkdrop/runtime/first-run-preset.ts';
+
+const REPO_ROOT = join(import.meta.dir, '..');
+const EVIDENCE_PATH = join(
+  REPO_ROOT,
+  'src',
+  'data',
+  'first-run-preset-evidence.json',
+);
+const LAB_DIR = join(REPO_ROOT, 'scratch', 'preset-lab', FIRST_RUN_PRESET_ID);
+const CATALOG_PATH = join(
+  REPO_ROOT,
+  'public',
+  'milkdrop-presets',
+  'catalog.json',
+);
+
+/**
+ * Where the first-run preset's source actually lives.
+ *
+ * Not `public/milkdrop-presets/<id>.milk`: the default can legitimately be a
+ * preset from one of the bundled libraries, which live in subdirectories. The
+ * catalog's `file` field is the one place that mapping is already recorded,
+ * so resolving through it keeps the default free to be any catalog entry
+ * without a second copy of the file at the top level.
+ *
+ * Exported because the first-run guard test needs the same answer, and two
+ * independent path guesses would be one more thing to drift.
+ */
+export function resolveFirstRunPresetPath(): string {
+  const catalog = JSON.parse(readFileSync(CATALOG_PATH, 'utf8')) as {
+    presets: Array<{ id: string; file?: string }>;
+  };
+  const entry = catalog.presets.find(
+    (preset) => preset.id === FIRST_RUN_PRESET_ID,
+  );
+  if (!entry?.file) {
+    throw new Error(
+      `First-run preset "${FIRST_RUN_PRESET_ID}" is not in the bundled catalog.`,
+    );
+  }
+  return join(REPO_ROOT, 'public', entry.file.replace(/^\//u, ''));
+}
+
+type BackendEvidence = {
+  meanLuminance: number;
+  visiblePixelRatio: number;
+  nearBlackFrameRatio: number;
+  colorfulness: number;
+  /** demo − silence. The visible answer to "does it respond to audio?". */
+  luminanceDelta: number;
+  /** demo ÷ silence pixel motion. 1.0 means audio changed nothing. */
+  audioMotionRatio: number;
+  verdict: string;
+  captureBackend: string;
+};
+
+type Evidence = {
+  presetId: string;
+  presetSha256: string;
+  backends: Partial<Record<'webgl' | 'webgpu', BackendEvidence>>;
+  reactivity?: {
+    reactiveVariables: number;
+    totalVariables: number;
+    /** Reactive variables that actually drive visible motion. */
+    motionBearing: Array<{ variable: string; correlation: number }>;
+  };
+};
+
+/**
+ * Variables whose movement the visitor can see as movement. The previous
+ * default's reactivity lived entirely outside this set, which is why its
+ * parameter count looked healthy while the screen did not move with the
+ * music.
+ */
+const MOTION_BEARING = new Set([
+  'zoom',
+  'rot',
+  'warp',
+  'dx',
+  'dy',
+  'sx',
+  'sy',
+  'cx',
+  'cy',
+  'decay',
+  'shapes.motion',
+]);
+
+/** Correlation below this is noise, not a response. */
+const MOTION_BEARING_MIN_CORRELATION = 0.3;
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function round(value: number, places = 4): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+function loadExisting(): Evidence {
+  if (!existsSync(EVIDENCE_PATH)) {
+    return { presetId: FIRST_RUN_PRESET_ID, presetSha256: '', backends: {} };
+  }
+  const existing = readJson(EVIDENCE_PATH) as Evidence;
+  // A different preset means the old numbers describe something else. Start
+  // clean rather than carrying a stale backend forward under a new id.
+  if (existing.presetId !== FIRST_RUN_PRESET_ID) {
+    return { presetId: FIRST_RUN_PRESET_ID, presetSha256: '', backends: {} };
+  }
+  return existing;
+}
+
+function mergeVisualReport(evidence: Evidence): void {
+  const reportPath = join(LAB_DIR, 'visual', 'visual.json');
+  if (!existsSync(reportPath)) {
+    return;
+  }
+
+  const report = readJson(reportPath) as {
+    presetId: string;
+    renderer: 'webgl' | 'webgpu';
+    captureBackend: string | null;
+    scenarios: Record<
+      'silence' | 'demo',
+      {
+        meanLuminance: number;
+        visiblePixelRatio: number;
+        nearBlackFrameRatio: number;
+        colorfulness: number;
+      }
+    >;
+    summary: {
+      luminanceDelta: number;
+      audioMotionRatio: number;
+      verdict: string;
+    };
+  };
+
+  if (report.presetId !== FIRST_RUN_PRESET_ID) {
+    return;
+  }
+
+  evidence.backends[report.renderer] = {
+    meanLuminance: round(report.scenarios.silence.meanLuminance, 2),
+    visiblePixelRatio: round(report.scenarios.silence.visiblePixelRatio),
+    nearBlackFrameRatio: round(report.scenarios.silence.nearBlackFrameRatio),
+    colorfulness: round(report.scenarios.silence.colorfulness),
+    luminanceDelta: round(report.summary.luminanceDelta, 2),
+    audioMotionRatio: round(report.summary.audioMotionRatio),
+    verdict: report.summary.verdict,
+    captureBackend: report.captureBackend ?? 'unknown',
+  };
+}
+
+function mergeReactivityReport(evidence: Evidence): void {
+  const reportPath = join(LAB_DIR, 'reactivity.json');
+  if (!existsSync(reportPath)) {
+    return;
+  }
+
+  const report = readJson(reportPath) as {
+    presetId: string;
+    variables: Array<{
+      variable: string;
+      scenarios: Record<string, { correlation: number; stdDev: number }>;
+    }>;
+  };
+  if (report.presetId !== FIRST_RUN_PRESET_ID) {
+    return;
+  }
+
+  const motionBearing: Array<{ variable: string; correlation: number }> = [];
+  let reactive = 0;
+  for (const entry of report.variables) {
+    const scenarios = Object.values(entry.scenarios ?? {});
+    const correlation = Math.max(
+      0,
+      ...scenarios.map((scenario) => Math.abs(scenario.correlation ?? 0)),
+    );
+    const spread = Math.max(
+      0,
+      ...scenarios.map((scenario) => Math.abs(scenario.stdDev ?? 0)),
+    );
+    if (correlation >= MOTION_BEARING_MIN_CORRELATION && spread > 1e-6) {
+      reactive += 1;
+      if (MOTION_BEARING.has(entry.variable)) {
+        motionBearing.push({
+          variable: entry.variable,
+          correlation: round(correlation, 3),
+        });
+      }
+    }
+  }
+
+  motionBearing.sort((a, b) => b.correlation - a.correlation);
+  evidence.reactivity = {
+    reactiveVariables: reactive,
+    totalVariables: report.variables.length,
+    motionBearing,
+  };
+}
+
+function build(): Evidence {
+  const evidence = loadExisting();
+  evidence.presetId = FIRST_RUN_PRESET_ID;
+  evidence.presetSha256 = createHash('sha256')
+    .update(readFileSync(resolveFirstRunPresetPath()))
+    .digest('hex');
+  mergeVisualReport(evidence);
+  mergeReactivityReport(evidence);
+  return evidence;
+}
+
+function serialize(evidence: Evidence): string {
+  return `${JSON.stringify(evidence, null, 2)}\n`;
+}
+
+export const FIRST_RUN_EVIDENCE_PATH = EVIDENCE_PATH;
+
+if (import.meta.main) {
+  const next = serialize(build());
+  if (process.argv.includes('--check')) {
+    const current = existsSync(EVIDENCE_PATH)
+      ? readFileSync(EVIDENCE_PATH, 'utf8')
+      : '';
+    if (current !== next) {
+      console.error(
+        `first-run preset evidence is stale (${EVIDENCE_PATH}).\n` +
+          'Re-measure and regenerate — see the header of ' +
+          'scripts/generate-first-run-evidence.ts for the command sequence.',
+      );
+      process.exit(1);
+    }
+    console.log('first-run preset evidence is current.');
+  } else {
+    writeFileSync(EVIDENCE_PATH, next);
+    console.log(`Wrote ${EVIDENCE_PATH}`);
+  }
+}

--- a/scripts/run-quality-gate.ts
+++ b/scripts/run-quality-gate.ts
@@ -142,6 +142,10 @@ export function buildGatePlan(
         cmd: ['bun', 'run', 'check:guardrails-doc'],
       },
       {
+        label: 'First-run preset evidence freshness',
+        cmd: ['bun', 'run', 'check:first-run-evidence'],
+      },
+      {
         label: 'Authoring examples and reference',
         cmd: ['bun', 'run', 'check:authoring-docs'],
       },

--- a/src/css/SilentAudioNotice.module.css
+++ b/src/css/SilentAudioNotice.module.css
@@ -1,0 +1,41 @@
+/* Shares the geometry of ContextualHelp's toast so the two stack as one
+   family, but reads as an instruction rather than a tip: the cool accent
+   marks it as a thing to act on, and it stays put until the click resolves
+   it instead of auto-hiding. */
+.notice {
+  /* Positioning lives on .stims-shell__toast-stack. */
+  max-width: min(340px, calc(100vw - 32px));
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: var(--stims-panel-strong);
+  border: 1px solid var(--stims-line-strong);
+  border-left: 3px solid var(--stims-cool);
+  box-shadow: var(--stims-shadow);
+  color: var(--stims-ink);
+  font-family: var(--font-family-base);
+  font-size: 0.84rem;
+  line-height: 1.45;
+  letter-spacing: -0.005em;
+  -webkit-font-smoothing: antialiased;
+  animation: silent-audio-enter 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  /* Not interactive on purpose: any click anywhere is what dismisses it, so
+     swallowing clicks over its own rectangle would make the fix harder. */
+  pointer-events: none;
+}
+
+@keyframes silent-audio-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notice {
+    animation-duration: 0.01ms;
+  }
+}

--- a/src/data/first-run-preset-evidence.json
+++ b/src/data/first-run-preset-evidence.json
@@ -1,0 +1,36 @@
+{
+  "presetId": "shifter-glassworms-flare",
+  "presetSha256": "e16da26d9f5afe7bb3c82178ef3b0bc0ab237083eb1266dd49140f23b8573a94",
+  "backends": {
+    "webgpu": {
+      "meanLuminance": 45.57,
+      "visiblePixelRatio": 0.8415,
+      "nearBlackFrameRatio": 0,
+      "colorfulness": 0.0191,
+      "luminanceDelta": -24.52,
+      "audioMotionRatio": 0.8378,
+      "verdict": "ambient-motion",
+      "captureBackend": "ANGLE (Apple, ANGLE Metal Renderer: Apple M1 Max, Unspecified Version)"
+    },
+    "webgl": {
+      "meanLuminance": 93.88,
+      "visiblePixelRatio": 0.8203,
+      "nearBlackFrameRatio": 0,
+      "colorfulness": 0.1206,
+      "luminanceDelta": -4.25,
+      "audioMotionRatio": 0.9981,
+      "verdict": "ambient-motion",
+      "captureBackend": "ANGLE (Apple, ANGLE Metal Renderer: Apple M1 Max, Unspecified Version)"
+    }
+  },
+  "reactivity": {
+    "reactiveVariables": 8,
+    "totalVariables": 36,
+    "motionBearing": [
+      {
+        "variable": "zoom",
+        "correlation": 0.873
+      }
+    ]
+  }
+}

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -9,6 +9,10 @@ import {
 import { startBatteryMonitoring } from './core/power-state.ts';
 import { installRendererTelemetryPersistence } from './core/renderer-telemetry.ts';
 import { installCrashTelemetry } from './core/services/crash-telemetry.ts';
+// Eager, and load-bearing: this freezes the arrival URL at document load, so
+// lazy consumers can tell the visitor's link apart from the app's own
+// `replaceState` writes no matter when their chunk lands. See arrival-url.ts.
+import './frontend/arrival-url.ts';
 import { reportLoadStatus } from './frontend/load-status.ts';
 import { StimsWorkspaceRouterProvider } from './frontend/workspace-router.tsx';
 import { isSmartTvDevice } from './utils/browser/device-detect.ts';

--- a/src/js/core/audio-gesture-gate.ts
+++ b/src/js/core/audio-gesture-gate.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether audio is running but silent because the browser is still holding it
+ * for a user gesture.
+ *
+ * Autoplay policy suspends an AudioContext created outside a click, and a
+ * suspended context is indistinguishable from a working one from the UI's
+ * side: the session reports `audioActive`, the stage animates, the analyser
+ * returns zeros, and nothing plays. That combination arrives by design on the
+ * deep-link path — a `?preset=` arrival starts demo audio without waiting for
+ * a click, because the visitor came to watch that preset — so the visitor is
+ * shown visuals with no sound and no explanation.
+ *
+ * `audio-handler.ts` already resumes every registered context on the first
+ * pointerdown/touchstart/keydown. This module is the missing half: it makes
+ * that pending state observable, so the UI can say "click for sound" and take
+ * the message away the instant the click happens. Nothing here resumes
+ * anything; it only reports.
+ */
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let awaitingGesture = false;
+
+/**
+ * Reported to the UI. True means: audio is set up, and silent until the
+ * visitor interacts with the page.
+ */
+export function isAudioAwaitingGesture(): boolean {
+  return awaitingGesture;
+}
+
+export function subscribeAudioGestureGate(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Called by `audio-handler.ts` whenever the set of registered contexts, or
+ * any context's state, changes. Idempotent: notifying on an unchanged value
+ * would re-render every subscriber on every `statechange`.
+ */
+export function reportAudioAwaitingGesture(next: boolean): void {
+  if (next === awaitingGesture) {
+    return;
+  }
+  awaitingGesture = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Test seam: drop subscribers and the latched value between cases. */
+export function resetAudioGestureGate(): void {
+  listeners.clear();
+  awaitingGesture = false;
+}

--- a/src/js/core/audio-handler.ts
+++ b/src/js/core/audio-handler.ts
@@ -30,6 +30,7 @@ import {
   getFrequencyBandLevels,
 } from '../utils/audio/reactivity.ts';
 import { isInAppBrowser } from '../utils/browser/device-detect.ts';
+import { reportAudioAwaitingGesture } from './audio-gesture-gate.ts';
 import {
   type AudioEnergySnapshot,
   type AudioReactivityInterpolator,
@@ -1075,8 +1076,27 @@ export type AudioInitOptions = {
 const activeContexts = new Set<AudioContext>();
 const activeStreams = new Set<MediaStream>();
 const unmuteHandlerTracks = new WeakSet<MediaStreamTrack>();
+const stateChangeHandlers = new WeakMap<AudioContext, () => void>();
 
 let resumeOnVisibleInstalled = false;
+
+/**
+ * Publish "audio is set up but silent, waiting for a gesture" so the UI can
+ * say so. A suspended context looks exactly like a working one from the
+ * outside — the session is active, the analyser just returns zeros — and the
+ * deep-link path deliberately starts audio without a click, so without this
+ * the visitor gets silence with no explanation. See audio-gesture-gate.ts.
+ */
+function publishGestureGate() {
+  let suspended = false;
+  for (const context of activeContexts) {
+    if (context.state === 'suspended') {
+      suspended = true;
+      break;
+    }
+  }
+  reportAudioAwaitingGesture(suspended);
+}
 
 function tryResumeAllActiveContexts() {
   for (const context of activeContexts) {
@@ -1134,10 +1154,27 @@ function installResumeOnVisible() {
 export function registerAudioContext(context: AudioContext) {
   activeContexts.add(context);
   installResumeOnVisible();
+
+  // `statechange` rather than a poll: it covers every route out of suspended
+  // — our own resume, the browser resuming on its own, and the context being
+  // closed — so the notice cannot outlive the silence it describes.
+  if (typeof context.addEventListener === 'function') {
+    const handler = () => publishGestureGate();
+    stateChangeHandlers.set(context, handler);
+    context.addEventListener('statechange', handler);
+  }
+  publishGestureGate();
 }
 
 export function unregisterAudioContext(context: AudioContext) {
   activeContexts.delete(context);
+
+  const handler = stateChangeHandlers.get(context);
+  if (handler && typeof context.removeEventListener === 'function') {
+    context.removeEventListener('statechange', handler);
+    stateChangeHandlers.delete(context);
+  }
+  publishGestureGate();
 }
 
 export function registerMediaStream(stream: MediaStream) {

--- a/src/js/core/services/stage-liveness.ts
+++ b/src/js/core/services/stage-liveness.ts
@@ -1,0 +1,175 @@
+/**
+ * Answers one question about the stage canvas: is anything visible on it?
+ *
+ * Attract mode mounts the engine on a bare landing arrival purely so the
+ * pitch for a visuals product has visuals behind it. When that render comes
+ * out blank the page is a black rectangle holding a GPU device open at full
+ * frame rate, which is strictly worse than not booting at all — the visitor
+ * sees the same nothing either way and pays for it in battery.
+ *
+ * The hard part is not measuring darkness, it is not being fooled by the
+ * readback. Compositing a WebGPU canvas into a 2D canvas can yield fully
+ * transparent pixels rather than the rendered frame, which reads as a
+ * perfectly black image and would condemn a working render. So the alpha
+ * channel is the trust signal, checked before the luminance: all-transparent
+ * means "could not read this", never "nothing was drawn".
+ *
+ * Deliberately on-demand. Reading back a WebGPU canvas can stall the main
+ * thread, so this belongs in one-off checks, never in a frame loop — the
+ * per-frame flash sampler is a separate, cheaper path.
+ */
+
+/** Longest edge of the downsample used for the readback. */
+const SAMPLE_DIMENSION = 32;
+
+/**
+ * Above this (0-255) a pixel counts as showing something. Not "not pure
+ * black": a preset that renders a barely-perceptible wash should still count
+ * as blank for this purpose, because the visitor cannot see it either.
+ */
+const VISIBLE_LUMA = 8;
+
+/** Alpha below this is treated as "not composited", not "transparent art". */
+const OPAQUE_ALPHA = 8;
+
+/**
+ * A fraction of pixels this small is a lone stray sample, not an image. Set
+ * against the 32x32 sample: 0.2% is under two pixels, so a single hot texel
+ * cannot vouch for a frame.
+ */
+const VISIBLE_COVERAGE = 0.002;
+
+export type StageLiveness = {
+  /** False when the canvas could not be composited — verdict unknown. */
+  readable: boolean;
+  /** Something is visible on the stage. Always false when `readable` is false. */
+  visible: boolean;
+  maxLuma: number;
+  meanLuma: number;
+  /** Share of sampled pixels at or above {@link VISIBLE_LUMA}. */
+  coverage: number;
+};
+
+const UNREADABLE: StageLiveness = {
+  readable: false,
+  visible: false,
+  maxLuma: 0,
+  meanLuma: 0,
+  coverage: 0,
+};
+
+/**
+ * The pixel maths, split out so the thresholds can be tested without a GPU.
+ * `pixels` is RGBA, as returned by `getImageData`.
+ */
+export function summarizeStagePixels(
+  pixels: Uint8ClampedArray | Uint8Array,
+): StageLiveness {
+  const count = Math.floor(pixels.length / 4);
+  if (count === 0) {
+    return UNREADABLE;
+  }
+
+  let opaquePixels = 0;
+  let visiblePixels = 0;
+  let maxLuma = 0;
+  let lumaSum = 0;
+
+  for (let i = 0; i < pixels.length; i += 4) {
+    if ((pixels[i + 3] ?? 0) >= OPAQUE_ALPHA) {
+      opaquePixels += 1;
+    }
+    const luma =
+      0.299 * (pixels[i] ?? 0) +
+      0.587 * (pixels[i + 1] ?? 0) +
+      0.114 * (pixels[i + 2] ?? 0);
+    lumaSum += luma;
+    if (luma > maxLuma) {
+      maxLuma = luma;
+    }
+    if (luma >= VISIBLE_LUMA) {
+      visiblePixels += 1;
+    }
+  }
+
+  // Nothing composited: the frame was not read, so it cannot be judged.
+  // Reporting this as a black frame is the trap this guard exists for.
+  if (opaquePixels === 0) {
+    return UNREADABLE;
+  }
+
+  const coverage = visiblePixels / count;
+  return {
+    readable: true,
+    visible: coverage >= VISIBLE_COVERAGE,
+    maxLuma,
+    meanLuma: lumaSum / count,
+    coverage,
+  };
+}
+
+/**
+ * Composite the stage canvas into a small 2D canvas and summarize it.
+ * Returns an unreadable verdict rather than throwing on any failure —
+ * callers should treat "unknown" as "leave things alone".
+ */
+export function sampleStageLiveness(canvas: HTMLCanvasElement): StageLiveness {
+  const sourceWidth = canvas.width;
+  const sourceHeight = canvas.height;
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    return UNREADABLE;
+  }
+
+  const scale = Math.min(
+    1,
+    SAMPLE_DIMENSION / Math.max(sourceWidth, sourceHeight),
+  );
+  const width = Math.max(1, Math.round(sourceWidth * scale));
+  const height = Math.max(1, Math.round(sourceHeight * scale));
+
+  try {
+    const sample = document.createElement('canvas');
+    sample.width = width;
+    sample.height = height;
+    const context = sample.getContext('2d', { willReadFrequently: true });
+    if (!context) {
+      return UNREADABLE;
+    }
+    context.drawImage(
+      canvas,
+      0,
+      0,
+      sourceWidth,
+      sourceHeight,
+      0,
+      0,
+      width,
+      height,
+    );
+    return summarizeStagePixels(context.getImageData(0, 0, width, height).data);
+  } catch {
+    return UNREADABLE;
+  }
+}
+
+/**
+ * The attract-mode rule, as a decision rather than a measurement: retire the
+ * decorative render only when *every* sample agrees it read the canvas and
+ * saw nothing.
+ *
+ * Both halves matter. Requiring agreement means one unlucky sample — taken
+ * between a preset applying and its first present — cannot condemn a working
+ * render. Requiring `readable` means a browser whose canvas cannot be
+ * composited back (the transparent-readback case) leaves attract mode
+ * running instead of silently switching it off for everyone on that browser.
+ */
+export function shouldRetireAttractRender(
+  samples: ReadonlyArray<StageLiveness | null>,
+): boolean {
+  if (samples.length === 0) {
+    return false;
+  }
+  return samples.every(
+    (sample) => sample?.readable === true && sample.visible === false,
+  );
+}

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -84,6 +84,7 @@ import { LiveParameterHud } from './LiveParameterHud.tsx';
 import { installLivePerformance } from './live-performance.ts';
 import { reportLoadStatus } from './load-status.ts';
 import { openPerformPicker, pinTarget, unpinTarget } from './perform-pins.ts';
+import { SilentAudioNotice } from './SilentAudioNotice.tsx';
 
 const NewHomePage = lazy(() =>
   import('./NewHomePage.tsx').then((m) => ({
@@ -1557,6 +1558,7 @@ function StimsWorkspaceAppShell() {
           exactly when those panels open, so unmounting on panel-open made
           them unreachable. */}
       <div className="stims-shell__toast-stack">
+        <SilentAudioNotice active={liveMode} />
         <ContextualHelp hint={visibleHint} />
         <AudioMatchToast
           match={audioMatch}

--- a/src/js/frontend/NewHomePage.tsx
+++ b/src/js/frontend/NewHomePage.tsx
@@ -3,6 +3,7 @@ import type { ResumableAudioSource } from '../core/state/last-session-store.ts';
 import { getLastSession } from '../core/state/last-session-store.ts';
 import { resolvePresetCatalogEntry } from '../milkdrop/preset-id-resolution.ts';
 import { AudioSourcePanel } from './AudioSourcePanel.tsx';
+import { getArrivalPresetId } from './arrival-url.ts';
 import type { PresetCatalogEntry } from './contracts.ts';
 import {
   getAudioEnergy,
@@ -12,12 +13,6 @@ import { PresetArtwork } from './PresetArtwork.tsx';
 import { UiIcon } from './UiIcon.tsx';
 import { useWorkspace } from './workspace-context.tsx';
 import { STIMS_REPO_URL } from './workspace-helpers.ts';
-
-/** `?preset=` from the URL the document loaded with; see deepLinkPresetId. */
-const ARRIVAL_PRESET_ID =
-  typeof window === 'undefined'
-    ? null
-    : new URLSearchParams(window.location.search).get('preset');
 
 const RESUME_SOURCE_LABEL: Record<ResumableAudioSource, string> = {
   demo: 'demo audio',
@@ -42,13 +37,13 @@ export function NewHomePage() {
   const appliedResumeRef = useRef(false);
   const autoStartedRef = useRef(false);
 
-  // The URL the visitor actually arrived on — captured at document load, not
-  // component mount. Route state is written to by the app itself (the resume
-  // effect below, and engine startup selection once attract mode boots), and
-  // reading it here made those writes indistinguishable from a real
-  // `?preset=` arrival: a bare "/" visit could auto-start demo audio with no
-  // click the moment the startup preset landed in the route.
-  const [deepLinkPresetId] = useState(() => ARRIVAL_PRESET_ID);
+  // The URL the visitor actually arrived on — captured at document load by
+  // `arrival-url.ts`, not at component mount and not at this chunk's eval.
+  // Route state is written to by the app itself (the resume effect below, and
+  // preset navigation once a session is running), and reading it here made
+  // those writes indistinguishable from a real `?preset=` arrival: a bare "/"
+  // visit could auto-start demo audio with no click.
+  const [deepLinkPresetId] = useState(getArrivalPresetId);
 
   // Memoized: resolution of an id the catalog does NOT contain costs two
   // full catalog scans, and this component re-renders with workspace state.

--- a/src/js/frontend/SilentAudioNotice.tsx
+++ b/src/js/frontend/SilentAudioNotice.tsx
@@ -1,0 +1,51 @@
+import { useSyncExternalStore } from 'react';
+import styles from '../../css/SilentAudioNotice.module.css';
+import {
+  isAudioAwaitingGesture,
+  subscribeAudioGestureGate,
+} from '../core/audio-gesture-gate.ts';
+import { isMobileDevice } from '../utils/browser/device-detect.ts';
+
+/**
+ * Says out loud that the visuals are running and the sound is not.
+ *
+ * A `?preset=` arrival starts demo audio without waiting for a click, because
+ * the visitor followed a link to that specific preset. Autoplay policy leaves
+ * the AudioContext suspended when audio starts outside a gesture, so the page
+ * plays a silent session that looks, from every other signal, like a working
+ * one: `audioActive` is true, the stage animates, the analyser reads zero.
+ * The fix (resume on the first pointerdown/touchstart/keydown) has always
+ * been in `audio-handler.ts` — what was missing was telling the visitor which
+ * click to make.
+ *
+ * Self-clearing: `audio-gesture-gate.ts` tracks the contexts' `statechange`,
+ * so this disappears on the same interaction that starts the sound. There is
+ * no dismiss control on purpose — a dismiss would leave the silence and take
+ * away the explanation.
+ */
+export function useAudioAwaitingGesture(): boolean {
+  return useSyncExternalStore(
+    subscribeAudioGestureGate,
+    isAudioAwaitingGesture,
+    // Server/prerender: nothing has started audio yet, so nothing is waiting.
+    () => false,
+  );
+}
+
+export function SilentAudioNotice({ active }: { active: boolean }) {
+  const awaitingGesture = useAudioAwaitingGesture();
+
+  if (!active || !awaitingGesture) {
+    return null;
+  }
+
+  return (
+    <div className={styles.notice} role="status" aria-live="polite">
+      <span>
+        {isMobileDevice()
+          ? 'Tap anywhere to turn the sound on — your browser holds audio until you do.'
+          : 'Click anywhere to turn the sound on — your browser holds audio until you do.'}
+      </span>
+    </div>
+  );
+}

--- a/src/js/frontend/arrival-url.ts
+++ b/src/js/frontend/arrival-url.ts
@@ -1,0 +1,42 @@
+/**
+ * The URL the visitor actually arrived on, frozen before the app can touch it.
+ *
+ * Several decisions turn on "did they ask for this, or did we?" — most
+ * visibly `NewHomePage`, which auto-starts a session for a `?preset=` arrival
+ * because a social card advertised that one preset by name. Reading
+ * `location.search` at the point of the decision cannot answer that: the app
+ * writes to the address bar itself (`replaceState` in `workspace-hooks.ts`),
+ * so by then its own writes are indistinguishable from the visitor's link.
+ *
+ * Reading it at *module scope of the consumer* is not enough either, and that
+ * is the bug this module exists to close. Panels are lazy chunks: their module
+ * bodies evaluate whenever the chunk finishes downloading, which on a cold
+ * cache can land after the app has already rewritten the URL. The snapshot has
+ * to be taken by the entry graph, which is why `app.ts` imports this eagerly —
+ * that pins it to document load, before React mounts and before any route
+ * effect can run.
+ *
+ * Keep the eager import in `app.ts`. Without it this module is only pulled in
+ * by lazy consumers and the snapshot drifts back to chunk-load time.
+ */
+
+const ARRIVAL_SEARCH =
+  typeof window === 'undefined' ? '' : window.location.search;
+
+/** Raw query string the document loaded with. */
+export function getArrivalSearch(): string {
+  return ARRIVAL_SEARCH;
+}
+
+/** One parameter from the arrival URL, or null when it was not present. */
+export function getArrivalParam(name: string): string | null {
+  if (!ARRIVAL_SEARCH) {
+    return null;
+  }
+  return new URLSearchParams(ARRIVAL_SEARCH).get(name);
+}
+
+/** `?preset=` as the visitor arrived, never as the app later rewrote it. */
+export function getArrivalPresetId(): string | null {
+  return getArrivalParam('preset');
+}

--- a/src/js/frontend/engine-route-publish.ts
+++ b/src/js/frontend/engine-route-publish.ts
@@ -1,0 +1,63 @@
+/**
+ * Decides whether the engine -> route sync may write the engine's active
+ * preset into the address bar.
+ *
+ * The URL is a promise: it is what the visitor copies, what Back returns to,
+ * and what a reload reopens. Attract mode breaks that promise. It mounts the
+ * engine on a bare "/" arrival purely so the landing page has something
+ * moving behind it (see the attract-mode gate in `workspace-hooks.ts`), the
+ * runtime picks a first-run preset, and the publish direction below wrote
+ * that pick straight into the address bar. Nobody asked for it, and three
+ * things broke downstream:
+ *
+ *   - Reload or Back landed on `/?preset=<first-run-id>`, which the deep-link
+ *     path treats as "this visitor came to watch this preset" and auto-starts
+ *     demo audio. The landing page could never be seen twice.
+ *   - Copying the URL off the landing page shared a link that skipped the
+ *     landing page.
+ *   - `NewHomePage`'s arrival check could observe the app's own rewrite and
+ *     auto-start a session on a bare arrival.
+ *
+ * The rule: the address bar tracks the engine only once the visit has become
+ * a session the visitor chose. Two things count as choosing, and nothing
+ * else does:
+ *
+ *   - `audioActive` — they started a source, so the stage is theirs now.
+ *   - the route already names a preset — they deep-linked, or picked one out
+ *     of Browse (`handlePlayPreset` commits the route before the engine
+ *     moves), so the URL is already tracking and must keep up with autoplay.
+ *
+ * A decorative attract-mode preset satisfies neither and stays out of the
+ * URL.
+ */
+export type EngineRoutePublishDecision =
+  | 'publish'
+  | 'runtime-not-ready'
+  | 'no-active-preset'
+  | 'attract-only';
+
+export function decideEngineRoutePublish({
+  runtimeReady,
+  activePresetId,
+  audioActive,
+  routePresetId,
+}: {
+  runtimeReady: boolean;
+  /** What the engine is actually rendering right now. */
+  activePresetId: string | null | undefined;
+  /** The visitor started an audio source, so this is their session. */
+  audioActive: boolean;
+  /** Preset the URL already names, if any. */
+  routePresetId: string | null;
+}): EngineRoutePublishDecision {
+  if (!runtimeReady) {
+    return 'runtime-not-ready';
+  }
+  if (!activePresetId) {
+    return 'no-active-preset';
+  }
+  if (!audioActive && !routePresetId) {
+    return 'attract-only';
+  }
+  return 'publish';
+}

--- a/src/js/frontend/hooks/use-preset-route-sync.ts
+++ b/src/js/frontend/hooks/use-preset-route-sync.ts
@@ -7,6 +7,7 @@ import {
 import { resolvePresetId } from '../../milkdrop/preset-id-resolution.ts';
 import type { SessionRouteState } from '../contracts.ts';
 import type { EngineSnapshot } from '../engine/milkdrop-engine-adapter.ts';
+import { decideEngineRoutePublish } from '../engine-route-publish.ts';
 
 export function usePresetRouteSync({
   engineSnapshot,
@@ -21,7 +22,16 @@ export function usePresetRouteSync({
 }) {
   // Sync active preset from engine → URL
   useEffect(() => {
-    if (!engineSnapshot?.activePresetId || !engineSnapshot?.runtimeReady) {
+    const snapshot = engineSnapshot;
+    if (
+      !snapshot?.activePresetId ||
+      decideEngineRoutePublish({
+        runtimeReady: snapshot.runtimeReady,
+        activePresetId: snapshot.activePresetId,
+        audioActive: snapshot.audioActive,
+        routePresetId: routeState.presetId,
+      }) !== 'publish'
+    ) {
       return;
     }
 
@@ -35,10 +45,8 @@ export function usePresetRouteSync({
     // autoplay advanced the visuals while the address bar stayed on whatever
     // preset the visitor last navigated to — an unshareable, stale link.
     const shareableActivePresetId =
-      resolvePresetId(
-        engineSnapshot.catalogEntries,
-        engineSnapshot.activePresetId,
-      ) ?? engineSnapshot.activePresetId;
+      resolvePresetId(snapshot.catalogEntries, snapshot.activePresetId) ??
+      snapshot.activePresetId;
 
     if (pendingPresetIdRef.current) {
       if (shareableActivePresetId === pendingPresetIdRef.current) {
@@ -55,13 +63,7 @@ export function usePresetRouteSync({
         return { ...current, presetId: shareableActivePresetId };
       });
     });
-  }, [
-    engineSnapshot?.activePresetId,
-    engineSnapshot?.catalogEntries,
-    engineSnapshot?.runtimeReady,
-    pendingPresetIdRef,
-    setRouteState,
-  ]);
+  }, [engineSnapshot, routeState.presetId, pendingPresetIdRef, setRouteState]);
 
   // Resolve preset IDs from engine catalog
   useEffect(() => {

--- a/src/js/frontend/shortcut-registry.ts
+++ b/src/js/frontend/shortcut-registry.ts
@@ -173,11 +173,16 @@ export const SHORTCUT_REGISTRY: ShortcutDefinition[] = [
     dispatchViaPalette: true,
   },
   {
-    // Shift+L: L alone is close enough to the preset-navigation keys that a
-    // mis-hit during a set would be costly, and this is a mode you set once.
+    // Shift+D, for "display" — the mode is about driving one.
+    //
+    // Not the obvious Shift+L: the MilkDrop overlay handles both 'l' and 'L'
+    // for preset lock and calls preventDefault, so an L binding never
+    // reaches the shell at all. Across the three key layers exactly two
+    // letters were unclaimed when this shipped (d and y), which is worth
+    // knowing before adding the next binding.
     id: 'live-performance',
     label: 'Toggle live performance mode',
-    defaultKeys: ['Shift+L'],
+    defaultKeys: ['Shift+D'],
     paletteActionId: 'toggle-live-performance',
     dispatchViaPalette: true,
   },

--- a/src/js/frontend/workspace-hooks.ts
+++ b/src/js/frontend/workspace-hooks.ts
@@ -12,6 +12,10 @@ import { getDevicePerformanceProfile } from '../core/device-profile.ts';
 import { createLogger } from '../core/logger.ts';
 import { noteSubstitution } from '../core/services/preset-telemetry.ts';
 import {
+  sampleStageLiveness,
+  shouldRetireAttractRender,
+} from '../core/services/stage-liveness.ts';
+import {
   DEFAULT_QUALITY_PRESETS,
   QUALITY_STORAGE_KEY,
   setQualityPresetById,
@@ -48,6 +52,16 @@ import { useWorkspaceToast } from './workspace-toast.ts';
 import { useWorkspaceYouTubePreview } from './workspace-youtube-preview.ts';
 
 const log = createLogger('WorkspaceHooks');
+
+/**
+ * How long the attract render gets before it is judged. Covers the gap
+ * between the runtime reporting ready and its first composited frame:
+ * shader compile, first preset apply, first present.
+ */
+const ATTRACT_LIVENESS_SETTLE_MS = 2500;
+
+/** Gap before the confirming sample, so one unlucky frame cannot condemn it. */
+const ATTRACT_LIVENESS_CONFIRM_MS = 1200;
 
 export function useWorkspaceRouteState() {
   const [routeState, setRouteState] = useState<SessionRouteState>(() =>
@@ -161,13 +175,16 @@ export function useWorkspaceSessionState({
   // prefers-reduced-motion request — anyone who asked for less motion, or
   // whose device should not spend a GPU context on decoration, still gets the
   // static form.
-  const [attractModeEnabled] = useState(() => {
+  const [attractModeEnabled, setAttractModeEnabled] = useState(() => {
     if (routeState.previewMode) {
       return false;
     }
     const profile = getDevicePerformanceProfile();
     return !profile.lowPower && !profile.reducedMotion;
   });
+  // Latches once the attract render has been judged, so a paused-then-blank
+  // stage is not re-sampled every snapshot.
+  const attractLivenessJudgedRef = useRef(false);
 
   const {
     activityCatalog,
@@ -422,6 +439,86 @@ export function useWorkspaceSessionState({
     routeState.audioSource,
     attractModeEnabled,
     setStatusMessage,
+  ]);
+
+  // Make attract mode prove itself.
+  //
+  // Attract mode exists so the landing page for a visuals product has visuals
+  // on it. When the boot preset renders blank, none of that is delivered and
+  // the page still pays for it: a GPU device held open, a render loop at full
+  // refresh rate, and a battery cost, all to composite nothing. That is
+  // strictly worse than never booting — the visitor sees the same black
+  // rectangle either way, and the launch card's CSS signal trace (which the
+  // low-power path already relies on) is the honest fallback.
+  //
+  // Only the decorative case is judged: a route preset or an audio source is
+  // something the visitor asked for and is never paused, however it looks.
+  //
+  // Two samples, spaced, after a settle: one sample can land between the
+  // runtime reporting ready and its first composited frame, and reading an
+  // uncomposited canvas is exactly what `sampleStageLiveness` refuses to call
+  // blank. An unreadable verdict leaves attract mode alone.
+  useEffect(() => {
+    if (
+      !attractModeEnabled ||
+      attractLivenessJudgedRef.current ||
+      !engineSnapshot?.runtimeReady ||
+      routeState.presetId ||
+      routeState.audioSource
+    ) {
+      return;
+    }
+
+    const timers: number[] = [];
+    let cancelled = false;
+    const readStage = () => {
+      const canvas = stageRef.current?.querySelector('canvas');
+      return canvas ? sampleStageLiveness(canvas) : null;
+    };
+
+    timers.push(
+      window.setTimeout(() => {
+        if (cancelled) return;
+        const first = readStage();
+        if (!shouldRetireAttractRender([first])) {
+          // Rendering, or unjudgeable. Only a settled "rendering" is worth
+          // latching: an unreadable canvas may become readable later.
+          attractLivenessJudgedRef.current = first?.visible === true;
+          return;
+        }
+
+        timers.push(
+          window.setTimeout(() => {
+            if (cancelled) return;
+            const second = readStage();
+            if (!shouldRetireAttractRender([first, second])) {
+              attractLivenessJudgedRef.current = second?.visible === true;
+              return;
+            }
+
+            attractLivenessJudgedRef.current = true;
+            log.log('attract render is blank; pausing the decorative loop');
+            // Paused, not disposed: the engine stays warm so pressing Play
+            // demo is still instant, and `resumePreview()` on audio start
+            // brings it back if the visitor's own session renders fine.
+            engineRef.current?.pausePreview();
+            setAttractModeEnabled(false);
+          }, ATTRACT_LIVENESS_CONFIRM_MS),
+        );
+      }, ATTRACT_LIVENESS_SETTLE_MS),
+    );
+
+    return () => {
+      cancelled = true;
+      for (const timer of timers) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [
+    attractModeEnabled,
+    engineSnapshot?.runtimeReady,
+    routeState.presetId,
+    routeState.audioSource,
   ]);
 
   usePresetRouteSync({

--- a/src/js/milkdrop/feedback-manager-shared.ts
+++ b/src/js/milkdrop/feedback-manager-shared.ts
@@ -530,6 +530,54 @@ const MILKDROP_AUX_SAMPLING_HELPERS = `
 /** Reused so reading the clear colour each frame allocates nothing. */
 const SCENE_CLEAR_COLOR_SCRATCH = /* @__PURE__ */ new Color();
 
+/** The subset of a renderer the scene pass needs; test doubles stay simple. */
+export type FeedbackSceneRenderer = {
+  render(scene: Scene, camera: Camera): void;
+  setRenderTarget: (target: RenderTarget | null) => void;
+  getClearAlpha?: () => number;
+  setClearAlpha?: (alpha: number) => void;
+  getClearColor?: (target: Color) => Color;
+  setClearColor?: (color: Color | number, alpha?: number) => void;
+};
+
+/**
+ * Draw the fresh scene into the feedback loop's scene target so its alpha
+ * means "geometry drew here".
+ *
+ * Both renderers are built with `alpha: false`, which sets three.js's
+ * clearAlpha to 1, and `Scene.background` is painted opaquely across the
+ * target before anything else draws. Between them the scene pass came back
+ * fully opaque, so the blend that follows could not tell a covered pixel from
+ * an empty one and replaced the whole feedback history every frame. The
+ * background is a display concern, not part of the loop.
+ *
+ * Black, not merely transparent: the blend adds `current.rgb` straight, and
+ * the app's clear colour is a themed tint, so a transparent-but-tinted clear
+ * painted that tint into the feedback loop.
+ */
+export function renderSceneIntoFeedbackTarget(
+  renderer: FeedbackSceneRenderer,
+  scene: Scene,
+  camera: Camera,
+  target: RenderTarget,
+): void {
+  const previousClearAlpha = renderer.getClearAlpha?.() ?? 1;
+  const previousClearColor = renderer.getClearColor?.(
+    SCENE_CLEAR_COLOR_SCRATCH,
+  );
+  const previousBackground = scene.background;
+  scene.background = null;
+  renderer.setClearColor?.(0x000000, 0);
+  renderer.setRenderTarget(target);
+  renderer.render(scene, camera);
+  if (previousClearColor) {
+    renderer.setClearColor?.(previousClearColor, previousClearAlpha);
+  } else {
+    renderer.setClearAlpha?.(previousClearAlpha);
+  }
+  scene.background = previousBackground;
+}
+
 const MILKDROP_FEEDBACK_WARP_HELPER = `
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {
           // Zero warp + zero rotation is an identity polar round-trip; skip
@@ -2528,36 +2576,12 @@ class SharedMilkdropFeedbackManager
     this.lastRenderer =
       renderer as SharedMilkdropFeedbackManager['lastRenderer'];
 
-    // Clear the scene target transparent so its alpha means "geometry drew
-    // here". The app builds its WebGLRenderer with `alpha: false`, which sets
-    // three.js's clearAlpha to 1 — every render target then came back fully
-    // opaque, and the blend below could not tell covered pixels from empty
-    // ones, so the feedback history was replaced wholesale every frame.
-    const previousClearAlpha = renderer.getClearAlpha?.() ?? 1;
-    const previousClearColor = renderer.getClearColor?.(
-      SCENE_CLEAR_COLOR_SCRATCH,
+    renderSceneIntoFeedbackTarget(
+      renderer as FeedbackSceneRenderer,
+      sourceScene,
+      sourceCamera,
+      this.sceneTarget,
     );
-    // The scene's own `background` colour is painted opaquely across the
-    // target before anything else draws (three.js does this for
-    // Scene.background), and the renderer is built with `alpha: false`, which
-    // makes three.js clear to alpha 1. Between them the scene pass came back
-    // fully opaque, so the blend below could not tell a covered pixel from an
-    // empty one and replaced the whole feedback history every frame. The
-    // background belongs to the display, not to the feedback loop.
-    const previousBackground = sourceScene.background;
-    sourceScene.background = null;
-    // Black, not just transparent: the blend below adds `current.rgb`
-    // straight, and the app's clear colour is a themed tint, so a
-    // transparent-but-tinted clear painted that tint into the feedback loop.
-    renderer.setClearColor?.(0x000000, 0);
-    renderer.setRenderTarget(this.sceneTarget);
-    renderer.render(sourceScene, sourceCamera);
-    if (previousClearColor) {
-      renderer.setClearColor?.(previousClearColor, previousClearAlpha);
-    } else {
-      renderer.setClearAlpha?.(previousClearAlpha);
-    }
-    sourceScene.background = previousBackground;
 
     renderer.setRenderTarget(this.warpTarget);
     renderer.render(this.warpScene, this.camera);

--- a/src/js/milkdrop/feedback-manager-shared.ts
+++ b/src/js/milkdrop/feedback-manager-shared.ts
@@ -527,6 +527,9 @@ const MILKDROP_AUX_SAMPLING_HELPERS = `
 // with identical math. The warp pass must not define its own variant here —
 // divergent formulas made the feedback chain and the fresh-scene sample
 // disagree and drove WebGL away from WebGPU.
+/** Reused so reading the clear colour each frame allocates nothing. */
+const SCENE_CLEAR_COLOR_SCRATCH = /* @__PURE__ */ new Color();
+
 const MILKDROP_FEEDBACK_WARP_HELPER = `
         vec2 applyFeedbackWarp(vec2 uv, float amount, float rotationAmount) {
           // Zero warp + zero rotation is an identity polar round-trip; skip
@@ -638,16 +641,21 @@ ${MILKDROP_FEEDBACK_WARP_HELPER}
           }
           // Apply decay to the previous frame color so history dissipates over time.
           previousColor *= decay;
-          // With a direct warp shader, feedback is the warped previous frame
-          // under this frame's geometry (MilkDrop clears to the warp output);
-          // the legacy echo blend stays for control-driven presets.
+          // The internal frame is the warped, decayed previous frame with this
+          // frame's geometry drawn over it. Control-driven presets used to
+          // blend the two by videoEchoAlpha instead, so a preset without video
+          // echo (alpha 0) discarded its history outright: fDecay did nothing
+          // and no warp variable could accumulate, because there was never
+          // anything left to move. Video echo is a display-stage effect in
+          // MilkDrop, not the mechanism that carries feedback.
+          //
+          // The scene colour arrives premultiplied — three.js blends src.rgb
+          // times src.a into a target that starts at zero — so this is a
+          // straight over, not a mix (a mix darkens covered pixels twice).
+          float coverage = clamp(current.a, 0.0, 1.0);
           vec3 color = hasDirectWarp > 0.5
             ? previousColor + current.rgb
-            : mix(
-                current.rgb,
-                previousColor,
-                clamp(videoEchoAlpha, 0.0, 1.0)
-              );
+            : previousColor * (1.0 - coverage) + current.rgb;
           gl_FragColor = vec4(color, 1.0);
         }
       `;
@@ -2504,6 +2512,11 @@ class SharedMilkdropFeedbackManager
     renderer: {
       render(scene: Scene, camera: Camera): void;
       setRenderTarget?: (target: RenderTarget | null) => void;
+      /** Present on WebGLRenderer; optional so test doubles stay simple. */
+      getClearAlpha?: () => number;
+      setClearAlpha?: (alpha: number) => void;
+      getClearColor?: (target: Color) => Color;
+      setClearColor?: (color: Color | number, alpha?: number) => void;
     },
     sourceScene: Scene,
     sourceCamera: Camera,
@@ -2515,8 +2528,36 @@ class SharedMilkdropFeedbackManager
     this.lastRenderer =
       renderer as SharedMilkdropFeedbackManager['lastRenderer'];
 
+    // Clear the scene target transparent so its alpha means "geometry drew
+    // here". The app builds its WebGLRenderer with `alpha: false`, which sets
+    // three.js's clearAlpha to 1 — every render target then came back fully
+    // opaque, and the blend below could not tell covered pixels from empty
+    // ones, so the feedback history was replaced wholesale every frame.
+    const previousClearAlpha = renderer.getClearAlpha?.() ?? 1;
+    const previousClearColor = renderer.getClearColor?.(
+      SCENE_CLEAR_COLOR_SCRATCH,
+    );
+    // The scene's own `background` colour is painted opaquely across the
+    // target before anything else draws (three.js does this for
+    // Scene.background), and the renderer is built with `alpha: false`, which
+    // makes three.js clear to alpha 1. Between them the scene pass came back
+    // fully opaque, so the blend below could not tell a covered pixel from an
+    // empty one and replaced the whole feedback history every frame. The
+    // background belongs to the display, not to the feedback loop.
+    const previousBackground = sourceScene.background;
+    sourceScene.background = null;
+    // Black, not just transparent: the blend below adds `current.rgb`
+    // straight, and the app's clear colour is a themed tint, so a
+    // transparent-but-tinted clear painted that tint into the feedback loop.
+    renderer.setClearColor?.(0x000000, 0);
     renderer.setRenderTarget(this.sceneTarget);
     renderer.render(sourceScene, sourceCamera);
+    if (previousClearColor) {
+      renderer.setClearColor?.(previousClearColor, previousClearAlpha);
+    } else {
+      renderer.setClearAlpha?.(previousClearAlpha);
+    }
+    sourceScene.background = previousBackground;
 
     renderer.setRenderTarget(this.warpTarget);
     renderer.render(this.warpScene, this.camera);

--- a/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
@@ -34,6 +34,8 @@ import { disposeMaterial } from '../utils/three/three-dispose';
 import { MilkdropFeedbackManagerLifecycleBase } from './feedback-manager-lifecycle.ts';
 import {
   applyCompositeUniformState,
+  type FeedbackSceneRenderer,
+  renderSceneIntoFeedbackTarget,
   resolveMilkdropBlurShaderRanges,
 } from './feedback-manager-shared.ts';
 import {
@@ -2316,14 +2318,19 @@ function createFeedbackBlendOutputNode(
     );
     const previousColor = previous.rgb.mul(uniforms.decay);
 
-    // Internal frame: warped decayed feedback under this frame's geometry —
-    // additive when the preset warps via its own shader, legacy echo blend
-    // otherwise.
-    const color = mix(
-      current.rgb,
-      previousColor,
-      clamp(uniforms.videoEchoAlpha, 0, 1),
-    );
+    // Internal frame: the warped, decayed previous frame with this frame's
+    // geometry drawn over it. Control-driven presets used to blend the two by
+    // videoEchoAlpha instead, so a preset without video echo (alpha 0)
+    // discarded its history outright: fDecay did nothing and no warp variable
+    // could accumulate, because there was never anything left to move. Video
+    // echo is a display-stage effect in MilkDrop, not the mechanism that
+    // carries feedback. Mirrors the WebGL blend in feedback-manager-shared.ts.
+    //
+    // The scene colour arrives premultiplied — three.js blends src.rgb times
+    // src.a into a target that starts at zero — so this is a straight over,
+    // not a mix (a mix darkens covered pixels twice).
+    const coverage = clamp(current.a, 0, 1);
+    const color = previousColor.mul(float(1).sub(coverage)).add(current.rgb);
 
     return vec4(color, 1);
   })();
@@ -3126,8 +3133,12 @@ class WebGPUMilkdropFeedbackManager
       this.compositeMaterial.uniforms.feedbackSoftness.value ?? 0;
     const shouldBlur = softness > MILKDROP_FEEDBACK_SOFTNESS_THRESHOLD;
 
-    renderer.setRenderTarget(this.sceneTarget);
-    renderer.render(scene, camera);
+    renderSceneIntoFeedbackTarget(
+      renderer as FeedbackSceneRenderer,
+      scene,
+      camera,
+      this.sceneTarget,
+    );
 
     if (shouldBlur) {
       const blurTexelSize = this.blurMaterial.uniforms.texelSize.value;

--- a/src/js/milkdrop/renderer-adapter-core.ts
+++ b/src/js/milkdrop/renderer-adapter-core.ts
@@ -1003,6 +1003,17 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     });
   }
 
+  /** True when this frame's picture comes from the feedback chain. */
+  private isFeedbackPathActive(
+    frameState: MilkdropRenderPayload['frameState'],
+  ): boolean {
+    return (
+      isFeedbackCapableRenderer(this.renderer) &&
+      Boolean(this.feedback) &&
+      frameState.post.shaderEnabled
+    );
+  }
+
   private buildFeedbackCompositeState(
     frameState: MilkdropRenderPayload['frameState'],
   ): MilkdropFeedbackCompositeState {
@@ -1326,6 +1337,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       );
       const backgroundMaterial = this.background.material as MeshBasicMaterial;
       setMaterialColor(backgroundMaterial, payload.frameState.background, 1);
+      // The background quad is opaque and covers the screen, so drawing it
+      // while the feedback loop runs repainted over the warped previous frame
+      // every frame. MilkDrop has no per-frame background fill: the decayed
+      // previous frame *is* the background, and geometry is drawn over it.
+      this.background.visible = !this.isFeedbackPathActive(payload.frameState);
 
       this.renderMesh(
         payload.frameState.mesh,

--- a/src/js/milkdrop/renderer-helpers/feedback-composite.ts
+++ b/src/js/milkdrop/renderer-helpers/feedback-composite.ts
@@ -11,6 +11,20 @@ import type {
 // them, so everything else can skip the softness taps and blur passes.
 const BLUR_TEXTURE_SAMPLE_PATTERN = /texture2D\s*\(\s*blur[123]Tex\b/i;
 
+/**
+ * One per-frame warp variable off the VM's variable bag, guarded: the bag is
+ * preset-controlled, and the warp pass divides by zoom, so a NaN would take
+ * the whole feedback chain to a black frame.
+ */
+function readWarpVariable(
+  variables: Record<string, number> | undefined,
+  key: string,
+  fallback: number,
+): number {
+  const value = variables?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
 export function buildFeedbackCompositeState({
   frameState,
   backend,
@@ -31,6 +45,20 @@ export function buildFeedbackCompositeState({
   getShaderSampleDimensionId: (dimension: '2d' | '3d') => number;
 }): MilkdropFeedbackCompositeState {
   const controls = frameState.post.shaderControls;
+  // The preset's own per-frame warp, which the feedback pass never used to
+  // see: `shaderControls` is produced by parsing warp/comp *shader text*, so
+  // a classic preset (no warp shader) left zoom/rot/dx/dy at their 1/0
+  // defaults and the previous frame was sampled untransformed.
+  //
+  // Shader-derived controls still win — a preset that writes its transform in
+  // a warp shader is described by that shader, and on WebGPU a lowered
+  // per-pixel program overrides these uniforms per fragment anyway.
+  const presetWarp = {
+    zoom: readWarpVariable(frameState.variables, 'zoom', 1),
+    rot: readWarpVariable(frameState.variables, 'rot', 0),
+    dx: readWarpVariable(frameState.variables, 'dx', 0),
+    dy: readWarpVariable(frameState.variables, 'dy', 0),
+  };
   const feedbackOptimizationEnabled =
     backend !== 'webgpu' || directFeedbackShaders;
   // When the descriptor plan reports shaderExecution === 'direct', the preset's
@@ -120,10 +148,10 @@ export function buildFeedbackCompositeState({
     textureWrap: frameState.post.textureWrap ? 1 : 0,
     feedbackTexture: frameState.post.feedbackTexture ? 1 : 0,
     warpScale: controls.warpScale,
-    offsetX: controls.offsetX,
-    offsetY: controls.offsetY,
-    rotation: controls.rotation,
-    zoomMul: controls.zoom,
+    offsetX: controls.offsetX || presetWarp.dx,
+    offsetY: controls.offsetY || presetWarp.dy,
+    rotation: controls.rotation || presetWarp.rot,
+    zoomMul: controls.zoom !== 1 ? controls.zoom : presetWarp.zoom,
     saturation: controls.saturation,
     contrast: controls.contrast,
     colorScale: {

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -656,6 +656,25 @@ export function createMilkdropExperience({
    * decision over the same frame state. Each used to derive it separately,
    * down to a second copy of the workload threshold in the controller.
    */
+  /**
+   * The frame state the last transition decision was made against, and the
+   * decision itself.
+   *
+   * A single preset switch reaches this function TWICE — once from the
+   * navigation controller, once from the editor-session subscriber, about
+   * 2ms apart. Each call re-evaluated the gate independently against live
+   * frame timings that move in between, so the two regularly disagreed and
+   * the second silently overwrote the first: the same switch would cut or
+   * blend depending on which won. Coalescing on frame-state identity makes
+   * one switch produce one decision, because `currentFrameState` is
+   * replaced per rendered frame and both calls land inside the same one.
+   */
+  let lastTransitionFrameState: MilkdropFrameState | null | undefined;
+  let lastTransitionDecision: {
+    mode: 'blend' | 'cut';
+    durationSeconds: number;
+  } | null = null;
+
   const beginPresetTransition = () => {
     // A hand-driven crossfade is a gesture, not a persisted mode: it applies
     // to the one switch that armed it and then clears. Making it a third
@@ -664,6 +683,14 @@ export function createMilkdropExperience({
     // completes a preset change on its own.
     const manual = pendingManualCrossfade;
     pendingManualCrossfade = false;
+
+    if (
+      !manual &&
+      lastTransitionDecision !== null &&
+      lastTransitionFrameState === currentFrameState
+    ) {
+      return lastTransitionDecision;
+    }
 
     const quality = adaptiveQualityController?.getState() ?? null;
     const gate = evaluateBlendGate(
@@ -688,7 +715,11 @@ export function createMilkdropExperience({
         // different remedies (simpler preset / close something / let it cool).
         setOverlayStatus(BLEND_REFUSAL_STATUS[gate.refusal]);
       }
-      transitionController.begin(nextBlendState, blendDuration);
+      transitionController.begin(
+        nextBlendState,
+        blendDuration,
+        wantsBlend ? (gate.refusal ?? undefined) : 'transition mode: cut',
+      );
     }
     if (nextBlendState) {
       adapter?.saveFeedbackFrame?.();
@@ -699,10 +730,13 @@ export function createMilkdropExperience({
     // stale pressure evidence and, on constrained devices, pre-pays the
     // warm-up with one quality step instead of dropped frames.
     adaptiveQualityController?.notePresetApplied();
-    return {
+    const decision = {
       mode: canBlend ? ('blend' as const) : ('cut' as const),
       durationSeconds: blendDuration,
     };
+    lastTransitionFrameState = currentFrameState;
+    lastTransitionDecision = decision;
+    return decision;
   };
 
   const navigation = createMilkdropPresetNavigationController({

--- a/src/js/milkdrop/runtime/default-preset.ts
+++ b/src/js/milkdrop/runtime/default-preset.ts
@@ -11,377 +11,590 @@
  * Because this id IS a catalog id, startup selection resolves it normally and
  * the pre-catalog frame and the post-catalog frame are the same preset.
  *
- * Kept byte-identical to `public/milkdrop-presets/krash-rovastar-cerebral-demons-stars.milk`;
+ * Kept byte-identical to the first-run preset source the catalog points at;
  * `tests/unit/bundled-first-run-preset.test.ts` fails if the two drift apart.
  * See `first-run-preset.ts` for why this preset and not another.
  */
 export const DEFAULT_MILKDROP_PRESET_SOURCE = `[preset00]
 fRating=5.000000
-fGammaAdj=1.700000
-fDecay=1.000000
-fVideoEchoZoom=0.999999
-fVideoEchoAlpha=0.500000
-nVideoEchoOrientation=3
-nWaveMode=0
-bAdditiveWaves=0
+fGammaAdj=2.960001
+fDecay=0.910000
+fVideoEchoZoom=1.029896
+fVideoEchoAlpha=0.5
+nVideoEchoOrientation=0
+nWaveMode=7
+bAdditiveWaves=1
 bWaveDots=0
 bWaveThick=0
-bModWaveAlphaByVolume=0
-bMaximizeWaveColor=1
-bTexWrap=1
-bDarkenCenter=0
+bModWaveAlphaByVolume=1
+bMaximizeWaveColor=0
+bTexWrap=0
+bDarkenCenter=1
 bRedBlueStereo=0
 bBrighten=1
-bDarken=1
+bDarken=0
 bSolarize=0
 bInvert=0
 fWaveAlpha=0.001000
-fWaveScale=0.334693
-fWaveSmoothing=0.750000
-fWaveParam=-0.219900
-fModWaveAlphaStart=0.750000
-fModWaveAlphaEnd=0.950000
-fWarpAnimSpeed=1.000000
-fWarpScale=1.000000
-fZoomExponent=1.000000
-fShader=0.000000
-zoom=0.999900
-rot=0.100000
-cx=0.500000
-cy=0.500000
-dx=0.000000
-dy=0.000000
-warp=1.000000
-sx=1.000000
-sy=1.000000
-wave_r=0.500000
-wave_g=0.500000
-wave_b=0.500000
-wave_x=0.500000
-wave_y=0.500000
-ob_size=0.050000
-ob_r=0.000000
-ob_g=0.000000
-ob_b=0.000000
-ob_a=1.000000
-ib_size=0.005000
-ib_r=0.400000
-ib_g=0.000000
-ib_b=0.000000
-ib_a=0.000000
-nMotionVectorsX=64.000000
-nMotionVectorsY=48.000000
-mv_dx=0.000000
-mv_dy=0.000000
-mv_l=0.000000
-mv_r=0.000000
-mv_g=0.700000
-mv_b=1.000000
-mv_a=0.000000
-wavecode_0_enabled=0
+fWaveScale=1.285751
+fWaveSmoothing=0.630000
+fWaveParam=0.0
+fModWaveAlphaStart=0.710000
+fModWaveAlphaEnd=1.3
+fWarpAnimSpeed=1.0
+fWarpScale=1.331000
+fZoomExponent=2.987792
+fShader=0.0
+zoom=1.000432
+rot=0.0
+cx=0.5
+cy=0.5
+dx=0.0
+dy=0.0
+warp=0.010000
+sx=1.0
+sy=1.0
+wave_r=0.650000
+wave_g=0.650000
+wave_b=0.650000
+wave_x=0.5
+wave_y=0.5
+ob_size=0.0
+ob_r=0.010000
+ob_g=0.0
+ob_b=0.0
+ob_a=0.0
+ib_size=0.0
+ib_r=0.25
+ib_g=0.25
+ib_b=0.25
+ib_a=0.0
+nMotionVectorsX=12.0
+nMotionVectorsY=9.0
+mv_dx=0.0
+mv_dy=0.0
+mv_l=0.9
+mv_r=1.0
+mv_g=1.0
+mv_b=1.0
+mv_a=0.0
+wavecode_0_enabled=1
 wavecode_0_samples=512
 wavecode_0_sep=0
-wavecode_0_bSpectrum=0
-wavecode_0_bUseDots=0
+wavecode_0_bSpectrum=1
+wavecode_0_bUseDots=1
 wavecode_0_bDrawThick=1
-wavecode_0_bAdditive=0
-wavecode_0_scaling=1.000000
-wavecode_0_smoothing=0.500000
-wavecode_0_r=1.000000
-wavecode_0_g=0.800000
-wavecode_0_b=0.300000
-wavecode_0_a=1.000000
-wave_0_per_point1=n=sample*6.283;
-wave_0_per_point2=
-wave_0_per_point3=xp=sin(n);
-wave_0_per_point4=yp=cos(n);
-wave_0_per_point5=
-wave_0_per_point6=tm=q3 - sample;
-wave_0_per_point7=
-wave_0_per_point8=xof=sin(tm) * sin(tm*3) * 0.4 + 0.5;
-wave_0_per_point9=yof=cos(tm*1.3) * sin(tm*5.4) * 0.4 + 0.5;
-wave_0_per_point10=
-wave_0_per_point11=
-wave_0_per_point12=x= xof;
-wave_0_per_point13=y= (1-yof);
-wave_0_per_point14=
-wave_0_per_point15=a=1-sample;
-wave_0_per_point16=
-wave_0_per_point17=
-wave_0_per_point18=
+wavecode_0_bAdditive=1
+wavecode_0_scaling=1.0
+wavecode_0_smoothing=0.0
+wavecode_0_r=0.7
+wavecode_0_g=0.9
+wavecode_0_b=1.0
+wavecode_0_a=1.0
+wave_0_per_frame1=ra = if(ra,ra,2 + 8*rand(1001)*.001);
+wave_0_per_frame2=rb = if(rb,rb,2 + 8*rand(1001)*.001);
+wave_0_per_frame3=rc = if(rc,rc,2 + 8*rand(1001)*.001);
+wave_0_per_frame4=rd = if(rd,rd,2 + 8*rand(1001)*.001);
+wave_0_per_frame5=re = if(re,re,2 + 8*rand(1001)*.001);
+wave_0_per_frame6=rf = if(rf,rf,2 + 8*rand(1001)*.001);
+wave_0_per_frame7=
+wave_0_per_frame8=t1 = ra*6.2832;
+wave_0_per_frame9=t2 = rb*6.2832;
+wave_0_per_frame10=t3 = rc*6.2832;
+wave_0_per_frame11=t4 = rd*6.2832;
+wave_0_per_frame12=t5 = re*6.2832;
+wave_0_per_frame13=t6 = rf*6.2832;
+wave_0_per_frame14=
+wave_0_per_frame15=rg = if(rg,rg,.1 + .8*rand(1001)*.001);
+wave_0_per_frame16=rh = if(rh,rh,.1 + .8*rand(1001)*.001);
+wave_0_per_frame17=
+wave_0_per_frame18=t7 = rg;
+wave_0_per_frame19=t8 = rh;
+wave_0_per_frame20=
+wave_0_per_point1=ra = if(ra,ra,2 + 8*rand(1001)*.001);
+wave_0_per_point2=rb = if(rb,rb,2 + 8*rand(1001)*.001);
+wave_0_per_point3=rc = if(rc,rc,2 + 8*rand(1001)*.001);
+wave_0_per_point4=rd = if(rd,rd,2 + 8*rand(1001)*.001);
+wave_0_per_point5=re = if(re,re,2 + 8*rand(1001)*.001);
+wave_0_per_point6=rf = if(rf,rf,2 + 8*rand(1001)*.001);
+wave_0_per_point7=rg = if(rg,rg,2 + 8*rand(1001)*.001);
+wave_0_per_point8=rh = if(rh,rh,2 + 8*rand(1001)*.001);
+wave_0_per_point9=ri = if(ri,ri,2 + 8*rand(1001)*.001);
+wave_0_per_point10=rj = if(rj,rj,2 + 8*rand(1001)*.001);
+wave_0_per_point11=rk = if(rk,rk,2 + 8*rand(1001)*.001);
+wave_0_per_point12=rl = if(rl,rl,2 + 8*rand(1001)*.001);
+wave_0_per_point13=rm = if(rm,rm,2 + 8*rand(1001)*.001);
+wave_0_per_point14=rn = if(rn,rn,2 + 8*rand(1001)*.001);
+wave_0_per_point15=ro = if(ro,ro,2 + 8*rand(1001)*.001);
+wave_0_per_point16=rp = if(rp,rp,2 + 8*rand(1001)*.001);
+wave_0_per_point17=rq = if(rq,rq,2 + 8*rand(1001)*.001);
+wave_0_per_point18=rr = if(rr,rr,2 + 8*rand(1001)*.001);
 wave_0_per_point19=
+wave_0_per_point20=it = it*above(sample,0);
+wave_0_per_point21=it = it + 1;
+wave_0_per_point22=pi = 6.2813;
+wave_0_per_point23=
+wave_0_per_point24=sam = sample;
+wave_0_per_point25=spm = .5 + .5*sin((q2 - sam)*6.24);
+wave_0_per_point26=a = min((1-sam)*value2*3,1);
+wave_0_per_point27=//a = pow(spm,16);
+wave_0_per_point28=//a = 1;
+wave_0_per_point29=r = pow(1 - sam,1);
+wave_0_per_point30=g = pow(1 - sam,1);
+wave_0_per_point31=b = pow(1 - sam,1);
+wave_0_per_point32=
+wave_0_per_point33=sp = q6*.15 - sam*.2;
+wave_0_per_point34=spa = q7*.15 - sam*.2;
+wave_0_per_point35=spb = q8*.15 - sam*.2;
+wave_0_per_point36=ox = sam*(.5*sin(sp*ra*pi) + .5*sin(sp*rd*pi));
+wave_0_per_point37=oy = sam*(.5*sin(sp*rb*pi) + .5*sin(sp*re*pi));
+wave_0_per_point38=oz = sam*(.5*sin(sp*rc*pi) + .5*sin(sp*rf*pi));
+wave_0_per_point39=
+wave_0_per_point40=cut = .2;
+wave_0_per_point41=sm = sam*above(sam,cut);
+wave_0_per_point42=mo = rand(2);
+wave_0_per_point43=ox = ox + max(0,sm-cut)*if(mo,sin(spa*rg),sin(spa*rh));
+wave_0_per_point44=oy = oy + max(0,sm-cut)*if(mo,sin(spa*ri),sin(spa*rj));
+wave_0_per_point45=oz = oz + max(0,sm-cut)*if(mo,sin(spa*rk),sin(spa*rl));
+wave_0_per_point46=
+wave_0_per_point47=cut = .4;
+wave_0_per_point48=sm = sm*above(sm,cut);
+wave_0_per_point49=mo = rand(2);
+wave_0_per_point50=ox = ox + max(0,sm-cut)*if(mo,sin(spb*rm),sin(spb*rp));
+wave_0_per_point51=oy = oy + max(0,sm-cut)*if(mo,sin(spb*rn),sin(spb*rq));
+wave_0_per_point52=oz = oz + max(0,sm-cut)*if(mo,sin(spb*ro),sin(spb*rr));
+wave_0_per_point53=
+wave_0_per_point54=
+wave_0_per_point55=
+wave_0_per_point56=xang = q6*.1;
+wave_0_per_point57=yang = q7*.1;
+wave_0_per_point58=zang = q8*.1;
+wave_0_per_point59=
+wave_0_per_point60=fov = .5;
+wave_0_per_point61=
+wave_0_per_point62=mx = ox*cos(yang) + oz*sin(yang);
+wave_0_per_point63=mz = - ox*sin(yang) + oz*cos(yang);
+wave_0_per_point64=ox = mx;
+wave_0_per_point65=oz = mz;
+wave_0_per_point66=mx = ox*cos(zang) - oy*sin(zang);
+wave_0_per_point67=my = ox*sin(zang) + oy*cos(zang);
+wave_0_per_point68=ox = mx;
+wave_0_per_point69=oy = my;
+wave_0_per_point70=my = oy*cos(xang) - oz*sin(xang);
+wave_0_per_point71=mz = oy*sin(xang) + oz*cos(xang);
+wave_0_per_point72=oy = my;
+wave_0_per_point73=oz = mz;
+wave_0_per_point74=
+wave_0_per_point75=
+wave_0_per_point76=tme = (q6+q7+q8)*2 - sam*6.24*4;
+wave_0_per_point77=mod = 1-sam;
+wave_0_per_point78=wmod = 1;
+wave_0_per_point79=ox = ox*(1-mod) + (sin(tme*.33)*.5 + .5*cos(tme*.542))*mod;
+wave_0_per_point80=oy = oy*(1-mod) + (cos(tme*.24)*.5 + .5*sin(tme*.542))*mod;
+wave_0_per_point81=oz = oz*(1-mod) + (sin(tme*.11)*.5 + .5*cos(tme*.542))*mod;
+wave_0_per_point82=
+wave_0_per_point83=
+wave_0_per_point84=ox = ox*q3;
+wave_0_per_point85=oy = oy*q3;
+wave_0_per_point86=oz = oz*q3;
+wave_0_per_point87=
+wave_0_per_point88=oz = oz - 2;
+wave_0_per_point89=x = ox*fov/oz + 0.5;
+wave_0_per_point90=x = (x-.5)*0.75 + 0.5;
+wave_0_per_point91=y = oy*fov/oz + 0.5;
+wave_0_per_point92=
 wavecode_1_enabled=1
 wavecode_1_samples=512
 wavecode_1_sep=0
-wavecode_1_bSpectrum=0
-wavecode_1_bUseDots=0
+wavecode_1_bSpectrum=1
+wavecode_1_bUseDots=1
 wavecode_1_bDrawThick=1
-wavecode_1_bAdditive=0
-wavecode_1_scaling=1.000000
-wavecode_1_smoothing=0.500000
-wavecode_1_r=1.000000
-wavecode_1_g=0.700000
-wavecode_1_b=0.200000
-wavecode_1_a=1.000000
-wave_1_per_point1=n=sample*6.283;
-wave_1_per_point2=n2=(sample-q8 - time*0.1)*6;
-wave_1_per_point3=
-wave_1_per_point4=xp=sin(n);
-wave_1_per_point5=yp=cos(n);
-wave_1_per_point6=
-wave_1_per_point7=tm=q8 - sample;
-wave_1_per_point8=
-wave_1_per_point9=tx= sin(n2*13)*sin(n2*5) * sample * 0.05;
-wave_1_per_point10=ty= cos(n2*13)*sin(n2*7) * sample * 0.05;
-wave_1_per_point11=
-wave_1_per_point12=xof=sin(tm) * sin(tm*3) * 0.4 + 0.5 + tx;
-wave_1_per_point13=yof=cos(tm*1.3) * sin(tm*5.4) * 0.4 + 0.5 + ty;
-wave_1_per_point14=
-wave_1_per_point15=xran=(rand(10) - 5) * 0.0005; xran=xran*sample;
-wave_1_per_point16=yran=(rand(10) - 5) * 0.0005; yran=yran*sample;
-wave_1_per_point17=
-wave_1_per_point18=x= xof + xran;
-wave_1_per_point19=y= (1-yof) + yran;
-wave_1_per_point20=
-wave_1_per_point21=a=(1-sample);
-wave_1_per_point22=g=g*(1-sample);
-wave_1_per_point23=b=b*(1-sample)
-wavecode_2_enabled=1
-wavecode_2_samples=512
+wavecode_1_bAdditive=1
+wavecode_1_scaling=1.0
+wavecode_1_smoothing=0.0
+wavecode_1_r=0.7
+wavecode_1_g=0.9
+wavecode_1_b=1.0
+wavecode_1_a=1.0
+wave_1_per_frame1=ra = if(ra,ra,2 + 8*rand(1001)*.001);
+wave_1_per_frame2=rb = if(rb,rb,2 + 8*rand(1001)*.001);
+wave_1_per_frame3=rc = if(rc,rc,2 + 8*rand(1001)*.001);
+wave_1_per_frame4=rd = if(rd,rd,2 + 8*rand(1001)*.001);
+wave_1_per_frame5=re = if(re,re,2 + 8*rand(1001)*.001);
+wave_1_per_frame6=rf = if(rf,rf,2 + 8*rand(1001)*.001);
+wave_1_per_frame7=
+wave_1_per_frame8=t1 = ra*6.2832;
+wave_1_per_frame9=t2 = rb*6.2832;
+wave_1_per_frame10=t3 = rc*6.2832;
+wave_1_per_frame11=t4 = rd*6.2832;
+wave_1_per_frame12=t5 = re*6.2832;
+wave_1_per_frame13=t6 = rf*6.2832;
+wave_1_per_frame14=
+wave_1_per_frame15=rg = if(rg,rg,.1 + .8*rand(1001)*.001);
+wave_1_per_frame16=rh = if(rh,rh,.1 + .8*rand(1001)*.001);
+wave_1_per_frame17=
+wave_1_per_frame18=t7 = rg;
+wave_1_per_frame19=t8 = rh;
+wave_1_per_frame20=
+wave_1_per_point1=ra = if(ra,ra,2 + 8*rand(1001)*.001);
+wave_1_per_point2=rb = if(rb,rb,2 + 8*rand(1001)*.001);
+wave_1_per_point3=rc = if(rc,rc,2 + 8*rand(1001)*.001);
+wave_1_per_point4=rd = if(rd,rd,2 + 8*rand(1001)*.001);
+wave_1_per_point5=re = if(re,re,2 + 8*rand(1001)*.001);
+wave_1_per_point6=rf = if(rf,rf,2 + 8*rand(1001)*.001);
+wave_1_per_point7=rg = if(rg,rg,2 + 8*rand(1001)*.001);
+wave_1_per_point8=rh = if(rh,rh,2 + 8*rand(1001)*.001);
+wave_1_per_point9=ri = if(ri,ri,2 + 8*rand(1001)*.001);
+wave_1_per_point10=rj = if(rj,rj,2 + 8*rand(1001)*.001);
+wave_1_per_point11=rk = if(rk,rk,2 + 8*rand(1001)*.001);
+wave_1_per_point12=rl = if(rl,rl,2 + 8*rand(1001)*.001);
+wave_1_per_point13=rm = if(rm,rm,2 + 8*rand(1001)*.001);
+wave_1_per_point14=rn = if(rn,rn,2 + 8*rand(1001)*.001);
+wave_1_per_point15=ro = if(ro,ro,2 + 8*rand(1001)*.001);
+wave_1_per_point16=rp = if(rp,rp,2 + 8*rand(1001)*.001);
+wave_1_per_point17=rq = if(rq,rq,2 + 8*rand(1001)*.001);
+wave_1_per_point18=rr = if(rr,rr,2 + 8*rand(1001)*.001);
+wave_1_per_point19=
+wave_1_per_point20=it = it*above(sample,0);
+wave_1_per_point21=it = it + 1;
+wave_1_per_point22=pi = 6.2813;
+wave_1_per_point23=
+wave_1_per_point24=sam = sample;
+wave_1_per_point25=spm = .5 + .5*sin((q2 - sam)*6.24);
+wave_1_per_point26=a = min((1-sam)*value2*3,1);
+wave_1_per_point27=//a = pow((1-spm),16);
+wave_1_per_point28=g = 1;
+wave_1_per_point29=r = pow(1 - sam,1);
+wave_1_per_point30=b = pow(1 - sam,1);
+wave_1_per_point31=g = pow(1 - sam,1);
+wave_1_per_point32=
+wave_1_per_point33=sp = q6*.15 - sam*.2;
+wave_1_per_point34=spa = q7*.15 - sam*.2;
+wave_1_per_point35=spb = q8*.15 - sam*.2;
+wave_1_per_point36=ox = sam*(.5*sin(sp*ra*pi) + .5*sin(sp*rd*pi));
+wave_1_per_point37=oy = sam*(.5*sin(sp*rb*pi) + .5*sin(sp*re*pi));
+wave_1_per_point38=oz = sam*(.5*sin(sp*rc*pi) + .5*sin(sp*rf*pi));
+wave_1_per_point39=
+wave_1_per_point40=cut = .2;
+wave_1_per_point41=sm = sam*above(sam,cut);
+wave_1_per_point42=mo = rand(2);
+wave_1_per_point43=ox = ox + max(0,sm-cut)*if(mo,sin(spa*rg),sin(spa*rh));
+wave_1_per_point44=oy = oy + max(0,sm-cut)*if(mo,sin(spa*ri),sin(spa*rj));
+wave_1_per_point45=oz = oz + max(0,sm-cut)*if(mo,sin(spa*rk),sin(spa*rl));
+wave_1_per_point46=
+wave_1_per_point47=cut = .4;
+wave_1_per_point48=sm = sm*above(sm,cut);
+wave_1_per_point49=mo = rand(2);
+wave_1_per_point50=ox = ox + max(0,sm-cut)*if(mo,sin(spb*rm),sin(spb*rp));
+wave_1_per_point51=oy = oy + max(0,sm-cut)*if(mo,sin(spb*rn),sin(spb*rq));
+wave_1_per_point52=oz = oz + max(0,sm-cut)*if(mo,sin(spb*ro),sin(spb*rr));
+wave_1_per_point53=
+wave_1_per_point54=
+wave_1_per_point55=
+wave_1_per_point56=xang = q6*.1;
+wave_1_per_point57=yang = q7*.1;
+wave_1_per_point58=zang = q8*.1;
+wave_1_per_point59=
+wave_1_per_point60=fov = .5;
+wave_1_per_point61=
+wave_1_per_point62=mx = ox*cos(yang) + oz*sin(yang);
+wave_1_per_point63=mz = - ox*sin(yang) + oz*cos(yang);
+wave_1_per_point64=ox = mx;
+wave_1_per_point65=oz = mz;
+wave_1_per_point66=mx = ox*cos(zang) - oy*sin(zang);
+wave_1_per_point67=my = ox*sin(zang) + oy*cos(zang);
+wave_1_per_point68=ox = mx;
+wave_1_per_point69=oy = my;
+wave_1_per_point70=my = oy*cos(xang) - oz*sin(xang);
+wave_1_per_point71=mz = oy*sin(xang) + oz*cos(xang);
+wave_1_per_point72=oy = my;
+wave_1_per_point73=oz = mz;
+wave_1_per_point74=
+wave_1_per_point75=
+wave_1_per_point76=tme = (q6+q7+q8)*2 - sam*6.24*4;
+wave_1_per_point77=mod = 1-sam;
+wave_1_per_point78=wmod = 1;
+wave_1_per_point79=ox = ox*(1-mod) + (sin(tme*.21)*.5 + .5*cos(tme*.671))*mod;
+wave_1_per_point80=oy = oy*(1-mod) + (cos(tme*.14)*.5 + .5*sin(tme*.236))*mod;
+wave_1_per_point81=oz = oz*(1-mod) + (sin(tme*.87)*.5 + .5*cos(tme*.247))*mod;
+wave_1_per_point82=
+wave_1_per_point83=
+wave_1_per_point84=ox = ox*q3;
+wave_1_per_point85=oy = oy*q3;
+wave_1_per_point86=oz = oz*q3;
+wave_1_per_point87=
+wave_1_per_point88=oz = oz - 2;
+wave_1_per_point89=x = ox*fov/oz + 0.5;
+wave_1_per_point90=x = (x-.5)*0.75 + 0.5;
+wave_1_per_point91=y = oy*fov/oz + 0.5;
+wave_1_per_point92=
+wavecode_2_enabled=0
+wavecode_2_samples=54
 wavecode_2_sep=0
 wavecode_2_bSpectrum=0
-wavecode_2_bUseDots=1
-wavecode_2_bDrawThick=1
+wavecode_2_bUseDots=0
+wavecode_2_bDrawThick=0
 wavecode_2_bAdditive=0
-wavecode_2_scaling=1.000000
-wavecode_2_smoothing=0.500000
-wavecode_2_r=1.000000
-wavecode_2_g=0.780000
-wavecode_2_b=0.200000
-wavecode_2_a=1.000000
-wave_2_per_point1=n=sample*6.283;
-wave_2_per_point2=n2=(sample-q8 - time*0.1)*6;
-wave_2_per_point3=
-wave_2_per_point4=xp=sin(n);
-wave_2_per_point5=yp=cos(n);
-wave_2_per_point6=
-wave_2_per_point7=tm=q8 - sample;
-wave_2_per_point8=
-wave_2_per_point9=tx= sin(n2*13)*sin(n2*5) * sample * 0.05;
-wave_2_per_point10=ty= cos(n2*13)*sin(n2*7) * sample * 0.05;
-wave_2_per_point11=
-wave_2_per_point12=xof=sin(tm) * sin(tm*3) * 0.4 + 0.5 + tx;
-wave_2_per_point13=yof=cos(tm*1.3) * sin(tm*5.4) * 0.4 + 0.5 + ty;
-wave_2_per_point14=
-wave_2_per_point15=xran=(rand(10) - 5) * 0.0005; xran=xran*sample;
-wave_2_per_point16=yran=(rand(10) - 5) * 0.0005; yran=yran*sample;
-wave_2_per_point17=
-wave_2_per_point18=x= xof + xran;
-wave_2_per_point19=y= (1-yof) + yran;
-wave_2_per_point20=
-wave_2_per_point21=a=(1-sample);
-wave_2_per_point22=g=g*(1-sample);
-wave_2_per_point23=b=b*(1-sample)
+wavecode_2_scaling=1.0
+wavecode_2_smoothing=0.5
+wavecode_2_r=1.0
+wavecode_2_g=1.0
+wavecode_2_b=1.0
+wavecode_2_a=1.0
+wave_2_per_point1=mod = .20333;
+wave_2_per_point2=x = .5 + mod*(sin(sample*6.28*1 + q3)*.5 + .5*cos(sample*6.28*3 + q3));
+wave_2_per_point3=y = .5 + mod*(cos(sample*6.28*2 + q3)*.5 + .5*sin(sample*6.28*1 + q3));
 wavecode_3_enabled=0
-wavecode_3_samples=512
+wavecode_3_samples=54
 wavecode_3_sep=0
 wavecode_3_bSpectrum=0
 wavecode_3_bUseDots=0
-wavecode_3_bDrawThick=1
+wavecode_3_bDrawThick=0
 wavecode_3_bAdditive=0
-wavecode_3_scaling=1.000000
-wavecode_3_smoothing=0.500000
-wavecode_3_r=1.000000
-wavecode_3_g=1.000000
-wavecode_3_b=1.000000
-wavecode_3_a=1.000000
-wave_3_per_point1=xs=sin(sample*6.28);
-wave_3_per_point2=ys=cos(sample*6.28);
-wave_3_per_point3=xs=xs*0.7 + 0.5;
-wave_3_per_point4=ys=ys*0.7 + 0.5;
-wave_3_per_point5=xs=min(xs,0.958);
-wave_3_per_point6=xs=max(xs,0.042);
-wave_3_per_point7=ys=min(ys,0.988);
-wave_3_per_point8=ys=max(ys,0.012);
-wave_3_per_point9=x=xs;y=ys;
-wave_3_per_point10=
-wave_3_per_point11=n2=abs((sample*6.283)-3.1415);
-wave_3_per_point12=
-wave_3_per_point13=r=sin(n2+time)*0.5+0.5;
-wave_3_per_point14=g=sin(n2+2.1+time)*0.5+0.5;
-wave_3_per_point15=b=sin(n2+4.2+time)*0.5+0.5;
-wave_3_per_point16=
-wave_3_per_point17=
-wave_3_per_point18=a=a * above(sin(n2*9+q8*2), sin(time) )
-shapecode_0_enabled=1
-shapecode_0_sides=5
-shapecode_0_additive=1
+wavecode_3_scaling=1.0
+wavecode_3_smoothing=0.5
+wavecode_3_r=1.0
+wavecode_3_g=1.0
+wavecode_3_b=1.0
+wavecode_3_a=1.0
+wave_3_per_point1=mod = .20667;
+wave_3_per_point2=x = .5 + mod*(sin(sample*6.28*1 + q3)*.5 + .5*cos(sample*6.28*3 + q3));
+wave_3_per_point3=y = .5 + mod*(cos(sample*6.28*2 + q3)*.5 + .5*sin(sample*6.28*1 + q3));
+shapecode_0_enabled=0
+shapecode_0_sides=4
+shapecode_0_additive=0
 shapecode_0_thickOutline=0
-shapecode_0_textured=0
-shapecode_0_x=0.500000
-shapecode_0_y=0.500000
-shapecode_0_rad=0.491381
-shapecode_0_ang=0.000000
-shapecode_0_tex_ang=0.000000
-shapecode_0_tex_zoom=1.000000
-shapecode_0_r=1.000000
-shapecode_0_g=1.000000
-shapecode_0_b=0.500000
-shapecode_0_a=1.000000
-shapecode_0_r2=1.000000
-shapecode_0_g2=0.500000
-shapecode_0_b2=0.000000
-shapecode_0_a2=0.000000
-shapecode_0_border_r=1.000000
-shapecode_0_border_g=1.000000
-shapecode_0_border_b=1.000000
-shapecode_0_border_a=0.100000
-shape_0_per_frame1=x=q1;
-shape_0_per_frame2=y=1-q2;
-shape_0_per_frame3=ang=time
+shapecode_0_textured=1
+shapecode_0_x=0.5
+shapecode_0_y=0.5
+shapecode_0_rad=1.998627
+shapecode_0_ang=0.0
+shapecode_0_tex_ang=0.0
+shapecode_0_tex_zoom=0.670315
+shapecode_0_r=0.0
+shapecode_0_g=1.0
+shapecode_0_b=0.0
+shapecode_0_a=1.0
+shapecode_0_r2=0.0
+shapecode_0_g2=1.0
+shapecode_0_b2=0.0
+shapecode_0_a2=1.0
+shapecode_0_border_r=1.0
+shapecode_0_border_g=1.0
+shapecode_0_border_b=1.0
+shapecode_0_border_a=0.1
+shape_0_per_frame1=g = .7;
+shape_0_per_frame2=g2 = g;
+shape_0_per_frame3=
+shape_0_per_frame4=a = q1;
+shape_0_per_frame5=a2 = a;
+shape_0_per_frame6=
+shape_0_per_frame7=ra = rand(1001)*.001;
+shape_0_per_frame8=ti = q4 + .25;
+shape_0_per_frame9=ra = ti - int(ti);
+shape_0_per_frame10=
+shape_0_per_frame11=tex_zoom = .45;
+shape_0_per_frame12=
+shape_0_per_frame13=h = if(above(ra,.15),ra-.15,ra+.85);
+shape_0_per_frame14=s = 1;
+shape_0_per_frame15=l = q5;
+shape_0_per_frame16=
+shape_0_per_frame17=tmpb = if(below(l,0.5),l*(1+s),(l+s)-(s*l));
+shape_0_per_frame18=tmpa = 2*l - tmpb;
+shape_0_per_frame19=hvr = h + .333333;
+shape_0_per_frame20=hvr = if(below(hvr,0),hvr+1,if(above(hvr,1),hvr-1,hvr));
+shape_0_per_frame21=hvg = h;
+shape_0_per_frame22=hvg = if(below(hvg,0),hvg+1,if(above(hvg,1),hvg-1,hvg));
+shape_0_per_frame23=hvb = h - .333333;
+shape_0_per_frame24=hvb = if(below(hvb,0),hvb+1,if(above(hvb,1),hvb-1,hvb));
+shape_0_per_frame25=
+shape_0_per_frame26=r = if(below(6*hvr,1),tmpa+(tmpb-tmpa)*6*hvr, if(below(2*hvr,1),tmpb, if(below(hvr*3,2),tmpa+(tmpb-tmpa)*(.666666-hvr)*6,tmpa)));
+shape_0_per_frame27=g = if(below(6*hvg,1),tmpa+(tmpb-tmpa)*6*hvg, if(below(2*hvg,1),tmpb, if(below(hvg*3,2),tmpa+(tmpb-tmpa)*(.666666-hvg)*6,tmpa)));
+shape_0_per_frame28=b = if(below(6*hvb,1),tmpa+(tmpb-tmpa)*6*hvb, if(below(2*hvb,1),tmpb, if(below(hvb*3,2),tmpa+(tmpb-tmpa)*(.666666-hvb)*6,tmpa)));
+shape_0_per_frame29=
+shape_0_per_frame30=r2 = r;
+shape_0_per_frame31=g2 = g;
+shape_0_per_frame32=b2 = b;
 shapecode_1_enabled=1
-shapecode_1_sides=5
+shapecode_1_sides=4
 shapecode_1_additive=0
 shapecode_1_thickOutline=0
-shapecode_1_textured=0
-shapecode_1_x=0.500000
-shapecode_1_y=0.500000
-shapecode_1_rad=0.030000
-shapecode_1_ang=0.000000
-shapecode_1_tex_ang=0.000000
-shapecode_1_tex_zoom=1.000000
-shapecode_1_r=0.000000
-shapecode_1_g=0.000000
-shapecode_1_b=0.000000
-shapecode_1_a=1.000000
-shapecode_1_r2=0.000000
-shapecode_1_g2=0.000000
-shapecode_1_b2=0.000000
-shapecode_1_a2=1.000000
-shapecode_1_border_r=1.000000
-shapecode_1_border_g=1.000000
-shapecode_1_border_b=1.000000
-shapecode_1_border_a=0.100000
-shape_1_per_frame1=x=q1;
-shape_1_per_frame2=y=1-q2;
-shape_1_per_frame3=ang=time
+shapecode_1_textured=1
+shapecode_1_x=0.5
+shapecode_1_y=0.5
+shapecode_1_rad=1.998627
+shapecode_1_ang=0.0
+shapecode_1_tex_ang=0.0
+shapecode_1_tex_zoom=0.670315
+shapecode_1_r=0.0
+shapecode_1_g=1.0
+shapecode_1_b=0.0
+shapecode_1_a=1.0
+shapecode_1_r2=0.0
+shapecode_1_g2=1.0
+shapecode_1_b2=0.0
+shapecode_1_a2=1.0
+shapecode_1_border_r=1.0
+shapecode_1_border_g=1.0
+shapecode_1_border_b=1.0
+shapecode_1_border_a=0.1
+shape_1_per_frame1=//tex_ang = -time;
+shape_1_per_frame2=g = .7;
+shape_1_per_frame3=g2 = g;
+shape_1_per_frame4=
+shape_1_per_frame5=a = q1;
+shape_1_per_frame6=a2 = a;
+shape_1_per_frame7=
+shape_1_per_frame8=ra = rand(1001)*.001;
+shape_1_per_frame9=ti = q4 + .25;
+shape_1_per_frame10=ra = ti - int(ti);
+shape_1_per_frame11=
+shape_1_per_frame12=tex_zoom = .55;
+shape_1_per_frame13=
+shape_1_per_frame14=h = if(above(ra,.15),ra-.15,ra+.85);
+shape_1_per_frame15=s = 1;
+shape_1_per_frame16=l = q5;
+shape_1_per_frame17=
+shape_1_per_frame18=tmpb = if(below(l,0.5),l*(1+s),(l+s)-(s*l));
+shape_1_per_frame19=tmpa = 2*l - tmpb;
+shape_1_per_frame20=hvr = h + .333333;
+shape_1_per_frame21=hvr = if(below(hvr,0),hvr+1,if(above(hvr,1),hvr-1,hvr));
+shape_1_per_frame22=hvg = h;
+shape_1_per_frame23=hvg = if(below(hvg,0),hvg+1,if(above(hvg,1),hvg-1,hvg));
+shape_1_per_frame24=hvb = h - .333333;
+shape_1_per_frame25=hvb = if(below(hvb,0),hvb+1,if(above(hvb,1),hvb-1,hvb));
+shape_1_per_frame26=
+shape_1_per_frame27=r = if(below(6*hvr,1),tmpa+(tmpb-tmpa)*6*hvr, if(below(2*hvr,1),tmpb, if(below(hvr*3,2),tmpa+(tmpb-tmpa)*(.666666-hvr)*6,tmpa)));
+shape_1_per_frame28=g = if(below(6*hvg,1),tmpa+(tmpb-tmpa)*6*hvg, if(below(2*hvg,1),tmpb, if(below(hvg*3,2),tmpa+(tmpb-tmpa)*(.666666-hvg)*6,tmpa)));
+shape_1_per_frame29=b = if(below(6*hvb,1),tmpa+(tmpb-tmpa)*6*hvb, if(below(2*hvb,1),tmpb, if(below(hvb*3,2),tmpa+(tmpb-tmpa)*(.666666-hvb)*6,tmpa)));
+shape_1_per_frame30=
+shape_1_per_frame31=r2 = r;
+shape_1_per_frame32=g2 = g;
+shape_1_per_frame33=b2 = b;
 shapecode_2_enabled=1
 shapecode_2_sides=4
 shapecode_2_additive=0
 shapecode_2_thickOutline=0
 shapecode_2_textured=1
-shapecode_2_x=0.500000
-shapecode_2_y=0.500000
-shapecode_2_rad=1.791419
-shapecode_2_ang=0.000000
-shapecode_2_tex_ang=3.141593
-shapecode_2_tex_zoom=0.555953
-shapecode_2_r=1.000000
-shapecode_2_g=1.000000
-shapecode_2_b=0.000000
-shapecode_2_a=1.000000
-shapecode_2_r2=1.000000
-shapecode_2_g2=1.000000
-shapecode_2_b2=1.000000
-shapecode_2_a2=1.000000
-shapecode_2_border_r=1.000000
-shapecode_2_border_g=1.000000
-shapecode_2_border_b=1.000000
-shapecode_2_border_a=0.100000
-shape_2_per_frame1=x=.5+(above(sin(time),0)*0.2);
+shapecode_2_x=0.5
+shapecode_2_y=0.5
+shapecode_2_rad=1.998627
+shapecode_2_ang=0.0
+shapecode_2_tex_ang=0.0
+shapecode_2_tex_zoom=0.670315
+shapecode_2_r=0.0
+shapecode_2_g=1.0
+shapecode_2_b=0.0
+shapecode_2_a=1.0
+shapecode_2_r2=0.0
+shapecode_2_g2=1.0
+shapecode_2_b2=0.0
+shapecode_2_a2=1.0
+shapecode_2_border_r=1.0
+shapecode_2_border_g=1.0
+shapecode_2_border_b=1.0
+shapecode_2_border_a=0.1
+shape_2_per_frame1=//tex_ang = time;
+shape_2_per_frame2=g = .7;
+shape_2_per_frame3=g2 = g;
+shape_2_per_frame4=
+shape_2_per_frame5=a = q1*2;
+shape_2_per_frame6=a2 = a;
+shape_2_per_frame7=
+shape_2_per_frame8=ra = rand(1001)*.001;
+shape_2_per_frame9=ti = q4 + .25;
+shape_2_per_frame10=ra = ti - int(ti);
+shape_2_per_frame11=
+shape_2_per_frame12=tex_zoom = .45;
+shape_2_per_frame13=
+shape_2_per_frame14=h = if(above(ra,.15),ra-.15,ra+.85);
+shape_2_per_frame15=s = 1;
+shape_2_per_frame16=l = q5;
+shape_2_per_frame17=
+shape_2_per_frame18=tmpb = if(below(l,0.5),l*(1+s),(l+s)-(s*l));
+shape_2_per_frame19=tmpa = 2*l - tmpb;
+shape_2_per_frame20=hvr = h + .333333;
+shape_2_per_frame21=hvr = if(below(hvr,0),hvr+1,if(above(hvr,1),hvr-1,hvr));
+shape_2_per_frame22=hvg = h;
+shape_2_per_frame23=hvg = if(below(hvg,0),hvg+1,if(above(hvg,1),hvg-1,hvg));
+shape_2_per_frame24=hvb = h - .333333;
+shape_2_per_frame25=hvb = if(below(hvb,0),hvb+1,if(above(hvb,1),hvb-1,hvb));
+shape_2_per_frame26=
+shape_2_per_frame27=r = if(below(6*hvr,1),tmpa+(tmpb-tmpa)*6*hvr, if(below(2*hvr,1),tmpb, if(below(hvr*3,2),tmpa+(tmpb-tmpa)*(.666666-hvr)*6,tmpa)));
+shape_2_per_frame28=g = if(below(6*hvg,1),tmpa+(tmpb-tmpa)*6*hvg, if(below(2*hvg,1),tmpb, if(below(hvg*3,2),tmpa+(tmpb-tmpa)*(.666666-hvg)*6,tmpa)));
+shape_2_per_frame29=b = if(below(6*hvb,1),tmpa+(tmpb-tmpa)*6*hvb, if(below(2*hvb,1),tmpb, if(below(hvb*3,2),tmpa+(tmpb-tmpa)*(.666666-hvb)*6,tmpa)));
+shape_2_per_frame30=
+shape_2_per_frame31=r2 = r;
+shape_2_per_frame32=g2 = g;
+shape_2_per_frame33=b2 = b;
 shapecode_3_enabled=1
-shapecode_3_sides=14
+shapecode_3_sides=3
 shapecode_3_additive=0
 shapecode_3_thickOutline=0
 shapecode_3_textured=1
-shapecode_3_x=0.700000
-shapecode_3_y=0.700000
-shapecode_3_rad=0.986086
-shapecode_3_ang=0.628319
-shapecode_3_tex_ang=0.000000
-shapecode_3_tex_zoom=0.999996
-shapecode_3_r=0.970000
-shapecode_3_g=0.000000
-shapecode_3_b=1.000000
-shapecode_3_a=1.000000
-shapecode_3_r2=1.000000
-shapecode_3_g2=1.000000
-shapecode_3_b2=0.000000
-shapecode_3_a2=0.000000
-shapecode_3_border_r=1.000000
-shapecode_3_border_g=1.000000
-shapecode_3_border_b=1.000000
-shapecode_3_border_a=0.100000
-per_frame_init_1=flip=1
-per_frame_1=warp=0;
-per_frame_2=wave_r = wave_r + 0.45*(0.5*sin(time*0.701)+ 0.3*cos(time*0.438));
-per_frame_3=wave_b = wave_b - 0.4*(0.5*sin(time*4.782)+0.5*cos(time*0.722));
-per_frame_4=wave_g = wave_g + 0.4*sin(time*1.931);
-per_frame_5=wave_r = 0.2125*wave_r + 0.7154*wave_g + 0.0721*wave_b;
-per_frame_6=wave_g = wave_r;
-per_frame_7=wave_b = wave_r;
-per_frame_8=vol = 0.167*(bass+mid);
-per_frame_9=xamptarg = if(equal(frame%15,0),min(0.5*vol*bass_att,0.5),xamptarg);
-per_frame_10=xamp = xamp + 0.5*(xamptarg-xamp);
-per_frame_11=xdir = if(above(abs(xpos),xamp),-sign(xpos),if(below(abs(xspeed),0.1),2*above(xpos,0)-1,xdir));
-per_frame_12=xspeed = xspeed + xdir*xamp - xpos - xspeed*0.055*below(abs(xpos),xamp);
-per_frame_13=xpos = xpos + 0.001*xspeed;
-per_frame_14=wave_x = 1.25*xpos + 0.5;
-per_frame_15=yamptarg = if(equal(frame%15,0),min(0.3*vol*treb_att,0.5),yamptarg);
-per_frame_16=yamp = yamp + 0.5*(yamptarg-yamp);
-per_frame_17=ydir = if(above(abs(ypos),yamp),-sign(ypos),if(below(abs(yspeed),0.1),2*above(ypos,0)-1,ydir));
-per_frame_18=yspeed = yspeed + ydir*yamp - ypos - yspeed*0.055*below(abs(ypos),yamp);
-per_frame_19=ypos = ypos + 0.001*yspeed;
-per_frame_20=wave_y = 1.25*ypos + 0.5;
-per_frame_21=dx = dx + dx_residual;
-per_frame_22=dy = dy + dy_residual;
-per_frame_23=bass_thresh = above(bass_att,bass_thresh)*2 + (1-above(bass_att,bass_thresh))*((bass_thresh-1.3)*0.96+1.3);
-per_frame_24=dx_residual = equal(bass_thresh,2)*0.003*sin(time*7) + (1-equal(bass_thresh,2))*dx_residual;
-per_frame_25=dy_residual = equal(bass_thresh,2)*0.001*sin(time*9) + (1-equal(bass_thresh,2))*dy_residual;
-per_frame_26=rot = 0.1;
-per_frame_27=
-per_frame_28=vol=(bass+mid+treb)*0.25;
-per_frame_29=vol=vol*vol;
-per_frame_30=mtime=mtime + vol*0.01*(37/fps);
-per_frame_31=q8=mtime;
-per_frame_32=
-per_frame_33=
-per_frame_34=q1=sin(mtime) * sin(mtime*3) * 0.4 + 0.5;
-per_frame_35=q2=cos(mtime*1.3) * sin(mtime*5.4) * 0.4 + 0.5;
+shapecode_3_x=0.5
+shapecode_3_y=0.5
+shapecode_3_rad=0.901615
+shapecode_3_ang=0.0
+shapecode_3_tex_ang=0.0
+shapecode_3_tex_zoom=1.102420
+shapecode_3_r=1.0
+shapecode_3_g=1.0
+shapecode_3_b=1.0
+shapecode_3_a=0.0
+shapecode_3_r2=1.0
+shapecode_3_g2=1.0
+shapecode_3_b2=1.0
+shapecode_3_a2=1.0
+shapecode_3_border_r=1.0
+shapecode_3_border_g=1.0
+shapecode_3_border_b=1.0
+shapecode_3_border_a=0.0
+shape_3_per_frame1=ang = rand(1001)*.001*6.2832;
+shape_3_per_frame2=tex_ang = ang;
+per_frame_1=warp = 0;
+per_frame_2=arot = 1.5708;
+per_frame_3=
+per_frame_4=
+per_frame_5=decay = 1;
+per_frame_6=
+per_frame_7=// for shapes
+per_frame_8=q1 = .1; // = a
+per_frame_9=q5 = .6; // = luminance
+per_frame_10=
+per_frame_11=tic = min(time-tin,.1);
+per_frame_12=tin = time;
+per_frame_13=
+per_frame_14=vol = (bass_att + treb_att + mid_att)*.333333;
+per_frame_15=
+per_frame_16=ra = 10;
+per_frame_17=treb_avg = tic*(treb_avg*(1/tic - ra) + ra*treb);
+per_frame_18=mid_avg = tic*(mid_avg*(1/tic - ra) + ra*mid);
+per_frame_19=bass_avg = tic*(bass_avg*(1/tic - ra) + ra*bass);
+per_frame_20=vav = tic*(vav*(1/tic - ra) + ra*(bass+treb+mid)*.33333);
+per_frame_21=
+per_frame_22=tt = tt + tic*treb;
+per_frame_23=mt = mt + tic*mid;
+per_frame_24=bt = bt + tic*bass;
+per_frame_25=vt = vt + tic*vav;
+per_frame_26=
+per_frame_27=sp = abs(vav - slide)*.1;
+per_frame_28=slide = if(above(slide,vav),slide-tic*sp,slide+tic*sp) + (1-toc)*vav*.2;
+per_frame_29=toc = 1;
+per_frame_30=
+per_frame_31=// for waves
+per_frame_32=q6 = bt;
+per_frame_33=q7 = mt;
+per_frame_34=q8 = tt;
+per_frame_35=q3 = slide;
 per_frame_36=
-per_frame_37=
+per_frame_37=q2 = vt*.5; // speed of opacity cycle
 per_frame_38=
-per_frame_39=ib_r = tan(time);
-per_frame_40=ib_r = min(1, max(ib_r,0));
-per_frame_41=
-per_frame_42=ib_g = tan(time+2.1);
-per_frame_43=ib_g = min(1, max(ib_g,0));
+per_frame_39=vrt = vrt + tic*min(1,max(0.1,2-vav));
+per_frame_40=
+per_frame_41=q4 = vrt*6; // = timecycle of hue
+per_frame_42=
+per_frame_43=zoom = 1 + pow(vav,4)*.2;
 per_frame_44=
-per_frame_45=ib_b = tan(time+4.2);
-per_frame_46=ib_b = min(1, max(ib_b,0));
-per_frame_47=
-per_frame_48=q3 = 10+8*(0.6*sin(0.223*time) + 0.4*sin(0.153*time));
-per_frame_49=q4 = 1/q3;
-per_frame_50=q5 = 0.5*sign(xpos);
-per_frame_51=q6 = 0.5*sign(ypos);
-per_frame_52=
-per_frame_53=monitor=q4;
-per_frame_54=
-per_frame_55=flip=-flip;
-per_frame_56=sx=flip;
-per_frame_57=
-per_pixel_1=cx = ((0&(x*q3-q5))+q5)*q4;
-per_pixel_2=cy = ((0&(y*q3-q6))+q6)*q4;
-per_pixel_3=newx = q1-x;
-per_pixel_4=newy = q2-y;
-per_pixel_5=newrad = sqrt((newx)*(newx)+0.5625*(newy)*(newy))*2;
-per_pixel_6=newzoom = pow(1.05 + 0.03*newrad, pow(0.01+sin(newrad*newrad), newrad*2-1));
-per_pixel_7=dx = (newx)*newzoom - newx;
-per_pixel_8=dy = (newy)*newzoom - newy;
-per_pixel_9=dx =dx*0.1;
-per_pixel_10=dy=dy*0.1;
-per_pixel_11=rot = 2*newrad*(0.5*(0.5-rad)+0.1);
-per_pixel_12=rot=rot*sin(time)*0.2;
-per_pixel_13=sy=1.2/newx;
-per_pixel_14=zoom=1.1
+per_frame_45=monitor = vav;
 `;

--- a/src/js/milkdrop/runtime/first-run-preset.ts
+++ b/src/js/milkdrop/runtime/first-run-preset.ts
@@ -3,36 +3,65 @@
  * history, no favorites, no `?preset=` deep link, or a requested preset that
  * this backend cannot render.
  *
- * This is a deliberate pick, not "whatever sorts first". The selection used to
- * fall through to the head of the curated sort order, which was
- * `eos-glowsticks-v2-03-music` — a preset that measures badly on the two things
- * a first impression actually depends on:
+ * A deliberate pick, and — since 2026-08-22 — a measured one. The choice has
+ * now been wrong twice for the same reason, so the criterion is written down
+ * here and enforced by a test rather than re-argued each time.
  *
- * | preset                                | reactive params | preview mean luma |
- * | ------------------------------------- | --------------- | ----------------- |
- * | eos-glowsticks-v2-03-music (previous) | 3 of 36         | 1.1 / 255         |
- * | krash-rovastar-cerebral-demons-stars  | 8 of 36         | 67.1 / 255        |
+ * The landing page makes exactly one claim: "full-screen visuals that move to
+ * whatever you're listening to". The first-run preset is the only proof of it
+ * most visitors ever see, so it has to be lit enough to look at and it has to
+ * visibly change when the music does.
  *
- * On the previous default every motion parameter — zoom, warp, rot, dx, dy, sx,
- * sy — measured 0.000 correlation with audio, so the one claim the landing page
- * makes ("visuals that move to whatever you're listening to") was not
- * demonstrated by the first thing anyone saw, and 98.6% of the frame was below
- * near-black.
+ * What the two previous defaults got wrong:
+ *
+ * - `eos-glowsticks-v2-03-music` was chosen by curated sort order and was
+ *   98.6% below near-black — nothing to look at.
+ * - `krash-rovastar-cerebral-demons-stars` replaced it on a *parameter count*
+ *   (8 of 36 variables read audio, against glowsticks' 3). That count did not
+ *   predict anything visible: the reactive variables were q1/q2/q8, wave
+ *   deviation and dx/dy-with-no-baseline, while zoom, rot, warp, sx, sy, cx,
+ *   cy and decay — every variable that moves the whole frame — measured
+ *   0.000. At the pixel level demo audio moved it no more than silence did.
+ *
+ * Measured on 2026-08-22 with `bun run lab:visual` (silence vs demo audio):
+ *
+ * | preset (webgpu)                      | mean luma | visible | ΔL demo−silence | motion ratio |
+ * | ------------------------------------ | --------- | ------- | --------------- | ------------ |
+ * | krash-rovastar-cerebral-demons-stars | 65.0      | 89%     | −1.9            | 0.93         |
+ * | shifter-glassworms-flare             | 45.6      | 84%     | −24.5           | 0.84         |
+ *
+ * A ΔL of −1.9 is the incumbent's whole answer to "does it react": audio
+ * changed the image by under 1% of the luminance range. Glassworms answers
+ * with −24.5 on the same instrument, and the gap is an order of magnitude
+ * wider than the run-to-run variance (repeat runs put it at −17 to −25).
+ *
+ * Known limit, recorded rather than hidden: the same preset measures
+ * ΔL −4.2 on WebGL, where it is also much brighter (mean luma 94). The two
+ * backends do not render this preset the same, which is a fidelity bug in its
+ * own right — but WebGPU is the production default, and on WebGL glassworms
+ * still responds twice as strongly as the preset it replaces (−4.2 vs −0.2).
+ *
+ * The measurements are checked in at `src/data/first-run-preset-evidence.json`
+ * and `tests/unit/bundled-first-run-preset.test.ts` fails when the shipped id
+ * stops matching them. Changing this id means re-measuring:
+ *
+ *   bun run lab:visual -- --preset <id> --renderer webgl
+ *   bun run generate:first-run-evidence
+ *   bun run lab:visual -- --preset <id> --renderer webgpu
+ *   bun run generate:first-run-evidence
+ *   bun run lab:reactivity -- --preset <id>
+ *   bun run generate:first-run-evidence
  *
  * This preset's source is also compiled into the bundle
  * (`runtime/default-preset.ts`) so the frames rendered before the catalog
  * arrives are already this preset rather than a placeholder. Changing the id
  * here means regenerating that file — the guard test names the command.
- *
- * Re-measure before changing this:
- *   bun run lab:reactivity -- --preset <id>
  */
-export const FIRST_RUN_PRESET_ID = 'krash-rovastar-cerebral-demons-stars';
+export const FIRST_RUN_PRESET_ID = 'shifter-glassworms-flare';
 
 /** Catalog metadata for {@link FIRST_RUN_PRESET_ID}, needed before the catalog loads. */
-export const FIRST_RUN_PRESET_TITLE =
-  'Krash & Rovastar - Cerebral Demons (Stars Remix)';
-export const FIRST_RUN_PRESET_AUTHOR = 'Krash & Rovastar';
+export const FIRST_RUN_PRESET_TITLE = 'Shifter - Glassworms - Flare';
+export const FIRST_RUN_PRESET_AUTHOR = 'Shifter';
 
 /**
  * Crossfade length used when nothing is stored in preferences yet.

--- a/src/js/milkdrop/runtime/session.ts
+++ b/src/js/milkdrop/runtime/session.ts
@@ -134,8 +134,16 @@ export const MAX_BLEND_WORKLOAD = 6000;
  * geometry submission for its duration, so the headroom check is the honest
  * gate: a machine hitting budget can afford it, one already dropping frames
  * cannot.
+ *
+ * 2x, not something tighter. Against a 60Hz budget this refuses below about
+ * 30fps and allows everything above it. An earlier 1.25x looked defensible
+ * on paper and refused a machine running a perfectly serviceable 45fps —
+ * which is most laptops driving a projector, i.e. exactly the case the
+ * blend exists for. A gate this one has to earn its refusals: a crossfade
+ * that silently does not happen is the failure mode this whole path is
+ * being repaired for.
  */
-const BLEND_FRAME_BUDGET_TOLERANCE = 1.25;
+const BLEND_FRAME_BUDGET_TOLERANCE = 2;
 
 export type BlendPressureSnapshot = {
   rollingAverageFrameMs: number | null;

--- a/src/js/milkdrop/runtime/transition-controller.ts
+++ b/src/js/milkdrop/runtime/transition-controller.ts
@@ -92,7 +92,11 @@ export function createMilkdropTransitionController() {
      * cut is `begin(null, ...)`, which settles immediately — one entry
      * point for both so the event log sees every switch.
      */
-    begin(nextBlendState: MilkdropBlendState | null, seconds: number) {
+    begin(
+      nextBlendState: MilkdropBlendState | null,
+      seconds: number,
+      cutReason?: string,
+    ) {
       if (phase === 'manual') {
         // A preset switch reaches this controller twice — once from the
         // navigation controller and once from the editor-session subscriber
@@ -112,7 +116,10 @@ export function createMilkdropTransitionController() {
         lastTickAt = null;
         record('blend-started', `${seconds.toFixed(2)}s`);
       } else {
-        record('cut');
+        // The detail is the whole point of the log here: "why did that
+        // switch cut instead of blending" needs an answer that distinguishes
+        // "you asked for a cut" from "a gate refused you a blend".
+        record('cut', cutReason);
         settle('cut');
       }
     },

--- a/tests/e2e/preset-crossfade.test.ts
+++ b/tests/e2e/preset-crossfade.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Crossfades actually happen.
+ *
+ * The blend path shipped, had a workload gate, and was unreachable: the
+ * threshold (900) sat below the corpus MINIMUM frame workload (1323 — the
+ * warp mesh alone contributes ~992), so every preset switch in the product
+ * silently became a hard cut and the blend-duration control did nothing.
+ * `milkdrop-blend-gate.test.ts` pins the threshold against measured corpus
+ * numbers; this test pins the thing that actually matters, end to end, in a
+ * browser that is really rendering.
+ *
+ * It has to be an e2e test. `beginPresetTransition` clones the CURRENT
+ * frame state to blend out of, and a hidden tab has none — the browser
+ * stops scheduling rAF entirely — so any harness whose page is not visibly
+ * rendering records a cut no matter how the gate is configured. That is
+ * exactly the trap that made the original bug look like it might be a
+ * measurement artifact.
+ */
+import { afterAll, beforeAll, expect } from 'bun:test';
+import { chromium } from 'playwright';
+import { hasChromium, requiredBrowserTest } from './browser-availability.ts';
+import { closeQuietly } from './deadline.ts';
+import { type DevServerHandle, startDevServer } from './dev-server.ts';
+import { HEADLESS, SOFTWARE_RENDERER_ARGS } from './webgl-launch.ts';
+
+const browserTest = requiredBrowserTest;
+const TEST_PORT = 5188;
+/** Light, always-bundled, and already used as the first-run preset. */
+const TARGET_PRESET_ID = 'geiss-experimental-lsb-bass-cubes';
+const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+let devServer: DevServerHandle | null = null;
+
+type TransitionEvent = { at: number; event: string; detail?: string };
+type AgentWindow = typeof window & {
+  __milkdropRuntimeDebug?: {
+    getTransition: () => {
+      phase: string;
+      crossfade: number | null;
+      events: ReadonlyArray<TransitionEvent>;
+    };
+  };
+  __stims_agent?: {
+    run: (
+      actionId: string,
+      params?: Record<string, unknown>,
+    ) => Promise<{ ok: boolean; error?: string }>;
+  };
+};
+
+beforeAll(
+  async () => {
+    if (!hasChromium) return;
+    devServer = await startDevServer({ port: TEST_PORT });
+  },
+  { timeout: 60000 },
+);
+
+afterAll(async () => {
+  const server = devServer;
+  devServer = null;
+  await server?.stop();
+});
+
+browserTest(
+  'a preset switch in blend mode crossfades instead of cutting',
+  async () => {
+    const browser = await chromium.launch({
+      headless: HEADLESS,
+      args: SOFTWARE_RENDERER_ARGS,
+    });
+    const ctx = await browser.newContext({
+      viewport: { width: 1280, height: 720 },
+      deviceScaleFactor: 1,
+    });
+    const page = await ctx.newPage();
+
+    try {
+      await page.goto(`${SERVER_URL}/?agent=true&renderer=webgl`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.waitForSelector('body[data-engine-state="ready"]', {
+        timeout: 30000,
+      });
+      await page.evaluate(() =>
+        (window as AgentWindow).__stims_agent?.run('audio-demo'),
+      );
+      await page.waitForSelector('body[data-engine-state="live"]', {
+        timeout: 20000,
+      });
+
+      // Frames must have been rendered before the switch: the outgoing
+      // frame state is what a crossfade blends FROM, and under a software
+      // renderer the first few frames take a while to arrive.
+      await page.waitForFunction(
+        () =>
+          ((window as AgentWindow).__milkdropRuntimeDebug?.getTransition()
+            ?.phase ?? null) !== null,
+        undefined,
+        { timeout: 10000 },
+      );
+      await page.waitForTimeout(3000);
+
+      await page.evaluate(() =>
+        (window as AgentWindow).__stims_agent?.run('transition-2s'),
+      );
+
+      const before = await page.evaluate(
+        () =>
+          (window as AgentWindow).__milkdropRuntimeDebug?.getTransition().events
+            .length ?? 0,
+      );
+
+      // A named target, not `next-preset`: which preset the shuffle lands
+      // on is random, and a heavy one can spend longer compiling under a
+      // software renderer than this test is willing to wait — a flaky
+      // failure that would say nothing about the gate.
+      const advance = await page.evaluate(
+        (presetId) =>
+          (window as AgentWindow).__stims_agent?.run('select-preset', {
+            id: presetId,
+          }),
+        TARGET_PRESET_ID,
+      );
+      expect(advance?.ok).toBe(true);
+
+      await page.waitForFunction(
+        (seen) => {
+          const events =
+            (window as AgentWindow).__milkdropRuntimeDebug?.getTransition()
+              .events ?? [];
+          return events.length > (seen as number);
+        },
+        before,
+        // Generous: under a software renderer a preset switch has to compile
+        // shaders before it can transition at all.
+        { timeout: 30000 },
+      );
+      await page.waitForTimeout(500);
+
+      const events: TransitionEvent[] = await page.evaluate(
+        (seen) =>
+          ((window as AgentWindow).__milkdropRuntimeDebug
+            ?.getTransition()
+            .events.slice(seen as number) ?? []) as TransitionEvent[],
+        before,
+      );
+
+      expect(events.length).toBeGreaterThan(0);
+
+      // What this pins is that the WORKLOAD gate never refuses a normal
+      // preset — the regression that made the whole blend path dead code.
+      //
+      // It deliberately does not demand a blend outright. CI renders through
+      // SwiftShader at a handful of frames per second, where the frame-
+      // pressure and thermal gates refuse crossfades for entirely correct
+      // reasons; asserting `blend-started` there would pin the renderer's
+      // speed, not the gate's logic. Each cut now carries its reason, so the
+      // one refusal that must never appear can be named exactly.
+      const workloadRefusals = events.filter(
+        (entry) => entry.event === 'cut' && entry.detail === 'workload',
+      );
+      expect(workloadRefusals).toEqual([]);
+
+      // And whatever did happen has to be an outcome the controller can
+      // account for, rather than silence.
+      const kinds = new Set(events.map((entry) => entry.event));
+      expect(
+        ['blend-started', 'cut', 'begin-ignored'].some((kind) =>
+          kinds.has(kind),
+        ),
+      ).toBe(true);
+    } finally {
+      await closeQuietly(page, ctx, browser);
+    }
+  },
+  { timeout: 120000 },
+);

--- a/tests/unit/arrival-url.test.ts
+++ b/tests/unit/arrival-url.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The arrival URL must be frozen at document load, not at the moment a lazy
+ * chunk happens to evaluate.
+ *
+ * The regression: `NewHomePage` read `location.search` at its own module
+ * scope. It is a lazy chunk, so on a cold cache it could evaluate *after* the
+ * app had already rewritten the address bar, read the app's own
+ * `?preset=` back, and auto-start a session on a bare "/" arrival.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  installDomEnvironment,
+  resetDomEnvironment,
+} from '../environment/dom.ts';
+import { importFresh } from '../test-helpers.ts';
+
+type ArrivalModule = typeof import('../../src/js/frontend/arrival-url.ts');
+
+const load = (search: string) => {
+  const domWindow = installDomEnvironment();
+  domWindow.happyDOM.setURL(`https://toil.fyi/${search}`);
+  return importFresh<ArrivalModule>('../../src/js/frontend/arrival-url.ts');
+};
+
+afterEach(() => {
+  resetDomEnvironment();
+});
+
+describe('arrival URL snapshot', () => {
+  test('reports the preset a deep link asked for', async () => {
+    const arrival = await load('?preset=aderrasi-potion-of-spirits');
+    expect(arrival.getArrivalPresetId()).toBe('aderrasi-potion-of-spirits');
+  });
+
+  test('reports no preset for a bare arrival', async () => {
+    const arrival = await load('');
+    expect(arrival.getArrivalPresetId()).toBeNull();
+  });
+
+  test('ignores a preset the app writes into the URL after load', async () => {
+    const arrival = await load('');
+    window.history.replaceState(null, '', '?preset=written-by-attract-mode');
+
+    expect(window.location.search).toBe('?preset=written-by-attract-mode');
+    expect(arrival.getArrivalPresetId()).toBeNull();
+  });
+
+  test('keeps reporting the visitor’s preset after the app rewrites the URL', async () => {
+    const arrival = await load('?preset=from-a-social-card');
+    window.history.replaceState(null, '', '?preset=autoplay-moved-on');
+
+    expect(arrival.getArrivalPresetId()).toBe('from-a-social-card');
+  });
+
+  test('reads other arrival parameters from the same snapshot', async () => {
+    const arrival = await load('?preset=one&collection=hall-of-fame');
+    expect(arrival.getArrivalParam('collection')).toBe('hall-of-fame');
+    expect(arrival.getArrivalParam('absent')).toBeNull();
+    expect(arrival.getArrivalSearch()).toBe(
+      '?preset=one&collection=hall-of-fame',
+    );
+  });
+});
+
+describe('arrival URL snapshot wiring', () => {
+  test('the entry module imports it eagerly, which is what pins it to document load', () => {
+    const entry = readFileSync(
+      join(import.meta.dir, '..', '..', 'src', 'js', 'app.ts'),
+      'utf8',
+    );
+
+    expect(entry).toMatch(/import '\.\/frontend\/arrival-url\.ts';/u);
+  });
+
+  test('the launch page reads the snapshot instead of live location', () => {
+    const homePage = readFileSync(
+      join(
+        import.meta.dir,
+        '..',
+        '..',
+        'src',
+        'js',
+        'frontend',
+        'NewHomePage.tsx',
+      ),
+      'utf8',
+    );
+
+    expect(homePage).toContain('getArrivalPresetId');
+    expect(homePage).not.toContain('window.location.search');
+  });
+});

--- a/tests/unit/audio-gesture-gate.test.ts
+++ b/tests/unit/audio-gesture-gate.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A suspended AudioContext is silent but looks active from every other
+ * signal: the session reports `audioActive`, the stage animates, the analyser
+ * reads zero. The deep-link path starts audio without a click on purpose, so
+ * that state is reachable by design — this gate is what lets the UI say so
+ * and take the message away the moment the click lands.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  isAudioAwaitingGesture,
+  reportAudioAwaitingGesture,
+  resetAudioGestureGate,
+  subscribeAudioGestureGate,
+} from '../../src/js/core/audio-gesture-gate.ts';
+
+afterEach(() => {
+  resetAudioGestureGate();
+});
+
+describe('audio gesture gate', () => {
+  test('starts closed, because nothing has started audio yet', () => {
+    expect(isAudioAwaitingGesture()).toBe(false);
+  });
+
+  test('notifies subscribers when audio starts out suspended', () => {
+    let notifications = 0;
+    subscribeAudioGestureGate(() => {
+      notifications += 1;
+    });
+
+    reportAudioAwaitingGesture(true);
+
+    expect(notifications).toBe(1);
+    expect(isAudioAwaitingGesture()).toBe(true);
+  });
+
+  test('does not re-notify on an unchanged value', () => {
+    let notifications = 0;
+    subscribeAudioGestureGate(() => {
+      notifications += 1;
+    });
+
+    reportAudioAwaitingGesture(true);
+    reportAudioAwaitingGesture(true);
+    reportAudioAwaitingGesture(true);
+
+    // Every `statechange` on every registered context calls through here; a
+    // notify per event would re-render the whole shell on each one.
+    expect(notifications).toBe(1);
+  });
+
+  test('closes again when the context resumes', () => {
+    const seen: boolean[] = [];
+    subscribeAudioGestureGate(() => {
+      seen.push(isAudioAwaitingGesture());
+    });
+
+    reportAudioAwaitingGesture(true);
+    reportAudioAwaitingGesture(false);
+
+    expect(seen).toEqual([true, false]);
+    expect(isAudioAwaitingGesture()).toBe(false);
+  });
+
+  test('unsubscribing stops notifications', () => {
+    let notifications = 0;
+    const unsubscribe = subscribeAudioGestureGate(() => {
+      notifications += 1;
+    });
+
+    unsubscribe();
+    reportAudioAwaitingGesture(true);
+
+    expect(notifications).toBe(0);
+    expect(isAudioAwaitingGesture()).toBe(true);
+  });
+});
+
+describe('audio gesture gate wiring', () => {
+  test('audio-handler publishes the gate from real context state', async () => {
+    const source = await Bun.file('src/js/core/audio-handler.ts').text();
+
+    // The gate must be recomputed from the live contexts, not set optimistically
+    // at start: the browser can resume on its own, and a stale `true` would
+    // leave "click for sound" on screen over working audio.
+    expect(source).toContain('reportAudioAwaitingGesture');
+    expect(source).toMatch(/addEventListener\('statechange'/u);
+    expect(source).toMatch(/function publishGestureGate\(\)/u);
+    // Registering and unregistering both republish, so the notice cannot
+    // survive the session it describes.
+    expect(
+      source.match(/publishGestureGate\(\);/gu)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/bundled-first-run-preset.test.ts
+++ b/tests/unit/bundled-first-run-preset.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  FIRST_RUN_EVIDENCE_PATH,
+  resolveFirstRunPresetPath,
+} from '../../scripts/generate-first-run-evidence.ts';
 import { compileMilkdropPresetSource } from '../../src/js/milkdrop/compiler.ts';
 import { DEFAULT_MILKDROP_PRESET_SOURCE } from '../../src/js/milkdrop/runtime/default-preset.ts';
 import {
@@ -10,11 +15,10 @@ import {
 } from '../../src/js/milkdrop/runtime/first-run-preset.ts';
 
 const repoRoot = path.resolve(import.meta.dir, '../..');
-const presetPath = path.join(
-  repoRoot,
-  'public/milkdrop-presets',
-  `${FIRST_RUN_PRESET_ID}.milk`,
-);
+// Resolved through the catalog rather than assumed to sit at the top level:
+// the default can legitimately be a preset from one of the bundled libraries,
+// which live in subdirectories.
+const presetPath = resolveFirstRunPresetPath();
 const catalogPath = path.join(repoRoot, 'public/milkdrop-presets/catalog.json');
 
 function findCatalogEntry() {
@@ -34,10 +38,12 @@ describe('bundled first-run preset', () => {
     // The bundled copy exists so the pre-catalog frames are already the preset
     // startup selection will land on. If the two drift, the visitor sees one
     // preset and then a crossfade to a different one — the exact failure the
-    // copy was added to remove. Regenerate with:
-    //   bun -e "const raw = await Bun.file('public/milkdrop-presets/${FIRST_RUN_PRESET_ID}.milk').text(); \
+    // copy was added to remove. Regenerate with (splitting on the export, not
+    // on the first backtick — the docblock above it contains backticks too):
+    //   bun -e "const raw = await Bun.file(<the catalog's file for the preset>).text(); \
     //     const f = 'src/js/milkdrop/runtime/default-preset.ts'; const cur = await Bun.file(f).text(); \
-    //     await Bun.write(f, cur.slice(0, cur.indexOf('\`') + 1) + raw + '\`;\n')"
+    //     const m = 'export const DEFAULT_MILKDROP_PRESET_SOURCE = \`'; \
+    //     await Bun.write(f, cur.slice(0, cur.indexOf(m) + m.length) + raw + '\`;\n')"
     expect(DEFAULT_MILKDROP_PRESET_SOURCE).toBe(
       fs.readFileSync(presetPath, 'utf8'),
     );
@@ -77,5 +83,115 @@ describe('bundled first-run preset', () => {
 
     expect(compiled.source.id).toBe(FIRST_RUN_PRESET_ID);
     expect(compiled.ir).toBeDefined();
+  });
+});
+
+/**
+ * The measured bar the first-run preset has to clear.
+ *
+ * The default has now been wrong twice for the same reason — chosen on a
+ * proxy (curated sort order, then a count of audio-reading variables) that
+ * did not predict what the visitor sees. These thresholds are the product
+ * requirement stated numerically, checked against evidence recorded by
+ * `bun run generate:first-run-evidence`, so the next change to
+ * FIRST_RUN_PRESET_ID has to come with a measurement.
+ *
+ * They are set well clear of the run-to-run variance of `lab:visual` (repeat
+ * runs of the shipped preset put mean luminance at 33-46 and ΔL at -17 to
+ * -25) and well above the preset they replaced (ΔL -1.9, motion ratio 0.93).
+ */
+const EVIDENCE_BAR = {
+  /** Below this the frame is too dark to be the product's first impression. */
+  minMeanLuminance: 25,
+  /** Below this the frame is a few lit pixels on black, not an image. */
+  minVisiblePixelRatio: 0.3,
+  /**
+   * Either of these clears "the visuals move to what you're listening to":
+   * audio changes the frame's brightness, or it changes how much of the
+   * frame is moving. One of them must hold on the production backend.
+   */
+  minLuminanceDelta: 8,
+  minMotionRatioDelta: 0.12,
+} as const;
+
+/** WebGPU is what production selects wherever it is available. */
+const PRODUCTION_BACKEND = 'webgpu';
+
+describe('first-run preset evidence', () => {
+  const evidence = JSON.parse(
+    fs.readFileSync(FIRST_RUN_EVIDENCE_PATH, 'utf8'),
+  ) as {
+    presetId: string;
+    presetSha256: string;
+    backends: Record<
+      string,
+      {
+        meanLuminance: number;
+        visiblePixelRatio: number;
+        nearBlackFrameRatio: number;
+        luminanceDelta: number;
+        audioMotionRatio: number;
+      }
+    >;
+    reactivity?: {
+      motionBearing: Array<{ variable: string; correlation: number }>;
+    };
+  };
+
+  test('describes the preset that actually ships', () => {
+    // Swapping the id without re-measuring leaves the landing page making a
+    // claim backed by another preset's numbers.
+    expect(evidence.presetId).toBe(FIRST_RUN_PRESET_ID);
+  });
+
+  test('describes the preset bytes that actually ship', () => {
+    // Editing the .milk invalidates the measurement even when the id is
+    // unchanged.
+    const sha = createHash('sha256')
+      .update(fs.readFileSync(presetPath))
+      .digest('hex');
+
+    expect(evidence.presetSha256).toBe(sha);
+  });
+
+  test('is measured on both backends', () => {
+    expect(Object.keys(evidence.backends).sort()).toEqual(['webgl', 'webgpu']);
+  });
+
+  test('is bright enough to look at on both backends', () => {
+    for (const [backend, measured] of Object.entries(evidence.backends)) {
+      expect(
+        measured.meanLuminance,
+        `${backend} mean luminance`,
+      ).toBeGreaterThanOrEqual(EVIDENCE_BAR.minMeanLuminance);
+      expect(
+        measured.visiblePixelRatio,
+        `${backend} visible pixels`,
+      ).toBeGreaterThanOrEqual(EVIDENCE_BAR.minVisiblePixelRatio);
+      expect(measured.nearBlackFrameRatio, `${backend} near-black`).toBe(0);
+    }
+  });
+
+  test('visibly answers to audio on the production backend', () => {
+    const measured = evidence.backends[PRODUCTION_BACKEND];
+    expect(measured).toBeDefined();
+    if (!measured) return;
+
+    const brightnessResponse = Math.abs(measured.luminanceDelta);
+    const motionResponse = Math.abs(1 - measured.audioMotionRatio);
+
+    // Deliberately an OR: a preset may answer the music by changing what is
+    // lit or by changing how much moves, and either one is visible.
+    expect(
+      brightnessResponse >= EVIDENCE_BAR.minLuminanceDelta ||
+        motionResponse >= EVIDENCE_BAR.minMotionRatioDelta,
+    ).toBe(true);
+  });
+
+  test('drives at least one variable the whole frame moves with', () => {
+    // The trap that produced the last default: eight "reactive" variables,
+    // none of which moved the picture. q-vars and wave deviation do not
+    // count here — zoom, rot, warp, sx, sy, cx, cy, dx, dy and decay do.
+    expect(evidence.reactivity?.motionBearing?.length ?? 0).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/engine-route-publish.test.ts
+++ b/tests/unit/engine-route-publish.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guards the address bar against attract mode.
+ *
+ * The regression: a bare "/" arrival mounts the engine purely as decoration
+ * behind the launch card, the runtime picks a first-run preset, and that pick
+ * used to be published into the URL. Reload or Back then landed on
+ * `/?preset=<first-run-id>`, which the deep-link path reads as "came to watch
+ * this preset" and auto-starts demo audio — so the landing page could never be
+ * seen a second time, and its URL was not safe to copy.
+ */
+import { describe, expect, test } from 'bun:test';
+import { decideEngineRoutePublish } from '../../src/js/frontend/engine-route-publish.ts';
+
+const base = {
+  runtimeReady: true,
+  activePresetId: 'preset-a' as string | null | undefined,
+  audioActive: false,
+  routePresetId: null as string | null,
+};
+
+describe('decideEngineRoutePublish', () => {
+  test('keeps the attract-mode preset out of a bare arrival URL', () => {
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        audioActive: false,
+        routePresetId: null,
+      }),
+    ).toBe('attract-only');
+  });
+
+  test('publishes once the visitor starts an audio source', () => {
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        audioActive: true,
+        routePresetId: null,
+      }),
+    ).toBe('publish');
+  });
+
+  test('publishes when the URL already names a preset, so autoplay keeps the link current', () => {
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        activePresetId: 'preset-b',
+        audioActive: false,
+        routePresetId: 'preset-a',
+      }),
+    ).toBe('publish');
+  });
+
+  test('still publishes for a deep link whose audio has not started yet', () => {
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        audioActive: false,
+        routePresetId: 'preset-a',
+      }),
+    ).toBe('publish');
+  });
+
+  test('waits for the runtime before writing anything', () => {
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        runtimeReady: false,
+        audioActive: true,
+      }),
+    ).toBe('runtime-not-ready');
+  });
+
+  test('has nothing to publish before a preset is applied', () => {
+    for (const activePresetId of [null, undefined, '']) {
+      expect(
+        decideEngineRoutePublish({
+          ...base,
+          activePresetId,
+          audioActive: true,
+        }),
+      ).toBe('no-active-preset');
+    }
+  });
+
+  test('a stopped session keeps tracking, because the URL is already the visitor’s', () => {
+    // Stopping audio does not un-choose the preset they are looking at.
+    expect(
+      decideEngineRoutePublish({
+        ...base,
+        audioActive: false,
+        routePresetId: 'preset-a',
+        activePresetId: 'preset-b',
+      }),
+    ).toBe('publish');
+  });
+});

--- a/tests/unit/milkdrop-blend-gate.test.ts
+++ b/tests/unit/milkdrop-blend-gate.test.ts
@@ -88,16 +88,19 @@ describe('blend gate', () => {
     expect(
       evaluateBlendGate(CORPUS_MEDIAN, {
         ...HEALTHY,
-        rollingAverageFrameMs: 30,
+        // ~14fps against a 60Hz budget.
+        rollingAverageFrameMs: 70,
       }),
     ).toEqual({ canBlend: false, refusal: 'frame-pressure' });
   });
 
-  test('mild overrun stays inside tolerance', () => {
+  test('a serviceable frame rate still crossfades', () => {
+    // 45fps on a laptop driving a projector is the normal case the blend
+    // exists for, not a machine in trouble. A tighter tolerance refused it.
     expect(
       evaluateBlendGate(CORPUS_MEDIAN, {
         ...HEALTHY,
-        rollingAverageFrameMs: 18,
+        rollingAverageFrameMs: 22,
       }).canBlend,
     ).toBe(true);
   });

--- a/tests/unit/milkdrop-feedback-composite-profile.test.ts
+++ b/tests/unit/milkdrop-feedback-composite-profile.test.ts
@@ -97,7 +97,13 @@ test('samples warp textures in warp-stage UV space inside the feedback blend sha
   }
 });
 
-test('keeps the legacy echo path projectM-like by avoiding extra frame-mix fusion', () => {
+/**
+ * The internal frame carries the feedback loop for every preset. It used to
+ * blend history in by `videoEchoAlpha` for control-driven presets, which
+ * meant a preset with no video echo threw its history away every frame —
+ * fDecay was inert and no warp variable could accumulate.
+ */
+test('carries feedback for control-driven presets, not just echo ones', () => {
   const manager = createSharedMilkdropFeedbackManager(
     320,
     180,
@@ -108,13 +114,13 @@ test('keeps the legacy echo path projectM-like by avoiding extra frame-mix fusio
   };
 
   try {
-    expect(manager.feedbackBlendMaterial.fragmentShader).toContain(
-      'clamp(videoEchoAlpha, 0.0, 1.0)',
-    );
-    expect(manager.feedbackBlendMaterial.fragmentShader).not.toContain(
-      'clamp(mixAlpha, 0.0, 1.0)',
-    );
-    expect(manager.feedbackBlendMaterial.fragmentShader).not.toContain(
+    const shader = manager.feedbackBlendMaterial.fragmentShader;
+    // History is composited under this frame's geometry by its coverage...
+    expect(shader).toContain('previousColor * (1.0 - coverage) + current.rgb');
+    // ...and never gated on the echo amount.
+    expect(shader).not.toContain('clamp(videoEchoAlpha, 0.0, 1.0)');
+    expect(shader).not.toContain('clamp(mixAlpha, 0.0, 1.0)');
+    expect(shader).not.toContain(
       'color = mix(color, current.rgb, clamp(currentFrameBoost',
     );
   } finally {

--- a/tests/unit/milkdrop-feedback-manager-webgpu.test.ts
+++ b/tests/unit/milkdrop-feedback-manager-webgpu.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { RepeatWrapping, SRGBColorSpace, Texture, TextureLoader } from 'three';
+import {
+  Color,
+  PerspectiveCamera,
+  RepeatWrapping,
+  Scene,
+  SRGBColorSpace,
+  Texture,
+  TextureLoader,
+} from 'three';
 import {
   createMilkdropWebGPUFeedbackManager,
   resolveDirectShaderConstructorPattern,
@@ -492,4 +500,70 @@ test('binds resolved custom sampler textures through the shared MilkDrop texture
   expect(first?.textureFile).toBe('water_caustics.png');
   expect(first?.texture).toBe(second?.texture);
   expect(bindCustomMilkdropSamplerTexture('sampler_missing', null)).toBeNull();
+});
+
+/**
+ * The native WebGPU feedback loop used to draw the fresh scene into the scene
+ * target with the renderer's own clear settings and the scene's background
+ * still attached. Both are opaque — the renderer is built with `alpha: false`,
+ * so three.js clears to alpha 1, and `Scene.background` paints across the
+ * target — which left every pixel reading as covered, so the blend pass could
+ * not tell drawn geometry from empty space. The WebGL path was fixed for this;
+ * WebGPU kept the old behaviour.
+ */
+test('draws the scene pass over a transparent black clear, background off', () => {
+  const manager = createMilkdropWebGPUFeedbackManager(64, 64) as {
+    render: (
+      renderer: unknown,
+      scene: Scene,
+      camera: PerspectiveCamera,
+    ) => void;
+    dispose: () => void;
+  };
+  const scene = new Scene();
+  const background = new Color(0x223344);
+  scene.background = background;
+  const camera = new PerspectiveCamera();
+
+  const appClearColor = new Color(0x112233);
+  let clearColor = appClearColor.clone();
+  let clearAlpha = 1;
+  const scenePassState: Array<{
+    background: Color | null;
+    clear: [number, number];
+  }> = [];
+
+  const renderer = {
+    setRenderTarget: () => {},
+    render: (rendered: Scene) => {
+      if (rendered !== scene) return;
+      scenePassState.push({
+        background: rendered.background as Color | null,
+        clear: [clearColor.getHex(), clearAlpha],
+      });
+    },
+    getClearAlpha: () => clearAlpha,
+    getClearColor: (target: Color) => target.copy(clearColor),
+    setClearColor: (color: number | Color, alpha = 1) => {
+      clearColor =
+        typeof color === 'number' ? new Color(color) : (color as Color).clone();
+      clearAlpha = alpha;
+    },
+  };
+
+  try {
+    manager.render(renderer, scene, camera);
+
+    expect(scenePassState).toHaveLength(1);
+    // Alpha means "geometry drew here", and the clear colour must not tint the
+    // loop with the app's theme.
+    expect(scenePassState[0]?.clear).toEqual([0x000000, 0]);
+    expect(scenePassState[0]?.background).toBeNull();
+    // The display's own settings survive the pass.
+    expect(scene.background).toBe(background);
+    expect(clearColor.getHex()).toBe(appClearColor.getHex());
+    expect(clearAlpha).toBe(1);
+  } finally {
+    manager.dispose();
+  }
 });

--- a/tests/unit/play-toy.test.ts
+++ b/tests/unit/play-toy.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, test } from 'bun:test';
+import sharp from 'sharp';
 import {
   buildPlayToyArtifactStem,
   buildPlayToyPerformanceMetrics,
@@ -222,41 +223,100 @@ test('shouldUseCanvasBitmapCapture only keeps bitmap capture when the live canva
   ).toBe(false);
 });
 
-test('captureActiveToyCanvas isolates undersized backing buffers from shell overlays', async () => {
-  const outputPath = '/tmp/stims-canvas-capture-regression.png';
-  const screenshot = mock(async ({ path }: { path: string }) => {
-    expect(path).toBe(outputPath);
-  });
-  let evaluateCall = 0;
-  const evaluate = mock(async () => {
-    evaluateCall += 1;
-    if (evaluateCall === 1) {
-      return {
-        bitmapWidth: 910,
-        bitmapHeight: 518,
-        rectWidth: 1215,
-        rectHeight: 690,
-        viewportWidth: 1280,
-        viewportHeight: 720,
-      };
-    }
-    if (evaluateCall === 2) {
-      return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVR4nGNgYGD4DwABBAEAX+XDSwAAAABJRU5ErkJggg==';
-    }
-    return null;
-  });
-  const locator = {
-    screenshot,
-  };
+/**
+ * The capture path changed shape: it screenshots the canvas *element* with
+ * siblings hidden by visibility (what lab:visual has always done and what
+ * survives on WebGPU), and refuses a frame with no picture in it rather than
+ * writing it as evidence. The compositor clip is the second chance, not the
+ * first.
+ */
+test('captureActiveToyCanvas screenshots the canvas element', async () => {
+  const outputPath = '/tmp/stims-canvas-capture-element.png';
+  // Two different pixels, so the blank-frame guard keeps it.
+  const png = await sharp({
+    create: {
+      width: 2,
+      height: 1,
+      channels: 3,
+      background: { r: 0, g: 0, b: 0 },
+    },
+  })
+    .composite([
+      {
+        input: {
+          create: {
+            width: 1,
+            height: 1,
+            channels: 3,
+            background: { r: 255, g: 255, b: 255 },
+          },
+        },
+        left: 0,
+        top: 0,
+      },
+    ])
+    .png()
+    .toBuffer();
+  const elementScreenshot = mock(async () => png);
+  const pageScreenshot = mock(async () => png);
   const page = {
-    evaluate,
-    viewportSize: () => ({ width: 1280, height: 720 }),
-    locator: () => locator,
+    evaluate: mock(async () => ({
+      bitmapWidth: 910,
+      bitmapHeight: 518,
+      rectX: 0,
+      rectY: 0,
+      rectWidth: 1215,
+      rectHeight: 690,
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      backend: 'webgl',
+    })),
+    viewportSize: () => ({ width: 4, height: 2 }),
+    locator: () => ({ first: () => ({ screenshot: elementScreenshot }) }),
+    screenshot: pageScreenshot,
   } as never;
 
   expect(await captureActiveToyCanvas(page, outputPath)).toBe(true);
+  expect(elementScreenshot).toHaveBeenCalledTimes(1);
+  // The compositor path is only the fallback for a blank element capture.
+  expect(pageScreenshot).toHaveBeenCalledTimes(0);
+});
 
-  expect(screenshot).toHaveBeenCalledTimes(0);
+test('captureActiveToyCanvas refuses a frame with no picture in it', async () => {
+  const outputPath = '/tmp/stims-canvas-capture-blank.png';
+  const blank = await sharp({
+    create: {
+      width: 2,
+      height: 2,
+      channels: 3,
+      background: { r: 0, g: 0, b: 0 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const elementScreenshot = mock(async () => blank);
+  const pageScreenshot = mock(async () => blank);
+  const page = {
+    evaluate: mock(async () => ({
+      bitmapWidth: 1142,
+      bitmapHeight: 648,
+      rectX: 15,
+      rectY: 10,
+      rectWidth: 1265,
+      rectHeight: 720,
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      backend: 'webgpu',
+    })),
+    viewportSize: () => ({ width: 4, height: 4 }),
+    locator: () => ({ first: () => ({ screenshot: elementScreenshot }) }),
+    screenshot: pageScreenshot,
+  } as never;
+
+  expect(await captureActiveToyCanvas(page, outputPath)).toBe(false);
+  // Both paths tried before giving up, and neither result was kept.
+  expect(elementScreenshot).toHaveBeenCalledTimes(1);
+  expect(pageScreenshot).toHaveBeenCalledTimes(1);
 });
 
 test('captureActiveToyCanvas fails closed when WebGL pixel reads are unavailable', async () => {
@@ -284,49 +344,6 @@ test('captureActiveToyCanvas fails closed when WebGL pixel reads are unavailable
     false,
   );
   expect(screenshot).toHaveBeenCalledTimes(0);
-});
-
-test('captureActiveToyCanvas uses compositor pixels for native WebGPU canvases', async () => {
-  const png = Buffer.from(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVR4nGNgYGD4DwABBAEAX+XDSwAAAABJRU5ErkJggg==',
-    'base64',
-  );
-  const screenshot = mock(async () => png);
-  let evaluateCall = 0;
-  const page = {
-    evaluate: mock(async (callback: unknown) => {
-      evaluateCall += 1;
-      if (evaluateCall === 1) {
-        return {
-          bitmapWidth: 1142,
-          bitmapHeight: 648,
-          rectX: 15,
-          rectY: 10,
-          rectWidth: 1265,
-          rectHeight: 720,
-          viewportWidth: 1280,
-          viewportHeight: 720,
-          backend: 'webgpu',
-        };
-      }
-      if (evaluateCall === 2) {
-        expect(String(callback)).not.toContain('body * { visibility: hidden');
-        expect(String(callback)).toContain(':has(canvas[');
-      }
-      return undefined;
-    }),
-    viewportSize: () => ({ width: 1280, height: 720 }),
-    screenshot,
-  } as never;
-  const outputPath = '/tmp/stims-webgpu-compositor-capture.png';
-
-  expect(await captureActiveToyCanvas(page, outputPath)).toBe(true);
-  expect(screenshot).toHaveBeenCalledTimes(1);
-  expect(screenshot).toHaveBeenCalledWith({
-    animations: 'disabled',
-    clip: { x: 15, y: 10, width: 1265, height: 720 },
-  });
-  expect(evaluateCall).toBe(3);
 });
 
 test('summarizePlayToyPerformanceSamples computes average and p95 frame timings', () => {

--- a/tests/unit/promote-projectm-reference.test.ts
+++ b/tests/unit/promote-projectm-reference.test.ts
@@ -144,6 +144,7 @@ test('promoteProjectMReference copies a projectM artifact into tracked fixtures 
         height: 3,
         warmupMs: 5000,
         captureOffsetMs: 0,
+        warmupFrames: 900,
       },
     }),
   );

--- a/tests/unit/stage-liveness.test.ts
+++ b/tests/unit/stage-liveness.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Attract mode boots the engine purely to put visuals behind the landing
+ * card. When that render is blank the page pays a GPU device and a full-rate
+ * render loop to composite nothing, so the runtime checks and pauses it.
+ *
+ * The check has one dangerous failure mode: compositing a WebGPU canvas into
+ * a 2D canvas can return fully transparent pixels instead of the frame, which
+ * looks exactly like a black image. Condemning a working render on that
+ * evidence would break the landing page for everyone it currently works for,
+ * so "no alpha anywhere" must report unknown, never blank.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  shouldRetireAttractRender,
+  summarizeStagePixels,
+} from '../../src/js/core/services/stage-liveness.ts';
+
+/** `count` RGBA pixels, all the same value. */
+function fill(
+  count: number,
+  [r, g, b, a]: [number, number, number, number],
+): Uint8ClampedArray {
+  const pixels = new Uint8ClampedArray(count * 4);
+  for (let i = 0; i < pixels.length; i += 4) {
+    pixels[i] = r;
+    pixels[i + 1] = g;
+    pixels[i + 2] = b;
+    pixels[i + 3] = a;
+  }
+  return pixels;
+}
+
+describe('summarizeStagePixels', () => {
+  test('a fully transparent readback is unknown, not blank', () => {
+    // The trap: every channel reads 0, so luminance alone says "black".
+    const verdict = summarizeStagePixels(fill(1024, [0, 0, 0, 0]));
+
+    expect(verdict.readable).toBe(false);
+    expect(verdict.visible).toBe(false);
+  });
+
+  test('an opaque black frame is blank', () => {
+    const verdict = summarizeStagePixels(fill(1024, [0, 0, 0, 255]));
+
+    expect(verdict.readable).toBe(true);
+    expect(verdict.visible).toBe(false);
+    expect(verdict.coverage).toBe(0);
+  });
+
+  test('a rendered frame is visible', () => {
+    const verdict = summarizeStagePixels(fill(1024, [180, 60, 200, 255]));
+
+    expect(verdict.readable).toBe(true);
+    expect(verdict.visible).toBe(true);
+    expect(verdict.coverage).toBe(1);
+    expect(verdict.maxLuma).toBeGreaterThan(80);
+  });
+
+  test('a near-black wash counts as blank, because nobody can see it either', () => {
+    const verdict = summarizeStagePixels(fill(1024, [4, 4, 4, 255]));
+
+    expect(verdict.readable).toBe(true);
+    expect(verdict.visible).toBe(false);
+  });
+
+  test('a dark frame with real content in it is visible', () => {
+    // The case the attract check must not kill: mostly dark, but drawing.
+    const pixels = fill(1024, [0, 0, 0, 255]);
+    for (let i = 0; i < 40 * 4; i += 4) {
+      pixels[i] = 200;
+      pixels[i + 1] = 220;
+      pixels[i + 2] = 255;
+    }
+
+    const verdict = summarizeStagePixels(pixels);
+
+    expect(verdict.visible).toBe(true);
+    expect(verdict.meanLuma).toBeLessThan(20);
+  });
+
+  test('a single stray bright pixel does not vouch for a frame', () => {
+    const pixels = fill(1024, [0, 0, 0, 255]);
+    pixels[0] = 255;
+    pixels[1] = 255;
+    pixels[2] = 255;
+
+    expect(summarizeStagePixels(pixels).visible).toBe(false);
+  });
+
+  test('an empty readback is unknown', () => {
+    expect(summarizeStagePixels(new Uint8ClampedArray(0)).readable).toBe(false);
+  });
+});
+
+describe('shouldRetireAttractRender', () => {
+  const blank = {
+    readable: true,
+    visible: false,
+    maxLuma: 0,
+    meanLuma: 0,
+    coverage: 0,
+  };
+  const rendering = {
+    readable: true,
+    visible: true,
+    maxLuma: 200,
+    meanLuma: 90,
+    coverage: 0.8,
+  };
+  const unknown = {
+    readable: false,
+    visible: false,
+    maxLuma: 0,
+    meanLuma: 0,
+    coverage: 0,
+  };
+
+  test('retires a render both samples agree is blank', () => {
+    expect(shouldRetireAttractRender([blank, blank])).toBe(true);
+  });
+
+  test('keeps a render either sample saw', () => {
+    expect(shouldRetireAttractRender([blank, rendering])).toBe(false);
+    expect(shouldRetireAttractRender([rendering, blank])).toBe(false);
+  });
+
+  test('keeps a render it could not read', () => {
+    // A browser whose canvas will not composite back must not have attract
+    // mode switched off for every visitor on it.
+    expect(shouldRetireAttractRender([unknown, unknown])).toBe(false);
+    expect(shouldRetireAttractRender([blank, unknown])).toBe(false);
+  });
+
+  test('a missing sample is not evidence', () => {
+    expect(shouldRetireAttractRender([blank, null])).toBe(false);
+    expect(shouldRetireAttractRender([])).toBe(false);
+  });
+});


### PR DESCRIPTION
An audit of what actually happens on a first load of toil.fyi, and the five fixes it produced. Each commit carries its own reasoning; this is the summary.

## The address bar was being written by the app

A bare `/` arrival mounts the engine as decoration behind the launch card, the runtime picks a first-run preset, and the engine→route sync published that pick into the URL. Nobody asked for it, and it cost three things: reload or Back landed on `/?preset=<id>`, which the deep-link path reads as "came to watch this preset" and auto-starts demo audio — so the landing page could not be seen twice; copying the URL off the landing page shared a link that skipped the landing page; and `NewHomePage`'s arrival check could read the app's own rewrite back and auto-start a session on a bare arrival.

`decideEngineRoutePublish` states the missing rule: the URL tracks the engine only once the visit is a session the visitor chose. The arrival check also moved onto a snapshot frozen at document load, because reading `location.search` at a lazy chunk's module scope loses the race on a cold cache.

## The first-run preset did not demonstrate the product's one claim

The default has been wrong twice for the same reason — chosen on a proxy that did not predict what the visitor sees. Measured at the pixel level with `lab:visual` on webgpu, silence vs demo audio:

| preset | mean luma | visible | ΔL | motion ratio |
| --- | --- | --- | --- | --- |
| krash-rovastar-cerebral-demons-stars (old) | 65.0 | 89% | −1.9 | 0.93 |
| shifter-glassworms-flare (new) | 45.6 | 84% | −24.5 | 0.84 |

A ΔL of −1.9 is under 1% of the luminance range: the landing page's claim was being disproved by the first thing anyone saw. Four other candidates were measured and rejected. The criterion is now enforced rather than argued — `src/data/first-run-preset-evidence.json` holds the numbers, the quality gate fails when they go stale, and the guard test fails when the shipped id, the preset's bytes, or the numbers stop clearing the bar.

## Attract mode was not asked to prove anything

It holds a GPU device open at full refresh rate purely so the landing page has visuals. If that render is blank the page pays for it and delivers nothing. It is now sampled and paused when blank — paused, not disposed, so Play demo stays instant. The alpha channel is checked before the luminance, because a canvas that will not composite back reads as a perfect black image and must report unknown rather than condemn a working render.

## Silence with no explanation

The deep-link path starts audio outside a user gesture, so autoplay policy leaves the context suspended and the session looks active while producing nothing. The resume-on-first-gesture handler was always there; what was missing was telling the visitor which click to make.

## Flash audit on the new default

`lab:flash-audit --beat-pulse`, 300 deterministic frames: peak 0 flashes/s, 0 red flashes/s, `flashRiskLevel: "none"`. Merged into the catalog so the measurement reaches the UI.

---

`bun run check` passes (2633 tests). Known and pre-existing on main: `tests/e2e/e2e-engine-mount.test.ts` fails on stale microphone-constraint expectations left behind by 94f89dac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)