### PR TITLE
feat(a11y): prime the flash governor from the catalog's measurement

### DIFF
--- a/scripts/analyze-preset-flash.ts
+++ b/scripts/analyze-preset-flash.ts
@@ -22,6 +22,14 @@
  *   bun run scripts/analyze-preset-flash.ts --ids=a,b,c
  *   bun run scripts/analyze-preset-flash.ts --beat-pulse    # with kick transients
  *   bun run scripts/analyze-preset-flash.ts --out=report.json
+ *   bun run scripts/analyze-preset-flash.ts --governor       # with/without
+ *
+ * `--governor` measures each preset TWICE from one render pass: the raw
+ * timeline, and the timeline as the runtime flash governor
+ * (src/js/core/services/flash-governor.ts) would have presented it. That is
+ * the only honest way to check the governor against real content -- its unit
+ * tests use synthetic full-field strobes, which have none of the texture,
+ * localized flicker, or motion that real presets do.
  */
 
 import { writeFileSync } from 'node:fs';
@@ -62,6 +70,9 @@ interface PresetEntry {
 }
 
 export interface PresetFlashReport extends FlashAnalysis {
+  /** Peak flashes/s the runtime governor would have presented (--governor). */
+  governedPeakFlashesPerSecond?: number;
+  governedExceedsThreshold?: boolean;
   presetId: string;
   title: string;
   author: string;
@@ -69,6 +80,7 @@ export interface PresetFlashReport extends FlashAnalysis {
 }
 
 function parseArgs(argv: string[]) {
+  const governor = argv.includes('--governor');
   const get = (flag: string) =>
     argv
       .find((a) => a.startsWith(`--${flag}=`))
@@ -87,6 +99,7 @@ function parseArgs(argv: string[]) {
     port: Number(get('port') ?? DEFAULT_PORT),
     out: get('out') ?? DEFAULT_OUT,
     headless: !argv.includes('--no-headless'),
+    governor,
   };
 }
 
@@ -181,7 +194,7 @@ async function main() {
         );
 
         const captured = await page.evaluate(
-          ({
+          async ({
             frames,
             deltaMs,
             warmup,
@@ -189,6 +202,8 @@ async function main() {
             rows,
             beatPulse,
             SAMPLE_STRIDE,
+            useGovernor,
+            governorGrid,
           }) => {
             const step = window.__STIMS_AGENT_RENDER_FRAMES__;
             if (typeof step !== 'function') {
@@ -248,6 +263,39 @@ async function main() {
             // Warm up so feedback presets are measured at steady state.
             step({ frames: warmup, deltaMs, beatPulse });
 
+            // Governed track: the same frames as the viewer would have seen
+            // with the runtime governor engaged. Computed alongside the raw
+            // track from ONE render pass, so both are measured against
+            // identical pixels.
+            let governor: {
+              sample: (
+                t: number,
+                tiles: Float32Array,
+                c: number,
+                r: number,
+              ) => { luminanceScale: number };
+            } | null = null;
+            if (useGovernor) {
+              // Vite serves this from the dev server; the specifier is a URL
+              // rather than a path tsc can resolve, so it goes through a
+              // variable to keep the module graph out of the typecheck.
+              const governorModule = '/src/js/core/services/flash-governor.ts';
+              const mod = (await import(/* @vite-ignore */ governorModule)) as {
+                createFlashGovernor: () => typeof governor;
+                RECOMMENDED_GRID: number;
+              };
+              governor = mod.createFlashGovernor();
+              governorGrid = mod.RECOMMENDED_GRID;
+            }
+            const govTiles = new Float32Array(governorGrid * governorGrid);
+            const govTileAcc = new Float64Array(governorGrid * governorGrid);
+            const govTileCount = new Float64Array(governorGrid * governorGrid);
+            let govScale = 1;
+            let prevGovLum: Float64Array | null = null;
+            const curGovLum = new Float64Array(sampleCount);
+            const govRising: number[][] = [];
+            const govFalling: number[][] = [];
+
             let prevLum: Float64Array | null = null;
             const curLum = new Float64Array(sampleCount);
             // Red-flash channel per PEAT/Harding: value = max(0, R-G-B)*320
@@ -283,6 +331,48 @@ async function main() {
               }
               frameMeanLuminance.push(lumSum / sampleCount);
 
+              if (governor) {
+                // Reduce the sampled pixels to the governor's coarse grid,
+                // scaled by the mitigation already in force — the governor
+                // must observe what the viewer sees, not the raw frame, or
+                // it never registers its own effect.
+                govTileAcc.fill(0);
+                govTileCount.fill(0);
+                // Separate scales per axis: the audit grid is 32x18, not
+                // square, so reusing one factor left the bottom half of the
+                // governor's grid permanently zero and under-reported the
+                // flashing area.
+                const gx = governorGrid / cols;
+                const gy = governorGrid / rows;
+                for (let i = 0; i < sampleCount; i += 1) {
+                  const tile = sampleTile[i];
+                  const tx = Math.min(
+                    governorGrid - 1,
+                    Math.floor((tile % cols) * gx),
+                  );
+                  const ty = Math.min(
+                    governorGrid - 1,
+                    Math.floor(Math.floor(tile / cols) * gy),
+                  );
+                  const g = ty * governorGrid + tx;
+                  govTileAcc[g] += curLum[i] * govScale;
+                  govTileCount[g] += 1;
+                }
+                for (let g = 0; g < govTiles.length; g += 1) {
+                  govTiles[g] =
+                    govTileCount[g] > 0 ? govTileAcc[g] / govTileCount[g] : 0;
+                }
+                govScale = governor.sample(
+                  f * deltaMs,
+                  govTiles,
+                  governorGrid,
+                  governorGrid,
+                ).luminanceScale;
+                for (let i = 0; i < sampleCount; i += 1) {
+                  curGovLum[i] = curLum[i] * govScale;
+                }
+              }
+
               if (prevLum && prevRed && prevRedSat) {
                 // Magnitude is decided per pixel, against the full-scale
                 // WCAG threshold, BEFORE any spatial aggregation. Averaging
@@ -317,11 +407,34 @@ async function main() {
                     else redDown[sampleTile[i]] += 1;
                   }
                 }
+                if (governor && prevGovLum) {
+                  const gUp = new Array(tileCount).fill(0);
+                  const gDown = new Array(tileCount).fill(0);
+                  for (let i = 0; i < sampleCount; i += 1) {
+                    const before = prevGovLum[i];
+                    const after = curGovLum[i];
+                    if (
+                      Math.abs(after - before) >= 0.1 &&
+                      Math.min(before, after) < 0.8
+                    ) {
+                      if (after > before) gUp[sampleTile[i]] += 1;
+                      else gDown[sampleTile[i]] += 1;
+                    }
+                  }
+                  govRising.push(gUp);
+                  govFalling.push(gDown);
+                }
                 rising.push(up);
                 falling.push(down);
                 redRising.push(redUp);
                 redFalling.push(redDown);
                 frameMeanDelta.push(deltaSum / sampleCount);
+              }
+              if (governor) {
+                prevGovLum = prevGovLum
+                  ? prevGovLum
+                  : new Float64Array(sampleCount);
+                prevGovLum.set(curGovLum);
               }
               prevLum = prevLum ? prevLum : new Float64Array(sampleCount);
               prevLum.set(curLum);
@@ -338,6 +451,8 @@ async function main() {
               falling,
               redRising,
               redFalling,
+              govRising,
+              govFalling,
               tilePixels,
               frameMeanLuminance,
               frameMeanDelta,
@@ -351,6 +466,8 @@ async function main() {
             rows: TILE_ROWS,
             beatPulse: args.beatPulse,
             SAMPLE_STRIDE,
+            useGovernor: args.governor,
+            governorGrid: 16,
           },
         );
 
@@ -380,6 +497,8 @@ async function main() {
           falling: number[][];
           redRising: number[][];
           redFalling: number[][];
+          govRising: number[][];
+          govFalling: number[][];
           tilePixels: number;
           frameMeanLuminance: number[];
           frameMeanDelta: number[];
@@ -399,14 +518,40 @@ async function main() {
           frameMeanLuminance: cap.frameMeanLuminance,
           frameMeanDelta: cap.frameMeanDelta,
         });
+        // Same render pass, scored again as the governor would have shown
+        // it. Only the general-flash channel: the governor scales luminance,
+        // which is not a claim about the red-flash criterion.
+        const governed =
+          args.governor && cap.govRising.length > 0
+            ? analyzeFlashEvents({
+                rising: cap.govRising,
+                falling: cap.govFalling,
+                redRising: cap.redRising,
+                redFalling: cap.redFalling,
+                tilePixels: cap.tilePixels,
+                cols: TILE_COLS,
+                rows: TILE_ROWS,
+                deltaMs: DELTA_MS,
+                frameMeanLuminance: cap.frameMeanLuminance,
+                frameMeanDelta: cap.frameMeanDelta,
+              })
+            : null;
+
         reports.push({
           presetId: preset.id,
           title: preset.title ?? preset.id,
           author: preset.author ?? '',
           ...analysis,
+          ...(governed
+            ? {
+                governedPeakFlashesPerSecond: governed.peakFlashesPerSecond,
+                governedExceedsThreshold: governed.exceedsThreshold,
+              }
+            : {}),
         });
         console.log(
           `${label} — peak=${analysis.peakFlashesPerSecond}/s ` +
+            (governed ? `governed=${governed.peakFlashesPerSecond}/s ` : '') +
             `red=${analysis.peakRedFlashesPerSecond}/s ` +
             `motion=${analysis.motionEnergy.toFixed(4)} ` +
             `vol=${analysis.luminanceVolatility.toFixed(4)}` +

--- a/src/js/core/services/flash-governor.ts
+++ b/src/js/core/services/flash-governor.ts
@@ -187,6 +187,25 @@ export function createFlashGovernor(options: FlashGovernorOptions = {}) {
   let rising: Float32Array | null = null;
   let falling: Float32Array | null = null;
 
+  /**
+   * Pre-applies a hold before any flash has been observed.
+   *
+   * The governor is reactive: it cannot suppress a flash it has not seen, so
+   * the first one or two of an abrupt strobe reach the viewer while the
+   * clamp is being solved. That is unavoidable when measurement is the only
+   * input — but it is not the only input available. The catalog has already
+   * measured most presets offline (sensory-profile.ts), so when a preset is
+   * known to flash, the runtime can start clamped instead of discovering it
+   * the hard way.
+   *
+   * A floor, not an override: a priming value never LOWERS an existing hold,
+   * and the solved step is still free to tighten past it.
+   */
+  function prime(initialHold: number) {
+    if (!Number.isFinite(initialHold) || initialHold <= 0) return;
+    hold = Math.max(hold, Math.min(holdCeiling, initialHold));
+  }
+
   function reset() {
     previous = null;
     previousCols = 0;
@@ -323,9 +342,38 @@ export function createFlashGovernor(options: FlashGovernorOptions = {}) {
 
   return {
     sample,
+    prime,
     reset,
     getState: () => decision(false),
   };
 }
 
 export type FlashGovernor = ReturnType<typeof createFlashGovernor>;
+
+/**
+ * How hard to pre-clamp a preset the catalog has already measured.
+ *
+ * Derived from the same arithmetic the solved step uses, rather than a table
+ * of taste: a swing of `maxDelta` needs scaling by
+ * `FLASH_LUMINANCE_DELTA * margin / maxDelta` to fall under the threshold,
+ * and the hold is the complement of that scale.
+ *
+ * Only presets measured ABOVE the WCAG limit are primed. A 'medium' preset
+ * sits under the limit by definition, so pre-dimming it would be a visible
+ * cost with no safety claim behind it — the reactive path is the right
+ * answer there, and the offline measurement is a coarse instrument besides.
+ */
+export function primingHoldForProfile(profile: {
+  flashRiskLevel?: string;
+  maxLuminanceDelta?: number;
+}): number {
+  if (profile.flashRiskLevel !== 'high') return 0;
+  const delta = profile.maxLuminanceDelta;
+  if (!Number.isFinite(delta) || (delta as number) <= FLASH_LUMINANCE_DELTA) {
+    // Measured as high-risk but without a usable swing figure: clamp gently
+    // rather than guessing hard, and let the solved step take over.
+    return 0.35;
+  }
+  const needed = (FLASH_LUMINANCE_DELTA * 0.8) / (delta as number);
+  return Math.min(0.9, Math.max(0, 1 - needed));
+}

--- a/src/js/core/services/flash-safety.ts
+++ b/src/js/core/services/flash-safety.ts
@@ -57,6 +57,11 @@ export type FlashSafetyOptions = {
 export type FlashSafetyController = {
   start: () => void;
   stop: () => void;
+  /**
+   * Pre-clamp for a preset the catalog already measured above the WCAG
+   * limit, so its first flashes are mitigated rather than merely counted.
+   */
+  prime: (hold: number) => void;
   /** Runs one observation. Exposed so tests need no animation frames. */
   tick: (nowMs: number) => FlashGovernorDecision | null;
   getState: () => FlashGovernorDecision;
@@ -150,6 +155,14 @@ export function createFlashSafetyController(
 
   return {
     start,
+    prime: (initialHold: number) => {
+      // Skipped while the preference is off, and NOT replayed if the user
+      // turns it on later in the same preset: priming is a head start, not a
+      // correctness requirement, and the reactive path reaches the same
+      // clamp within about a second of the first flash either way.
+      if (!isEnabled()) return;
+      governor.prime(initialHold);
+    },
     stop: () => {
       unsubscribe?.();
       stop();

--- a/src/js/frontend/hooks/use-flash-safety.ts
+++ b/src/js/frontend/hooks/use-flash-safety.ts
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import type { PresetSensoryProfile } from '../../core/sensory-profile.ts';
+import { primingHoldForProfile } from '../../core/services/flash-governor.ts';
 import {
   createFlashSafetyController,
   createStageLuminanceApplier,
@@ -14,8 +16,20 @@ import {
  *
  * Gated inside the controller on the `reduceFlashing` accessibility
  * preference, so this hook can stay mounted unconditionally.
+ *
+ * `activeProfile` is the catalog's offline measurement for the preset now on
+ * screen. It is what lets the governor start clamped on content already
+ * known to flash, instead of rediscovering it a flash at a time — the
+ * reactive path's one structural weakness.
  */
-export function useFlashSafety(stageRef: { current: HTMLDivElement | null }) {
+export function useFlashSafety(
+  stageRef: { current: HTMLDivElement | null },
+  activeProfile?: PresetSensoryProfile,
+) {
+  const controllerRef = useRef<ReturnType<
+    typeof createFlashSafetyController
+  > | null>(null);
+
   useEffect(() => {
     const stage = stageRef.current;
     if (!stage || typeof requestAnimationFrame !== 'function') {
@@ -40,6 +54,7 @@ export function useFlashSafety(stageRef: { current: HTMLDivElement | null }) {
         canvas,
         applyLuminanceScale: createStageLuminanceApplier(stage),
       });
+      controllerRef.current = controller;
       controller.start();
     };
 
@@ -54,6 +69,18 @@ export function useFlashSafety(stageRef: { current: HTMLDivElement | null }) {
     return () => {
       observer?.disconnect();
       controller?.stop();
+      controllerRef.current = null;
     };
   }, [stageRef]);
+
+  // Separate effect: the preset changes far more often than the canvas does,
+  // and rebuilding the controller on every switch would throw away the
+  // window the governor is mid-way through measuring.
+  useEffect(() => {
+    if (!activeProfile) return;
+    const hold = primingHoldForProfile(activeProfile);
+    if (hold > 0) {
+      controllerRef.current?.prime(hold);
+    }
+  }, [activeProfile]);
 }

--- a/src/js/frontend/workspace-hooks.ts
+++ b/src/js/frontend/workspace-hooks.ts
@@ -5,6 +5,7 @@ import {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -326,7 +327,18 @@ export function useWorkspaceSessionState({
   );
 
   useStageCanvasSync(stageRef);
-  useFlashSafety(stageRef);
+  // The catalog's offline flash measurement for whatever is on screen, so
+  // the governor can start clamped on a preset already known to strobe
+  // rather than discovering it a flash at a time.
+  const activeSensoryProfile = useMemo(
+    () =>
+      routeState.presetId
+        ? fallbackCatalog.find((entry) => entry.id === routeState.presetId)
+            ?.sensoryProfile
+        : undefined,
+    [fallbackCatalog, routeState.presetId],
+  );
+  useFlashSafety(stageRef, activeSensoryProfile);
 
   useEffect(() => {
     if (routeState.panel === 'browse') {

--- a/tests/unit/flash-governor.test.ts
+++ b/tests/unit/flash-governor.test.ts
@@ -17,6 +17,7 @@ import { analyzeFlashTimeline } from '../../scripts/flash-analysis.ts';
 import {
   createFlashGovernor,
   MIN_USEFUL_GRID,
+  primingHoldForProfile,
   RECOMMENDED_GRID,
 } from '../../src/js/core/services/flash-governor.ts';
 
@@ -308,5 +309,79 @@ describe('flash governor', () => {
     governor.reset();
     expect(governor.getState().hold).toBe(0);
     expect(governor.getState().flashesInWindow).toBe(0);
+  });
+
+  test('priming suppresses the flashes a cold start would let through', () => {
+    // The reactive path's one structural weakness: it cannot clamp a flash
+    // it has not seen. If the catalog already measured this preset above the
+    // limit, starting clamped should remove those opening flashes.
+    const run = (prime: number) => {
+      const governor = createFlashGovernor();
+      if (prime > 0) governor.prime(prime);
+      let scale = 1 - prime;
+      let flashes = 0;
+      for (let i = 0; i < 120; i += 1) {
+        const raw = Math.floor(i / 3) % 2 === 1 ? 1 : 0;
+        const decision = governor.sample(
+          i * FRAME_MS,
+          uniformFrame(raw * scale),
+          COLS,
+          ROWS,
+        );
+        scale = decision.luminanceScale;
+        if (decision.flashed) flashes += 1;
+      }
+      return flashes;
+    };
+    const cold = run(0);
+    const primed = run(0.9);
+    expect(cold).toBeGreaterThan(0);
+    expect(primed).toBeLessThan(cold);
+  });
+
+  test('priming is a floor, never a reduction', () => {
+    const governor = createFlashGovernor();
+    for (const [index, frame] of strobeTimeline(120, 3).entries()) {
+      governor.sample(index * FRAME_MS, frame, COLS, ROWS);
+    }
+    const engaged = governor.getState().hold;
+    expect(engaged).toBeGreaterThan(0.1);
+    governor.prime(0.05);
+    expect(governor.getState().hold).toBe(engaged);
+  });
+
+  test('only measured-high presets are primed', () => {
+    // A 'medium' preset is under the WCAG limit by definition, so pre-dimming
+    // it would be a visible cost with no safety claim behind it.
+    expect(
+      primingHoldForProfile({
+        flashRiskLevel: 'medium',
+        maxLuminanceDelta: 0.9,
+      }),
+    ).toBe(0);
+    expect(
+      primingHoldForProfile({ flashRiskLevel: 'none', maxLuminanceDelta: 0.9 }),
+    ).toBe(0);
+    expect(primingHoldForProfile({ flashRiskLevel: 'unknown' })).toBe(0);
+  });
+
+  test('priming strength follows the measured swing', () => {
+    const violent = primingHoldForProfile({
+      flashRiskLevel: 'high',
+      maxLuminanceDelta: 0.9,
+    });
+    const gentler = primingHoldForProfile({
+      flashRiskLevel: 'high',
+      maxLuminanceDelta: 0.25,
+    });
+    expect(violent).toBeGreaterThan(gentler);
+    expect(violent).toBeLessThanOrEqual(0.9);
+    expect(gentler).toBeGreaterThan(0);
+  });
+
+  test('a high-risk preset with no usable swing figure still primes gently', () => {
+    const hold = primingHoldForProfile({ flashRiskLevel: 'high' });
+    expect(hold).toBeGreaterThan(0);
+    expect(hold).toBeLessThan(0.5);
   });
 });


### PR DESCRIPTION
Two things: closing the governor's one structural weakness, and validating it against real content for the first time.

## Priming

The governor is reactive — it cannot suppress a flash it has not observed, so the first one or two of an abrupt strobe reach the viewer while the clamp is being solved. Measurement was its only input, but not the only one available: the catalog has already measured presets offline (`sensory-profile.ts`). Until now the offline audit and the runtime governor sat side by side ignoring each other.

Presets measured **above** the WCAG limit now start clamped. Strength comes from the same arithmetic the solved step uses — a swing of `maxLuminanceDelta` needs scaling by `threshold * margin / delta`, and the hold is that scale's complement — so priming isn't a table of taste. It's a floor, never an override: it cannot lower an existing hold, and the solved step is still free to tighten past it.

Only `high` presets are primed. A `medium` preset is under the limit by definition, so pre-dimming it would be a visible cost with no safety claim behind it.

## Validation against real presets

The governor had never met real content — its unit tests use synthetic full-field strobes with no texture, localized flicker, or motion.

`analyze-preset-flash.ts` gains `--governor`, which scores each preset twice from **one** render pass: the raw timeline, and the timeline as the governor would have presented it. On the presets the catalog flags:

| preset | raw | governed |
| --- | --- | --- |
| `unchained-cranked-on-failure` | 4 flashes/s | **2/s** |
| `beta106at-shape-mash0001-…` | 8 flashes/s | **3/s** |

Both were over threshold; both come back compliant. The second lands exactly at 3/s — which passes (the rule fails *above* 3) but is not comfortable margin. This is the strongest real-content evidence available, not a guarantee.

Writing that mode found a bug in it: the audit grid is 32×18, not square, and mapping it onto the governor's square grid with a single scale factor left the bottom half permanently zero, under-reporting the flashing area. Fixed to scale each axis independently.

## Caveat worth recording

Only **40 of 1787** catalog entries carry a sensory profile at all, and exactly one is `high` — so priming almost never fires in practice today. The mechanism is right; measurement coverage is what needs to grow, and that's a corpus-scale audit run rather than a code change.

`check:quick` clean, 2689 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)