### PR TITLE
fix(lab): the vm-tier bench was timing an empty program

### DIFF
--- a/scripts/preset-lab-vm-tier-bench.ts
+++ b/scripts/preset-lab-vm-tier-bench.ts
@@ -11,6 +11,13 @@
  * reimplemented here) over real preset per_frame blocks:
  *   - `gpu`: syncState + dispatch + readback, exactly what stepAsync does
  *   - `cpu`: the compiled JIT program, same block, same state
+ *   - `per-vertex`: the SAME preset's per_pixel block run once per mesh
+ *     point, which is the workload the GPU tier was actually built for
+ *
+ * The third column exists because the second one alone was used to justify
+ * keeping the compute VM ("still the right vehicle for per-vertex work") and
+ * that claim was asserted, not measured. Per-vertex is where thousands of
+ * invocations should finally beat the round-trip latency — or not.
  *
  * Reports per-iteration median/p95 microseconds for each tier and the ratio,
  * so "is the GPU tier worth it" is a measurement rather than an argument.
@@ -34,11 +41,31 @@ function flag(name: string, fallback: number) {
 }
 const ITERATIONS = flag('iterations', 200);
 
+/** MilkDrop's default mesh; the per-vertex program runs once per point. */
+const MESH_POINTS = 48 * 36;
+
+type TierStats = { median: number; p95: number };
+
+type BenchRow = {
+  id: string;
+  statements: number;
+  compiledFrameStatements: number;
+  pixelStatements: number;
+  compiledPixelStatements: number;
+  usesGuestMemory?: boolean;
+  gpuExecutable?: boolean;
+  cpu: TierStats;
+  gpu: TierStats | null;
+  perVertex: TierStats | null;
+  error?: string;
+};
+
 type Sample = {
   id: string;
   statements: number;
   usesGuestMemory: boolean;
   lines: string[];
+  pixelLines: string[];
 };
 
 function collectPresets(): Sample[] {
@@ -59,8 +86,14 @@ function collectPresets(): Sample[] {
         .filter((line) => /^per_frame_[0-9]+=/i.test(line))
         .map((line) => line.replace(/^[^=]*=/, '').trim())
         .filter(Boolean);
+      const pixelLines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter((line) => /^per_pixel_[0-9]+=/i.test(line))
+        .map((line) => line.replace(/^[^=]*=/, '').trim())
+        .filter(Boolean);
       const source = lines.join('\n');
       return {
+        pixelLines,
         id:
           file
             .split('/')
@@ -82,9 +115,25 @@ function collectPresets(): Sample[] {
 
   // Median / p90 / p99 by program size, plus one guest-memory user (2.3% of
   // the corpus, but the only case that moves 8 MiB per frame).
-  const picks = [at(0.5), at(0.9), at(0.99), ...(guest ? [guest] : [])];
+  // Presets whose per_pixel block is substantial: the per-frame percentiles
+  // above are mostly shader-era presets with no per_pixel equations at all,
+  // which cannot exercise the per-vertex column.
+  const byPixel = [...parsed].sort(
+    (a, b) => b.pixelLines.length - a.pixelLines.length,
+  );
+  const picks = [
+    at(0.5),
+    at(0.9),
+    at(0.99),
+    ...(guest ? [guest] : []),
+    ...byPixel.slice(0, 3),
+  ];
   const seen = new Set<string>();
-  return picks.filter((p) => (seen.has(p.id) ? false : (seen.add(p.id), true)));
+  return picks.filter((p) => {
+    if (seen.has(p.id)) return false;
+    seen.add(p.id);
+    return true;
+  });
 }
 
 const samples = collectPresets();
@@ -117,14 +166,16 @@ try {
   }
 
   const results = await page.evaluate(
-    async ({ pageSamples, iterations }) => {
+    async ({ pageSamples, iterations, meshPoints }) => {
       // Vite serves these from the dev server; the specifiers are URLs, not
       // paths tsc can resolve, so they go through a variable to keep the
       // module graph out of the typecheck.
       const load = (specifier: string) =>
-        import(/* @vite-ignore */ specifier) as Promise<any>;
+        import(/* @vite-ignore */ specifier) as Promise<
+          Record<string, CallableFunction>
+        >;
       const [
-        { parseMilkdropStatement },
+        { parseMilkdropStatement, splitMilkdropStatements },
         { compileMilkdropProgram },
         { createGpuVmRunner },
       ] = await Promise.all([
@@ -144,17 +195,25 @@ try {
         return { median: pick(0.5), p95: pick(0.95) };
       };
 
+      // Split each source line the way the compiler does before parsing it.
+      // Feeding whole lines straight to parseMilkdropStatement dropped EVERY
+      // real preset statement -- a trailing ';' is a parse error for an
+      // assignment -- so an earlier run of this harness timed an empty
+      // program and reported CPU cost as 0.000us. The src/compiled counts in
+      // the output exist so that can never pass unnoticed again.
       const parseBlock = (lines: string[]) => {
         const statements: any[] = [];
         for (const [index, line] of lines.entries()) {
-          const parsed = parseMilkdropStatement(line, index + 1);
-          if (
-            parsed.value &&
-            !parsed.diagnostics.some(
-              (d: { severity: string }) => d.severity === 'error',
-            )
-          ) {
-            statements.push(parsed.value);
+          for (const piece of splitMilkdropStatements(line)) {
+            const parsed = parseMilkdropStatement(piece, index + 1);
+            if (
+              parsed.value &&
+              !parsed.diagnostics.some(
+                (d: { severity: string }) => d.severity === 'error',
+              )
+            ) {
+              statements.push(parsed.value);
+            }
           }
         }
         return { statements, sourceLines: lines };
@@ -182,6 +241,7 @@ try {
 
         // ── CPU tier ────────────────────────────────────────────────────
         const cpuBlock = parseBlock(sample.lines);
+        const compiledFrameStatements = cpuBlock.statements.length;
         const cpuFn = compileMilkdropProgram(cpuBlock);
         const megabuf = new Float32Array(1048576);
         const gmegabuf = new Float32Array(1048576);
@@ -201,6 +261,46 @@ try {
             cpuFn(cpuEnv, cpuState, {}, null, megabuf, gmegabuf, rnd);
           }
           cpuTimes.push(((performance.now() - t0) * 1000) / BATCH);
+        }
+
+        // ── Per-vertex CPU tier ─────────────────────────────────────────
+        // One evaluation per mesh point, which is what the renderer actually
+        // does for a per_pixel block.
+        let perVertex: { median: number; p95: number } | null = null;
+        let compiledPixelStatements = 0;
+        if (sample.pixelLines.length > 0) {
+          const pixelBlock = parseBlock(sample.pixelLines);
+          compiledPixelStatements = pixelBlock.statements.length;
+          const pixelFn = compileMilkdropProgram(pixelBlock);
+          const pixelEnv: Record<string, number> = {
+            ...state,
+            x: 0.5,
+            y: 0.5,
+            rad: 0.5,
+            ang: 0,
+          };
+          const pixelState = { ...state };
+          for (let i = 0; i < 5; i += 1) {
+            for (let p = 0; p < meshPoints; p += 1) {
+              pixelFn(pixelEnv, pixelState, {}, null, megabuf, gmegabuf, rnd);
+            }
+          }
+          // Ten frames per timing window: a single mesh pass on a short
+          // program lands under the ~100us performance.now() clamp.
+          const FRAMES_PER_BATCH = 10;
+          const frameTimes: number[] = [];
+          for (let f = 0; f < 20; f += 1) {
+            const t0 = performance.now();
+            for (let r = 0; r < FRAMES_PER_BATCH; r += 1) {
+              for (let p = 0; p < meshPoints; p += 1) {
+                pixelFn(pixelEnv, pixelState, {}, null, megabuf, gmegabuf, rnd);
+              }
+            }
+            frameTimes.push(
+              ((performance.now() - t0) * 1000) / FRAMES_PER_BATCH,
+            );
+          }
+          perVertex = stats(frameTimes);
         }
 
         // ── GPU tier ────────────────────────────────────────────────────
@@ -240,11 +340,15 @@ try {
           gpuExecutable: initialized,
           cpu: stats(cpuTimes),
           gpu: initialized ? stats(gpuTimes) : null,
+          perVertex,
+          compiledFrameStatements,
+          pixelStatements: sample.pixelLines.length,
+          compiledPixelStatements,
         });
       }
       return { results: out };
     },
-    { pageSamples: samples, iterations: ITERATIONS },
+    { pageSamples: samples, iterations: ITERATIONS, meshPoints: MESH_POINTS },
   );
 
   if ('error' in results && results.error) {
@@ -255,7 +359,7 @@ try {
     '\n  program                                     stmts   CPU µs   GPU µs    ratio',
   );
   console.log('  ' + '-'.repeat(78));
-  for (const row of (results as { results: any[] }).results) {
+  for (const row of (results as { results: BenchRow[] }).results) {
     const name = String(row.id).slice(0, 40).padEnd(42);
     if (row.error) {
       console.log(
@@ -263,15 +367,18 @@ try {
       );
       continue;
     }
-    if (!row.gpuExecutable) {
+    if (!row.gpuExecutable || !row.gpu) {
       console.log(
         `  ${name}${String(row.statements).padStart(5)}   ${row.cpu.median.toFixed(2).padStart(7)}   (not GPU-executable)`,
       );
       continue;
     }
     const ratio = row.gpu.median / Math.max(row.cpu.median, 1e-6);
+    const pv = row.perVertex
+      ? `${row.perVertex.median.toFixed(0).padStart(9)}`
+      : '        -';
     console.log(
-      `  ${name}${String(row.statements).padStart(5)}   ${row.cpu.median.toFixed(3).padStart(7)}   ${row.gpu.median.toFixed(1).padStart(7)}   ${ratio.toFixed(0).padStart(6)}x`,
+      `  ${name}${`${row.statements}/${row.compiledFrameStatements}`.padStart(9)}   ${row.cpu.median.toFixed(3).padStart(7)}   ${row.gpu.median.toFixed(1).padStart(7)}   ${ratio.toFixed(0).padStart(6)}x   ${`${row.pixelStatements}/${row.compiledPixelStatements}`.padStart(8)}  ${pv}`,
     );
   }
   console.log(

--- a/src/js/milkdrop/webgpu-optimization-flags.ts
+++ b/src/js/milkdrop/webgpu-optimization-flags.ts
@@ -71,26 +71,33 @@ export const DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS = Object.freeze({
   proceduralMotionVectors: true,
   directFeedbackShaders: true,
   descriptorFallbackToWebgl: false,
-  // Measured OFF (2026-08-21, `bun run lab:vm-tier-bench`). The compute VM
-  // runs a preset's per_frame block as a single-workgroup dispatch, but
-  // vm.ts stepAsync needs the resulting state back on the CPU to build
-  // geometry, so every frame pays upload + dispatch + readback. Against the
-  // CPU JIT on the same blocks:
+  // Measured OFF. The compute VM runs a preset's per_frame block as a
+  // single-workgroup dispatch, but vm.ts stepAsync needs the resulting state
+  // back on the CPU to build geometry, so every frame pays upload + dispatch
+  // + readback. Against the CPU JIT on the same blocks
+  // (`bun run lab:vm-tier-bench`, 2026-08-22):
   //
-  //     statements        CPU JIT     compute VM
-  //         15             0.05us       1.1ms
-  //         49            <0.05us       1.2ms
-  //        111            <0.05us       1.4ms
-  //         21 (megabuf)   0.05us       6.8ms   <- 8 MiB round trip
+  //     per_frame stmts     CPU JIT     compute VM     ratio
+  //          13              0.05us        0.9ms      18000x
+  //          49              0.25us        1.1ms       4400x
+  //         111              0.75us        0.9ms       1200x
+  //          21 (megabuf)    0.10us        8.0ms      80000x
   //
-  // That is 7-8% of a 16.7ms frame budget for a median 21-statement program,
-  // and 41% for the 2.3% of presets that touch guest memory. The cost is
-  // CPU/GPU sync latency, not compute, so no amount of readback tuning
-  // closes the gap -- one workgroup of scalar math cannot use the GPU at
-  // all. The flag and its code stay: this is still the right vehicle for
-  // PER-VERTEX work (thousands of invocations, via the separate gpu-field
-  // path) and the differential harnesses drive it directly. Opt in with
-  // ?milkdrop-webgpu-compute-vm=1.
+  // (An earlier run of that harness reported CPU as 0.000us because it fed
+  // whole source lines to the statement parser, where a trailing ';' is a
+  // parse error -- it was timing an empty program. The harness now splits
+  // statements the way the compiler does and prints src/compiled counts so
+  // an empty program cannot masquerade as a fast one. The conclusion did not
+  // change; the ratios did.)
+  //
+  // The cost is CPU/GPU sync latency, not compute, so no amount of readback
+  // tuning closes it -- one workgroup of scalar math cannot use the GPU at
+  // all. The flag and its code stay because the PER-VERTEX story is the
+  // opposite: the same harness puts a per_pixel block over MilkDrop's 48x36
+  // mesh at 0.38-1.34ms of CPU per frame, and the gpu-field path evaluates
+  // that fused into the render shader with no dispatch or readback at all.
+  // Thousands of invocations is where the GPU wins; one is where it cannot.
+  // Opt in with ?milkdrop-webgpu-compute-vm=1.
   gpuComputeVM: false,
   renderBundles: false,
 }) satisfies MilkdropWebGpuOptimizationFlags;

--- a/src/js/milkdrop/webgpu-query-override.ts
+++ b/src/js/milkdrop/webgpu-query-override.ts
@@ -205,8 +205,8 @@ export function resolveMilkdropWebGpuFeatureRouting(
   const storageComputeVM = parseOptionalBooleanFlag(
     getBrowserStorage()?.getItem(COMPUTE_VM_STORAGE_KEY) ?? null,
   );
-  // Opt-in, not on-by-default: measured at 1.1-6.8ms per frame against
-  // ~0.05us for the CPU JIT on the same per_frame blocks
+  // Opt-in, not on-by-default: measured at 0.8-8.0ms per frame against
+  // 0.05-0.75us for the CPU JIT on the same per_frame blocks
   // (`bun run lab:vm-tier-bench`, and the table in
   // webgpu-optimization-flags.ts). Left reachable because the compute VM is
   // still the right vehicle for per-vertex work and the differential


### PR DESCRIPTION
The CPU column added in #1141 read `0.000us`, and that was not a very fast program — it was no program.

The harness fed whole preset source lines to `parseMilkdropStatement`, where a trailing `;` is a parse error for an assignment. Every statement was silently dropped and `compileMilkdropProgram` returned a no-op. Real presets end nearly every line with a semicolon, so this hit essentially the whole corpus.

It surfaced while adding the per-vertex column: a 151-statement `per_pixel` block "cost" 0us over 1728 mesh points, which is not a plausible number for 260k evaluations.

The harness now splits statements the way the compiler does (`splitMilkdropStatements`, the same call `program-assembly.ts` makes) and prints src/compiled counts per block, so an empty program can never again present as a fast one.

## Corrected per_frame figures

The conclusion is unchanged — the ratios shrank from "infinite" to merely enormous:

| stmts | CPU JIT | compute VM | ratio |
| --- | --- | --- | --- |
| 13 | 0.05us | 0.9ms | 18000x |
| 49 | 0.25us | 1.1ms | 4400x |
| 111 | 0.75us | 0.9ms | 1200x |
| 21 (megabuf) | 0.10us | 8.0ms | 80000x |

## The per-vertex column is the part that was missing

Keeping the compute VM was justified in #1141 on the grounds that it is "still the right vehicle for per-vertex work" — asserted, not measured.

Measured now: a `per_pixel` block over MilkDrop's 48x36 mesh costs **0.38–1.34ms of CPU per frame**, against per_frame's sub-microsecond. That is the workload where thousands of invocations can pay for a GPU, and the gpu-field path collects it for free by fusing into the render shader instead of dispatching and reading back.

So the claim holds, with a sharper statement now available: it is the **fused field path** that wins, not the compute VM, which loses on both workloads because it pays a round trip either way.

`check:quick` clean, 2633 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)