### PR TITLE
perf(lab): cut sensitivity 14x, and surface the flash audit's variance

### DIFF
--- a/scripts/analyze-preset-flash.ts
+++ b/scripts/analyze-preset-flash.ts
@@ -15,6 +15,33 @@
  * This flags presets for review. It is not a medical determination, and a
  * preset under threshold here is not thereby certified safe for anyone.
  *
+ * KNOWN: repeated captures of the same preset do not always agree.
+ *
+ * Three back-to-back captures in one process, same preset, same flags:
+ * `peak=7/s (runs 5/8/7, red 1/0/0)`. Across separate processes the swing is
+ * as wide -- one preset measured 13, 8 and 10 flashes/s on three identical
+ * invocations, and another moved its RED peak from 0 to 6, which is enough to
+ * cross the `classifyFlashRisk` boundary and change its published risk band.
+ * The `motion` figures move too, so the FRAMES differ: something in the
+ * render path is not reproducing despite frames being stepped deterministically
+ * through the agent hook. Presets with heavy feedback vary most; mig-056 was
+ * stable at 6/s across every run.
+ *
+ * Root cause is not yet found. Until it is, `--repeat=N` captures each preset
+ * N times, reports the MEDIAN, and carries the spread into both the console
+ * line and the report (`repeatPeaks`, `repeatRedPeaks`), so a single unstable
+ * number cannot pass as a measurement. Use it for anything that will be
+ * merged into the catalog.
+ *
+ * ALSO KNOWN: measuring at a smaller viewport is not a valid shortcut. The
+ * per-frame `gl.readPixels` dominates runtime, so 320x180 with stride 1 --
+ * the same 57,600 samples as the 960x540 default at stride 3 -- looks like a
+ * free 9x. It is not: mig-056 reports 6/s at full size and 0/s at 320x180,
+ * a clean-versus-failing disagreement, because the renderer rasterises thin
+ * bright structures out of existence at that size. It was also only ~1.8x
+ * faster in practice. The viewport is configurable for experiments; do not
+ * sweep the corpus with it.
+ *
  * Usage:
  *   bun run scripts/analyze-preset-flash.ts                 # 50-preset sample
  *   bun run scripts/analyze-preset-flash.ts --count=200
@@ -75,9 +102,10 @@ const TILE_ROWS = 18;
 // enough to catch sparse bright structures a centre sample misses,
 // without making a 300-frame capture quadratically expensive.
 const SAMPLE_STRIDE = 3;
+const DEFAULT_VIEWPORT = { width: 960, height: 540 };
 const BOOT_TIMEOUT_MS = 45000;
 const SWAP_TIMEOUT_MS = 90000;
-const VIEWPORT = { width: 960, height: 540 };
+
 // Each preset compiles shaders and allocates feedback targets; hundreds of
 // swaps in one context eventually exhausts GPU resources and kills the
 // page. generate-thumbnails.ts hits the same wall and recycles every 100 —
@@ -91,7 +119,22 @@ interface PresetEntry {
   author?: string;
 }
 
+type CapturedFrames = {
+  rising: number[][];
+  falling: number[][];
+  redRising: number[][];
+  redFalling: number[][];
+  govRising: number[][];
+  govFalling: number[][];
+  tilePixels: number;
+  frameMeanLuminance: number[];
+  frameMeanDelta: number[];
+};
+
 export interface PresetFlashReport extends FlashAnalysis {
+  /** Spread across --repeat captures of the same preset, when > 1. */
+  repeatPeaks?: number[];
+  repeatRedPeaks?: number[];
   /** Peak flashes/s the runtime governor would have presented (--governor). */
   governedPeakFlashesPerSecond?: number;
   governedExceedsThreshold?: boolean;
@@ -103,6 +146,19 @@ export interface PresetFlashReport extends FlashAnalysis {
 
 function parseArgs(argv: string[]) {
   const governor = argv.includes('--governor');
+  const repeatArg = argv.find((a) => a.startsWith('--repeat='))?.split('=')[1];
+  const repeat = repeatArg ? Math.max(1, Number(repeatArg)) : 1;
+  const viewportArg = argv
+    .find((a) => a.startsWith('--viewport='))
+    ?.split('=')[1];
+  const viewport = viewportArg
+    ? {
+        width: Number(viewportArg.split('x')[0]),
+        height: Number(viewportArg.split('x')[1]),
+      }
+    : DEFAULT_VIEWPORT;
+  const strideArg = argv.find((a) => a.startsWith('--stride='))?.split('=')[1];
+  const stride = strideArg ? Number(strideArg) : SAMPLE_STRIDE;
   const shardArg = argv.find((a) => a.startsWith('--shard='))?.split('=')[1];
   let shardIndex = 0;
   let shardCount = 1;
@@ -141,6 +197,9 @@ function parseArgs(argv: string[]) {
     shardIndex,
     shardCount,
     swapTimeoutMs: swapTimeoutArg ? Number(swapTimeoutArg) : SWAP_TIMEOUT_MS,
+    viewport,
+    stride,
+    repeat,
   };
 }
 
@@ -193,7 +252,7 @@ async function main() {
 
   const devServer = await ensureDevServer(args.port);
   const browser = await chromium.launch({ headless: args.headless });
-  const ctx = await browser.newContext({ viewport: VIEWPORT });
+  const ctx = await browser.newContext({ viewport: args.viewport });
 
   const reports: PresetFlashReport[] = [];
 
@@ -254,344 +313,393 @@ async function main() {
         }, preset.id);
 
         await page.waitForFunction(
-          (presetId) => {
+          ({ presetId, minCanvasWidth }) => {
             const main = document.querySelector('#stims-main');
             if (main?.getAttribute('data-active-preset-id') !== presetId) {
               return false;
             }
             return [...document.querySelectorAll('canvas')].some(
-              (c) => c.width >= 400,
+              (c) => c.width >= minCanvasWidth,
             );
           },
-          preset.id,
+          // Relative to the viewport, not a fixed 400: the constant silently
+          // made every preset time out at any viewport narrower than 400,
+          // which is exactly the configuration a cheaper corpus sweep wants.
+          {
+            presetId: preset.id,
+            minCanvasWidth: Math.floor(args.viewport.width * 0.4),
+          },
           { timeout: args.swapTimeoutMs },
         );
 
-        const captured = await page.evaluate(
-          async ({
-            frames,
-            deltaMs,
-            warmup,
-            cols,
-            rows,
-            beatPulse,
-            SAMPLE_STRIDE,
-            useGovernor,
-            governorGrid,
-          }) => {
-            const step = window.__STIMS_AGENT_RENDER_FRAMES__;
-            if (typeof step !== 'function') {
-              return { error: 'render hook missing' };
-            }
-            const canvas = [...document.querySelectorAll('canvas')].sort(
-              (a, b) => b.width * b.height - a.width * a.height,
-            )[0] as HTMLCanvasElement | undefined;
-            if (!canvas || canvas.width < 400) {
-              return { error: 'stage canvas not available' };
-            }
-            const gl =
-              (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
-              (canvas.getContext('webgl') as WebGLRenderingContext | null);
-            if (!gl) return { error: 'no WebGL context' };
+        const attempts: Array<{
+          cap: CapturedFrames;
+          analysis: FlashAnalysis;
+        }> = [];
+        for (let attempt = 0; attempt < args.repeat; attempt += 1) {
+          const captured = await page.evaluate(
+            async ({
+              frames,
+              deltaMs,
+              warmup,
+              cols,
+              rows,
+              beatPulse,
+              SAMPLE_STRIDE,
+              useGovernor,
+              governorGrid,
+              minCanvasWidth,
+            }) => {
+              const step = window.__STIMS_AGENT_RENDER_FRAMES__;
+              if (typeof step !== 'function') {
+                return { error: 'render hook missing' };
+              }
+              const canvas = [...document.querySelectorAll('canvas')].sort(
+                (a, b) => b.width * b.height - a.width * a.height,
+              )[0] as HTMLCanvasElement | undefined;
+              // Same reason as the swap predicate: a fixed 400 rejects every
+              // frame at any viewport narrower than that, so the threshold
+              // follows the viewport instead of a constant.
+              if (!canvas || canvas.width < minCanvasWidth) {
+                return { error: 'stage canvas not available' };
+              }
+              const gl =
+                (canvas.getContext(
+                  'webgl2',
+                ) as WebGL2RenderingContext | null) ??
+                (canvas.getContext('webgl') as WebGLRenderingContext | null);
+              if (!gl) return { error: 'no WebGL context' };
 
-            // sRGB -> linear, WCAG relative luminance weights. Only 256
-            // possible byte values, so the transfer function is tabulated
-            // once instead of running ~72M pow() calls per preset — that
-            // cost, not the GPU readback, is what made per-tile averaging
-            // slow enough to be unusable.
-            const LUT = new Float64Array(256);
-            for (let i = 0; i < 256; i += 1) {
-              const c = i / 255;
-              LUT[i] = c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-            }
+              // sRGB -> linear, WCAG relative luminance weights. Only 256
+              // possible byte values, so the transfer function is tabulated
+              // once instead of running ~72M pow() calls per preset — that
+              // cost, not the GPU readback, is what made per-tile averaging
+              // slow enough to be unusable.
+              const LUT = new Float64Array(256);
+              for (let i = 0; i < 256; i += 1) {
+                const c = i / 255;
+                LUT[i] =
+                  c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+              }
 
-            const w = gl.drawingBufferWidth;
-            const h = gl.drawingBufferHeight;
-            const px = new Uint8Array(w * h * 4);
-            const tileW = Math.max(1, Math.floor(w / cols));
-            const tileH = Math.max(1, Math.floor(h / rows));
+              const w = gl.drawingBufferWidth;
+              const h = gl.drawingBufferHeight;
+              const px = new Uint8Array(w * h * 4);
+              const tileW = Math.max(1, Math.floor(w / cols));
+              const tileH = Math.max(1, Math.floor(h / rows));
 
-            // Sampled-pixel grid, fixed across frames so pixel N in one
-            // frame is the same screen location in the next.
-            const sampleXs: number[] = [];
-            const sampleYs: number[] = [];
-            const sampleTile: number[] = [];
-            for (let ty = 0; ty < rows; ty += 1) {
-              for (let tx = 0; tx < cols; tx += 1) {
-                const x1 = Math.min(w, tx * tileW + tileW);
-                const y1 = Math.min(h, ty * tileH + tileH);
-                for (let y = ty * tileH; y < y1; y += SAMPLE_STRIDE) {
-                  for (let x = tx * tileW; x < x1; x += SAMPLE_STRIDE) {
-                    sampleXs.push(x);
-                    sampleYs.push(y);
-                    sampleTile.push(ty * cols + tx);
+              // Sampled-pixel grid, fixed across frames so pixel N in one
+              // frame is the same screen location in the next.
+              const sampleXs: number[] = [];
+              const sampleYs: number[] = [];
+              const sampleTile: number[] = [];
+              for (let ty = 0; ty < rows; ty += 1) {
+                for (let tx = 0; tx < cols; tx += 1) {
+                  const x1 = Math.min(w, tx * tileW + tileW);
+                  const y1 = Math.min(h, ty * tileH + tileH);
+                  for (let y = ty * tileH; y < y1; y += SAMPLE_STRIDE) {
+                    for (let x = tx * tileW; x < x1; x += SAMPLE_STRIDE) {
+                      sampleXs.push(x);
+                      sampleYs.push(y);
+                      sampleTile.push(ty * cols + tx);
+                    }
                   }
                 }
               }
-            }
-            const sampleCount = sampleXs.length;
-            const tileCount = cols * rows;
-            // Even sampling means every tile gets the same denominator.
-            const tilePixels = Math.max(1, Math.floor(sampleCount / tileCount));
+              const sampleCount = sampleXs.length;
+              const tileCount = cols * rows;
+              // Even sampling means every tile gets the same denominator.
+              const tilePixels = Math.max(
+                1,
+                Math.floor(sampleCount / tileCount),
+              );
 
-            // Warm up so feedback presets are measured at steady state.
-            step({ frames: warmup, deltaMs, beatPulse });
+              // Warm up so feedback presets are measured at steady state.
+              step({ frames: warmup, deltaMs, beatPulse });
 
-            // Governed track: the same frames as the viewer would have seen
-            // with the runtime governor engaged. Computed alongside the raw
-            // track from ONE render pass, so both are measured against
-            // identical pixels.
-            let governor: {
-              sample: (
-                t: number,
-                tiles: Float32Array,
-                c: number,
-                r: number,
-              ) => { luminanceScale: number };
-            } | null = null;
-            if (useGovernor) {
-              // Vite serves this from the dev server; the specifier is a URL
-              // rather than a path tsc can resolve, so it goes through a
-              // variable to keep the module graph out of the typecheck.
-              const governorModule = '/src/js/core/services/flash-governor.ts';
-              const mod = (await import(/* @vite-ignore */ governorModule)) as {
-                createFlashGovernor: () => typeof governor;
-                RECOMMENDED_GRID: number;
-              };
-              governor = mod.createFlashGovernor();
-              governorGrid = mod.RECOMMENDED_GRID;
-            }
-            const govTiles = new Float32Array(governorGrid * governorGrid);
-            const govTileAcc = new Float64Array(governorGrid * governorGrid);
-            const govTileCount = new Float64Array(governorGrid * governorGrid);
-            let govScale = 1;
-            let prevGovLum: Float64Array | null = null;
-            const curGovLum = new Float64Array(sampleCount);
-            const govRising: number[][] = [];
-            const govFalling: number[][] = [];
-
-            let prevLum: Float64Array | null = null;
-            const curLum = new Float64Array(sampleCount);
-            // Red-flash channel per PEAT/Harding: value = max(0, R-G-B)*320
-            // on 0..1 channels, and a transition only qualifies when it
-            // moves to or from a saturated red (R/(R+G+B) >= 0.8).
-            let prevRed: Float64Array | null = null;
-            let prevRedSat: Uint8Array | null = null;
-            const curRed = new Float64Array(sampleCount);
-            const curRedSat = new Uint8Array(sampleCount);
-            const rising: number[][] = [];
-            const falling: number[][] = [];
-            const redRising: number[][] = [];
-            const redFalling: number[][] = [];
-            const frameMeanLuminance: number[] = [];
-            const frameMeanDelta: number[] = [];
-
-            for (let f = 0; f < frames; f += 1) {
-              step({ frames: 1, deltaMs, beatPulse });
-              gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
-
-              let lumSum = 0;
-              for (let i = 0; i < sampleCount; i += 1) {
-                const o = (sampleYs[i] * w + sampleXs[i]) * 4;
-                const r = px[o];
-                const g = px[o + 1];
-                const b = px[o + 2];
-                const l = 0.2126 * LUT[r] + 0.7152 * LUT[g] + 0.0722 * LUT[b];
-                curLum[i] = l;
-                lumSum += l;
-                curRed[i] = Math.max(0, (r - g - b) / 255) * 320;
-                const rgbSum = r + g + b;
-                curRedSat[i] = rgbSum > 0 && r / rgbSum >= 0.8 ? 1 : 0;
+              // Governed track: the same frames as the viewer would have seen
+              // with the runtime governor engaged. Computed alongside the raw
+              // track from ONE render pass, so both are measured against
+              // identical pixels.
+              let governor: {
+                sample: (
+                  t: number,
+                  tiles: Float32Array,
+                  c: number,
+                  r: number,
+                ) => { luminanceScale: number };
+              } | null = null;
+              if (useGovernor) {
+                // Vite serves this from the dev server; the specifier is a URL
+                // rather than a path tsc can resolve, so it goes through a
+                // variable to keep the module graph out of the typecheck.
+                const governorModule =
+                  '/src/js/core/services/flash-governor.ts';
+                const mod = (await import(
+                  /* @vite-ignore */ governorModule
+                )) as {
+                  createFlashGovernor: () => typeof governor;
+                  RECOMMENDED_GRID: number;
+                };
+                governor = mod.createFlashGovernor();
+                governorGrid = mod.RECOMMENDED_GRID;
               }
-              frameMeanLuminance.push(lumSum / sampleCount);
+              const govTiles = new Float32Array(governorGrid * governorGrid);
+              const govTileAcc = new Float64Array(governorGrid * governorGrid);
+              const govTileCount = new Float64Array(
+                governorGrid * governorGrid,
+              );
+              let govScale = 1;
+              let prevGovLum: Float64Array | null = null;
+              const curGovLum = new Float64Array(sampleCount);
+              const govRising: number[][] = [];
+              const govFalling: number[][] = [];
 
-              if (governor) {
-                // Reduce the sampled pixels to the governor's coarse grid,
-                // scaled by the mitigation already in force — the governor
-                // must observe what the viewer sees, not the raw frame, or
-                // it never registers its own effect.
-                govTileAcc.fill(0);
-                govTileCount.fill(0);
-                // Separate scales per axis: the audit grid is 32x18, not
-                // square, so reusing one factor left the bottom half of the
-                // governor's grid permanently zero and under-reported the
-                // flashing area.
-                const gx = governorGrid / cols;
-                const gy = governorGrid / rows;
-                for (let i = 0; i < sampleCount; i += 1) {
-                  const tile = sampleTile[i];
-                  const tx = Math.min(
-                    governorGrid - 1,
-                    Math.floor((tile % cols) * gx),
-                  );
-                  const ty = Math.min(
-                    governorGrid - 1,
-                    Math.floor(Math.floor(tile / cols) * gy),
-                  );
-                  const g = ty * governorGrid + tx;
-                  govTileAcc[g] += curLum[i] * govScale;
-                  govTileCount[g] += 1;
-                }
-                for (let g = 0; g < govTiles.length; g += 1) {
-                  govTiles[g] =
-                    govTileCount[g] > 0 ? govTileAcc[g] / govTileCount[g] : 0;
-                }
-                govScale = governor.sample(
-                  f * deltaMs,
-                  govTiles,
-                  governorGrid,
-                  governorGrid,
-                ).luminanceScale;
-                for (let i = 0; i < sampleCount; i += 1) {
-                  curGovLum[i] = curLum[i] * govScale;
-                }
-              }
+              let prevLum: Float64Array | null = null;
+              const curLum = new Float64Array(sampleCount);
+              // Red-flash channel per PEAT/Harding: value = max(0, R-G-B)*320
+              // on 0..1 channels, and a transition only qualifies when it
+              // moves to or from a saturated red (R/(R+G+B) >= 0.8).
+              let prevRed: Float64Array | null = null;
+              let prevRedSat: Uint8Array | null = null;
+              const curRed = new Float64Array(sampleCount);
+              const curRedSat = new Uint8Array(sampleCount);
+              const rising: number[][] = [];
+              const falling: number[][] = [];
+              const redRising: number[][] = [];
+              const redFalling: number[][] = [];
+              const frameMeanLuminance: number[] = [];
+              const frameMeanDelta: number[] = [];
 
-              if (prevLum && prevRed && prevRedSat) {
-                // Magnitude is decided per pixel, against the full-scale
-                // WCAG threshold, BEFORE any spatial aggregation. Averaging
-                // luminance over a tile first would scale each swing down
-                // by the flashing region's coverage — on sparse
-                // bright-on-black presets that pushed genuine flashes two
-                // orders of magnitude under the threshold and reported
-                // zero flashes corpus-wide.
-                const up = new Array(tileCount).fill(0);
-                const down = new Array(tileCount).fill(0);
-                const redUp = new Array(tileCount).fill(0);
-                const redDown = new Array(tileCount).fill(0);
-                let deltaSum = 0;
+              for (let f = 0; f < frames; f += 1) {
+                step({ frames: 1, deltaMs, beatPulse });
+                gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, px);
+
+                let lumSum = 0;
                 for (let i = 0; i < sampleCount; i += 1) {
-                  const before = prevLum[i];
-                  const after = curLum[i];
-                  deltaSum += Math.abs(after - before);
-                  if (
-                    Math.abs(after - before) >= 0.1 &&
-                    Math.min(before, after) < 0.8
-                  ) {
-                    if (after > before) up[sampleTile[i]] += 1;
-                    else down[sampleTile[i]] += 1;
-                  }
-                  const redBefore = prevRed[i];
-                  const redAfter = curRed[i];
-                  if (
-                    (prevRedSat[i] === 1 || curRedSat[i] === 1) &&
-                    Math.abs(redAfter - redBefore) > 20
-                  ) {
-                    if (redAfter > redBefore) redUp[sampleTile[i]] += 1;
-                    else redDown[sampleTile[i]] += 1;
-                  }
+                  const o = (sampleYs[i] * w + sampleXs[i]) * 4;
+                  const r = px[o];
+                  const g = px[o + 1];
+                  const b = px[o + 2];
+                  const l = 0.2126 * LUT[r] + 0.7152 * LUT[g] + 0.0722 * LUT[b];
+                  curLum[i] = l;
+                  lumSum += l;
+                  curRed[i] = Math.max(0, (r - g - b) / 255) * 320;
+                  const rgbSum = r + g + b;
+                  curRedSat[i] = rgbSum > 0 && r / rgbSum >= 0.8 ? 1 : 0;
                 }
-                if (governor && prevGovLum) {
-                  const gUp = new Array(tileCount).fill(0);
-                  const gDown = new Array(tileCount).fill(0);
+                frameMeanLuminance.push(lumSum / sampleCount);
+
+                if (governor) {
+                  // Reduce the sampled pixels to the governor's coarse grid,
+                  // scaled by the mitigation already in force — the governor
+                  // must observe what the viewer sees, not the raw frame, or
+                  // it never registers its own effect.
+                  govTileAcc.fill(0);
+                  govTileCount.fill(0);
+                  // Separate scales per axis: the audit grid is 32x18, not
+                  // square, so reusing one factor left the bottom half of the
+                  // governor's grid permanently zero and under-reported the
+                  // flashing area.
+                  const gx = governorGrid / cols;
+                  const gy = governorGrid / rows;
                   for (let i = 0; i < sampleCount; i += 1) {
-                    const before = prevGovLum[i];
-                    const after = curGovLum[i];
+                    const tile = sampleTile[i];
+                    const tx = Math.min(
+                      governorGrid - 1,
+                      Math.floor((tile % cols) * gx),
+                    );
+                    const ty = Math.min(
+                      governorGrid - 1,
+                      Math.floor(Math.floor(tile / cols) * gy),
+                    );
+                    const g = ty * governorGrid + tx;
+                    govTileAcc[g] += curLum[i] * govScale;
+                    govTileCount[g] += 1;
+                  }
+                  for (let g = 0; g < govTiles.length; g += 1) {
+                    govTiles[g] =
+                      govTileCount[g] > 0 ? govTileAcc[g] / govTileCount[g] : 0;
+                  }
+                  govScale = governor.sample(
+                    f * deltaMs,
+                    govTiles,
+                    governorGrid,
+                    governorGrid,
+                  ).luminanceScale;
+                  for (let i = 0; i < sampleCount; i += 1) {
+                    curGovLum[i] = curLum[i] * govScale;
+                  }
+                }
+
+                if (prevLum && prevRed && prevRedSat) {
+                  // Magnitude is decided per pixel, against the full-scale
+                  // WCAG threshold, BEFORE any spatial aggregation. Averaging
+                  // luminance over a tile first would scale each swing down
+                  // by the flashing region's coverage — on sparse
+                  // bright-on-black presets that pushed genuine flashes two
+                  // orders of magnitude under the threshold and reported
+                  // zero flashes corpus-wide.
+                  const up = new Array(tileCount).fill(0);
+                  const down = new Array(tileCount).fill(0);
+                  const redUp = new Array(tileCount).fill(0);
+                  const redDown = new Array(tileCount).fill(0);
+                  let deltaSum = 0;
+                  for (let i = 0; i < sampleCount; i += 1) {
+                    const before = prevLum[i];
+                    const after = curLum[i];
+                    deltaSum += Math.abs(after - before);
                     if (
                       Math.abs(after - before) >= 0.1 &&
                       Math.min(before, after) < 0.8
                     ) {
-                      if (after > before) gUp[sampleTile[i]] += 1;
-                      else gDown[sampleTile[i]] += 1;
+                      if (after > before) up[sampleTile[i]] += 1;
+                      else down[sampleTile[i]] += 1;
+                    }
+                    const redBefore = prevRed[i];
+                    const redAfter = curRed[i];
+                    if (
+                      (prevRedSat[i] === 1 || curRedSat[i] === 1) &&
+                      Math.abs(redAfter - redBefore) > 20
+                    ) {
+                      if (redAfter > redBefore) redUp[sampleTile[i]] += 1;
+                      else redDown[sampleTile[i]] += 1;
                     }
                   }
-                  govRising.push(gUp);
-                  govFalling.push(gDown);
+                  if (governor && prevGovLum) {
+                    const gUp = new Array(tileCount).fill(0);
+                    const gDown = new Array(tileCount).fill(0);
+                    for (let i = 0; i < sampleCount; i += 1) {
+                      const before = prevGovLum[i];
+                      const after = curGovLum[i];
+                      if (
+                        Math.abs(after - before) >= 0.1 &&
+                        Math.min(before, after) < 0.8
+                      ) {
+                        if (after > before) gUp[sampleTile[i]] += 1;
+                        else gDown[sampleTile[i]] += 1;
+                      }
+                    }
+                    govRising.push(gUp);
+                    govFalling.push(gDown);
+                  }
+                  rising.push(up);
+                  falling.push(down);
+                  redRising.push(redUp);
+                  redFalling.push(redDown);
+                  frameMeanDelta.push(deltaSum / sampleCount);
                 }
-                rising.push(up);
-                falling.push(down);
-                redRising.push(redUp);
-                redFalling.push(redDown);
-                frameMeanDelta.push(deltaSum / sampleCount);
+                if (governor) {
+                  prevGovLum = prevGovLum
+                    ? prevGovLum
+                    : new Float64Array(sampleCount);
+                  prevGovLum.set(curGovLum);
+                }
+                prevLum = prevLum ? prevLum : new Float64Array(sampleCount);
+                prevLum.set(curLum);
+                prevRed = prevRed ? prevRed : new Float64Array(sampleCount);
+                prevRed.set(curRed);
+                prevRedSat = prevRedSat
+                  ? prevRedSat
+                  : new Uint8Array(sampleCount);
+                prevRedSat.set(curRedSat);
               }
-              if (governor) {
-                prevGovLum = prevGovLum
-                  ? prevGovLum
-                  : new Float64Array(sampleCount);
-                prevGovLum.set(curGovLum);
-              }
-              prevLum = prevLum ? prevLum : new Float64Array(sampleCount);
-              prevLum.set(curLum);
-              prevRed = prevRed ? prevRed : new Float64Array(sampleCount);
-              prevRed.set(curRed);
-              prevRedSat = prevRedSat
-                ? prevRedSat
-                : new Uint8Array(sampleCount);
-              prevRedSat.set(curRedSat);
-            }
 
-            return {
-              rising,
-              falling,
-              redRising,
-              redFalling,
-              govRising,
-              govFalling,
-              tilePixels,
-              frameMeanLuminance,
-              frameMeanDelta,
-            };
-          },
-          {
-            frames: CAPTURE_FRAMES,
-            deltaMs: DELTA_MS,
-            warmup: WARMUP_FRAMES,
+              return {
+                rising,
+                falling,
+                redRising,
+                redFalling,
+                govRising,
+                govFalling,
+                tilePixels,
+                frameMeanLuminance,
+                frameMeanDelta,
+              };
+            },
+            {
+              frames: CAPTURE_FRAMES,
+              deltaMs: DELTA_MS,
+              warmup: WARMUP_FRAMES,
+              cols: TILE_COLS,
+              rows: TILE_ROWS,
+              beatPulse: args.beatPulse,
+              SAMPLE_STRIDE: args.stride,
+              minCanvasWidth: Math.floor(args.viewport.width * 0.4),
+              useGovernor: args.governor,
+              governorGrid: 16,
+            },
+          );
+
+          if ('error' in captured && captured.error) {
+            console.log(`${label} — SKIP (${captured.error})`);
+            reports.push({
+              presetId: preset.id,
+              title: preset.title ?? preset.id,
+              author: preset.author ?? '',
+              error: captured.error,
+              peakFlashesPerSecond: 0,
+              totalFlashes: 0,
+              exceedsThreshold: false,
+              peakRedFlashesPerSecond: 0,
+              totalRedFlashes: 0,
+              exceedsRedThreshold: false,
+              motionEnergy: 0,
+              luminanceVolatility: 0,
+              meanLuminance: 0,
+              frameCount: 0,
+            });
+            continue;
+          }
+
+          const cap = captured as CapturedFrames & {
+            rising: number[][];
+            falling: number[][];
+            redRising: number[][];
+            redFalling: number[][];
+            govRising: number[][];
+            govFalling: number[][];
+            tilePixels: number;
+            frameMeanLuminance: number[];
+            frameMeanDelta: number[];
+          };
+          const analysisOnce = analyzeFlashEvents({
+            rising: cap.rising,
+            falling: cap.falling,
+            redRising: cap.redRising,
+            redFalling: cap.redFalling,
+            tilePixels: cap.tilePixels,
+            // Grid shape drives WCAG's "25% of any 10 degree visual field"
+            // window; without it the area test degrades to whole-screen and
+            // silently misses flashes confined to one region.
             cols: TILE_COLS,
             rows: TILE_ROWS,
-            beatPulse: args.beatPulse,
-            SAMPLE_STRIDE,
-            useGovernor: args.governor,
-            governorGrid: 16,
-          },
-        );
-
-        if ('error' in captured && captured.error) {
-          console.log(`${label} — SKIP (${captured.error})`);
-          reports.push({
-            presetId: preset.id,
-            title: preset.title ?? preset.id,
-            author: preset.author ?? '',
-            error: captured.error,
-            peakFlashesPerSecond: 0,
-            totalFlashes: 0,
-            exceedsThreshold: false,
-            peakRedFlashesPerSecond: 0,
-            totalRedFlashes: 0,
-            exceedsRedThreshold: false,
-            motionEnergy: 0,
-            luminanceVolatility: 0,
-            meanLuminance: 0,
-            frameCount: 0,
+            deltaMs: DELTA_MS,
+            frameMeanLuminance: cap.frameMeanLuminance,
+            frameMeanDelta: cap.frameMeanDelta,
           });
-          continue;
+          attempts.push({ cap, analysis: analysisOnce });
         }
 
-        const cap = captured as {
-          rising: number[][];
-          falling: number[][];
-          redRising: number[][];
-          redFalling: number[][];
-          govRising: number[][];
-          govFalling: number[][];
-          tilePixels: number;
-          frameMeanLuminance: number[];
-          frameMeanDelta: number[];
-        };
-        const analysis = analyzeFlashEvents({
-          rising: cap.rising,
-          falling: cap.falling,
-          redRising: cap.redRising,
-          redFalling: cap.redFalling,
-          tilePixels: cap.tilePixels,
-          // Grid shape drives WCAG's "25% of any 10 degree visual field"
-          // window; without it the area test degrades to whole-screen and
-          // silently misses flashes confined to one region.
-          cols: TILE_COLS,
-          rows: TILE_ROWS,
-          deltaMs: DELTA_MS,
-          frameMeanLuminance: cap.frameMeanLuminance,
-          frameMeanDelta: cap.frameMeanDelta,
-        });
+        if (attempts.length === 0) continue;
+        // Identical captures of the same preset do NOT always agree — see the
+        // module docblock. Reporting one number would hide that, so with
+        // --repeat the MEDIAN run is reported and the spread travels with it.
+        const ordered = [...attempts].sort(
+          (a, b) =>
+            a.analysis.peakFlashesPerSecond - b.analysis.peakFlashesPerSecond,
+        );
+        const chosen = ordered[
+          Math.floor(ordered.length / 2)
+        ] as (typeof attempts)[number];
+        const cap = chosen.cap;
+        const analysis = chosen.analysis;
+        const repeatPeaks = attempts.map(
+          (a) => a.analysis.peakFlashesPerSecond,
+        );
+        const repeatRedPeaks = attempts.map(
+          (a) => a.analysis.peakRedFlashesPerSecond,
+        );
         // Same render pass, scored again as the governor would have shown
         // it. Only the general-flash channel: the governor scales luminance,
         // which is not a claim about the red-flash criterion.
@@ -616,6 +724,7 @@ async function main() {
           title: preset.title ?? preset.id,
           author: preset.author ?? '',
           ...analysis,
+          ...(args.repeat > 1 ? { repeatPeaks, repeatRedPeaks } : {}),
           ...(governed
             ? {
                 governedPeakFlashesPerSecond: governed.peakFlashesPerSecond,
@@ -626,6 +735,9 @@ async function main() {
         flush();
         console.log(
           `${label} — peak=${analysis.peakFlashesPerSecond}/s ` +
+            (args.repeat > 1
+              ? `(runs ${repeatPeaks.join('/')}, red ${repeatRedPeaks.join('/')}) `
+              : '') +
             (governed ? `governed=${governed.peakFlashesPerSecond}/s ` : '') +
             `red=${analysis.peakRedFlashesPerSecond}/s ` +
             `motion=${analysis.motionEnergy.toFixed(4)} ` +

--- a/scripts/preset-lab-sensitivity.ts
+++ b/scripts/preset-lab-sensitivity.ts
@@ -55,6 +55,21 @@ const FRAMES = Number(flag('frames', '16'));
 const TOP = Number(flag('top', '15'));
 /** Relative step. Large enough to clear f32 noise, small enough to stay local. */
 const EPSILON = Number(flag('epsilon', '0.05'));
+const ALL_FIELDS = args.includes('--all-fields');
+
+/**
+ * Per-shape and per-custom-wave parameters, which cannot move the warp mesh.
+ *
+ * They are 1504 of a typical preset's 1594 numeric fields — 960 `shape_*` and
+ * 544 `custom_wave*` — so scanning them costs ~17x the runtime for results
+ * that are structurally zero: shapes and waves are drawn over the warp, they
+ * do not feed it. Exhaustive runs on geiss-sunsets and
+ * unchained-cranked-on-failure confirm it, with every live field in both
+ * coming from the warp/motion base set and not one shape or wave field
+ * registering. `--all-fields` restores the exhaustive scan for anyone who
+ * wants to re-check that on a different preset.
+ */
+const NON_MESH_FIELD = /^(shape_|custom_wave)/;
 
 function findPresetFile(id: string): string | null {
   const roots = ['public/milkdrop-presets', 'tests/fixtures/milkdrop'];
@@ -162,9 +177,13 @@ if (!baseline.positions) {
   process.exit(1);
 }
 
-const candidates = Object.entries(baseline.fields)
+const allNumeric = Object.entries(baseline.fields)
   .filter(([, v]) => Number.isFinite(v))
   .map(([k]) => k);
+const candidates = ALL_FIELDS
+  ? allNumeric
+  : allNumeric.filter((k) => !NON_MESH_FIELD.test(k));
+const skipped = allNumeric.length - candidates.length;
 
 type Row = { field: string; base: number; sensitivity: number };
 const rows: Row[] = [];
@@ -199,8 +218,12 @@ const live = rows.filter((r) => r.sensitivity > 1e-9);
 
 console.log(`\n  ${PRESET}`);
 console.log(
-  `  ${candidates.length} numeric fields, ${live.length} move the mesh ` +
-    `(${FRAMES} frames, central difference, eps=${EPSILON})\n`,
+  `  ${candidates.length} candidate fields, ${live.length} move the mesh ` +
+    `(${FRAMES} frames, central difference, eps=${EPSILON})` +
+    (skipped > 0
+      ? `\n  ${skipped} shape/custom-wave fields skipped — pass --all-fields to include them`
+      : '') +
+    '\n',
 );
 console.log('  field                        base        sensitivity');
 console.log(`  ${'-'.repeat(56)}`);


### PR DESCRIPTION
Started as efficiency work. The efficiency part landed; the important part is what verifying it turned up.

## `lab:sensitivity`: 17.8s → 1.29s

The probe scanned all 1594 numeric fields, but **1504 are `shape_*` (960) and `custom_wave*` (544)** — parameters of things drawn *over* the warp, which cannot feed it. Skipping them is **13.8×** with byte-identical output: same 11 live fields for `geiss-sunsets`, same values. Exhaustive runs on two presets back the filter — every live field came from the warp/motion base set, not one shape or wave field. `--all-fields` restores the exhaustive scan.

## Two hardcoded `400`s that broke every non-default viewport

Both the swap predicate and the capture guard required a canvas ≥400px wide. Any narrower viewport failed **100%** of presets, the swap predicate simply timing out — a silent, total failure for anyone who changed `VIEWPORT`. Both now scale with the configured viewport.

## Measuring smaller is not a valid shortcut

Chasing the ~40-hour corpus cost, the obvious lever is the per-frame `readPixels` of a 960×540 buffer. 320×180 at stride 1 samples exactly the same 57,600 pixels the default does at stride 3 — apparently a free 9×.

It isn't. **`mig-056` reports 6/s at full size and 0/s at 320×180** — clean versus failing — because thin bright structures are rasterised out of existence. Same reason the analysis thresholds per pixel *before* spatial averaging. It was also only ~1.8× faster. Now documented so it isn't re-derived.

## The audit does not reproduce — and now says so

Verifying that comparison turned up the larger problem: **the baseline doesn't reproduce either.**

| preset | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| unchained-cranked-on-failure | 13/s | 8/s | 10/s |
| beta106at-shape-mash0001 | 5/s (red 0) | 4/s (red 0) | 2/s (**red 6**) |
| mig-056 | 6/s | 6/s | 6/s |

`beta106at`'s red peak crosses the `classifyFlashRisk` boundary, so **its published risk band depends on which run you kept.** `--repeat=3` in a single process shows the same: `peak=7/s (runs 5/8/7, red 1/0/0)`. The `motion` figures move too, so the *frames* differ — something in the render path isn't reproducing despite deterministic frame stepping. Feedback-heavy presets vary most; `mig-056` was stable throughout.

**Root cause is not found.** What ships is the instrument admitting it: `--repeat=N` captures N times, reports the median, and carries the spread into the console line and the report (`repeatPeaks`, `repeatRedPeaks`). A single unstable number can no longer pass as a measurement.

This matters more than the throughput work it came from: `sensoryProfile` drives a photosensitivity warning, and until this is fixed a preset's band is partly a coin flip.

`check:quick` clean, 2673 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)