### PR TITLE
fix(webgpu): typecheck the WebGPU renderer for the first time

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "stims",
       "dependencies": {
         "@codemirror/autocomplete": "6.20.3",
-        "@codemirror/commands": "6.10.4",
+        "@codemirror/commands": "6.11.0",
         "@codemirror/language": "6.12.4",
         "@codemirror/lint": "^6.9.7",
         "@codemirror/search": "^6.7.0",
@@ -35,14 +35,14 @@
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@types/three": "^0.185.4",
-        "@vitejs/plugin-react": "6.0.5",
+        "@vitejs/plugin-react": "6.1.0",
         "@webgpu/types": "^0.1.72",
         "axe-core": "^4.13.0",
         "butterchurn": "^2.6.7",
         "butterchurn-presets": "^2.4.7",
-        "dependency-cruiser": "^17.3.9",
+        "dependency-cruiser": "^18.2.0",
         "esbuild": "^0.28.1",
-        "happy-dom": "20.11.1",
+        "happy-dom": "20.11.6",
         "husky": "^9.1.7",
         "pixelmatch": "^7.2.0",
         "playwright": "1.62.1",
@@ -103,7 +103,7 @@
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
-    "@codemirror/commands": ["@codemirror/commands@6.10.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg=="],
+    "@codemirror/commands": ["@codemirror/commands@6.11.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA=="],
 
     "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
 
@@ -405,13 +405,13 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.5", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.0", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.72", "", {}, "sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -471,7 +471,7 @@
 
     "comlink": ["comlink@4.4.2", "", {}, "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -501,7 +501,7 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
-    "dependency-cruiser": ["dependency-cruiser@17.4.3", "", { "dependencies": { "acorn": "8.16.0", "acorn-jsx": "5.3.2", "acorn-jsx-walk": "2.0.0", "acorn-loose": "8.5.2", "acorn-walk": "8.3.5", "commander": "14.0.3", "enhanced-resolve": "5.22.1", "ignore": "7.0.5", "interpret": "3.1.1", "is-installed-globally": "1.0.0", "json5": "2.2.3", "picomatch": "4.0.4", "prompts": "2.4.2", "rechoir": "0.8.0", "safe-regex": "2.1.1", "semver": "7.8.1", "tsconfig-paths-webpack-plugin": "4.2.0", "watskeburt": "5.0.3" }, "bin": { "depcruise": "bin/dependency-cruise.mjs", "depcruise-fmt": "bin/depcruise-fmt.mjs", "dependency-cruise": "bin/dependency-cruise.mjs", "depcruise-baseline": "bin/depcruise-baseline.mjs", "dependency-cruiser": "bin/dependency-cruise.mjs", "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs" } }, "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w=="],
+    "dependency-cruiser": ["dependency-cruiser@18.2.0", "", { "dependencies": { "acorn": "8.18.0", "acorn-jsx": "5.3.2", "acorn-jsx-walk": "2.0.0", "acorn-loose": "8.5.2", "acorn-walk": "8.3.5", "commander": "15.0.0", "enhanced-resolve": "5.24.5", "ignore": "7.0.6", "interpret": "3.1.1", "is-installed-globally": "1.0.0", "json5": "2.2.3", "picomatch": "4.0.5", "prompts": "2.4.2", "rechoir": "0.8.0", "safe-regex": "2.1.1", "semver": "7.8.5", "tsconfig-paths-webpack-plugin": "4.2.0", "watskeburt": "6.0.0" }, "bin": { "depcruise": "bin/dependency-cruise.mjs", "depcruise-fmt": "bin/depcruise-fmt.mjs", "dependency-cruise": "bin/dependency-cruise.mjs", "depcruise-baseline": "bin/depcruise-baseline.mjs", "dependency-cruiser": "bin/dependency-cruise.mjs", "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs" } }, "sha512-xMDoLD0no6pDInR8/4rIIqZ4mERDnsjezk8PkNORYSfBLvjCOogUxaruepmi1uQtZQlYUgdT2u7G3jTlgKqNjw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -515,7 +515,7 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -583,7 +583,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
+    "happy-dom": ["happy-dom@20.11.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -599,7 +599,7 @@
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
-    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+    "ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -713,7 +713,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
@@ -763,7 +763,7 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -841,7 +841,7 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
-    "watskeburt": ["watskeburt@5.0.3", "", { "bin": { "watskeburt": "dist/run-cli.js" } }, "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA=="],
+    "watskeburt": ["watskeburt@6.0.0", "", { "bin": { "watskeburt": "dist/run-cli.js" } }, "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ=="],
 
     "wav": ["wav@1.0.2", "", { "dependencies": { "buffer-alloc": "^1.1.0", "buffer-from": "^1.0.0", "debug": "^2.2.0", "readable-stream": "^1.1.14", "stream-parser": "^0.3.1" } }, "sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg=="],
 
@@ -877,7 +877,7 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "@rollup/pluginutils/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+    "@strudel/transpiler/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "@tonaljs/chord-detect/@tonaljs/chord-type": ["@tonaljs/chord-type@5.1.1", "", { "dependencies": { "@tonaljs/pcset": "4.10.1" } }, "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw=="],
 
@@ -913,29 +913,27 @@
 
     "@types/ws/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
+    "acorn-loose/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-walk/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "buffer-image-size/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "bun-types/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
-    "happy-dom/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
-
     "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
-    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
     "stream-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+    "tsconfig-paths-webpack-plugin/enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "wav/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -958,8 +956,6 @@
     "buffer-image-size/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "happy-dom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "stream-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/scripts/android-test.ts
+++ b/scripts/android-test.ts
@@ -10,7 +10,6 @@
  * quality preset, a 2s FPS sample, and live telemetry.
  */
 import { $ } from 'bun';
-// @ts-expect-error - resolved at runtime via vite
 import { createServer } from 'vite';
 
 const DEV_SERVER_PORT = 5173;

--- a/src/js/core/webgpu-renderer.ts
+++ b/src/js/core/webgpu-renderer.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error - 'three/webgpu' requires moduleResolution: "bundler" or "nodenext", but project uses "node".
 import { WebGPURenderer } from 'three/webgpu';
 
 export type WebGPURendererType = typeof WebGPURenderer;

--- a/src/js/milkdrop/feedback-manager-webgpu-composite.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-composite.ts
@@ -1,4 +1,5 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: TSL node graphs are not fully typed under the repo's current moduleResolution.
+
 import type { Camera, Scene, Texture } from 'three';
 import {
   ClampToEdgeWrapping,
@@ -16,7 +17,6 @@ import {
   Vector2,
   Vector4,
 } from 'three';
-// @ts-expect-error - 'three/webgpu' is available at runtime but not under the repo's current moduleResolution.
 import { RenderTarget, TSL } from 'three/webgpu';
 import { getSharedMilkdropCapturedVideoTexture } from '../core/services/captured-video-texture.ts';
 import { WEBGPU_MILKDROP_BACKEND_BEHAVIOR } from './backend-behavior';
@@ -30,6 +30,7 @@ import {
   createMilkdropNoiseVolumeAtlasTexture,
   MILKDROP_NOISE_VOLUME_ATLAS_SLICE_SIZE,
 } from './milkdrop-native-noise.ts';
+import type { TslNode } from './renderer-helpers/tsl-node-types.ts';
 import { MILKDROP_SHADER_AUX_TEXTURE_SOURCE_IDS } from './shader-samplers.ts';
 import type { MilkdropFeedbackCompositeState } from './types';
 
@@ -620,7 +621,16 @@ function selectBySourceId(
   return chain;
 }
 
-export function sampleFeedbackTarget(textureNode: any, screenUv: any) {
+/**
+ * Return type stated rather than inferred: `textureNode` is `any` (three has
+ * no single type covering every texture node these managers hold), so
+ * without this the sampled texel is `any` too, and every `.rgb`/`.a` derived
+ * from it silently degrades to a scalar downstream. A sample is a vec4.
+ */
+export function sampleFeedbackTarget(
+  textureNode: any,
+  screenUv: any,
+): TslNode<'vec4'> {
   return textureNode.sample(flipFeedbackSampleUv(screenUv));
 }
 
@@ -642,23 +652,31 @@ export function createSampleUvNode() {
 }
 
 export function createApplyFeedbackWarpNode() {
-  return Fn(([sampleUv, amount, rotationAmount]: [any, any, any]) => {
-    const centered = sampleUv.sub(0.5);
-    const radius = length(centered);
-    const angle = atan(centered.y, centered.x);
-    const spiral = sin(radius.mul(18).sub(angle.mul(4)))
-      .mul(amount)
-      .mul(0.08);
-    const warpedAngle = angle.add(spiral).add(rotationAmount.mul(0.22));
-    const warpedRadius = radius.mul(
-      float(1).add(
-        cos(warpedAngle.mul(3).add(radius.mul(10)))
-          .mul(amount)
-          .mul(0.05),
-      ),
-    );
-    return vec2(cos(warpedAngle), sin(warpedAngle)).mul(warpedRadius).add(0.5);
-  });
+  return Fn(
+    ([sampleUv, amount, rotationAmount]: [
+      TslNode<'vec2'>,
+      TslNode<'float'>,
+      TslNode<'float'>,
+    ]) => {
+      const centered = sampleUv.sub(0.5);
+      const radius = length(centered);
+      const angle = atan(centered.y, centered.x);
+      const spiral = sin(radius.mul(18).sub(angle.mul(4)))
+        .mul(amount)
+        .mul(0.08);
+      const warpedAngle = angle.add(spiral).add(rotationAmount.mul(0.22));
+      const warpedRadius = radius.mul(
+        float(1).add(
+          cos(warpedAngle.mul(3).add(radius.mul(10)))
+            .mul(amount)
+            .mul(0.05),
+        ),
+      );
+      return vec2(cos(warpedAngle), sin(warpedAngle))
+        .mul(warpedRadius)
+        .add(0.5);
+    },
+  );
 }
 
 export function createSampleAuxTextureNode(
@@ -753,9 +771,17 @@ export function createSampleAuxTextureNode(
       // margins so cross-slice color never bleeds near atlas seams.
       const edgeMargin = 0.02;
       const blended = mix(lowerSample, upperSample, blend);
-      const snapLow = select(step(edgeMargin, blend), blended, lowerSample);
+      // `select()` takes a boolean condition. These two read the same as the
+      // `step(edge, blend)` they replace — step is 1 exactly when
+      // blend >= edge — but say the predicate directly instead of routing it
+      // through a float that then has to be reinterpreted as a bool.
+      const snapLow = select(
+        blend.greaterThanEqual(edgeMargin),
+        blended,
+        lowerSample,
+      );
       const snapHigh = select(
-        step(float(1).sub(edgeMargin), blend),
+        blend.greaterThanEqual(float(1).sub(edgeMargin)),
         upperSample,
         snapLow,
       );
@@ -764,7 +790,15 @@ export function createSampleAuxTextureNode(
   );
 
   return Fn(
-    ([source, sampleDimension, sampleUv, sliceZ]: [any, any, any, any]) => {
+    // Typed rather than `any`: `fract(sampleUv)` feeds `vec3(uv, z)` below,
+    // which needs the uv to still be a vec2. Left as `any` the whole chain
+    // degrades to float and every 3D sample loses its overload.
+    ([source, sampleDimension, sampleUv, sliceZ]: [
+      TslNode<'float'>,
+      TslNode<'float'>,
+      TslNode<'vec2'>,
+      TslNode<'float'>,
+    ]) => {
       const wrappedUv = fract(sampleUv);
       const wrappedZ = fract(sliceZ);
       const flat = vec4(0.5, 0.5, 0.5, 1);

--- a/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
@@ -17,6 +17,7 @@
  * are not fully typed under the repo's current module resolution.
  */
 // biome-ignore-all lint/suspicious/noExplicitAny: TSL node graphs are not fully typed under the repo's current moduleResolution.
+
 import type { Camera, Texture } from 'three';
 import {
   Color,
@@ -27,7 +28,6 @@ import {
   Vector2,
   Vector4,
 } from 'three';
-// @ts-expect-error - 'three/webgpu' requires moduleResolution: "bundler" or "nodenext", but project uses "node".
 import { NodeMaterial, type RenderTarget, TSL } from 'three/webgpu';
 import { isAgentMode } from '../core/agent-api.ts';
 import { disposeMaterial } from '../utils/three/three-dispose';
@@ -61,6 +61,7 @@ import {
   type OutputConversionRenderer,
   renderWithoutOutputConversion,
 } from './output-conversion-passthrough.ts';
+import type { TslNode } from './renderer-helpers/tsl-node-types.ts';
 
 export {
   resolveDirectShaderSamplerBinding,
@@ -352,7 +353,9 @@ function createPresentOutputNode(
     const q = p3.add(dot(p3, p3.yzx.add(33.33)));
     return fract(q.x.add(q.y).mul(q.z));
   };
-  const valueNoise = (p: any) => {
+  // p is a 2D sample point: `u` below swizzles .x/.y, which only exists if
+  // the parameter says it is a vec2 rather than `any`.
+  const valueNoise = (p: TslNode<'vec2'>) => {
     const i = floor(p);
     const f = fract(p);
     const u = f.mul(f).mul(f.mul(-2.0).add(3.0));
@@ -490,11 +493,21 @@ type ShaderBinaryOperator =
   | '&'
   | '|';
 
-type ShaderNodeEnv = {
+export type ShaderNodeEnv = {
   values: Map<string, ShaderNodeValue>;
   uniforms: CompositeUniformBag;
   sampleUvNode: ReturnType<typeof createSampleUvNode>;
-  sampleAuxTextureNode: ReturnType<typeof createSampleAuxTextureNode>;
+  /**
+   * Declared as returning a vec4 rather than inheriting the factory's
+   * inferred type. That factory is a single `select()` chain over ~15
+   * branches, every one of which constructs a vec4; three widens the chain
+   * to `Node<'float' | 'vec4'>`, which is an artifact of the operand count
+   * and not a path that yields a scalar. Callers immediately take `.rgb` or
+   * `.rg`, which the union does not carry.
+   */
+  sampleAuxTextureNode: (
+    ...args: Parameters<ReturnType<typeof createSampleAuxTextureNode>>
+  ) => TslNode<'vec4'>;
   /** Stage-specific meaning of sampler_main. The comp stage sets this to the
    * reconstructed composited frame (feedback + geometry); without it, main
    * samples fall back to the geometry-only scene texture. */
@@ -503,7 +516,13 @@ type ShaderNodeEnv = {
 
 type DirectShaderSwizzleComponent = 'x' | 'y' | 'z' | 'w';
 
-function hueRotateNode(colorValue: any, angle: any) {
+/**
+ * `colorValue` is declared as a vec3 rather than `any` so the mat3 multiply
+ * below resolves to the vec3 overload. Left as `any`, three infers
+ * `mat3.mul(any)` as returning another mat3, and the surrounding `clamp`
+ * against vec3 bounds then has no matching overload.
+ */
+function hueRotateNode(colorValue: TslNode<'vec3'>, angle: TslNode<'float'>) {
   return Fn(() => {
     const s = sin(angle);
     const c = cos(angle);
@@ -2319,7 +2338,20 @@ function applyDirectCompProgram(
   ).node;
 }
 
-function createCompositeAuxSampler(uniforms: CompositeUniformBag) {
+/**
+ * The aux-texture sampler, typed as returning the vec4 it always builds.
+ *
+ * `createSampleAuxTextureNode` is one `select()` chain over ~15 branches,
+ * each constructing a vec4; three widens the chain to
+ * `Node<'float' | 'vec4'>` because of the operand count, not because any
+ * path yields a scalar. Callers take `.rgb`/`.rg`, which the union does not
+ * carry, so the narrowing is stated once here rather than at every use.
+ */
+function createCompositeAuxSampler(
+  uniforms: CompositeUniformBag,
+): (
+  ...args: Parameters<ReturnType<typeof createSampleAuxTextureNode>>
+) => TslNode<'vec4'> {
   return createSampleAuxTextureNode(
     uniforms.noiseTex,
     uniforms.perlinTex,
@@ -2348,7 +2380,9 @@ function createCompositeAuxSampler(uniforms: CompositeUniformBag) {
       perlin: uniforms.perlinTex3D,
       noisevol: uniforms.noisevolTex3D,
     },
-  );
+  ) as unknown as (
+    ...args: Parameters<ReturnType<typeof createSampleAuxTextureNode>>
+  ) => TslNode<'vec4'>;
 }
 
 /**
@@ -2569,9 +2603,14 @@ function createFeedbackBlendOutputNode(
     const warpTextureMask = step(0.5, uniforms.warpTextureSource).mul(
       step(0.0001, uniforms.warpTextureAmount),
     );
+    // `CompositeUniformBag` is `Record<string, any>`, so `.mul(any)` resolves
+    // to the widest overload (vec3) and the uv chain stops being a vec2.
+    // These two are `uniform(new Vector2(...))` at their declaration
+    // (feedback-manager-webgpu-composite.ts), so saying so here keeps the
+    // chain honest without typing all 114 uniforms.
     const warpUv = currentUv
-      .mul(uniforms.warpTextureScale)
-      .add(uniforms.warpTextureOffset);
+      .mul(uniforms.warpTextureScale as TslNode<'vec2'>)
+      .add(uniforms.warpTextureOffset as TslNode<'vec2'>);
     const warpVector = sampleAuxTextureNode(
       uniforms.warpTextureSource,
       uniforms.warpTextureSampleDimension,
@@ -2686,9 +2725,14 @@ function createCompositeOutputNode(
     const overlayMask = overlaySourceMask.mul(
       max(overlayReplaceMask, overlayBlendMask),
     );
+    // `CompositeUniformBag` is `Record<string, any>`, so `.mul(any)` resolves
+    // to the widest overload (vec3) and the uv chain stops being a vec2.
+    // These two are `uniform(new Vector2(...))` at their declaration
+    // (feedback-manager-webgpu-composite.ts), so saying so here keeps the
+    // chain honest without typing all 114 uniforms.
     const overlayUv = baseUv
-      .mul(uniforms.overlayTextureScale)
-      .add(uniforms.overlayTextureOffset);
+      .mul(uniforms.overlayTextureScale as TslNode<'vec2'>)
+      .add(uniforms.overlayTextureOffset as TslNode<'vec2'>);
     const overlaySample = sampleAuxTextureNode(
       uniforms.overlayTextureSource,
       uniforms.overlayTextureSampleDimension,

--- a/src/js/milkdrop/renderer-backends/webgpu-batching-materials.ts
+++ b/src/js/milkdrop/renderer-backends/webgpu-batching-materials.ts
@@ -1,11 +1,14 @@
 import type { Material, Texture } from 'three';
 import { DataTexture, DoubleSide } from 'three';
-// @ts-expect-error - 'three/webgpu' is available at runtime but not under the repo's current moduleResolution.
 import { NodeMaterial, TSL } from 'three/webgpu';
 import type {
   ShapeBatchMaterialFactory,
   ShapeFillBatchMaterial,
 } from '../renderer-adapter-webgpu-batching';
+import {
+  type TslNode,
+  typedAttribute,
+} from '../renderer-helpers/tsl-node-types.ts';
 
 // NodeMaterial/TSL twins of the GLSL ShaderMaterials in
 // renderer-adapter-webgpu-batching.ts, for the native WebGPU renderer (which
@@ -67,9 +70,9 @@ function applyFlatBatchMaterialFlags(material: Material) {
 }
 
 function rotate2d(
-  value: { x: TslNode; y: TslNode },
-  cosR: TslNode,
-  sinR: TslNode,
+  value: { x: TslNode<'float'>; y: TslNode<'float'> },
+  cosR: TslNode<'float'>,
+  sinR: TslNode<'float'>,
 ) {
   return vec2(
     value.x.mul(cosR).sub(value.y.mul(sinR)),
@@ -77,39 +80,23 @@ function rotate2d(
   );
 }
 
-type TslNode = {
-  x: TslNode;
-  y: TslNode;
-  z: TslNode;
-  w: TslNode;
-  rgb: TslNode;
-  a: TslNode;
-  value: unknown;
-  mul: (other: unknown) => TslNode;
-  add: (other: unknown) => TslNode;
-  sub: (other: unknown) => TslNode;
-  div: (other: unknown) => TslNode;
-  sample: (uv: unknown) => TslNode;
-  [key: string]: unknown;
-};
-
 function createTslShapeFillMaterial(): ShapeFillBatchMaterial {
-  const shapeTextureNode = texture(getFallbackShapeTexture()) as TslNode;
-  const textureAspectY = uniform(1) as TslNode;
+  const shapeTextureNode = texture(getFallbackShapeTexture());
+  const textureAspectY = uniform(1);
 
-  const transform = attribute('instanceTransform', 'vec4') as TslNode;
-  const primary = attribute('instancePrimaryColorAlpha', 'vec4') as TslNode;
-  const secondary = attribute('instanceSecondaryColorAlpha', 'vec4') as TslNode;
-  const fillControl = attribute('instanceFillControl', 'vec4') as TslNode;
+  const transform = typedAttribute('instanceTransform', 'vec4');
+  const primary = typedAttribute('instancePrimaryColorAlpha', 'vec4');
+  const secondary = typedAttribute('instanceSecondaryColorAlpha', 'vec4');
+  const fillControl = typedAttribute('instanceFillControl', 'vec4');
 
-  const local = positionGeometry.xy as TslNode;
-  const cosR = cos(transform.w) as TslNode;
-  const sinR = sin(transform.w) as TslNode;
+  const local = positionGeometry.xy;
+  const cosR = cos(transform.w);
+  const sinR = sin(transform.w);
   const rotated = rotate2d(
     { x: local.x.mul(transform.z), y: local.y.mul(transform.z) },
     cosR,
     sinR,
-  ) as TslNode;
+  );
 
   const material = new NodeMaterial();
   applyFlatBatchMaterialFlags(material);
@@ -118,16 +105,16 @@ function createTslShapeFillMaterial(): ShapeFillBatchMaterial {
     .mul(vec4(rotated.add(transform.xy), 0.14, 1.0));
 
   const gradientBlend = clamp(length(local), 0.0, 1.0).mul(fillControl.x);
-  const baseColor = mix(primary, secondary, gradientBlend) as TslNode;
-  const texCos = cos(fillControl.w) as TslNode;
-  const texSin = sin(fillControl.w) as TslNode;
+  const baseColor = mix(primary, secondary, gradientBlend);
+  const texCos = cos(fillControl.w);
+  const texSin = sin(fillControl.w);
   const texRotated = rotate2d({ x: local.x, y: local.y }, texCos, texSin);
-  const zoom = max(fillControl.z, 0.0001) as TslNode;
+  const zoom = max(fillControl.z, 0.0001);
   const sampleUv = vec2(
     float(0.5).add(texRotated.x.mul(0.5).mul(textureAspectY).div(zoom)),
     float(0.5).add(texRotated.y.mul(0.5).div(zoom)),
   );
-  const sampled = shapeTextureNode.sample(fract(sampleUv)) as TslNode;
+  const sampled = shapeTextureNode.sample(fract(sampleUv));
   const texturedColor = vec4(
     sampled.rgb.mul(baseColor.rgb),
     baseColor.a.mul(sampled.a),
@@ -151,22 +138,20 @@ function createTslShapeFillMaterial(): ShapeFillBatchMaterial {
 }
 
 function createTslShapeRingMaterial(layerZ: number): Material {
-  const unitCorner = attribute('unitCorner', 'vec2') as TslNode;
-  const innerWeight = attribute('innerWeight', 'float') as TslNode;
-  const transform = attribute('instanceTransform', 'vec4') as TslNode;
-  const colorAlpha = attribute('instanceColorAlpha', 'vec4') as TslNode;
-  const scales = attribute('instanceScales', 'vec2') as TslNode;
+  const unitCorner = typedAttribute('unitCorner', 'vec2');
+  const innerWeight = typedAttribute('innerWeight', 'float');
+  const transform = typedAttribute('instanceTransform', 'vec4');
+  const colorAlpha = typedAttribute('instanceColorAlpha', 'vec4');
+  const scales = typedAttribute('instanceScales', 'vec2');
 
-  const localScale = mix(scales.x, scales.y, innerWeight).mul(
-    transform.z,
-  ) as TslNode;
-  const cosR = cos(transform.w) as TslNode;
-  const sinR = sin(transform.w) as TslNode;
+  const localScale = mix(scales.x, scales.y, innerWeight).mul(transform.z);
+  const cosR = cos(transform.w);
+  const sinR = sin(transform.w);
   const rotated = rotate2d(
     { x: unitCorner.x.mul(localScale), y: unitCorner.y.mul(localScale) },
     cosR,
     sinR,
-  ) as TslNode;
+  );
 
   const material = new NodeMaterial();
   applyFlatBatchMaterialFlags(material);
@@ -178,16 +163,14 @@ function createTslShapeRingMaterial(layerZ: number): Material {
 }
 
 function createTslBorderMaterial(): Material {
-  const unitCorner = attribute('unitCorner', 'vec2') as TslNode;
-  const innerWeight = attribute('innerWeight', 'float') as TslNode;
-  const insets = attribute('instanceInsets', 'vec4') as TslNode;
-  const colorAlpha = attribute('instanceColorAlpha', 'vec4') as TslNode;
+  const unitCorner = typedAttribute('unitCorner', 'vec2');
+  const innerWeight = typedAttribute('innerWeight', 'float');
+  const insets = typedAttribute('instanceInsets', 'vec4');
+  const colorAlpha = typedAttribute('instanceColorAlpha', 'vec4');
 
-  const outerScale = float(1.0).sub(insets.y) as TslNode;
-  const innerScale = float(1.0).sub(insets.z) as TslNode;
-  const scale = mix(outerScale, innerScale, innerWeight).mul(
-    insets.w,
-  ) as TslNode;
+  const outerScale = float(1.0).sub(insets.y);
+  const innerScale = float(1.0).sub(insets.z);
+  const scale = mix(outerScale, innerScale, innerWeight).mul(insets.w);
 
   const material = new NodeMaterial();
   applyFlatBatchMaterialFlags(material);

--- a/src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts
+++ b/src/js/milkdrop/renderer-backends/webgpu-procedural-materials.ts
@@ -11,7 +11,6 @@
  * the author does not have.
  */
 import { Color } from 'three';
-// @ts-expect-error - 'three/webgpu' is available at runtime but not under the repo's current moduleResolution.
 import { NodeMaterial, TSL } from 'three/webgpu';
 import {
   EEL_BINARY_OPERATORS,
@@ -28,6 +27,14 @@ import {
   createProceduralFieldUniformState,
   createProceduralInteractionUniformState,
 } from '../renderer-helpers/procedural-field-uniforms';
+import {
+  asColorNode,
+  type TslNode,
+  type TslUniformNode,
+  type TslUniformNodes,
+  typedAttribute,
+  typedUniform,
+} from '../renderer-helpers/tsl-node-types.ts';
 import { registerWebGpuHelperMaterials } from '../renderer-helpers/webgpu-materials-loader';
 import type {
   MilkdropGpuFieldExpression,
@@ -57,7 +64,6 @@ import type {
 const {
   Discard,
   Fn,
-  attribute,
   cameraProjectionMatrix,
   modelViewMatrix,
   uniform,
@@ -67,20 +73,16 @@ const {
   wgslFn,
 } = TSL;
 
-type TslNode = {
-  value: number & Color;
-  x: TslNode;
-  y: TslNode;
-  z: TslNode;
-  w: TslNode;
-  mul: (other: unknown) => TslNode;
-  lessThanEqual: (other: unknown) => TslNode;
-  [key: string]: unknown;
-};
-
-type TslVertexFn = (inputs: object) => TslNode;
-
-type TslUniformNodes<T> = { [K in keyof T]: TslNode };
+/**
+ * A compiled TSL vertex function: takes the graph inputs, returns a vec4.
+ *
+ * `wgslFn()` is typed as a variadic callable over `number | Node`, which is
+ * how three describes ANY generated function. These are all called with a
+ * single named-inputs object and all return a vec4, so this states the
+ * calling convention this file actually uses; the conversion at each
+ * `wgslFn()` site is the one place that knowledge is asserted.
+ */
+type TslVertexFn = (inputs: object) => TslNode<'vec4'>;
 
 // The per-preset field programs arrive as expression ASTs and historically
 // compiled to GLSL. On WebGPU they must compile to WGSL instead; the
@@ -556,7 +558,14 @@ const WGSL_APPLY_INTERACTION = `
     );
 `;
 
-const transformIncludeCache = new Map<string, unknown>();
+/**
+ * Cached `wgsl()` includes, keyed by field-program signature.
+ *
+ * Typed as what `wgsl()` returns rather than `unknown`: these are handed
+ * straight to `wgslFn()`'s includes list, which wants `CodeNodeInclude[]`.
+ */
+type WgslInclude = ReturnType<typeof wgsl>;
+const transformIncludeCache = new Map<string, WgslInclude>();
 
 function getTransformInclude(
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,
@@ -570,12 +579,12 @@ function getTransformInclude(
   return include;
 }
 
-function toUniformNodes<T extends Record<string, { value: unknown }>>(
+function toUniformNodes<T extends Record<string, { value: number | Color }>>(
   state: T,
 ): TslUniformNodes<T> {
-  const nodes: Record<string, TslNode> = {};
+  const nodes: Record<string, TslUniformNode<number | Color>> = {};
   for (const [key, entry] of Object.entries(state)) {
-    nodes[key] = uniform(entry.value);
+    nodes[key] = typedUniform(entry.value);
   }
   return nodes as TslUniformNodes<T>;
 }
@@ -600,19 +609,22 @@ function packSignalUniformVectors(
   uniforms: Record<string, TslNode>,
   prefix: 'signal' | 'previousSignal',
 ) {
-  const packed = {} as Record<SignalUniformVectorKey, TslNode>;
+  const packed = {} as Record<SignalUniformVectorKey, TslNode<'vec4'>>;
   for (const [key, suffixes] of Object.entries(
     SIGNAL_UNIFORM_VECTOR_LAYOUT,
   ) as [SignalUniformVectorKey, readonly string[]][]) {
     const [x, y, z, w] = suffixes.map(
       (suffix) => uniforms[`${prefix}${suffix}`],
     );
-    packed[key] = vec4(x, y, z, w) as TslNode;
+    packed[key] = vec4(x, y, z, w);
   }
   return packed;
 }
 
-function packFieldParamVectors(uniforms: Record<string, TslNode>, prefix = '') {
+function packFieldParamVectors(
+  uniforms: Record<string, TslUniformNode>,
+  prefix = '',
+) {
   const get = (name: string) =>
     uniforms[
       prefix === ''
@@ -643,7 +655,10 @@ function packRegisterVectorArgs(
   uniforms: Record<string, TslNode>,
   program: MilkdropGpuFieldProgramDescriptor | null | undefined,
 ) {
-  const args: Record<string, TslNode> = {};
+  // The inputs bag for a generated WGSL function: heterogeneous by nature
+  // (vec4 register banks here, vec3 positions and scalars elsewhere), and
+  // consumed through TslVertexFn's `inputs: object`.
+  const args: Record<string, TslNode<'vec4'>> = {};
   for (const vector of getRegisterVectorIndices(program)) {
     const base = vector * 4;
     args[`registers${REGISTER_VECTOR_LETTERS[vector]}`] = vec4(
@@ -651,7 +666,7 @@ function packRegisterVectorArgs(
       uniforms[`registerSlot${base + 1}`],
       uniforms[`registerSlot${base + 2}`],
       uniforms[`registerSlot${base + 3}`],
-    ) as TslNode;
+    );
   }
   return args;
 }
@@ -712,7 +727,7 @@ function getProceduralMeshVertexFn(
   const fn = wgslFn(buildProceduralMeshVertexFnWgsl(program), [
     MILKDROP_FIELD_WGSL_HELPERS,
     getTransformInclude(program),
-  ]) as TslVertexFn;
+  ]) as unknown as TslVertexFn;
   meshVertexFnCache.set(key, fn);
   return fn;
 }
@@ -727,7 +742,7 @@ export function createProceduralMeshMaterial(
   const signals = packSignalUniformVectors(uniforms, 'signal');
   const fieldParams = packFieldParamVectors(uniforms);
   const vertex = getProceduralMeshVertexFn(program)({
-    sourcePosition: attribute('sourcePosition', 'vec3'),
+    sourcePosition: typedAttribute('sourcePosition', 'vec3'),
     fieldParamsA: fieldParams.a,
     fieldParamsB: fieldParams.b,
     fieldParamsC: fieldParams.c,
@@ -747,7 +762,7 @@ export function createProceduralMeshMaterial(
     .mul(modelViewMatrix)
     .mul(vec4(vertex, 1.0));
   material.colorNode = vec4(
-    uniforms.tint,
+    asColorNode(uniforms.tint),
     uniforms.alpha.mul(uniforms.interactionAlpha),
   );
 
@@ -863,7 +878,7 @@ function getProceduralMotionVectorVertexFn(
   const fn = wgslFn(buildProceduralMotionVectorVertexFnWgsl(program), [
     MILKDROP_FIELD_WGSL_HELPERS,
     getTransformInclude(program),
-  ]) as TslVertexFn;
+  ]) as unknown as TslVertexFn;
   motionVectorVertexFnCache.set(key, fn);
   return fn;
 }
@@ -925,8 +940,8 @@ export function createProceduralMotionVectorMaterial(
   const previousFieldParams = packFieldParamVectors(uniforms, 'previous');
   const result = varying(
     getProceduralMotionVectorVertexFn(program)({
-      sourcePosition: attribute('sourcePosition', 'vec3'),
-      endpointWeight: attribute('endpointWeight', 'float'),
+      sourcePosition: typedAttribute('sourcePosition', 'vec3'),
+      endpointWeight: typedAttribute('endpointWeight', 'float'),
       fieldParamsA: fieldParams.a,
       fieldParamsB: fieldParams.b,
       fieldParamsC: fieldParams.c,
@@ -958,7 +973,7 @@ export function createProceduralMotionVectorMaterial(
       ),
       interactionTransform: packInteractionVector(uniforms),
     }),
-  ) as TslNode;
+  );
 
   const material = new NodeMaterial();
   material.transparent = true;
@@ -968,7 +983,7 @@ export function createProceduralMotionVectorMaterial(
     .mul(vec4(result.x, result.y, result.w, 1.0));
   material.colorNode = Fn(() => {
     Discard(result.z.lessThanEqual(0.0));
-    return vec4(uniforms.tint, result.z);
+    return vec4(asColorNode(uniforms.tint), result.z);
   })();
 
   return Object.assign(material, { uniforms });
@@ -1108,14 +1123,14 @@ function getProceduralCustomWaveVertexFn(
   if (cached) {
     return cached;
   }
-  const includes: unknown[] = [MILKDROP_FIELD_WGSL_HELPERS];
+  const includes: WgslInclude[] = [MILKDROP_FIELD_WGSL_HELPERS];
   if (program) {
     includes.push(wgsl(buildCustomWaveProgramWgslCode(program)));
   }
   const fn = wgslFn(
     buildCustomWaveVertexWgslCode(Boolean(program)),
     includes,
-  ) as TslVertexFn;
+  ) as unknown as TslVertexFn;
   customWaveVertexFnCache.set(key, fn);
   return fn;
 }
@@ -1188,11 +1203,11 @@ export function createProceduralCustomWaveMaterial(
   const signals = packSignalUniformVectors(uniforms, 'signal');
   const previousSignals = packSignalUniformVectors(uniforms, 'previousSignal');
   const point = getProceduralCustomWaveVertexFn(program)({
-    sampleT: attribute('sampleT', 'float'),
-    sampleValue: attribute('sampleValue', 'float'),
-    sampleValue2: attribute('sampleValue2', 'float'),
-    previousSampleValue: attribute('previousSampleValue', 'float'),
-    previousSampleValue2: attribute('previousSampleValue2', 'float'),
+    sampleT: typedAttribute('sampleT', 'float'),
+    sampleValue: typedAttribute('sampleValue', 'float'),
+    sampleValue2: typedAttribute('sampleValue2', 'float'),
+    previousSampleValue: typedAttribute('previousSampleValue', 'float'),
+    previousSampleValue2: typedAttribute('previousSampleValue2', 'float'),
     waveParams: vec4(
       uniforms.centerX,
       uniforms.centerY,
@@ -1237,7 +1252,7 @@ export function createProceduralCustomWaveMaterial(
     .mul(modelViewMatrix)
     .mul(vec4(point.x, point.y, 0.28, 1.0));
   material.colorNode = vec4(
-    uniforms.tint,
+    asColorNode(uniforms.tint),
     uniforms.alpha.mul(uniforms.interactionAlpha),
   );
 
@@ -1373,7 +1388,9 @@ const PROCEDURAL_WAVE_POINT_WGSL = `
   }
 `;
 
-const computeProceduralWavePoint = wgslFn(PROCEDURAL_WAVE_POINT_WGSL);
+const computeProceduralWavePoint = wgslFn(
+  PROCEDURAL_WAVE_POINT_WGSL,
+) as unknown as TslVertexFn;
 
 export function createProceduralWaveMaterial() {
   const uniforms = {
@@ -1385,7 +1402,7 @@ export function createProceduralWaveMaterial() {
     signalTime: uniform(0),
     beatPulse: uniform(0),
     trebleAtt: uniform(0),
-    tint: uniform(new Color(1, 1, 1)),
+    tint: typedUniform(new Color(1, 1, 1)),
     alpha: uniform(1),
     previousCenterX: uniform(0),
     previousCenterY: uniform(0),
@@ -1404,10 +1421,10 @@ export function createProceduralWaveMaterial() {
 
   const point = computeProceduralWavePoint({
     mode: uniforms.mode,
-    t: attribute('sampleT', 'float'),
-    sampleData: attribute('sampleData', 'vec4'),
-    previousSampleData: attribute('previousSampleData', 'vec4'),
-    sampleMisc: attribute('sampleMisc', 'vec3'),
+    t: typedAttribute('sampleT', 'float'),
+    sampleData: typedAttribute('sampleData', 'vec4'),
+    previousSampleData: typedAttribute('previousSampleData', 'vec4'),
+    sampleMisc: typedAttribute('sampleMisc', 'vec3'),
     centerX: uniforms.centerX,
     centerY: uniforms.centerY,
     scale: uniforms.scale,
@@ -1435,7 +1452,7 @@ export function createProceduralWaveMaterial() {
     .mul(modelViewMatrix)
     .mul(vec4(point.x, point.y, 0.24, 1.0));
   material.colorNode = vec4(
-    uniforms.tint,
+    asColorNode(uniforms.tint),
     uniforms.alpha.mul(uniforms.interactionAlpha),
   );
 

--- a/src/js/milkdrop/renderer-bundles.ts
+++ b/src/js/milkdrop/renderer-bundles.ts
@@ -42,7 +42,6 @@ let webGpuBundleGroupCtorPromise: Promise<BundleGroupConstructor> | null = null;
 
 function loadWebGpuBundleGroupCtor(): Promise<BundleGroupConstructor> {
   if (!webGpuBundleGroupCtorPromise) {
-    // @ts-expect-error - 'three/webgpu' resolves at runtime via the bundler but not under moduleResolution: "node".
     webGpuBundleGroupCtorPromise = import('three/webgpu')
       .then((module: { BundleGroup: BundleGroupConstructor }) => {
         webGpuBundleGroupCtor = module.BundleGroup;

--- a/src/js/milkdrop/renderer-helpers/motion-vector-renderer.ts
+++ b/src/js/milkdrop/renderer-helpers/motion-vector-renderer.ts
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Float32BufferAttribute,
   type LineBasicMaterial,
+  type Material,
   type ShaderMaterial,
   Vector3,
 } from 'three';
@@ -104,9 +105,12 @@ export function renderMotionVectors({
   previousFrame?: MilkdropRenderPayload['frameState'] | null;
   blendMix?: number;
   cpuGroup: Group;
+  // Material is Line/Shader on WebGL and a NodeMaterial on WebGPU — this
+  // function swaps in the latter a few lines below. The union said otherwise
+  // and the assignment was simply unchecked while this layer was untyped.
   proceduralObject: LineSegments<
     BufferGeometry,
-    LineBasicMaterial | ShaderMaterial
+    LineBasicMaterial | ShaderMaterial | Material
   >;
   clearGroup: (group: Group) => void;
   renderLineVisualGroup: (

--- a/src/js/milkdrop/renderer-helpers/particle-field-renderer.ts
+++ b/src/js/milkdrop/renderer-helpers/particle-field-renderer.ts
@@ -22,6 +22,7 @@ import type {
   MilkdropRenderPayload,
   MilkdropRuntimeSignals,
 } from '../types';
+import { typedAttribute, typedUniform } from './tsl-node-types.ts';
 import {
   getWebGpuHelperMaterialsSync,
   isWebGpuNodeMaterial,
@@ -114,12 +115,10 @@ function createParticleFieldNodeMaterial(
 ) {
   const { NodeMaterial, TSL } = getWebGpuHelperMaterialsSync();
   const {
-    attribute,
     cameraProjectionMatrix,
     modelViewMatrix,
     positionGeometry,
     smoothstep,
-    uniform,
     uv,
     varying,
     vec3,
@@ -132,12 +131,15 @@ function createParticleFieldNodeMaterial(
     alphaMultiplier,
   );
   const uniforms = Object.fromEntries(
-    Object.entries(state).map(([key, entry]) => [key, uniform(entry.value)]),
+    Object.entries(state).map(([key, entry]) => [
+      key,
+      typedUniform(entry.value),
+    ]),
   );
 
-  const instanceAnchor = attribute('instanceAnchor', 'vec3');
-  const instanceSeed = attribute('instanceSeed', 'float');
-  const instanceId = attribute('instanceId', 'float');
+  const instanceAnchor = typedAttribute('instanceAnchor', 'vec3');
+  const instanceSeed = typedAttribute('instanceSeed', 'float');
+  const instanceId = typedAttribute('instanceId', 'float');
 
   const phase = instanceSeed
     .mul(6.2831853)

--- a/src/js/milkdrop/renderer-helpers/tsl-node-types.ts
+++ b/src/js/milkdrop/renderer-helpers/tsl-node-types.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared typing for three.js TSL node graphs.
+ *
+ * These materials used to carry a hand-rolled `TslNode` structural type,
+ * declared independently in two files with a `[key: string]: unknown` escape
+ * hatch. It existed for a reason that has since disappeared: under the
+ * repo's old `moduleResolution: node10`, `three/webgpu` did not resolve to
+ * any types at all — the imports carried `@ts-expect-error` saying exactly
+ * that — so the entire native-WebGPU layer typechecked as `any` and a
+ * stand-in was the only way to get member access to compile.
+ *
+ * `moduleResolution: bundler` reaches @types/three's real node typings, so
+ * the stand-in is obsolete. This module exists so the replacement is named
+ * once rather than three times.
+ */
+
+import type { Color } from 'three';
+import type ThreeNode from 'three/src/nodes/core/Node.js';
+import { TSL } from 'three/webgpu';
+
+/**
+ * A TSL node carrying its value type, e.g. `TslNode<'vec4'>`.
+ *
+ * Imported through three's `./src/*` export rather than `three/webgpu`
+ * because the generic `Node` alias is not re-exported from the bundle entry
+ * point — only the concrete node classes are.
+ *
+ * The default is `'float'`, not `unknown`: `Node<unknown>` carries no
+ * swizzles and no arithmetic, so a bare `TslNode` would be useless, and
+ * scalars are what the bare form is used for throughout these materials. A
+ * vector position must say so — `TslNode<'vec4'>` — which is the point.
+ */
+export type TslNode<T = 'float'> = ThreeNode<T>;
+
+/** Value types an instanced attribute can carry in these materials. */
+export type TslAttributeType = 'float' | 'vec2' | 'vec3' | 'vec4';
+
+/**
+ * `attribute()` typed by the value it actually holds.
+ *
+ * three types the return as `AttributeNode<Name>` — the generic carries the
+ * attribute NAME, not its value type — so `.x`, `.w`, `.mul()` and friends
+ * are invisible on it. The value type is always known at the call site (it
+ * is the second argument), so this states the correspondence once instead of
+ * casting at every use.
+ */
+export function typedAttribute<T extends TslAttributeType>(
+  name: string,
+  nodeType: T,
+): TslNode<T> {
+  return TSL.attribute(name, nodeType) as unknown as TslNode<T>;
+}
+
+/**
+ * A uniform node: a TSL node whose `value` the host writes each frame.
+ *
+ * The previous stand-in declared this as `value: number & Color`, an
+ * intersection nothing can satisfy — it compiled only because the whole
+ * module was untyped. Materials here write both numbers and Colors through
+ * the same handles, so the value is genuinely heterogeneous and is typed as
+ * such rather than as a fiction.
+ *
+ * The node half is `'float'`, which is what all but a handful of these
+ * uniforms are used as. Deriving it from the value type instead (vec3 for
+ * `Color`) is more faithful and was tried: it makes every uniform bank
+ * heterogeneous, so the `Record<string, …>` parameters that take a whole
+ * bank stop matching, and the error count went up rather than down. The few
+ * colour uniforms that need their vec3-ness say so at the point of use via
+ * `asColorNode`, which keeps the exception where it is legible.
+ */
+/** What these materials actually push through a uniform each frame. */
+export type TslUniformValue = number | Color;
+
+export type TslUniformNode<V = TslUniformValue> = TslNode<'float'> & {
+  value: V;
+};
+
+/**
+ * Map of uniform handles, keyed like the state object they mirror.
+ *
+ * Uniform banks are passed around whole, so every entry carries the same
+ * node type; see `asColorNode` for the colour exception.
+ */
+export type TslUniformNodes<T> = { [K in keyof T]: TslUniformNode };
+
+/**
+ * `uniform()` for a value whose type is only known as a union.
+ *
+ * three overloads `uniform()` per value type, and TypeScript cannot pick an
+ * overload for a union argument — `uniform(number | Color)` resolves to
+ * nothing. These materials build uniform banks by mapping over a state
+ * object whose entries are exactly that union, so the narrowing happens once
+ * here. It is a real branch, not a cast: each call reaches the overload that
+ * actually matches the value being passed.
+ */
+export function typedUniform(
+  value: number | Color,
+): TslUniformNode<number | Color> {
+  const node =
+    typeof value === 'number' ? TSL.uniform(value) : TSL.uniform(value);
+  return node as unknown as TslUniformNode<number | Color>;
+}
+
+/**
+ * A colour uniform seen as the vec3 node it actually is.
+ *
+ * Uniform banks are typed uniformly as float nodes so they can be passed
+ * around as a whole (see `TslUniformNode`). A handful of entries hold a
+ * `Color` and get spread into a `vec4(tint, alpha)`, which needs three
+ * components. This is the single place that exception is stated, rather than
+ * making every bank heterogeneous to serve three call sites.
+ */
+export function asColorNode(node: TslUniformNode): TslNode<'vec3'> {
+  return node as unknown as TslNode<'vec3'>;
+}
+
+/**
+ * A sampled texel seen as the vec4 it is.
+ *
+ * The aux-texture samplers are a single `select()` chain over ~15 branches,
+ * every one of which constructs a vec4. three infers the chain's type as
+ * `Node<'float' | 'vec4'>` — an artifact of widening across that many
+ * operands, not a branch that genuinely yields a scalar — and `.rgb` is
+ * unavailable on the union. Checked against the source before narrowing:
+ * there is no float-returning path.
+ */
+export function asVec4Node(node: TslNode<'float' | 'vec4'>): TslNode<'vec4'> {
+  return node as unknown as TslNode<'vec4'>;
+}

--- a/src/js/milkdrop/renderer-helpers/webgpu-materials-loader.ts
+++ b/src/js/milkdrop/renderer-helpers/webgpu-materials-loader.ts
@@ -20,7 +20,6 @@
  * WebGPU never fetch it.
  */
 
-// @ts-expect-error - 'three/webgpu' resolves at runtime via the bundler but not under moduleResolution: "node".
 import type { NodeMaterial, TSL } from 'three/webgpu';
 import type {
   createProceduralCustomWaveMaterial,
@@ -70,7 +69,16 @@ export function getWebGpuHelperMaterialsSync(): WebGpuHelperMaterials {
  * shared chunk. When the toolkit has not loaded, no NodeMaterial can exist,
  * so the answer is false.
  */
-export function isWebGpuNodeMaterial(value: unknown): boolean {
+/**
+ * Type predicate, not a bare boolean: callers immediately reach for
+ * `.userData` on the narrowed value, and `material` on a three Object3D is
+ * `Material | Material[]`. Returning `boolean` left that union intact, so
+ * every guarded access was unchecked — which went unnoticed while this whole
+ * layer was untyped.
+ */
+export function isWebGpuNodeMaterial(
+  value: unknown,
+): value is InstanceType<typeof NodeMaterial> {
   return registeredMaterials
     ? value instanceof registeredMaterials.NodeMaterial
     : false;

--- a/tests/unit/milkdrop-renderer-adapter.test.ts
+++ b/tests/unit/milkdrop-renderer-adapter.test.ts
@@ -21,7 +21,6 @@ import {
   WebGLRenderer,
   ZeroFactor,
 } from 'three';
-// @ts-expect-error - 'three/webgpu' is available at runtime but not under the repo's current moduleResolution.
 import { NodeMaterial } from 'three/webgpu';
 import { getFeedbackBackendProfile } from '../../src/js/milkdrop/backend-behavior';
 import { compileMilkdropPresetSource } from '../../src/js/milkdrop/compiler.ts';

--- a/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
+++ b/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
@@ -6,6 +6,7 @@ import {
   createSampleAuxTextureNode,
   createSampleUvNode,
 } from '../../src/js/milkdrop/feedback-manager-webgpu-composite.ts';
+import type { ShaderNodeEnv } from '../../src/js/milkdrop/feedback-manager-webgpu-tsl.ts';
 import { parseMilkdropShaderStatement } from '../../src/js/milkdrop/shader-ast.ts';
 
 function buildShaderEnv() {
@@ -22,6 +23,10 @@ function buildShaderEnv() {
   };
   const uniforms = createCompositeUniforms(new Texture(), new Texture(), aux);
   const sampleUvNode = createSampleUvNode();
+  // Narrowed the same way production does (see `createCompositeAuxSampler`):
+  // the factory's inferred return widens to `Node<'float' | 'vec4'>` across
+  // its ~15-branch select chain, and ShaderNodeEnv declares the vec4 that
+  // every branch actually builds.
   const sampleAuxTextureNode = createSampleAuxTextureNode(
     uniforms.noiseTex,
     uniforms.perlinTex,
@@ -57,7 +62,8 @@ function buildShaderEnv() {
     ]),
     uniforms,
     sampleUvNode,
-    sampleAuxTextureNode,
+    sampleAuxTextureNode:
+      sampleAuxTextureNode as unknown as ShaderNodeEnv['sampleAuxTextureNode'],
   } as const;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,
     "incremental": true,


### PR DESCRIPTION
This began as "upgrade TypeScript" and turned into something else.

TS 7.0.2 itself produces **zero** errors here. What it does is remove `moduleResolution: node10` — and under node10, `three/webgpu` resolved to **nothing**. The imports said so out loud:

```ts
// @ts-expect-error - 'three/webgpu' requires moduleResolution:
// "bundler" or "nodenext", but project uses "node".
```

So the whole native-WebGPU layer — materials, TSL graphs, feedback composite, particle field — has been typechecked as `any` for as long as those directives existed. The hand-rolled `TslNode` (declared **twice**, with a `[key: string]: unknown` escape hatch and a `value: number & Color` field nothing can satisfy) existed only because no real types were reachable.

Moving to `moduleResolution: bundler` reaches @types/three's real node typings and turns checking on for that layer **for the first time**. 115 errors appeared. All 115 are fixed here.

## TypeScript stays on 6.0.3 — deliberately

The version bump is **not** included, for a reason worth recording. Under TS 7, dependency-cruiser cannot parse TypeScript at all (`typescript: >=2.0.0 <7.0.0`) — **and it does not fail.**

| | typecheck errors | dependency-cruiser |
| --- | --- | --- |
| TS 7.0.2 + bundler | 0 | **57 modules / 79 deps** — green tick, checks almost nothing |
| TS 6.0.3 + bundler | **0** | **1688 modules / 5010 deps** |

Trading a working architecture guard for a version number is a bad trade, and the migration works identically on 6.0.3 (same 115 errors before, zero after). Revisit when dependency-cruiser ships TS 7 support.

## What the typing found

`renderer-helpers/tsl-node-types.ts` names the replacement once: `TslNode<T>` (three's real `Node<T>`, via three's supported `./src/*` export), `typedAttribute`, `typedUniform`, `TslUniformNode`, and two documented narrowings.

The recurring cause was `any` parameters on TSL functions — `any` makes three pick its widest overload, so a vec2 uv chain silently became vec3 and every downstream call lost its overload. Typing `sampleAuxTexture`'s four parameters alone cleared **eight** errors.

Two real defects, both invisible while the layer was untyped:

- **`isWebGpuNodeMaterial` returned `boolean`, not a type predicate** — so every `.userData` access guarded by it was unchecked against a `Material | Material[]` union.
- **`motion-vector-renderer`** declares its material `LineBasicMaterial | ShaderMaterial` and assigns a `NodeMaterial` to it a few lines later.

## Runtime impact

One deliberate change: `select(step(edge, blend), …)` → `select(blend.greaterThanEqual(edge), …)`. `select` takes a boolean; `step` returns a float that then had to be reinterpreted. Same predicate — step is 1 exactly when `blend >= edge` — stated directly.

Everything else is type-only, and that's **verified rather than asserted**: transpiling each touched file on both sides and diffing the emitted JavaScript leaves five of nine byte-identical, with the rest differing only by wrapper calls forwarding to the same three functions.

`lab:backend-diff` cannot adjudicate this and says so in its own docblock — native WebGPU's same-backend noise floor is ~49%, so a subtle change is invisible to it. The emitted-JS diff is the stronger instrument.

`check:quick` clean, 2672 tests pass, dependency-cruiser back to 1688 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)