### PR TITLE
fix(test): stop one file's DOM teardown breaking every file after it

### DIFF
--- a/tests/environment/dom.ts
+++ b/tests/environment/dom.ts
@@ -78,7 +78,32 @@ export function getDomWindow() {
   return windowInstance;
 }
 
+/**
+ * Replaces the DOM globals with a fresh window.
+ *
+ * Deliberately reinstalls rather than tearing down. `tests/setup.ts` installs
+ * this environment once as the ambient baseline for the whole suite, and most
+ * test files never install it themselves — they just use `document`. Bun runs
+ * many files in one process, so a file that ended by *deleting* the globals
+ * left every file scheduled after it with no `document` at all: the suite
+ * failed on whichever file happened to come next (`ReferenceError: document is
+ * not defined`) while each file passed when run alone.
+ *
+ * A test that wants a clean DOM wants exactly this. If real teardown is ever
+ * needed, `uninstallDomEnvironment()` is the explicit way to ask for it — and
+ * whatever asks must restore the baseline before the next file runs.
+ */
 export function resetDomEnvironment() {
+  return installDomEnvironment();
+}
+
+/**
+ * Removes the DOM globals entirely, leaving the process without a `document`.
+ *
+ * Only safe when nothing else will run afterwards in this process. Prefer
+ * `resetDomEnvironment()`.
+ */
+export function uninstallDomEnvironment() {
   windowInstance = null;
   restoreGlobals();
 }

--- a/tests/unit/dom-environment.test.ts
+++ b/tests/unit/dom-environment.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+import {
+  getDomWindow,
+  installDomEnvironment,
+  resetDomEnvironment,
+} from '../environment/dom.ts';
+
+/**
+ * Bun runs many test files in one process, and `tests/setup.ts` installs the
+ * DOM once as the ambient baseline for all of them — most files never install
+ * it themselves, they just use `document`. So a file whose teardown *removed*
+ * the globals broke whichever file happened to run next, with a
+ * `ReferenceError: document is not defined` far from its cause and a pass when
+ * that file was run alone. Guard the invariant directly.
+ */
+test('resetting the DOM environment leaves a usable document behind', () => {
+  resetDomEnvironment();
+
+  expect(typeof document).toBe('object');
+  expect(typeof window).toBe('object');
+
+  // Usable, not merely defined.
+  document.body.innerHTML = '<div id="probe"></div>';
+  expect(document.getElementById('probe')).not.toBeNull();
+  document.body.innerHTML = '';
+});
+
+test('resetting swaps in a fresh window rather than reusing the old one', () => {
+  const before = getDomWindow();
+  document.body.innerHTML = '<div id="stale"></div>';
+
+  const after = resetDomEnvironment();
+
+  expect(after).not.toBe(before);
+  expect(getDomWindow()).toBe(after);
+  expect(document.getElementById('stale')).toBeNull();
+});
+
+test('installing is itself repeatable', () => {
+  const first = installDomEnvironment();
+  const second = installDomEnvironment();
+
+  expect(second).not.toBe(first);
+  expect(typeof document).toBe('object');
+});


### PR DESCRIPTION
## Summary

`bun run check` could not complete on `main`. `tests/unit/milkdrop-overlay-panels.test.ts` died with `ReferenceError: document is not defined` under a full-suite run and passed when run alone, so the gate bailed at the first failure and roughly 1,800 tests never ran.

**The cause is file order, not that file.** `tests/setup.ts` installs the DOM once as the ambient baseline for the whole suite — most test files never install it themselves, they just use `document`. Bun runs many files in one process, so `tests/unit/arrival-url.test.ts` calling `resetDomEnvironment()` in its `afterEach` deleted those globals permanently, and whichever file the scheduler placed next died on a missing `document`, far from the cause.

Two files reproduce it deterministically:

```
$ bun test tests/unit/arrival-url.test.ts tests/unit/milkdrop-overlay-panels.test.ts
16 pass, 3 fail   # ReferenceError: document is not defined
```

`resetDomEnvironment()` now installs a fresh window instead of tearing down — which is what a test asking for a clean DOM actually wants, and what its only caller wanted. Genuine teardown remains available under the explicitly named `uninstallDomEnvironment()`, documented as safe only when nothing runs afterwards in the process.

Fixing this at the helper rather than at the one caller means the next test file that wants a clean DOM cannot reintroduce the same cross-file breakage.

## Testing

- `bun run check` — **exits 0**. Previously it bailed at the first failure.
- Full suite: **2691 pass, 0 fail** across 269 files (previously bailed after 852 with 1 fail).
- `bun test tests/unit/arrival-url.test.ts tests/unit/milkdrop-overlay-panels.test.ts` — 19 pass, 0 fail; was 16 pass / 3 fail.
- New `tests/unit/dom-environment.test.ts` guards the invariant: a usable `document` survives a reset, the window is genuinely swapped (not reused), and repeated installs are safe. **Verified it fails on the old behavior** — restoring the previous `resetDomEnvironment()` body turns it 1 pass / 2 fail.
- `bun run typecheck`, Biome — clean.

## Docs touched

None. The reasoning lives in the docblocks on `resetDomEnvironment` / `uninstallDomEnvironment` and at the top of the new test, next to the code it constrains.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token) — n/a, no visual changes
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [ ] `bun run build` (if build/runtime output changed) — n/a, test-harness only, no runtime code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01D56bBpzJLoN19ZaWfhh7sr)_