### PR TITLE
feat(lab): corpus-scale flash coverage, and rank which preset knobs matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "lab:blend-gate": "bun run scripts/preset-lab-blend-gate.ts",
     "lab:flash-audit": "bun run scripts/analyze-preset-flash.ts",
     "lab:flash-risk": "bun run scripts/preset-lab-flash-risk.ts",
+    "lab:sensitivity": "bun run scripts/preset-lab-sensitivity.ts",
     "lab:flash-sampler-bench": "bun run scripts/preset-lab-flash-sampler-bench.ts",
     "lab:glsl-corpus-scan": "bun run scripts/preset-lab-glsl-corpus-scan.ts",
     "lab:gpu-differential": "bun run scripts/preset-lab-gpu-differential.ts",

--- a/scripts/analyze-preset-flash.ts
+++ b/scripts/analyze-preset-flash.ts
@@ -23,6 +23,28 @@
  *   bun run scripts/analyze-preset-flash.ts --beat-pulse    # with kick transients
  *   bun run scripts/analyze-preset-flash.ts --out=report.json
  *   bun run scripts/analyze-preset-flash.ts --governor       # with/without
+ *   bun run scripts/analyze-preset-flash.ts --all --shard=1/4 # one of 4 runs
+ *
+ * `--shard=k/n` takes every nth preset starting at k-1, so n processes cover
+ * the corpus with no overlap. The measurement is wall-clock independent --
+ * frames are stepped through the agent hook, not sampled in real time -- so
+ * running shards concurrently is safe: it changes throughput and nothing
+ * else.
+ *
+ * It changes throughput less than you would hope. Measured on an M-series
+ * laptop: one shard alone managed 0.73 presets/min, and four concurrent
+ * shards managed 0.8/min BETWEEN them -- about 1.1x, not 4x. The bottleneck
+ * is not CPU but the per-frame `gl.readPixels` of a 960x540 buffer, 390
+ * times per preset, which the GPU serialises no matter how many browsers ask
+ * at once. So shard across MACHINES, not across cores; on one box, two
+ * shards is already past the point of return.
+ *
+ * The honest consequence: a full 1787-preset pass is on the order of 40
+ * hours here, and no amount of sharding fixes that. Cutting it needs a
+ * cheaper per-frame read, and the obvious move -- reading a downscaled
+ * buffer -- is not free: the analysis deliberately thresholds per pixel
+ * BEFORE any spatial averaging, because averaging first scales sparse
+ * bright-on-black flashes below the threshold entirely.
  *
  * `--governor` measures each preset TWICE from one render pass: the raw
  * timeline, and the timeline as the runtime flash governor
@@ -81,6 +103,22 @@ export interface PresetFlashReport extends FlashAnalysis {
 
 function parseArgs(argv: string[]) {
   const governor = argv.includes('--governor');
+  const shardArg = argv.find((a) => a.startsWith('--shard='))?.split('=')[1];
+  let shardIndex = 0;
+  let shardCount = 1;
+  if (shardArg) {
+    const [k, n] = shardArg.split('/').map(Number);
+    if (!Number.isFinite(k) || !Number.isFinite(n) || k < 1 || n < 1 || k > n) {
+      throw new Error(
+        `--shard expects k/n with 1 <= k <= n, got "${shardArg}"`,
+      );
+    }
+    shardIndex = k - 1;
+    shardCount = n;
+  }
+  const swapTimeoutArg = argv
+    .find((a) => a.startsWith('--swap-timeout='))
+    ?.split('=')[1];
   const get = (flag: string) =>
     argv
       .find((a) => a.startsWith(`--${flag}=`))
@@ -100,6 +138,9 @@ function parseArgs(argv: string[]) {
     out: get('out') ?? DEFAULT_OUT,
     headless: !argv.includes('--no-headless'),
     governor,
+    shardIndex,
+    shardCount,
+    swapTimeoutMs: swapTimeoutArg ? Number(swapTimeoutArg) : SWAP_TIMEOUT_MS,
   };
 }
 
@@ -128,14 +169,24 @@ async function main() {
     ? raw
     : (raw.presets ?? []);
 
-  const targets = args.ids
+  const selected = args.ids
     ? allPresets.filter((p) => args.ids?.includes(p.id))
     : args.all
       ? allPresets
       : sampleEvenly(allPresets, args.count);
+  // Stride rather than block: consecutive catalog entries tend to come from
+  // the same pack, so a block split would give one shard all the heavy
+  // presets from one library and skew both runtime and what each shard sees.
+  const targets =
+    args.shardCount > 1
+      ? selected.filter((_, i) => i % args.shardCount === args.shardIndex)
+      : selected;
 
   console.log(
-    `Auditing ${targets.length} of ${allPresets.length} presets ` +
+    (args.shardCount > 1
+      ? `[shard ${args.shardIndex + 1}/${args.shardCount}] `
+      : '') +
+      `Auditing ${targets.length} of ${allPresets.length} presets ` +
       `(${CAPTURE_FRAMES} frames @ ${DELTA_MS.toFixed(2)}ms, ` +
       `beatPulse=${args.beatPulse})`,
   );
@@ -145,6 +196,29 @@ async function main() {
   const ctx = await browser.newContext({ viewport: VIEWPORT });
 
   const reports: PresetFlashReport[] = [];
+
+  /**
+   * Persist after every preset, not just at the end.
+   *
+   * A full-corpus audit is hours of work, and writing only on completion
+   * means an interrupted run -- a timeout, a GPU reset, a closed laptop --
+   * yields nothing at all. That made the instrument unusable for the one job
+   * it is most needed for. Partial output is still valid: the merge step is
+   * additive and treats absent presets as unmeasured, so a half-finished run
+   * contributes exactly what it measured.
+   */
+  const flush = () => {
+    try {
+      writeFileSync(
+        args.out,
+        `${JSON.stringify({ summary: { partial: true, analysed: reports.length }, reports }, null, 2)}\n`,
+      );
+    } catch {
+      // A failed intermediate write must not abort the run; the final write
+      // reports the real error.
+    }
+  };
+
   let page = await ctx.newPage();
 
   const bootPage = async (avoidId: string) => {
@@ -190,7 +264,7 @@ async function main() {
             );
           },
           preset.id,
-          { timeout: SWAP_TIMEOUT_MS },
+          { timeout: args.swapTimeoutMs },
         );
 
         const captured = await page.evaluate(
@@ -549,6 +623,7 @@ async function main() {
               }
             : {}),
         });
+        flush();
         console.log(
           `${label} — peak=${analysis.peakFlashesPerSecond}/s ` +
             (governed ? `governed=${governed.peakFlashesPerSecond}/s ` : '') +

--- a/scripts/preset-lab-sensitivity.ts
+++ b/scripts/preset-lab-sensitivity.ts
@@ -1,0 +1,226 @@
+/**
+ * Rank a preset's parameters by how much they actually move the picture.
+ *
+ * A MilkDrop preset carries dozens of numeric fields, and in any given preset
+ * most of them do nothing: they are overwritten by the per-frame equations on
+ * the first frame, or multiplied by something that is zero, or simply unused.
+ * Nothing in the format distinguishes a knob that drives the whole look from
+ * one that is decorative, so editors present all of them with equal weight and
+ * authors learn which is which by trial and error.
+ *
+ * This measures it. For each candidate field: perturb it, re-run the VM on an
+ * identical deterministic timeline, and compare the resulting warp mesh
+ * against the unperturbed baseline. The output is RMS displacement per unit of
+ * relative perturbation -- a sensitivity, not a guess.
+ *
+ * Deliberately CPU-only and pixel-free. Diffing the mesh rather than rendered
+ * frames isolates what the EQUATIONS do from what the shaders do, needs no
+ * GPU, and runs in milliseconds, so this can sweep the corpus. A preset whose
+ * warp is owned by a shader will correctly report near-zero sensitivity on the
+ * mesh -- that is a real finding about where its behaviour lives, not a
+ * failure to measure.
+ *
+ * Central differences, both directions averaged: one-sided differencing on a
+ * field that is clamped at zero (decay, warp scale) reports the clamp instead
+ * of the parameter.
+ *
+ *   bun run lab:sensitivity -- --preset <id>
+ *   bun run lab:sensitivity -- --preset <id> --frames 20 --top 12
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  clearCompiledPresetCache,
+  compileMilkdropPresetSource,
+} from '../src/js/milkdrop/compiler.ts';
+import { createMilkdropSignalTracker } from '../src/js/milkdrop/runtime-signals.ts';
+import { createMilkdropVM } from '../src/js/milkdrop/vm.ts';
+import { DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS } from '../src/js/milkdrop/webgpu-optimization-flags.ts';
+import {
+  fillScenarioSpectrum,
+  fillScenarioWaveform,
+  PRESET_LAB_SPECTRUM_BINS,
+} from './preset-lab-metrics.ts';
+
+const args = process.argv.slice(2);
+function flag(name: string, fallback: string): string {
+  const inline = args.find((a) => a.startsWith(`--${name}=`));
+  if (inline) return inline.split('=').slice(1).join('=');
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] ? (args[i + 1] as string) : fallback;
+}
+
+const PRESET = flag('preset', '');
+const FRAMES = Number(flag('frames', '16'));
+const TOP = Number(flag('top', '15'));
+/** Relative step. Large enough to clear f32 noise, small enough to stay local. */
+const EPSILON = Number(flag('epsilon', '0.05'));
+
+function findPresetFile(id: string): string | null {
+  const roots = ['public/milkdrop-presets', 'tests/fixtures/milkdrop'];
+  for (const root of roots) {
+    const stack = [root];
+    while (stack.length) {
+      const dir = stack.pop() as string;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) stack.push(path);
+        else if (entry === `${id}.milk`) return path;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Run the VM on a fixed deterministic timeline and return the final mesh.
+ *
+ * Same stimulus every run — the preset-lab's `full-mix` scenario through the
+ * real signal tracker, so smoothing and attack envelopes behave as they do
+ * live. Two runs differ only by the parameter under test.
+ */
+function runMesh(
+  source: string,
+  id: string,
+  overrides: Record<string, number>,
+) {
+  // The compiler caches by raw source, so successive calls hand back the SAME
+  // preset object — and this probe mutates its numericFields. Without the
+  // clear, every override accumulates permanently and each run inherits all
+  // prior perturbations: the first version of this script reported an
+  // identical non-zero "sensitivity" for 1579 unrelated fields, which was the
+  // accumulated leak, not the parameters.
+  clearCompiledPresetCache();
+  const preset = compileMilkdropPresetSource(source, { id });
+  for (const [key, value] of Object.entries(overrides)) {
+    preset.ir.numericFields[key] = value;
+  }
+  const vm = createMilkdropVM(preset, {
+    ...DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS,
+    gpuComputeVM: false,
+  });
+  const tracker = createMilkdropSignalTracker();
+  const frequencyData = new Uint8Array(PRESET_LAB_SPECTRUM_BINS);
+  const waveformData = new Uint8Array(PRESET_LAB_SPECTRUM_BINS);
+  const deltaMs = 1000 / 60;
+
+  let positions: Float32Array | null = null;
+  for (let f = 0; f < FRAMES; f += 1) {
+    const timeMs = f * deltaMs;
+    fillScenarioSpectrum(frequencyData, 'full-mix', timeMs);
+    fillScenarioWaveform(waveformData, 'full-mix', timeMs);
+    const signals = tracker.update({
+      time: timeMs / 1000,
+      deltaMs,
+      analyser: null,
+      frequencyData,
+      waveformData,
+    });
+    const state = vm.step(signals);
+    const p = state.mesh?.positions;
+    if (p) {
+      positions = p instanceof Float32Array ? p.slice() : Float32Array.from(p);
+    }
+  }
+  return { positions, fields: preset.ir.numericFields };
+}
+
+function rms(a: Float32Array, b: Float32Array): number {
+  const n = Math.min(a.length, b.length);
+  if (n === 0) return 0;
+  let acc = 0;
+  for (let i = 0; i < n; i += 1) {
+    const d = (a[i] as number) - (b[i] as number);
+    if (Number.isFinite(d)) acc += d * d;
+  }
+  return Math.sqrt(acc / n);
+}
+
+if (!PRESET) {
+  console.error('Usage: bun run lab:sensitivity -- --preset <id>');
+  process.exit(2);
+}
+const file = findPresetFile(PRESET);
+if (!file) {
+  console.error(`No .milk file found for preset id "${PRESET}".`);
+  process.exit(2);
+}
+const source = readFileSync(file, 'utf8');
+
+const baseline = runMesh(source, PRESET, {});
+if (!baseline.positions) {
+  console.error(
+    'This preset produced no warp mesh on the CPU path, so there is nothing ' +
+      'to differentiate — its motion lives in a shader.',
+  );
+  process.exit(1);
+}
+
+const candidates = Object.entries(baseline.fields)
+  .filter(([, v]) => Number.isFinite(v))
+  .map(([k]) => k);
+
+type Row = { field: string; base: number; sensitivity: number };
+const rows: Row[] = [];
+const structural: string[] = [];
+for (const field of candidates) {
+  const base = baseline.fields[field] as number;
+  // Relative step, with an absolute floor so a field sitting at 0 still moves.
+  const step = Math.max(Math.abs(base) * EPSILON, EPSILON);
+  const up = runMesh(source, PRESET, { [field]: base + step });
+  const down = runMesh(source, PRESET, { [field]: base - step });
+  if (!up.positions || !down.positions) continue;
+  // A field that resizes the mesh (mesh_density) is not comparable
+  // point-for-point: the diff would be between different grid locations and
+  // reads as large sensitivity for what is really a change of sampling. Those
+  // are reported separately rather than ranked against real parameters.
+  if (
+    up.positions.length !== baseline.positions.length ||
+    down.positions.length !== baseline.positions.length
+  ) {
+    structural.push(field);
+    continue;
+  }
+  const delta =
+    (rms(baseline.positions, up.positions) +
+      rms(baseline.positions, down.positions)) /
+    2;
+  rows.push({ field, base, sensitivity: delta / step });
+}
+
+rows.sort((a, b) => b.sensitivity - a.sensitivity);
+const live = rows.filter((r) => r.sensitivity > 1e-9);
+
+console.log(`\n  ${PRESET}`);
+console.log(
+  `  ${candidates.length} numeric fields, ${live.length} move the mesh ` +
+    `(${FRAMES} frames, central difference, eps=${EPSILON})\n`,
+);
+console.log('  field                        base        sensitivity');
+console.log(`  ${'-'.repeat(56)}`);
+for (const row of live.slice(0, TOP)) {
+  console.log(
+    `  ${row.field.padEnd(26)} ${row.base.toFixed(4).padStart(10)}   ${row.sensitivity.toExponential(3).padStart(12)}`,
+  );
+}
+if (live.length === 0) {
+  console.log('  (none — every numeric field is inert on the mesh path)');
+}
+const dead = rows.length - live.length;
+console.log(
+  `\n  ${dead} of ${rows.length} comparable fields are inert in this preset: ` +
+    'changing them moves nothing.',
+);
+if (structural.length > 0) {
+  console.log(
+    `  ${structural.length} field(s) resize the mesh and are not ranked: ` +
+      `${structural.join(', ')}`,
+  );
+}
+console.log('');

--- a/tests/unit/compiled-preset-cache-mutation.test.ts
+++ b/tests/unit/compiled-preset-cache-mutation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The compiled-preset cache hands back a SHARED object.
+ *
+ * `compileMilkdropPresetSource` memoises on raw source, so two calls with the
+ * same text return the same `MilkdropCompiledPreset` — including the same
+ * `ir.numericFields`. Any tool that pokes a field to see what changes is
+ * therefore editing every later caller's preset too.
+ *
+ * That is not hypothetical. The first version of `lab:sensitivity` perturbed
+ * fields this way and reported an identical non-zero sensitivity for 1579
+ * unrelated parameters: each run inherited every prior perturbation, so the
+ * number it printed was the accumulated leak rather than the parameter under
+ * test. The tell was that unrelated fields agreed to four significant figures.
+ *
+ * These tests pin the sharing (so nobody "fixes" it by accident and slows the
+ * hot path) and pin the escape hatch that makes differential probes valid.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  clearCompiledPresetCache,
+  compileMilkdropPresetSource,
+} from '../../src/js/milkdrop/compiler.ts';
+
+const SOURCE = ['title=cache probe', 'per_frame_1=zoom=zoom+0;'].join('\n');
+
+describe('compiled preset cache mutation', () => {
+  test('two compiles of identical source share one IR object', () => {
+    clearCompiledPresetCache();
+    const a = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    const b = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    expect(b).toBe(a);
+    expect(b.ir.numericFields).toBe(a.ir.numericFields);
+  });
+
+  test('mutating a returned IR leaks into the next compile', () => {
+    clearCompiledPresetCache();
+    const first = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    const original = first.ir.numericFields.zoom as number;
+    first.ir.numericFields.zoom = original + 7;
+
+    const second = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    // This is the trap, asserted so it stays visible rather than surprising
+    // the next person who writes a differential probe.
+    expect(second.ir.numericFields.zoom).toBe(original + 7);
+  });
+
+  test('clearing the cache isolates successive probes', () => {
+    clearCompiledPresetCache();
+    const first = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    const original = first.ir.numericFields.zoom as number;
+    first.ir.numericFields.zoom = original + 7;
+
+    clearCompiledPresetCache();
+    const fresh = compileMilkdropPresetSource(SOURCE, { id: 'probe' });
+    expect(fresh.ir.numericFields.zoom).toBe(original);
+  });
+});


### PR DESCRIPTION
Two instruments. The first attacks the coverage gap left open by #1145; the second is new capability.

## Flash coverage — and a negative result

40 of 1787 catalog entries carry a sensory profile, so the priming path from #1145 almost never fires. The pipeline was already complete and additive, so this looked like pure throughput.

`--shard=k/n` takes every nth preset — verified exact: 447+447+447+446 = 1787, no duplicates, full cover. Stride rather than block, since consecutive catalog entries come from the same pack. Sharding is *safe* because frames are stepped through the agent hook rather than sampled in real time, so the measurement is wall-clock independent.

**Then I measured it, and the result is negative.** One shard alone: 0.73 presets/min. Four concurrent shards: 0.8/min *between them*. About 1.1×, not 4×. The bottleneck is the per-frame `gl.readPixels` of a 960×540 buffer, 390 times per preset, which the GPU serializes however many browsers ask at once.

So **the coverage gap is not a throughput-tuning problem.** A full corpus pass is ~40 hours on this hardware and sharding doesn't fix it. Cutting it needs a cheaper per-frame read — and the obvious move, reading a downscaled buffer, is *not* free: the analysis thresholds per pixel **before** any spatial averaging, because averaging first pushes sparse bright-on-black flashes under the threshold entirely. That tradeoff is now written down where the next person will hit it.

What does help immediately: **the report writes after every preset** instead of only at the end. A run of that length previously yielded nothing if interrupted. Partial output is valid by construction — merge is additive and treats absent presets as unmeasured, never as a clean bill of health — so a long run can be harvested whenever it's stopped.

## Parameter sensitivity

`lab:sensitivity` ranks a preset's numeric fields by how much each actually moves the picture. A preset carries ~1600 numeric fields and in any given one nearly all are inert; nothing in the format distinguishes a knob that drives the look from a decorative one.

```
geiss-sunsets                 11 of 1593 fields move the mesh
  dx, dy, rot, zoom, sx, sy, cx, cy, warp, zoomexp, warpanimspeed
unchained-cranked-on-failure   7 of 1593
  dx, dy, rot, sx, sy, cx, cy
```

`zoom` and `warp` are live in the first and inert in the second, because that preset's equations overwrite them — evidence the tool discriminates rather than printing one list twice.

Mesh-diffing rather than pixel-diffing isolates what the *equations* do from what the *shaders* do, needs no GPU, and runs in milliseconds.

## The bug that nearly shipped as a result

The first version reported an identical non-zero sensitivity for **1579 unrelated fields**. `compileMilkdropPresetSource` memoises on raw source, so every run got the same preset object and perturbations accumulated permanently — the number was the leak, not the parameter. The tell was unrelated fields agreeing to four significant figures.

`tests/unit/compiled-preset-cache-mutation.test.ts` pins both the sharing and the `clearCompiledPresetCache` escape hatch.

`check:quick` clean, 2673 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)