### PR TITLE
fix: green the quality gate and stop ungated production deploys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@types/bun": "^1.3.14",
         "@types/node": "^26.2.0",
         "@types/react": "19.2.18",
-        "@types/react-dom": "19.2.4",
+        "@types/react-dom": "19.2.5",
         "@types/three": "^0.185.4",
         "@vitejs/plugin-react": "6.1.0",
         "@webgpu/types": "^0.1.72",
@@ -391,7 +391,7 @@
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+    "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -57,7 +57,9 @@ Keep the orchestration in `scripts/build-site.mjs`. Running both compilers as a 
 Done in the Cloudflare dashboard (Workers & Pages → the `stims` Worker → Settings → Builds, or "Import a repository" if the Worker does not exist yet):
 
 1. Connect the `zz-plant/stims` GitHub repository.
-2. Build command: `bun run site:build`. Deploy command: `bunx wrangler deploy --config wrangler.site.jsonc`. Non-production branch command: `bunx wrangler versions upload --config wrangler.site.jsonc`.
+2. Build command: `bun run site:build:gated`. Deploy command: `bunx wrangler deploy --config wrangler.site.jsonc`. Non-production branch command: `bunx wrangler versions upload --config wrangler.site.jsonc`.
+
+   `site:build:gated` runs `test:fast` (unit + compat) before the build. Workers Builds deploys on push and does not wait for GitHub Actions, so without a test step in the build itself a commit pushed straight to `main` reaches production whether or not CI is green — which is how the failing `check` run on `ad65ee2d` still shipped. A failing test now fails the build, and production keeps serving the previous version. Use the plain `bun run site:build` only if you deliberately want an ungated deploy path.
 3. Production branch: `main`.
 4. Enable **Build cache** under Settings → Build. Workers Builds then preserves Bun's package cache between builds; see [Cloudflare's build-caching guide](https://developers.cloudflare.com/workers/ci-cd/builds/build-caching/).
 

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "setup:browsers": "bun run scripts/link-preinstalled-browsers.ts",
     "setup:codex": "bash scripts/codex-setup.sh",
     "site:build": "bun run scripts/build-site.mjs",
+    "site:build:gated": "bun run test:fast && bun run scripts/build-site.mjs",
     "site:check": "bun run site:build && bunx wrangler deploy --dry-run --config wrangler.site.jsonc",
     "site:deploy": "bun run site:build && bunx wrangler deploy --config wrangler.site.jsonc",
     "site:dev": "bun run site:build && bunx wrangler dev --config wrangler.site.jsonc",

--- a/src/js/frontend/ErrorBoundary.tsx
+++ b/src/js/frontend/ErrorBoundary.tsx
@@ -24,14 +24,14 @@ function ErrorButton({
 
 export class StimsErrorBoundary extends Component<
   { children: ReactNode },
-  { error: Error | null }
+  { error: Error | null; copyStatus: 'idle' | 'copied' | 'failed' }
 > {
   constructor(props: { children: ReactNode }) {
     super(props);
-    this.state = { error: null };
+    this.state = { error: null, copyStatus: 'idle' };
   }
   static getDerivedStateFromError(error: Error) {
-    return { error };
+    return { error, copyStatus: 'idle' as const };
   }
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('Stims crashed:', error, info);
@@ -58,10 +58,8 @@ export class StimsErrorBoundary extends Component<
                   Error details ({this.state.error.name})
                 </summary>
                 <pre className="stims-shell__error-stack">
-                  {this.state.error.name}: {this.state.error.message}
-                  {this.state.error.stack
-                    ? `\n\n${this.state.error.stack}`
-                    : ''}
+                  {this.state.error.stack?.trim() ||
+                    `${this.state.error.name}: ${this.state.error.message}`}
                 </pre>
               </details>
             )}
@@ -70,19 +68,32 @@ export class StimsErrorBoundary extends Component<
                 Reload page
               </ErrorButton>
               <ErrorButton
-                onClick={() => {
-                  const text = `${this.state.error?.name}: ${this.state.error?.message}\n\n${this.state.error?.stack ?? ''}`;
-                  if (navigator?.clipboard?.writeText) {
-                    navigator.clipboard.writeText(text).catch((err) => {
-                      console.warn(
-                        'Could not copy error details to clipboard:',
-                        err,
-                      );
-                    });
+                onClick={async () => {
+                  const error = this.state.error;
+                  const clipboard = globalThis.navigator?.clipboard;
+                  if (!error || !clipboard?.writeText) {
+                    this.setState({ copyStatus: 'failed' });
+                    return;
+                  }
+                  const text =
+                    error.stack?.trim() || `${error.name}: ${error.message}`;
+                  try {
+                    await clipboard.writeText(text);
+                    this.setState({ copyStatus: 'copied' });
+                  } catch (err) {
+                    this.setState({ copyStatus: 'failed' });
+                    console.warn(
+                      'Could not copy error details to clipboard:',
+                      err,
+                    );
                   }
                 }}
               >
-                Copy error details
+                {this.state.copyStatus === 'copied'
+                  ? 'Copied error details'
+                  : this.state.copyStatus === 'failed'
+                    ? 'Copy unavailable'
+                    : 'Copy error details'}
               </ErrorButton>
               <ErrorButton
                 onClick={() => {

--- a/src/js/milkdrop/compiler/ast-constant-fold.ts
+++ b/src/js/milkdrop/compiler/ast-constant-fold.ts
@@ -320,12 +320,65 @@ function foldBinary(
   return null;
 }
 
+const EMPTY_NAMES: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Names the program writes to, lowercased. A written name is never treated as
+ * a compile-time constant, because a later read of it must see the assigned
+ * value rather than the builtin one.
+ *
+ * Deliberately flow-insensitive: a single assignment anywhere in the block
+ * (including inside a loop or conditional body) disqualifies the name for the
+ * whole block. Reads that precede the first write lose a fold they could have
+ * kept; nothing loses correctness.
+ */
+export function collectAssignedNames(
+  statements: readonly import('../types').MilkdropCompiledStatement[],
+  inherited: ReadonlySet<string> = EMPTY_NAMES,
+): ReadonlySet<string> {
+  const names = new Set<string>(inherited);
+  const visitExpression = (node: MilkdropExpressionNode): void => {
+    switch (node.type) {
+      case 'binary':
+        if (node.operator === '=' && node.left.type === 'identifier') {
+          names.add(node.left.name.toLowerCase());
+        }
+        visitExpression(node.left);
+        visitExpression(node.right);
+        return;
+      case 'unary':
+        visitExpression(node.operand);
+        return;
+      case 'call':
+        node.args.forEach(visitExpression);
+        return;
+      default:
+    }
+  };
+  const visitStatement = (
+    stmt: import('../types').MilkdropCompiledStatement,
+  ): void => {
+    if (stmt.control) {
+      if (stmt.control.count) visitExpression(stmt.control.count);
+      if (stmt.control.condition) visitExpression(stmt.control.condition);
+      stmt.control.body.forEach(visitStatement);
+      return;
+    }
+    names.add(stmt.target.toLowerCase());
+    if (stmt.targetExpression) visitExpression(stmt.targetExpression);
+    visitExpression(stmt.expression);
+  };
+  statements.forEach(visitStatement);
+  return names;
+}
+
 /**
  * Recursively fold an expression tree. Returns a (possibly simplified) node.
  * Does not mutate the input.
  */
 export function foldExpression(
   node: MilkdropExpressionNode,
+  shadowed: ReadonlySet<string> = EMPTY_NAMES,
 ): MilkdropExpressionNode {
   switch (node.type) {
     case 'literal':
@@ -333,14 +386,18 @@ export function foldExpression(
 
     case 'identifier': {
       const name = node.name.toLowerCase();
-      // Resolve known constants inline
+      // Resolve known constants inline — but only while the preset leaves
+      // them alone. MilkDrop lets a program assign `pi`/`e` like any other
+      // variable, and presets do (`per_pixel_1=pi=3.14159;`). Inlining the
+      // builtin value there would silently ignore the override.
+      if (shadowed.has(name)) return node;
       if (name === 'pi') return { type: 'literal', value: Math.PI };
       if (name === 'e') return { type: 'literal', value: Math.E };
       return node;
     }
 
     case 'unary': {
-      const operand = foldExpression(node.operand);
+      const operand = foldExpression(node.operand, shadowed);
       const simplified = foldUnary(node.operator, operand);
       return simplified;
     }
@@ -348,13 +405,13 @@ export function foldExpression(
     case 'binary': {
       // Do not fold assignment operators — they have side effects
       if (node.operator === '=') {
-        const left = foldExpression(node.left);
-        const right = foldExpression(node.right);
+        const left = foldExpression(node.left, shadowed);
+        const right = foldExpression(node.right, shadowed);
         return { type: 'binary', operator: '=', left, right };
       }
 
-      const left = foldExpression(node.left);
-      const right = foldExpression(node.right);
+      const left = foldExpression(node.left, shadowed);
+      const right = foldExpression(node.right, shadowed);
       const folded = foldBinary(node.operator, left, right);
       if (folded) return folded;
       return { type: 'binary', operator: node.operator, left, right };
@@ -362,7 +419,7 @@ export function foldExpression(
 
     case 'call': {
       const name = node.name.toLowerCase();
-      const args = node.args.map(foldExpression);
+      const args = node.args.map((arg) => foldExpression(arg, shadowed));
 
       // Fold pure functions with all-literal args
       if (PURE_FUNCTIONS.has(name) && isAllLiterals(args)) {
@@ -383,12 +440,15 @@ export function foldExpression(
  */
 export function foldStatement(
   stmt: import('../types').MilkdropCompiledStatement,
+  shadowed: ReadonlySet<string> = EMPTY_NAMES,
 ): import('../types').MilkdropCompiledStatement {
-  const expression = foldExpression(stmt.expression);
+  const expression = foldExpression(stmt.expression, shadowed);
   const targetExpression = stmt.targetExpression
-    ? foldExpression(stmt.targetExpression)
+    ? foldExpression(stmt.targetExpression, shadowed)
     : undefined;
-  const control = stmt.control ? foldControlFlow(stmt.control) : undefined;
+  const control = stmt.control
+    ? foldControlFlow(stmt.control, shadowed)
+    : undefined;
 
   if (
     expression === stmt.expression &&
@@ -408,12 +468,15 @@ export function foldStatement(
 
 function foldControlFlow(
   control: import('../types').MilkdropControlFlowStatement,
+  shadowed: ReadonlySet<string> = EMPTY_NAMES,
 ): import('../types').MilkdropControlFlowStatement {
-  const count = control.count ? foldExpression(control.count) : undefined;
-  const condition = control.condition
-    ? foldExpression(control.condition)
+  const count = control.count
+    ? foldExpression(control.count, shadowed)
     : undefined;
-  const body = control.body.map(foldStatement);
+  const condition = control.condition
+    ? foldExpression(control.condition, shadowed)
+    : undefined;
+  const body = control.body.map((stmt) => foldStatement(stmt, shadowed));
 
   if (
     count === control.count &&
@@ -432,8 +495,14 @@ function foldControlFlow(
  */
 export function foldProgramBlock(
   block: import('../types').MilkdropProgramBlock,
+  shadowed: ReadonlySet<string> = EMPTY_NAMES,
 ): import('../types').MilkdropProgramBlock {
-  const statements = block.statements.map(foldStatement);
-  if (statements === block.statements) return block;
+  const blockShadowed = collectAssignedNames(block.statements, shadowed);
+  const statements = block.statements.map((stmt) =>
+    foldStatement(stmt, blockShadowed),
+  );
+  if (statements.every((stmt, index) => stmt === block.statements[index])) {
+    return block;
+  }
   return { ...block, statements };
 }

--- a/src/js/milkdrop/compiler/ir.ts
+++ b/src/js/milkdrop/compiler/ir.ts
@@ -34,7 +34,7 @@ import type {
   MilkdropVisualCertification,
   MilkdropWaveDefinition,
 } from '../types';
-import { foldProgramBlock } from './ast-constant-fold.ts';
+import { collectAssignedNames, foldProgramBlock } from './ast-constant-fold.ts';
 import { buildParityReport } from './compatibility-report.ts';
 import { extractCustomSamplerDeclarations } from './custom-samplers';
 import type { buildWebGpuDescriptorPlan } from './gpu-descriptor-plan';
@@ -605,8 +605,21 @@ export function createMilkdropIr({
   // descriptor planner and WGSL/JIT emission — so every downstream tier
   // (CPU interpreter, CPU JIT, WGSL compute VM, per-pixel field planner)
   // consumes the simplified tree.
-  for (const key of ['init', 'perFrame', 'perPixel'] as const) {
-    programs[key] = foldProgramBlock(programs[key]);
+  //
+  // `pi`/`e` are foldable constants only until a program assigns them, and an
+  // assignment in one block is visible to the others (init runs before
+  // per-frame, per-frame before per-pixel), so the shadow set is collected
+  // across all three before any block is folded.
+  const foldKeys = ['init', 'perFrame', 'perPixel'] as const;
+  let assignedNames = collectAssignedNames(programs.init.statements);
+  for (const key of ['perFrame', 'perPixel'] as const) {
+    assignedNames = collectAssignedNames(
+      programs[key].statements,
+      assignedNames,
+    );
+  }
+  for (const key of foldKeys) {
+    programs[key] = foldProgramBlock(programs[key], assignedNames);
   }
 
   const runtimeGlobals = fieldHelpers.resolveRuntimeGlobals({

--- a/src/js/milkdrop/runtime/preset-file-actions.ts
+++ b/src/js/milkdrop/runtime/preset-file-actions.ts
@@ -12,6 +12,8 @@ import type {
 import { downloadPresetFile } from './persistence';
 import { isEditablePreset } from './session';
 
+const MAX_PRESET_FILE_BYTES = 2 * 1024 * 1024;
+
 export function createMilkdropPresetFileActions({
   catalogStore,
   getActiveCatalogEntry,
@@ -38,20 +40,23 @@ export function createMilkdropPresetFileActions({
       const skipped: Array<{ name: string; reason: string }> = [];
       let importedCount = 0;
       let lastImportedId: string | null = null;
-      const MAX_PRESET_SIZE = 2 * 1024 * 1024; // 2MB limit per preset file
       for (const file of Array.from(files)) {
         try {
-          if (file.size > MAX_PRESET_SIZE) {
+          if (file.size > MAX_PRESET_FILE_BYTES) {
             throw new Error(
-              `File exceeds maximum size of 2MB (${(file.size / 1024 / 1024).toFixed(1)}MB).`,
+              'the file is larger than the 2 MB limit. Choose a smaller plain-text .milk file.',
             );
           }
           const raw = await file.text();
           if (raw.trim().length === 0) {
-            throw new Error('File is empty.');
+            throw new Error(
+              'the file is empty. Choose a .milk file that contains preset text.',
+            );
           }
           if (raw.includes('\0')) {
-            throw new Error('Binary or non-text file.');
+            throw new Error(
+              'binary data was detected. Choose a plain-text .milk file.',
+            );
           }
           const compiled = compileMilkdropPresetSource(raw, {
             title: file.name.replace(/\.[^.]+$/u, ''),
@@ -95,17 +100,19 @@ export function createMilkdropPresetFileActions({
       }
 
       if (skipped.length > 0) {
-        const names = skipped.map((entry) => entry.name).join(', ');
+        const details = skipped
+          .map((entry) => `"${entry.name}": ${entry.reason}`)
+          .join(' ');
         console.warn('[milkdrop] Skipped preset imports:', skipped);
         if (importedCount === 0) {
           throw new Error(
             skipped.length === 1
-              ? `Could not import ${names}: ${skipped[0].reason}`
-              : `Could not import ${skipped.length} presets (${names}).`,
+              ? `Failed to import ${details}`
+              : `Failed to import ${skipped.length} presets. ${details}`,
           );
         }
         setStatus?.(
-          `Imported ${importedCount} preset${importedCount === 1 ? '' : 's'}; skipped ${skipped.length} (${names}).`,
+          `Imported ${importedCount} preset${importedCount === 1 ? '' : 's'}; skipped ${skipped.length}. ${details}`,
         );
       } else if (importedCount > 1) {
         setStatus?.(`Imported ${importedCount} presets.`);

--- a/tests/unit/ast-constant-fold.test.ts
+++ b/tests/unit/ast-constant-fold.test.ts
@@ -122,6 +122,72 @@ describe('AST constant folding', () => {
     expectLiteral(foldExpression({ type: 'identifier', name: 'e' }), Math.E);
   });
 
+  test('keeps pi as an identifier when the block assigns it', () => {
+    // MilkDrop presets legitimately overwrite pi (`per_pixel_1=pi=3.14159;`).
+    // Inlining the builtin value at the read site would drop the override.
+    const block = foldProgramBlock({
+      statements: [
+        {
+          target: 'pi',
+          // A value nothing like pi, so a folded read is unmistakable.
+          expression: { type: 'literal', value: 1.5 },
+          line: 1,
+          source: 'pi = 1.5',
+        },
+        {
+          target: 'dx',
+          expression: {
+            type: 'binary',
+            operator: '*',
+            left: { type: 'identifier', name: 'pi' },
+            right: { type: 'literal', value: 2 },
+          },
+          line: 2,
+          source: 'dx = pi * 2',
+        },
+      ],
+      sourceLines: [],
+    });
+
+    const read = block.statements[1]?.expression;
+    expect(read?.type).toBe('binary');
+    expect((read as { left: { type: string } }).left.type).toBe('identifier');
+  });
+
+  test('an assignment inside a loop body still shadows the constant', () => {
+    const block = foldProgramBlock({
+      statements: [
+        {
+          target: 'loop',
+          expression: { type: 'literal', value: 0 },
+          line: 1,
+          source: '',
+          control: {
+            kind: 'loop',
+            count: { type: 'literal', value: 4 },
+            body: [
+              {
+                target: 'e',
+                expression: { type: 'literal', value: 2 },
+                line: 2,
+                source: 'e = 2',
+              },
+            ],
+          },
+        },
+        {
+          target: 'q1',
+          expression: { type: 'identifier', name: 'e' },
+          line: 3,
+          source: 'q1 = e',
+        },
+      ],
+      sourceLines: [],
+    });
+
+    expect(block.statements[1]?.expression.type).toBe('identifier');
+  });
+
   test('folds a full program block', () => {
     const block = foldProgramBlock({
       statements: [

--- a/tests/unit/error-boundary.test.tsx
+++ b/tests/unit/error-boundary.test.tsx
@@ -41,6 +41,8 @@ describe('StimsErrorBoundary recovery details', () => {
           <p>Visualizer</p>
         </StimsErrorBoundary>,
       );
+    });
+    act(() => {
       boundaryRef.current?.setState({ error });
     });
 


### PR DESCRIPTION
Main has been shipping to production with a red quality gate. Workers Builds deploys on every push and never consults GitHub Actions, so 542e2188 and ad65ee2d both reached toil.fyi with four unit tests failing. This fixes the four failures and adds a way to close the gap.

## The compiler bug behind the fourth failure

ad65ee2d's constant-folding pass resolved every `pi`/`e` identifier to the builtin literal. MilkDrop lets a program assign them like any other variable, and presets do — `per_pixel_1=pi=3.14159;`. The emitted WGSL assigned `field_pi` and then ignored it:

```
field_pi = milkdropFinite(3.14159);          // assigned…
... + 3.141592653589793)                      // …and then not used
```

Every preset overriding `pi` or `e` rendered with the wrong value on the WebGPU per-pixel path. The folder now collects the names a program writes to and skips constant resolution for them, accumulated across init/perFrame/perPixel since an assignment in one block is visible to the later ones. Two regression tests, including the loop-body case.

Also fixes `foldProgramBlock`'s unchanged-block fast path, which compared a freshly mapped array by identity and so never fired.

## The other three failures

Preset import rejections and the crash overlay's copy button, both of which were failing on message text. Import errors now name the file and the recovery in a full sentence; the copy button reports whether the clipboard write actually succeeded instead of swallowing the rejection into the console.

## Deploy gating

`site:build:gated` runs `test:fast` before the build so a failing test fails the Workers Build and production keeps the previous version. **This does nothing until the build command in the Cloudflare dashboard (`stims` Worker → Settings → Builds) is repointed from `bun run site:build` to `bun run site:build:gated`** — that step is manual.

## Verification

`bun run check` passes end to end: biome, typecheck, architecture boundaries, every guard, 1644 unit tests. `bun run site:check` builds and dry-run deploys with all eight bindings resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)