### PR TITLE
feat(webgpu): execute mat2 element writes directly on WebGPU (shader-translation gap 226 → 169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Current release status: actively developed. Latest release: **v1.3.0**._
 ### Changed
 
 - `mat2` element writes in a native `shader_body` now execute directly on WebGPU: the analysis gate that sent every matrix element write to the uniform-only approximation is narrowed to `mat3`/`mat4`, the only sizes the node executor cannot represent. 57 bundled presets move off the approximation (WebGPU shader-translation gap 226 → 169; fully supported on both backends 1521 → 1577).
+- The WebGPU node executor now binds MilkDrop per-frame registers a shader body reads without assigning (`tele`, `hordist`, `blur1_min`, …) as uniforms driven from the VM frame state, as the WebGL path already did with `uniform float` declarations. Reads of such names used to compile to nothing and silently dropped the statement and everything downstream of it (8 bundled presets, 3 of them among the `mat2` bodies above).
 - Bounded every growth path the `#1105`–`#1111` series touched: compiled-preset cache warmup, preset preview cache, idle renderer pool retention, source-diff memory, and offscreen shader identicons (`a63a1dda`, `12bd38be`, `663df8c8`, `fed4a2bb`, `9cf158e4`).
 - Coalesced stage-control activity and optimized preset stage transitions (`4d046c3d`, `d7f2e5a8`); removed redundant layers (`b28b4aa9`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _Current release status: actively developed. Latest release: **v1.3.0**._
 
 ### Changed
 
+- `mat2` element writes in a native `shader_body` now execute directly on WebGPU: the analysis gate that sent every matrix element write to the uniform-only approximation is narrowed to `mat3`/`mat4`, the only sizes the node executor cannot represent. 57 bundled presets move off the approximation (WebGPU shader-translation gap 226 → 169; fully supported on both backends 1521 → 1577).
 - Bounded every growth path the `#1105`–`#1111` series touched: compiled-preset cache warmup, preset preview cache, idle renderer pool retention, source-diff memory, and offscreen shader identicons (`a63a1dda`, `12bd38be`, `663df8c8`, `fed4a2bb`, `9cf158e4`).
 - Coalesced stage-control activity and optimized preset stage transitions (`4d046c3d`, `d7f2e5a8`); removed redundant layers (`b28b4aa9`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,13 +98,14 @@ Exit criteria:
 - Every certified preset in `src/data/milkdrop-parity/visual-reference-manifest.json` possesses matching measured diff reports for both `webgpu` and `webgl` backends; and
 - zero silent divergence between WebGL2 GLSL 300 es and WebGPU WGSL shader lowering.
 
-### Close the 226-preset WebGPU shader-translation gap
+### Close the 169-preset WebGPU shader-translation gap
 
-Measured by `tests/corpus/butterchurn-corpus-support.test.ts` on the bundled corpus: 1,521 presets are fully supported on both backends, 226 execute their shader programs directly on WebGL but fall back to extracted scalar controls on WebGPU, and 8 reference EEL identifiers the expression VM evaluates to `0`.
+Measured by `tests/corpus/butterchurn-corpus-support.test.ts` on the bundled corpus (2026-09-02): 1,577 presets are fully supported on both backends, 169 execute their shader programs directly on WebGL but fall back to extracted scalar controls on WebGPU, and 8 reference EEL identifiers the expression VM evaluates to `0`. (Was 226 / 1,521 before `mat2` element writes were let through to the WebGPU node executor, which already ran them.)
 
-- Resolve the packed feedback composite sampler (`sampler_fc_main` and `sampler_fw_main`) binding in WebGPU shader generation (`src/js/milkdrop/compiler/wgsl-generator.ts`).
+- ~~Resolve the packed feedback composite sampler (`sampler_fc_main` and `sampler_fw_main`) binding on WebGPU.~~ Done: both resolve to real bindings (`warpTex` / `currentTex`) end to end, covered by `tests/unit/milkdrop-shader-sampler-aliases.test.ts`. None of the remaining 169 is attributable to sampler binding.
 - Lower volumetric noise (`sampler_noisevol_lq`) directly to 3D texture bindings in WebGPU, replacing the simplex-atlas approximation that both backends use today.
-- Close the WebGPU executor gaps that keep the `shaderBranchDesugar` rewrite (226 → 19) behind a flag, starting with the one that takes down the GPU process, and the `mat2`/`mat3`/`mat4` element writes the node executor cannot express.
+- Give the WebGPU node executor (`src/js/milkdrop/feedback-manager-webgpu-tsl.ts`) a `mat3`/`mat4` representation. `mat2` is packed as a vec4 and executes; 20 presets still fall back because they write a `mat3` element (19 of them also branch, so the desugar is needed too).
+- Close the WebGPU executor gaps that keep the `shaderBranchDesugar` rewrite (169 → 50) behind a flag: the GPU-process crash is fixed; six presets still render white or black under the flag (named in `src/js/milkdrop/compiler/shader-branch-desugar.ts`).
 
 Exit criteria:
 - `tests/corpus/butterchurn-corpus-support.test.ts` reports 0 presets falling back to extracted scalar controls on the WebGPU path, with `fullySupported` at the full corpus count.

--- a/screenshots/butterchurn-support-sweep/summary.json
+++ b/screenshots/butterchurn-support-sweep/summary.json
@@ -1,22 +1,31 @@
 {
-  "total": 1748,
+  "total": 1743,
   "webgl": {
-    "supported": 1748,
-    "partial": 0,
+    "supported": 1735,
+    "partial": 8,
     "unsupported": 0
   },
   "webgpu": {
-    "supported": 1748,
-    "partial": 0,
+    "supported": 1570,
+    "partial": 173,
     "unsupported": 0
   },
-  "bothSupported": 1748,
-  "eitherSupported": 1748,
+  "bothSupported": 1570,
+  "eitherSupported": 1735,
   "softUnknownKeyFrequency": [],
-  "evidenceCodeFrequency": [],
+  "evidenceCodeFrequency": [
+    {
+      "code": "shader-text-translated",
+      "count": 169
+    },
+    {
+      "code": "unknown-function",
+      "count": 8
+    }
+  ],
   "unsupportedFeatureFrequency": [],
-  "presetsWithShaderBody": 1205,
-  "presetsWithoutShaderBody": 543,
+  "presetsWithShaderBody": 1201,
+  "presetsWithoutShaderBody": 542,
   "topBlockers": [],
   "results": [
     {
@@ -24,12 +33,12 @@
       "title": "!!!---flexi + amandio c - organic12-3d-2",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "royal-mashup-160",
@@ -108,9 +117,9 @@
       "title": "$$$ Royal - Mashup (253)",
       "file": "/milkdrop-presets/butterchurn/royal-mashup-253.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -197,7 +206,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "11",
@@ -257,7 +266,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "27-super-goats-neon-country-frequent-flier-program",
@@ -269,7 +278,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "27-super-goats-orbus-maximus",
@@ -341,7 +350,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "444",
@@ -384,12 +393,12 @@
       "title": "A Milk Art Detail 2 flexi - moebius transformation ft Martin With AdamFX B sentensual",
       "file": "/milkdrop-presets/butterchurn/a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "a-new-wave-trend-in-milk-martin-discomix-3-ft-phat-yin-n-adamfx-a",
@@ -485,7 +494,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs",
@@ -497,7 +506,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adam-fx-2-zylot-age-of-science-fierceness-starburst-5-mash0000",
@@ -593,7 +602,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye6",
@@ -605,7 +614,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7",
@@ -617,7 +626,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adamfx-mashup-2-martin-reflections-on-black-tile-raron-n-flexi",
@@ -641,7 +650,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "adamfx-2-geiss-somewhat-distort-me-3-1",
@@ -713,7 +722,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "aderrasi-geiss-airhandler-painterly-relief-mix",
@@ -725,7 +734,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "aderrasi-geiss-airhandler-square-mix",
@@ -1217,7 +1226,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "aderrasi-variants-of-eternity",
@@ -1272,9 +1281,9 @@
       "title": "An AdamFX n Martin Infusion 2 flexi - Why The Sky Looks Diffrent Today - AdamFx n Martin Infusion - Tack Tile Disfunction B",
       "file": "/milkdrop-presets/butterchurn/an-adamfx-n-martin-infusion-2-flexi-why-the-sky-looks-diffrent-today-adamfx-n-martin-infusion-tack-tile-disfunction-b.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1392,9 +1401,9 @@
       "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) - praise martin and flexi forever nz+ understarted",
       "file": "/milkdrop-presets/butterchurn/benjam-and-zylot-tie-dye-supernova-sunspots-mix-praise-martin-and-flexi-forever-nz-understarted.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1464,9 +1473,9 @@
       "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+",
       "file": "/milkdrop-presets/butterchurn/bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1512,12 +1521,12 @@
       "title": "Boz - Flip′d Moshun - mash0000 - forced to exist freely",
       "file": "/milkdrop-presets/butterchurn/boz-flip-d-moshun-mash0000-forced-to-exist-freely.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "brainstain-boiling-mix2-redi-jedi-full-carb-mix",
@@ -1553,7 +1562,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "brainstain-re-entry",
@@ -1656,9 +1665,9 @@
       "title": "Cope - Passage (mandala mix)[Flexis kaleidoscope] - ap3 colonosc roam3",
       "file": "/milkdrop-presets/butterchurn/cope-passage-mandala-mix-flexis-kaleidoscope-ap3-colonosc-roam3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1673,7 +1682,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-the-red",
@@ -1685,7 +1694,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-wip-strange-attractor-2",
@@ -1697,16 +1706,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice",
       "title": "DemonLD_-_Toxic_water_diffusion threx angela vs debi brown (nice)",
       "file": "/milkdrop-presets/butterchurn/demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1745,7 +1754,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "eo-s-geiss-glowsticks-v2-02-relief-mix",
@@ -1757,7 +1766,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-psychedelic-mix",
@@ -2056,8 +2065,8 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": true,
-      "diagnostics": 1
+      "hasShaderBody": false,
+      "diagnostics": 0
     },
     {
       "id": "eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix",
@@ -2628,9 +2637,9 @@
       "title": "Eo.S._Phat technicolor F breather E god cock gaia pussy",
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-technicolor-f-breather-e-god-cock-gaia-pussy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -2765,19 +2774,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix",
       "title": "Flexi + Geiss - pogo-cubes on tokamak matter [mind over matter remix]",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter",
@@ -2789,7 +2798,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-relief-2-anim-remix",
@@ -2801,7 +2810,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-martin-astral-projection",
@@ -2813,7 +2822,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-martin-cascading-decay-swing",
@@ -2849,7 +2858,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-phat-fractal-star-child-restless",
@@ -2868,12 +2877,12 @@
       "title": "Flexi + Rovastar - Fractopia [blame hexcollie]",
       "file": "/milkdrop-presets/butterchurn/flexi-rovastar-fractopia-blame-hexcollie.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-rovastar-fractopia-lovecraft",
@@ -2885,7 +2894,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-rovastar-landing-on-fractopia",
@@ -2897,7 +2906,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-shifter-sublimal-spaceship",
@@ -2909,7 +2918,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-piercing-05-kopie-2-kopie",
@@ -2921,7 +2930,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bdrv-va-ultramix-148-fucking-infinity-mix",
@@ -2957,16 +2966,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-operation-fatcap-techstyle-random-mashup",
       "title": "Flexi + fiShbRaiN - operation fatcap [techstyle] [random mashup]",
       "file": "/milkdrop-presets/butterchurn/flexi-fishbrain-operation-fatcap-techstyle-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -2993,7 +3002,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-jelly-showoff-parade",
@@ -3005,7 +3014,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-jelly-space",
@@ -3017,31 +3026,31 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-sto-aftermath",
       "title": "Flexi + sto - aftermath",
       "file": "/milkdrop-presets/butterchurn/flexi-sto-aftermath.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-sto-learning-curve",
       "title": "Flexi + sto - learning curve ",
       "file": "/milkdrop-presets/butterchurn/flexi-sto-learning-curve.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-100-shader-fractal-origami-edit",
@@ -3053,7 +3062,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishies",
@@ -3077,7 +3086,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-milkcore-martin-s-ripple-on-water-insertion",
@@ -3089,7 +3098,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-milkcore",
@@ -3101,7 +3110,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-age-of-shading-chaos",
@@ -3113,19 +3122,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-alien-fader",
       "title": "Flexi - alien fader",
       "file": "/milkdrop-presets/butterchurn/flexi-alien-fader.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-alien-fish-pond",
@@ -3161,7 +3170,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-area-51-reaction-diffusion-on-lotka-volterra-vertex-warp-alien-edge-glow-kaleidoscope-version",
@@ -3180,9 +3189,9 @@
       "title": "Flexi - area 51",
       "file": "/milkdrop-presets/butterchurn/flexi-area-51.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3192,12 +3201,12 @@
       "title": "Flexi - blame hexcollie twice",
       "file": "/milkdrop-presets/butterchurn/flexi-blame-hexcollie-twice.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-braggadocio",
@@ -3245,19 +3254,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-dimensions-projection-and-abstraction",
       "title": "Flexi - dimensions, projection and abstraction",
       "file": "/milkdrop-presets/butterchurn/flexi-dimensions-projection-and-abstraction.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-disruptor",
@@ -3293,7 +3302,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-gold-plated-maelstrom-of-chaos-mirrorized",
@@ -3305,7 +3314,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-gold-plated-maelstrom-of-chaos",
@@ -3317,7 +3326,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-hue-burst",
@@ -3329,7 +3338,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-impulse-drive",
@@ -3365,7 +3374,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-intensive-shader-fractal",
@@ -3377,7 +3386,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-intention-focus",
@@ -3413,7 +3422,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julian-affairs-remix",
@@ -3425,7 +3434,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-kaleidoscope-template-commented-composite-shader",
@@ -3437,7 +3446,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-layered-boz-buckwild",
@@ -3449,7 +3458,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-layered",
@@ -3461,19 +3470,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-learning-curve",
       "title": "Flexi - learning curve",
       "file": "/milkdrop-presets/butterchurn/flexi-learning-curve.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-meta4free-3-my-time-is-not-your-time",
@@ -3516,12 +3525,12 @@
       "title": "Flexi - mindblob mix [random mashup]",
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-mix-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-mindblob-mix",
@@ -3545,7 +3554,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-motion-blurred-moebius-fractal-early-alpha-version",
@@ -3557,7 +3566,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-multiverse-random-mashup",
@@ -3581,7 +3590,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-never-expected-to-play-the-game-on-this-level",
@@ -3593,7 +3602,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-oldschool-tree",
@@ -3617,7 +3626,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-predator-prey-spirals-geiss-laplacian-finish",
@@ -3660,9 +3669,9 @@
       "title": "Flexi - psychenapping",
       "file": "/milkdrop-presets/butterchurn/flexi-psychenapping.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3689,7 +3698,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-science-fraction",
@@ -3701,7 +3710,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-self-similarity-7",
@@ -3720,9 +3729,9 @@
       "title": "Flexi - self-lubricating",
       "file": "/milkdrop-presets/butterchurn/flexi-self-lubricating.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3737,7 +3746,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-smashing-fractals-geiss-bas-relief-finish",
@@ -3749,7 +3758,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-smashing-fractals-acid-etching-mix",
@@ -3761,7 +3770,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-strangely-dynamic-world",
@@ -3773,7 +3782,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-supersonic",
@@ -3804,9 +3813,9 @@
       "title": "Flexi - the bouncer and the crasher [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3828,12 +3837,12 @@
       "title": "Flexi - the bouncer and the crasher [random mashup 4]",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher-random-mashup-4.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-the-bouncer-and-the-crasher-random-mashup",
@@ -3852,9 +3861,9 @@
       "title": "Flexi - the bouncer and the crasher",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3869,7 +3878,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-truly-soft-piece-of-software-this-is-generic-texturing-jelly",
@@ -3881,7 +3890,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-using-jedi-forces",
@@ -3893,7 +3902,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-when-monopolies-were-the-future-simple-warp-non-reactive-moebius",
@@ -3929,16 +3938,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell",
       "title": "Flexi, BDRV, Aderrasi et al - Potion of Resurrection [rosswell]",
       "file": "/milkdrop-presets/butterchurn/flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3953,7 +3962,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit",
@@ -3965,7 +3974,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-phat-zylot-eo-s-work-with-lines-of-code",
@@ -3977,7 +3986,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-rovastar-geiss-fractopia-vs-bas-relief",
@@ -3989,7 +3998,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-nitorami-shifter-shader-authoring-motivation-set",
@@ -4055,10 +4064,10 @@
       "id": "fumbling-foo-flexi-martin-orb-star-forge-v16",
       "title": "Fumbling_Foo & Flexi, Martin, Orb - Star Forge v16",
       "file": "/milkdrop-presets/butterchurn/fumbling-foo-flexi-martin-orb-star-forge-v16.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 1
@@ -4067,13 +4076,13 @@
       "id": "fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b",
       "title": "Fumbling_Foo & Flexi, Martin, Orb, Unchained - Star Nova v7b",
       "file": "/milkdrop-presets/butterchurn/fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "future-ligh-show-adamfx-2-martin-flexi-lodus-geiss-ludicrous-speed-baked-hexocollie-eos-suksma-adamfx-ft-che-fishbrain-bmelgren-4",
@@ -4464,9 +4473,9 @@
       "title": "Geiss - Bas Relief - mash0000 - restructure society one sheep at a time",
       "file": "/milkdrop-presets/butterchurn/geiss-bas-relief-mash0000-restructure-society-one-sheep-at-a-time.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -4937,7 +4946,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-reverse-jelly-v3",
@@ -4949,16 +4958,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-game-of-life-mix",
       "title": "Geiss - Cosmic Dust 2 - Game of Life mix",
       "file": "/milkdrop-presets/butterchurn/geiss-cosmic-dust-2-game-of-life-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -4973,7 +4982,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
@@ -5033,7 +5042,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-desat-trails-2",
@@ -5045,7 +5054,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-desat-trails",
@@ -5057,7 +5066,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-dual-pane-window",
@@ -5153,7 +5162,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-dancing-spirits",
@@ -5165,7 +5174,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-de-la-moutard-1",
@@ -5189,7 +5198,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-desert-rose-2",
@@ -5333,7 +5342,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-el-cubismo",
@@ -5532,9 +5541,9 @@
       "title": "Geiss - Game of Life 2",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -5544,9 +5553,9 @@
       "title": "Geiss - Game of Life 3",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -5556,9 +5565,9 @@
       "title": "Geiss - Game of Life",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6256,7 +6265,7 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": true,
+      "hasShaderBody": false,
       "diagnostics": 0
     },
     {
@@ -6569,7 +6578,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-soft",
@@ -6617,7 +6626,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-spiral-artifact",
@@ -6912,9 +6921,9 @@
       "title": "Geiss, Nitorami + MackTuesday - Twitchy Paint fact fuct nz+",
       "file": "/milkdrop-presets/butterchurn/geiss-nitorami-macktuesday-twitchy-paint-fact-fuct-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6924,9 +6933,9 @@
       "title": "Goody + flexi - Irdu Lili",
       "file": "/milkdrop-presets/butterchurn/goody-flexi-irdu-lili.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6936,45 +6945,45 @@
       "title": "Goody + martin - crystal palace - Aqua Lumens",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-aqua-lumens.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-martin-crystal-palace-ocular-anima",
       "title": "Goody + martin - crystal palace - Ocular Anima",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-ocular-anima.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics",
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - Darkening mathematics",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one",
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - mess2 nz+ i have no character and feel entitled to one",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6984,12 +6993,12 @@
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-acid-angel-fallen-angel",
@@ -7025,7 +7034,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-clouded-reason-revisited",
@@ -7073,7 +7082,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-need-desire-remix",
@@ -7121,7 +7130,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-sonic-infection",
@@ -7217,7 +7226,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "hexcollie-cell-division",
@@ -7289,7 +7298,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "hexcollie-personal-mashup3-flexis-portal-mix",
@@ -7373,7 +7382,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "hexcollie-bdrv-n-unchained-the-hive",
@@ -7556,18 +7565,6 @@
       "diagnostics": 0
     },
     {
-      "id": "illusion-unchained-new-strategy",
-      "title": "Illusion & Unchained - New Strategy",
-      "file": "/milkdrop-presets/butterchurn/illusion-unchained-new-strategy.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
-      "softUnknownKeys": [],
-      "evidenceCodes": [],
-      "unsupportedFeatures": [],
-      "hasShaderBody": false,
-      "diagnostics": 0
-    },
-    {
       "id": "illusion-dance-of-the-planets",
       "title": "Illusion - Dance Of The Planets",
       "file": "/milkdrop-presets/butterchurn/illusion-dance-of-the-planets.milk",
@@ -7620,9 +7617,9 @@
       "title": "Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 6 ngorng",
       "file": "/milkdrop-presets/butterchurn/inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-6-ngorng.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -7661,7 +7658,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue",
@@ -7744,7 +7741,7 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": true,
+      "hasShaderBody": false,
       "diagnostics": 0
     },
     {
@@ -7775,18 +7772,6 @@
       "id": "krash-illusion-spiral-movement",
       "title": "Krash + Illusion - Spiral Movement",
       "file": "/milkdrop-presets/butterchurn/krash-illusion-spiral-movement.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
-      "softUnknownKeys": [],
-      "evidenceCodes": [],
-      "unsupportedFeatures": [],
-      "hasShaderBody": false,
-      "diagnostics": 0
-    },
-    {
-      "id": "krash-rovastar-cerebral-demons-phat-eo-s-stars-remix",
-      "title": "Krash + Rovastar - Cerebral Demons - Phat + Eo.S. Stars Remix",
-      "file": "/milkdrop-presets/butterchurn/krash-rovastar-cerebral-demons-phat-eo-s-stars-remix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -7908,9 +7893,9 @@
       "title": "Krash - interwoven (nightmare weft)_Phats_I_Wana_Fuck_Some_Candy_Kids... - mash0000 - elevator to the drugged up runaway penthouse",
       "file": "/milkdrop-presets/butterchurn/krash-interwoven-nightmare-weft-phats-i-wana-fuck-some-candy-kids-mash0000-elevator-to-the-drugged-up-runaway-penthouse.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -7949,7 +7934,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "luxxx-chillflower-blurface-ib",
@@ -8009,7 +7994,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "luxxx-fuck-your-code-ii",
@@ -8105,7 +8090,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "luxxx-melt-ur-face-i-b",
@@ -8225,7 +8210,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-diabolo",
@@ -8244,9 +8229,9 @@
       "title": "Martin - QBikal - Surface Turbulence II",
       "file": "/milkdrop-presets/butterchurn/martin-qbikal-surface-turbulence-ii.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8256,9 +8241,9 @@
       "title": "Martin - QBikal - Surface Turbulence IIb",
       "file": "/milkdrop-presets/butterchurn/martin-qbikal-surface-turbulence-iib.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8280,9 +8265,9 @@
       "title": "Martin - acid wiring",
       "file": "/milkdrop-presets/butterchurn/martin-acid-wiring.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8292,9 +8277,9 @@
       "title": "Martin - bombyx mori mix2",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-mix2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8388,9 +8373,9 @@
       "title": "Martin - underwater cathedral",
       "file": "/milkdrop-presets/butterchurn/martin-underwater-cathedral.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8424,21 +8409,21 @@
       "title": "Martin+Anandamide - Mandelbox_Explorer Quantum_Timepiece_remix",
       "file": "/milkdrop-presets/butterchurn/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2",
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8448,9 +8433,9 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 3]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8460,9 +8445,9 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8472,12 +8457,12 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "milk-artist-at-our-best-fed-slowfast-ft-adamfx-n-martin-hd-cosmofx",
@@ -8496,9 +8481,9 @@
       "title": "Milk King to the ExtreemFX flexi - divine struggle - Ft AdamFX n Martin - Picasso In Milk Molten Meltdown E",
       "file": "/milkdrop-presets/butterchurn/milk-king-to-the-extreemfx-flexi-divine-struggle-ft-adamfx-n-martin-picasso-in-milk-molten-meltdown-e.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8585,7 +8570,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "nighthawk-eye-of-gawd-phat-spiral-edit-v2",
@@ -8777,7 +8762,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "orb-magma-pool",
@@ -8945,7 +8930,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "orb-waaa",
@@ -8957,7 +8942,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "phat-eo-s-data-swimmer",
@@ -9092,9 +9077,9 @@
       "diagnostics": 0
     },
     {
-      "id": "phat-eo-s-rainbow-bubble-mid3-f-me-dood",
+      "id": "phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt",
       "title": "Phat_Eo.S. rainbow bubble_mid3-f. me dood",
-      "file": "/milkdrop-presets/butterchurn/phat-eo-s-rainbow-bubble-mid3-f-me-dood.milk",
+      "file": "/milkdrop-presets/butterchurn/phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -9260,9 +9245,9 @@
       "diagnostics": 0
     },
     {
-      "id": "phat-zylot-eo-s-work-with-lines",
+      "id": "phat-zylot-eo-s-work-with-lines-alt",
       "title": "Phat_Zylot_Eo.S. work with lines",
-      "file": "/milkdrop-presets/butterchurn/phat-zylot-eo-s-work-with-lines.milk",
+      "file": "/milkdrop-presets/butterchurn/phat-zylot-eo-s-work-with-lines-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -9912,9 +9897,9 @@
       "title": "Rovastar + Loadus + Geiss - FractalDrop (Spinning Mix)",
       "file": "/milkdrop-presets/butterchurn/rovastar-loadus-geiss-fractaldrop-spinning-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -10043,18 +10028,6 @@
       "id": "rovastar-telek-altars-of-madness-rolling-oceans-mix",
       "title": "Rovastar + Telek - Altars of Madness (Rolling Oceans Mix)",
       "file": "/milkdrop-presets/butterchurn/rovastar-telek-altars-of-madness-rolling-oceans-mix.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
-      "softUnknownKeys": [],
-      "evidenceCodes": [],
-      "unsupportedFeatures": [],
-      "hasShaderBody": false,
-      "diagnostics": 0
-    },
-    {
-      "id": "rovastar-unchained-ambrosia-mystic-dark-heart-mix",
-      "title": "Rovastar + Unchained - Ambrosia Mystic (Dark Heart Mix)",
-      "file": "/milkdrop-presets/butterchurn/rovastar-unchained-ambrosia-mystic-dark-heart-mix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -10661,7 +10634,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "rovastar-voov-s-light-pattern",
@@ -10920,9 +10893,9 @@
       "title": "ShadowHarlequin - Fitting Butterfly - v4 - [Loadus & Geiss - FractalDrop 22] v2v2v2v2newcolorsv2v2-22v2-NEWv222v2 bennett",
       "file": "/milkdrop-presets/butterchurn/shadowharlequin-fitting-butterfly-v4-loadus-geiss-fractaldrop-22-v2v2v2v2newcolorsv2v2-22v2-newv222v2-bennett.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -11009,7 +10982,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope",
@@ -11021,7 +10994,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-aderrasi-eo-s-geiss-fishbrain-prickly-abyss",
@@ -11045,7 +11018,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-a-feat-hexcollie",
@@ -11057,7 +11030,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-b",
@@ -11069,7 +11042,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-g",
@@ -11081,7 +11054,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1",
@@ -11105,7 +11078,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-relief-block-mix",
@@ -11117,7 +11090,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-jelly",
@@ -11129,7 +11102,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-che-geiss-illusion-unchained-shifty-jelly-v2",
@@ -11153,7 +11126,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-eo-s-geiss-orb-phat-fruitsticks-flexi-tex-shader",
@@ -11297,7 +11270,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-geiss-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
@@ -11405,7 +11378,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-fishbrain-geiss-martin-flowercraft",
@@ -11429,7 +11402,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-reflecto-fcukup",
@@ -11441,7 +11414,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-flexi-geiss-rovastar-shifter-fractal-feedback-for-hexcollie",
@@ -11453,7 +11426,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics",
@@ -11489,7 +11462,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-flexi-psychotic-flower-gelatine-burst",
@@ -11501,7 +11474,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-geiss-martin-ouboros-metal-finish-2",
@@ -11513,16 +11486,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess",
       "title": "Stahlregen + Geiss - Old school, baby (Flower V2)_1 - lack-of-torture torture mess",
       "file": "/milkdrop-presets/butterchurn/stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -11561,7 +11534,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "stahlregen-dots-pixels-blocky-jelly-v2",
@@ -11684,18 +11657,6 @@
       "diagnostics": 0
     },
     {
-      "id": "techno-sandstorm-psychodelic-highway",
-      "title": "TEcHNO + SandStorm - Psychodelic Highway",
-      "file": "/milkdrop-presets/butterchurn/techno-sandstorm-psychodelic-highway.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
-      "softUnknownKeys": [],
-      "evidenceCodes": [],
-      "unsupportedFeatures": [],
-      "hasShaderBody": false,
-      "diagnostics": 0
-    },
-    {
       "id": "tag-cradle-of-life-remix-of-yin-315",
       "title": "Tag - Cradle of Life(remix of yin 315)",
       "file": "/milkdrop-presets/butterchurn/tag-cradle-of-life-remix-of-yin-315.milk",
@@ -11777,7 +11738,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "tonymilkdrop-magellan-s-nebula-flexi-fancy-this-shall-not-retain",
@@ -11789,7 +11750,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "tonymilkdrop-magellan-s-nebula-flexi-grind-this-shall-not-retain",
@@ -11825,7 +11786,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "tripgnosis-negative-photon-burn",
@@ -12545,7 +12506,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "various-artists-goo",
@@ -12653,19 +12614,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "zylot-age-of-science-seeking-truth-mix",
       "title": "Zylot - Age of Science (seeking truth mix)",
       "file": "/milkdrop-presets/butterchurn/zylot-age-of-science-seeking-truth-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "zylot-block-of-sound-abstract-architecture-mix",
@@ -12713,7 +12674,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "zylot-crossing-over-paint-spatter-mix",
@@ -12725,7 +12686,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "zylot-digiscape-advanced-processor",
@@ -12768,9 +12729,9 @@
       "title": "Zylot - Heaven Bloom nz+",
       "file": "/milkdrop-presets/butterchurn/zylot-heaven-bloom-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -12840,9 +12801,9 @@
       "title": "Zylot - Paint Spill (Music Reactive Paint Mix)",
       "file": "/milkdrop-presets/butterchurn/zylot-paint-spill-music-reactive-paint-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -12929,7 +12890,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-color-mix",
@@ -12992,16 +12953,16 @@
       "diagnostics": 0
     },
     {
-      "id": "eo-s-zylot-skylight-stained-glass-majesty-mix",
+      "id": "eo-s-zylot-skylight-stained-glass-majesty-mix-alt",
       "title": "_Eo.S. + Zylot - skylight (Stained Glass Majesty mix)",
-      "file": "/milkdrop-presets/butterchurn/eo-s-zylot-skylight-stained-glass-majesty-mix.milk",
+      "file": "/milkdrop-presets/butterchurn/eo-s-zylot-skylight-stained-glass-majesty-mix-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "eo-s-glowsticks-v2-02-geiss-hpf",
@@ -13013,7 +12974,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-broth-mix",
@@ -13304,9 +13265,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-confetti-kaleidoscope-mix",
+      "id": "geiss-confetti-kaleidoscope-mix-alt",
       "title": "_Geiss - Confetti (Kaleidoscope Mix)",
-      "file": "/milkdrop-presets/butterchurn/geiss-confetti-kaleidoscope-mix.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-confetti-kaleidoscope-mix-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13328,9 +13289,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-desert-rose-2",
+      "id": "geiss-desert-rose-2-alt",
       "title": "_Geiss - Desert Rose 2",
-      "file": "/milkdrop-presets/butterchurn/geiss-desert-rose-2.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-desert-rose-2-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13376,9 +13337,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-kaleidoscope-1",
+      "id": "geiss-kaleidoscope-1-alt",
       "title": "_Geiss - Kaleidoscope 1",
-      "file": "/milkdrop-presets/butterchurn/geiss-kaleidoscope-1.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-kaleidoscope-1-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13436,9 +13397,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-reaction-diffusion-relief-mix",
+      "id": "geiss-reaction-diffusion-relief-mix-alt",
       "title": "_Geiss - Reaction Diffusion (Relief Mix)",
-      "file": "/milkdrop-presets/butterchurn/geiss-reaction-diffusion-relief-mix.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-reaction-diffusion-relief-mix-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13460,9 +13421,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-reducto-absurdum",
+      "id": "geiss-reducto-absurdum-alt",
       "title": "_Geiss - Reducto Absurdum",
-      "file": "/milkdrop-presets/butterchurn/geiss-reducto-absurdum.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-reducto-absurdum-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13496,9 +13457,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-skin-dots-multi-layer-3",
+      "id": "geiss-skin-dots-multi-layer-3-alt",
       "title": "_Geiss - Skin Dots Multi-layer 3",
-      "file": "/milkdrop-presets/butterchurn/geiss-skin-dots-multi-layer-3.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-skin-dots-multi-layer-3-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13517,7 +13478,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-spiral-artifact-filament-mix-beat-dots-mix",
@@ -13529,7 +13490,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-spiral-artifact-filament-mix-rad8-mix",
@@ -13541,7 +13502,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-beetle-bore-color-invert-mirror-animated",
@@ -13568,9 +13529,9 @@
       "diagnostics": 0
     },
     {
-      "id": "krash-eo-s-photographic-sentinel",
+      "id": "krash-eo-s-photographic-sentinel-alt",
       "title": "_Krash + Eo.S. - Photographic Sentinel",
-      "file": "/milkdrop-presets/butterchurn/krash-eo-s-photographic-sentinel.milk",
+      "file": "/milkdrop-presets/butterchurn/krash-eo-s-photographic-sentinel-alt.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -14369,7 +14330,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "geiss-flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-emboss",
@@ -14472,9 +14433,9 @@
       "title": "a crappy reality = you did well",
       "file": "/milkdrop-presets/butterchurn/a-crappy-reality-you-did-well.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14532,9 +14493,9 @@
       "title": "amandio c - fume",
       "file": "/milkdrop-presets/butterchurn/amandio-c-fume.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14592,9 +14553,9 @@
       "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter",
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14604,9 +14565,9 @@
       "title": "amandio c - pole - shf fab candiria pull ap5+ selectro-electronic afield asquid",
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-selectro-electronic-afield-asquid.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14868,9 +14829,9 @@
       "title": "beta106.S. + Phat - sentinel linearity b nz+ mbinistre ov mbajiq",
       "file": "/milkdrop-presets/butterchurn/beta106-s-phat-sentinel-linearity-b-nz-mbinistre-ov-mbajiq.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14928,9 +14889,9 @@
       "title": "beta106i - Airhandler (Radial Dreamers) - mash0000 - unload stones into black market torture houses",
       "file": "/milkdrop-presets/butterchurn/beta106i-airhandler-radial-dreamers-mash0000-unload-stones-into-black-market-torture-houses.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14964,9 +14925,9 @@
       "title": "beta106i - Have at You (Spin Strike) - mash0000 - more the game of death, jesus conway",
       "file": "/milkdrop-presets/butterchurn/beta106i-have-at-you-spin-strike-mash0000-more-the-game-of-death-jesus-conway.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15089,7 +15050,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-flexi-cartune-extrusion-machine-mix-inside-the-hive",
@@ -15120,9 +15081,9 @@
       "title": "cope + flexi - cartune (extrusion machine mix) [spiral out]",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-cartune-extrusion-machine-mix-spiral-out.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15132,21 +15093,21 @@
       "title": "cope + flexi - colorful marble (ghost mix) - rand wave 4 nz+",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-colorful-marble-ghost-mix-rand-wave-4-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz",
       "title": "cope + flexi - mother-of-whirl [composition from fractopia] roam3 nz+",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15281,7 +15242,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-strange-attractor-flexis-let-it-grow-mix-stahlregens-jelly-after-burner",
@@ -15293,7 +15254,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-strange-attractor-flexis-let-it-grow-mix-jelly-5-56-volume-noise-zoom-in",
@@ -15305,7 +15266,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-the-drain-to-heaven",
@@ -15324,12 +15285,12 @@
       "title": "cope, flexi + martin - cartune [reinventing the scene]",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-martin-cartune-reinventing-the-scene.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "cope-martin-flexi-the-slickery-of-alternative-varnish",
@@ -15377,7 +15338,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "ech0-liquid-firesticks-i",
@@ -15401,7 +15362,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "eo-s-phat-chasers-11-sentinel-c-jelly-v4-x",
@@ -15413,7 +15374,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fed-slowfast-1-1-geiss-composite-remix",
@@ -15444,12 +15405,12 @@
       "title": "felix capacitor",
       "file": "/milkdrop-presets/butterchurn/felix-capacitor.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-eo-s-phat-starburst-totem-pole",
@@ -15533,7 +15494,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-witchcraft-glow-mix",
@@ -15557,7 +15518,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix-3",
@@ -15569,7 +15530,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin",
@@ -15581,7 +15542,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix",
@@ -15593,7 +15554,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix",
@@ -15605,7 +15566,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-a-quiet-death",
@@ -15821,7 +15782,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-geiss-stahlregen-orb-witchcraft-yabm-tiled",
@@ -15833,7 +15794,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "fishbrain-flexi-stitchcraft",
@@ -15857,7 +15818,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic-random-mashup-2",
@@ -15869,7 +15830,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic-random-mashup",
@@ -15896,64 +15857,64 @@
       "diagnostics": 0
     },
     {
-      "id": "flexi-amandio-c-organic12-3d-2",
+      "id": "flexi-amandio-c-organic12-3d-2-alt",
       "title": "flexi + amandio c - organic12-3d-2",
-      "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2.milk",
+      "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2-alt.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic12-3d3",
       "title": "flexi + amandio c - organic12-3d3",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic12-3d4-2",
       "title": "flexi + amandio c - organic12-3d4-2",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d4-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic12-3d4",
       "title": "flexi + amandio c - organic12-3d4",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d4.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-amandio-c-organic4-columns",
       "title": "flexi + amandio c - organic4-columns",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic4-columns.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bdrv-acid-etching-jelly-v5-5",
@@ -15972,9 +15933,9 @@
       "title": "flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ wrepwrimindloss w8",
       "file": "/milkdrop-presets/butterchurn/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz-wrepwrimindloss-w8.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15984,9 +15945,9 @@
       "title": "flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+",
       "file": "/milkdrop-presets/butterchurn/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16013,7 +15974,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-warpcraft-random-mashup-2",
@@ -16025,7 +15986,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-warpcraft-random-mashup-3",
@@ -16073,7 +16034,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-warpcraft",
@@ -16097,7 +16058,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-witchcraft-complex-terraforming",
@@ -16109,7 +16070,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-redi-jedi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-mashup",
@@ -16140,9 +16101,9 @@
       "title": "flexi + geiss - infused with the spiral (Heavy Oil Mix) nz+ rapery",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16152,9 +16113,9 @@
       "title": "flexi + geiss - pogo cubes vs. tokamak vs. game of life [stahls jelly 4.5 finish]",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-vs-tokamak-vs-game-of-life-stahls-jelly-4-5-finish.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16169,19 +16130,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2",
       "title": "flexi + geiss - pogo-cubes on tokamak matter [mind over matter remix]2",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-geiss-tokamak-fallout-repellor",
@@ -16193,16 +16154,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-goody-the-prayerwheel-misplaced-prayers",
       "title": "flexi + goody - the prayerwheel - misplaced prayers",
       "file": "/milkdrop-presets/butterchurn/flexi-goody-the-prayerwheel-misplaced-prayers.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16217,7 +16178,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-nitorami-beat-explorer-cn-bc-jelly-4",
@@ -16253,7 +16214,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-gimme-color-spinner-mix-v2",
@@ -16265,7 +16226,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-gimme-color-spinner-mix",
@@ -16277,7 +16238,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-jelly-spin-off",
@@ -16289,7 +16250,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-jelly-strike",
@@ -16301,7 +16262,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-jewelry-tiles",
@@ -16313,7 +16274,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos",
@@ -16373,7 +16334,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-alien-canvas-learning",
@@ -16397,7 +16358,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-alien-canvas",
@@ -16433,7 +16394,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-alien-web-bouncer-edit-for-hexcollie",
@@ -16445,7 +16406,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-black-holes-sucking-fractals-for-breakfast",
@@ -16457,16 +16418,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-blame-moebius",
       "title": "flexi - blame moebius",
       "file": "/milkdrop-presets/butterchurn/flexi-blame-moebius.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16481,7 +16442,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bouncing-balls-double-mindblob-gastrointestinal-mix",
@@ -16493,7 +16454,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bouncing-balls-double-mindblob-neon-mix",
@@ -16505,7 +16466,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bouncing-balls-grafitti-mix",
@@ -16529,7 +16490,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-bouncing-balls-neon-mix",
@@ -16541,19 +16502,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-can-t-think-of-mosaic-cages",
       "title": "flexi - can′t think of mosaic cages",
       "file": "/milkdrop-presets/butterchurn/flexi-can-t-think-of-mosaic-cages.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-color-strike",
@@ -16565,7 +16526,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-crank-prototype",
@@ -16577,7 +16538,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-flow",
@@ -16589,7 +16550,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fractal-descent",
@@ -16601,7 +16562,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fractal-seafood",
@@ -16613,7 +16574,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-gimme-color-bc-cn-jelly-4",
@@ -16625,7 +16586,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-gimme-color",
@@ -16637,7 +16598,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-gravitational-chaos",
@@ -16661,7 +16622,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-hyperspaceflight-bn-cn-jelly-4",
@@ -16709,7 +16670,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-jelly-fish-mandala",
@@ -16721,7 +16682,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-island-output-stage",
@@ -16733,7 +16694,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-set-illuminating-example-parameter-play",
@@ -16745,7 +16706,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-set-illuminating-example",
@@ -16757,7 +16718,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-set-shader-neocortex-wiretapping",
@@ -16781,7 +16742,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-set-shader-example-2",
@@ -16793,7 +16754,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julia-set-shader-example",
@@ -16817,7 +16778,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-julian-affairs-bc-cn-jelly-v4",
@@ -16841,7 +16802,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-lollipop-overkill-bccn-jelly-v4",
@@ -16908,9 +16869,9 @@
       "title": "flexi - lorenz chaser [accidental shader-lock mashup] (ripples)2 nz+ discombobule lose",
       "file": "/milkdrop-presets/butterchurn/flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-2-nz-discombobule-lose.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16925,7 +16886,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-mindblob-2-0-bc-cn-jelly-4",
@@ -16949,19 +16910,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-mom-why-the-sky-looks-different-today",
       "title": "flexi - mom, why the sky looks different today",
       "file": "/milkdrop-presets/butterchurn/flexi-mom-why-the-sky-looks-different-today.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-patternton-district-of-media-capitol-of-the-united-abstractions-of-fractopia",
@@ -16973,7 +16934,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-predator-prey-seminar-paper-visualization-05-mathematical-biology-concepts-reaction-diffusion-on-predator-prey-spirals",
@@ -16997,7 +16958,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-romanesco-fantasies",
@@ -17009,7 +16970,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-smouldering",
@@ -17040,9 +17001,9 @@
       "title": "flexi - swing out on the spiral",
       "file": "/milkdrop-presets/butterchurn/flexi-swing-out-on-the-spiral.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17069,16 +17030,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-the-prayerwheel",
       "title": "flexi - the prayerwheel",
       "file": "/milkdrop-presets/butterchurn/flexi-the-prayerwheel.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17088,9 +17049,9 @@
       "title": "flexi - trickster zenarchy",
       "file": "/milkdrop-presets/butterchurn/flexi-trickster-zenarchy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17117,7 +17078,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-undercurrents-3-psychodelic-mix-mash0001-planck-based-dematerializer",
@@ -17141,16 +17102,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template",
       "title": "flexi - what to do with the inside of a torus [easily customizable moebius spiral template]",
       "file": "/milkdrop-presets/butterchurn/flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17165,16 +17126,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-why-random-mashups-should-be-forbidden",
       "title": "flexi - why random mashups should be forbidden",
       "file": "/milkdrop-presets/butterchurn/flexi-why-random-mashups-should-be-forbidden.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17189,7 +17150,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-fishbrain-stahlregen-witchcraft-jelly5-5",
@@ -17225,7 +17186,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-martin-indoctrinutrition",
@@ -17237,7 +17198,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "flexi-stahlregen-geiss-tobias-wolfboi-space-gelatine-burst-mash0000-chromatidal-pool-mirror-blasphemy",
@@ -17256,21 +17217,9 @@
       "title": "geiss + martin - mandelbox explorer - high speed demo version (fire mix)",
       "file": "/milkdrop-presets/butterchurn/geiss-martin-mandelbox-explorer-high-speed-demo-version-fire-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
-      "unsupportedFeatures": [],
-      "hasShaderBody": true,
-      "diagnostics": 1
-    },
-    {
-      "id": "geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix",
-      "title": "geiss + mstress - Cleaning a path - Painterly Crossfire (Crisp Emboss Mix)",
-      "file": "/milkdrop-presets/butterchurn/geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
-      "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17328,12 +17277,12 @@
       "title": "goody + martin - crystal palace - schizotoxin - the wild iris bloom - 16 iterations",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader-fixed",
@@ -17345,7 +17294,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader",
@@ -17357,7 +17306,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "had-to-cum-that-jaben",
@@ -17388,9 +17337,9 @@
       "title": "hexcollie(1), goody(3), stahlregen(3), fed(1) - 2nd collaboration(ps2.0) - 8",
       "file": "/milkdrop-presets/butterchurn/hexcollie-1-goody-3-stahlregen-3-fed-1-2nd-collaboration-ps2-0-8.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17400,9 +17349,9 @@
       "title": "high-altitude basket unraveling - singh grooves nitrogen argon nz+",
       "file": "/milkdrop-presets/butterchurn/high-altitude-basket-unraveling-singh-grooves-nitrogen-argon-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17436,9 +17385,9 @@
       "title": "lit claw (explorers grid) - i don′t have either a belfry or bats bitch",
       "file": "/milkdrop-presets/butterchurn/lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17448,21 +17397,21 @@
       "title": "martin  - mandelbox explorer - high speed demo  [flexi's complex polynomial version]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-flexi-s-complex-polynomial-version.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-flexi-bombyx-mori-mix2-in-the-beehive",
       "title": "martin + flexi - bombyx mori mix2 in the beehive",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-bombyx-mori-mix2-in-the-beehive.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17484,21 +17433,21 @@
       "title": "martin + flexi - mandelbox explorer - high speed oversustained bipolar",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-mandelbox-explorer-high-speed-oversustained-bipolar.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix",
       "title": "martin + flexi - mandelbox stepper mix [kinetic triangles gossip matrix]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17520,9 +17469,9 @@
       "title": "martin + stahlregen - martin in da mash 10 (infinity mix)",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-10-infinity-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17532,9 +17481,9 @@
       "title": "martin + stahlregen - martin in da mash 11",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-11.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17544,9 +17493,9 @@
       "title": "martin + stahlregen - martin in da mash 12",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-12.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17556,9 +17505,9 @@
       "title": "martin + stahlregen - martin in da mash 12a",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-12a.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17592,9 +17541,9 @@
       "title": "martin + stahlregen - martin in da mash 18",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-18.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17604,9 +17553,9 @@
       "title": "martin + stahlregen - martin in da mash 3",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17669,7 +17618,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-thinking-about-you",
@@ -17712,9 +17661,9 @@
       "title": "martin - alien grand theft water",
       "file": "/milkdrop-presets/butterchurn/martin-alien-grand-theft-water.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17832,9 +17781,9 @@
       "title": "martin - bombyx mori [flexi′s logarithmic edit]",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-flexi-s-logarithmic-edit.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17844,9 +17793,9 @@
       "title": "martin - bombyx mori",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17873,7 +17822,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-carpet-weaver",
@@ -17885,16 +17834,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-castle-in-the-air",
       "title": "martin - castle in the air",
       "file": "/milkdrop-presets/butterchurn/martin-castle-in-the-air.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17928,9 +17877,9 @@
       "title": "martin - cherry brain 2",
       "file": "/milkdrop-presets/butterchurn/martin-cherry-brain-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17952,9 +17901,9 @@
       "title": "martin - city of shadows",
       "file": "/milkdrop-presets/butterchurn/martin-city-of-shadows.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17976,9 +17925,9 @@
       "title": "martin - cope - laser dome",
       "file": "/milkdrop-presets/butterchurn/martin-cope-laser-dome.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18000,9 +17949,9 @@
       "title": "martin - crystal palace nz+",
       "file": "/milkdrop-presets/butterchurn/martin-crystal-palace-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18012,9 +17961,9 @@
       "title": "martin - crystal palace",
       "file": "/milkdrop-presets/butterchurn/martin-crystal-palace.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18047,13 +17996,13 @@
       "id": "martin-diamond-cutter",
       "title": "martin - diamond cutter",
       "file": "/milkdrop-presets/butterchurn/martin-diamond-cutter.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-disco-mix-1",
@@ -18120,9 +18069,9 @@
       "title": "martin - dont drink and drive (police mix)",
       "file": "/milkdrop-presets/butterchurn/martin-dont-drink-and-drive-police-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18131,13 +18080,13 @@
       "id": "martin-dune-racer",
       "title": "martin - dune racer",
       "file": "/milkdrop-presets/butterchurn/martin-dune-racer.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-electric-pool",
@@ -18156,9 +18105,9 @@
       "title": "martin - elusive impressions mix1",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix1.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18168,9 +18117,9 @@
       "title": "martin - elusive impressions mix2 - flacc mess proph nz+2",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix2-flacc-mess-proph-nz-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18180,9 +18129,9 @@
       "title": "martin - elusive impressions mix2",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18216,9 +18165,9 @@
       "title": "martin - flexi - laser dome [bipolar focus intent]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-laser-dome-bipolar-focus-intent.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18240,12 +18189,12 @@
       "title": "martin - frosty caves 2",
       "file": "/milkdrop-presets/butterchurn/martin-frosty-caves-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-fruit-machine",
@@ -18300,9 +18249,9 @@
       "title": "martin - girlie affairs",
       "file": "/milkdrop-presets/butterchurn/martin-girlie-affairs.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18347,22 +18296,22 @@
       "id": "martin-hardcore-mix-1",
       "title": "martin - hardcore mix 1",
       "file": "/milkdrop-presets/butterchurn/martin-hardcore-mix-1.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function", "shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-hardcore-mix-2",
       "title": "martin - hardcore mix 2",
       "file": "/milkdrop-presets/butterchurn/martin-hardcore-mix-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18384,9 +18333,9 @@
       "title": "martin - infinity (2008)",
       "file": "/milkdrop-presets/butterchurn/martin-infinity-2008.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18396,9 +18345,9 @@
       "title": "martin - infinity (2010 update)",
       "file": "/milkdrop-presets/butterchurn/martin-infinity-2010-update.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18408,9 +18357,9 @@
       "title": "martin - infinity",
       "file": "/milkdrop-presets/butterchurn/martin-infinity.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18444,9 +18393,9 @@
       "title": "martin - jellyfish dance",
       "file": "/milkdrop-presets/butterchurn/martin-jellyfish-dance.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18456,9 +18405,9 @@
       "title": "martin - liquid gold",
       "file": "/milkdrop-presets/butterchurn/martin-liquid-gold.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18492,9 +18441,9 @@
       "title": "martin - ludicrous speed",
       "file": "/milkdrop-presets/butterchurn/martin-ludicrous-speed.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18504,9 +18453,9 @@
       "title": "martin - mandelbox explorer - high speed demo version [Flexi's diffuse wave] [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18516,33 +18465,33 @@
       "title": "martin - mandelbox explorer - high speed demo version [Flexi's diffuse wave]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-mandelbox-explorer-high-speed-demo-version",
       "title": "martin - mandelbox explorer - high speed demo version",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-mandelbox-stepper",
       "title": "martin - mandelbox stepper",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-stepper.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18551,13 +18500,13 @@
       "id": "martin-mandelbulb-slideshow",
       "title": "martin - mandelbulb slideshow",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbulb-slideshow.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function", "shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 8
     },
     {
       "id": "martin-moonlight-splash",
@@ -18600,9 +18549,9 @@
       "title": "martin - musicogenic epilepsy",
       "file": "/milkdrop-presets/butterchurn/martin-musicogenic-epilepsy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18647,13 +18596,13 @@
       "id": "martin-night-cathedral",
       "title": "martin - night cathedral",
       "file": "/milkdrop-presets/butterchurn/martin-night-cathedral.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function", "shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-night-in-the-forest",
@@ -18672,9 +18621,9 @@
       "title": "martin - on silent paths",
       "file": "/milkdrop-presets/butterchurn/martin-on-silent-paths.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18684,9 +18633,9 @@
       "title": "martin - orbit trap playground",
       "file": "/milkdrop-presets/butterchurn/martin-orbit-trap-playground.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18720,9 +18669,9 @@
       "title": "martin - purple pulsator",
       "file": "/milkdrop-presets/butterchurn/martin-purple-pulsator.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18744,9 +18693,9 @@
       "title": "martin - resonant twister - steel spring",
       "file": "/milkdrop-presets/butterchurn/martin-resonant-twister-steel-spring.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18828,9 +18777,9 @@
       "title": "martin - silversmith",
       "file": "/milkdrop-presets/butterchurn/martin-silversmith.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18840,9 +18789,9 @@
       "title": "martin - skywards",
       "file": "/milkdrop-presets/butterchurn/martin-skywards.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18876,9 +18825,9 @@
       "title": "martin - sparky caleidoscope",
       "file": "/milkdrop-presets/butterchurn/martin-sparky-caleidoscope.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18917,7 +18866,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-starfield-sectors",
@@ -19008,9 +18957,9 @@
       "title": "martin - the Dome ps3",
       "file": "/milkdrop-presets/butterchurn/martin-the-dome-ps3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19044,9 +18993,9 @@
       "title": "martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix]",
       "file": "/milkdrop-presets/butterchurn/martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19103,13 +19052,13 @@
       "id": "martin-tunnel-race",
       "title": "martin - tunnel race",
       "file": "/milkdrop-presets/butterchurn/martin-tunnel-race.milk",
-      "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webglStatus": "partial",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["unknown-function", "shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-unholy-amulet-2",
@@ -19164,9 +19113,9 @@
       "title": "martin - witchcraft reloaded",
       "file": "/milkdrop-presets/butterchurn/martin-witchcraft-reloaded.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19188,9 +19137,9 @@
       "title": "martin, fishbrain + flexi - mandelbox explorer v1 Eo.S. optimize [bipolar witchcraft mix]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-mandelbox-explorer-v1-eo-s-optimize-bipolar-witchcraft-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19200,21 +19149,21 @@
       "title": "martin, flexi + sto - traumflug",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-sto-traumflug.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-flexi-fishbrain-sto-enterstate-random-mashup-2",
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19224,9 +19173,9 @@
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup 3]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19236,33 +19185,33 @@
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-flexi-fishbrain-sto-enterstate",
       "title": "martin, flexi, fishbrain + sto - enterstate",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "massive-crack-hit-maggot-trace",
       "title": "massive crack hit maggot trace",
       "file": "/milkdrop-presets/butterchurn/massive-crack-hit-maggot-trace.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19272,9 +19221,9 @@
       "title": "menstruating in reverse in reverse time max out crap roam3 nz+",
       "file": "/milkdrop-presets/butterchurn/menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19313,7 +19262,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "nil-did-you-speak-with-the-orb",
@@ -19344,12 +19293,12 @@
       "title": "no good rnz",
       "file": "/milkdrop-presets/butterchurn/no-good-rnz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "orb-fireworks-fusion",
@@ -19577,16 +19526,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "random-mash-up-round-47",
       "title": "random mash-up round 47",
       "file": "/milkdrop-presets/butterchurn/random-mash-up-round-47.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19601,7 +19550,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "raron-a-grayish-blob-mash0000-pungent-gastric-automata-cloud-fumes",
@@ -19632,21 +19581,21 @@
       "title": "rce-ordinary + flexi - far away distance (custom beat detection + bipolar colour ghost mix)",
       "file": "/milkdrop-presets/butterchurn/rce-ordinary-flexi-far-away-distance-custom-beat-detection-bipolar-colour-ghost-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "rediculator-qrem-glob",
       "title": "rediculator qrem glob",
       "file": "/milkdrop-presets/butterchurn/rediculator-qrem-glob.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19661,7 +19610,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "schglasmia-danqueer",
@@ -19709,7 +19658,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "shadowharlequin-cope-alternative-energy-antimatter-mod-1-rave-dreams",
@@ -19733,7 +19682,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "shifter-aderrasi-airhandler-sadako",
@@ -20016,9 +19965,9 @@
       "title": "shifter - liquid circuitry",
       "file": "/milkdrop-presets/butterchurn/shifter-liquid-circuitry.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20208,21 +20157,21 @@
       "title": "skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn",
       "title": "skipper skipper kiss me hard - thank god for martin nitorami - tgfmn",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20232,9 +20181,9 @@
       "title": "skipper skipper kiss me hard - thank god for martin nitorami nz",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20328,9 +20277,9 @@
       "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20405,7 +20354,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "suksma-blatantic-emissarial-crotch",
@@ -20484,9 +20433,9 @@
       "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored",
       "file": "/milkdrop-presets/butterchurn/suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20508,12 +20457,12 @@
       "title": "suksma - fiShbRaiN - white sceam firefly - mash0000 - liquid oxygen, jet fuel, and maybe some plutonium too",
       "file": "/milkdrop-presets/butterchurn/suksma-fishbrain-white-sceam-firefly-mash0000-liquid-oxygen-jet-fuel-and-maybe-some-plutonium-too.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "suksma-flexi-lorenz-chaser-heretical-tribal-necklace",
@@ -20568,9 +20517,9 @@
       "title": "suksma - in madness i purposely convince myself of all your lies, then slice you open and eat your lungs only nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-in-madness-i-purposely-convince-myself-of-all-your-lies-then-slice-you-open-and-eat-your-lungs-only-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20609,7 +20558,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "suksma-question-authority-take-what-you-want-be-a-nihilist",
@@ -20652,9 +20601,9 @@
       "title": "suksma - sun pod gambit couch nz+2 satangastriq",
       "file": "/milkdrop-presets/butterchurn/suksma-sun-pod-gambit-couch-nz-2-satangastriq.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20705,7 +20654,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "suksma-water-cooled-red-uranium-vs-dotes-freeenergynow-net",
@@ -20724,9 +20673,9 @@
       "title": "suksma - yin - 100 - Through the ether - Bitcore Tweak - mash0000 - dmt eye rub spher nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-yin-100-through-the-ether-bitcore-tweak-mash0000-dmt-eye-rub-spher-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "supported",
+      "webgpuStatus": "partial",
       "softUnknownKeys": [],
-      "evidenceCodes": [],
+      "evidenceCodes": ["shader-text-translated"],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20765,7 +20714,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "yin-030-dance-with-the-ocean",

--- a/screenshots/butterchurn-support-sweep/summary.json
+++ b/screenshots/butterchurn-support-sweep/summary.json
@@ -1,31 +1,22 @@
 {
-  "total": 1743,
+  "total": 1748,
   "webgl": {
-    "supported": 1735,
-    "partial": 8,
+    "supported": 1748,
+    "partial": 0,
     "unsupported": 0
   },
   "webgpu": {
-    "supported": 1570,
-    "partial": 173,
+    "supported": 1748,
+    "partial": 0,
     "unsupported": 0
   },
-  "bothSupported": 1570,
-  "eitherSupported": 1735,
+  "bothSupported": 1748,
+  "eitherSupported": 1748,
   "softUnknownKeyFrequency": [],
-  "evidenceCodeFrequency": [
-    {
-      "code": "shader-text-translated",
-      "count": 169
-    },
-    {
-      "code": "unknown-function",
-      "count": 8
-    }
-  ],
+  "evidenceCodeFrequency": [],
   "unsupportedFeatureFrequency": [],
-  "presetsWithShaderBody": 1201,
-  "presetsWithoutShaderBody": 542,
+  "presetsWithShaderBody": 1205,
+  "presetsWithoutShaderBody": 543,
   "topBlockers": [],
   "results": [
     {
@@ -33,12 +24,12 @@
       "title": "!!!---flexi + amandio c - organic12-3d-2",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "royal-mashup-160",
@@ -117,9 +108,9 @@
       "title": "$$$ Royal - Mashup (253)",
       "file": "/milkdrop-presets/butterchurn/royal-mashup-253.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -206,7 +197,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "11",
@@ -266,7 +257,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "27-super-goats-neon-country-frequent-flier-program",
@@ -278,7 +269,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "27-super-goats-orbus-maximus",
@@ -350,7 +341,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "444",
@@ -393,12 +384,12 @@
       "title": "A Milk Art Detail 2 flexi - moebius transformation ft Martin With AdamFX B sentensual",
       "file": "/milkdrop-presets/butterchurn/a-milk-art-detail-2-flexi-moebius-transformation-ft-martin-with-adamfx-b-sentensual.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "a-new-wave-trend-in-milk-martin-discomix-3-ft-phat-yin-n-adamfx-a",
@@ -494,7 +485,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adam-fx-2-zylot-age-of-science-fierceness-beast2-mash0000-ethics-is-for-weiner-dogs",
@@ -506,7 +497,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adam-fx-2-zylot-age-of-science-fierceness-starburst-5-mash0000",
@@ -602,7 +593,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye6",
@@ -614,7 +605,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adamfx-2-geiss-mash-up-sphere-xibit-graffiti-warp-me-tydye7",
@@ -626,7 +617,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adamfx-mashup-2-martin-reflections-on-black-tile-raron-n-flexi",
@@ -650,7 +641,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "adamfx-2-geiss-somewhat-distort-me-3-1",
@@ -722,7 +713,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "aderrasi-geiss-airhandler-painterly-relief-mix",
@@ -734,7 +725,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "aderrasi-geiss-airhandler-square-mix",
@@ -1226,7 +1217,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "aderrasi-variants-of-eternity",
@@ -1281,9 +1272,9 @@
       "title": "An AdamFX n Martin Infusion 2 flexi - Why The Sky Looks Diffrent Today - AdamFx n Martin Infusion - Tack Tile Disfunction B",
       "file": "/milkdrop-presets/butterchurn/an-adamfx-n-martin-infusion-2-flexi-why-the-sky-looks-diffrent-today-adamfx-n-martin-infusion-tack-tile-disfunction-b.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1401,9 +1392,9 @@
       "title": "Benjam and Zylot - Tie-Dye Supernova (Sunspots Mix) - praise martin and flexi forever nz+ understarted",
       "file": "/milkdrop-presets/butterchurn/benjam-and-zylot-tie-dye-supernova-sunspots-mix-praise-martin-and-flexi-forever-nz-understarted.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1473,9 +1464,9 @@
       "title": "Bmelgren & Unchained - Effort (Remix) - the city of glass that i live in, the coldness from my brother′s skin nz+",
       "file": "/milkdrop-presets/butterchurn/bmelgren-unchained-effort-remix-the-city-of-glass-that-i-live-in-the-coldness-from-my-brother-s-skin-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1521,12 +1512,12 @@
       "title": "Boz - Flip′d Moshun - mash0000 - forced to exist freely",
       "file": "/milkdrop-presets/butterchurn/boz-flip-d-moshun-mash0000-forced-to-exist-freely.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "brainstain-boiling-mix2-redi-jedi-full-carb-mix",
@@ -1562,7 +1553,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "brainstain-re-entry",
@@ -1665,9 +1656,9 @@
       "title": "Cope - Passage (mandala mix)[Flexis kaleidoscope] - ap3 colonosc roam3",
       "file": "/milkdrop-presets/butterchurn/cope-passage-mandala-mix-flexis-kaleidoscope-ap3-colonosc-roam3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1682,7 +1673,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-the-red",
@@ -1694,7 +1685,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-wip-strange-attractor-2",
@@ -1706,16 +1697,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice",
       "title": "DemonLD_-_Toxic_water_diffusion threx angela vs debi brown (nice)",
       "file": "/milkdrop-presets/butterchurn/demonld-toxic-water-diffusion-threx-angela-vs-debi-brown-nice.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -1754,7 +1745,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "eo-s-geiss-glowsticks-v2-02-relief-mix",
@@ -1766,7 +1757,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "eo-s-geiss-glowsticks-v2-03-music-shifter-edit-b-psychedelic-mix",
@@ -2065,8 +2056,8 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": false,
-      "diagnostics": 0
+      "hasShaderBody": true,
+      "diagnostics": 1
     },
     {
       "id": "eo-s-flexi-glowsticks-v2-05-and-proton-lights-krash-s-beat-code-phat-remix02b-illumination-stahl-s-mix",
@@ -2637,9 +2628,9 @@
       "title": "Eo.S._Phat technicolor F breather E god cock gaia pussy",
       "file": "/milkdrop-presets/butterchurn/eo-s-phat-technicolor-f-breather-e-god-cock-gaia-pussy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -2774,19 +2765,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix",
       "title": "Flexi + Geiss - pogo-cubes on tokamak matter [mind over matter remix]",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter",
@@ -2798,7 +2789,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-relief-2-anim-remix",
@@ -2810,7 +2801,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-martin-astral-projection",
@@ -2822,7 +2813,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-martin-cascading-decay-swing",
@@ -2858,7 +2849,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-phat-fractal-star-child-restless",
@@ -2877,12 +2868,12 @@
       "title": "Flexi + Rovastar - Fractopia [blame hexcollie]",
       "file": "/milkdrop-presets/butterchurn/flexi-rovastar-fractopia-blame-hexcollie.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-rovastar-fractopia-lovecraft",
@@ -2894,7 +2885,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-rovastar-landing-on-fractopia",
@@ -2906,7 +2897,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-shifter-sublimal-spaceship",
@@ -2918,7 +2909,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-piercing-05-kopie-2-kopie",
@@ -2930,7 +2921,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bdrv-va-ultramix-148-fucking-infinity-mix",
@@ -2966,16 +2957,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-operation-fatcap-techstyle-random-mashup",
       "title": "Flexi + fiShbRaiN - operation fatcap [techstyle] [random mashup]",
       "file": "/milkdrop-presets/butterchurn/flexi-fishbrain-operation-fatcap-techstyle-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3002,7 +2993,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-jelly-showoff-parade",
@@ -3014,7 +3005,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-jelly-space",
@@ -3026,31 +3017,31 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-sto-aftermath",
       "title": "Flexi + sto - aftermath",
       "file": "/milkdrop-presets/butterchurn/flexi-sto-aftermath.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-sto-learning-curve",
       "title": "Flexi + sto - learning curve ",
       "file": "/milkdrop-presets/butterchurn/flexi-sto-learning-curve.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-100-shader-fractal-origami-edit",
@@ -3062,7 +3053,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishies",
@@ -3086,7 +3077,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-milkcore-martin-s-ripple-on-water-insertion",
@@ -3098,7 +3089,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-milkcore",
@@ -3110,7 +3101,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-age-of-shading-chaos",
@@ -3122,19 +3113,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-alien-fader",
       "title": "Flexi - alien fader",
       "file": "/milkdrop-presets/butterchurn/flexi-alien-fader.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-alien-fish-pond",
@@ -3170,7 +3161,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-area-51-reaction-diffusion-on-lotka-volterra-vertex-warp-alien-edge-glow-kaleidoscope-version",
@@ -3189,9 +3180,9 @@
       "title": "Flexi - area 51",
       "file": "/milkdrop-presets/butterchurn/flexi-area-51.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3201,12 +3192,12 @@
       "title": "Flexi - blame hexcollie twice",
       "file": "/milkdrop-presets/butterchurn/flexi-blame-hexcollie-twice.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-braggadocio",
@@ -3254,19 +3245,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-dimensions-projection-and-abstraction",
       "title": "Flexi - dimensions, projection and abstraction",
       "file": "/milkdrop-presets/butterchurn/flexi-dimensions-projection-and-abstraction.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-disruptor",
@@ -3302,7 +3293,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-gold-plated-maelstrom-of-chaos-mirrorized",
@@ -3314,7 +3305,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-gold-plated-maelstrom-of-chaos",
@@ -3326,7 +3317,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-hue-burst",
@@ -3338,7 +3329,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-impulse-drive",
@@ -3374,7 +3365,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-intensive-shader-fractal",
@@ -3386,7 +3377,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-intention-focus",
@@ -3422,7 +3413,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julian-affairs-remix",
@@ -3434,7 +3425,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-kaleidoscope-template-commented-composite-shader",
@@ -3446,7 +3437,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-layered-boz-buckwild",
@@ -3458,7 +3449,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-layered",
@@ -3470,19 +3461,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-learning-curve",
       "title": "Flexi - learning curve",
       "file": "/milkdrop-presets/butterchurn/flexi-learning-curve.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-meta4free-3-my-time-is-not-your-time",
@@ -3525,12 +3516,12 @@
       "title": "Flexi - mindblob mix [random mashup]",
       "file": "/milkdrop-presets/butterchurn/flexi-mindblob-mix-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-mindblob-mix",
@@ -3554,7 +3545,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-motion-blurred-moebius-fractal-early-alpha-version",
@@ -3566,7 +3557,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-multiverse-random-mashup",
@@ -3590,7 +3581,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-never-expected-to-play-the-game-on-this-level",
@@ -3602,7 +3593,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-oldschool-tree",
@@ -3626,7 +3617,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-predator-prey-spirals-geiss-laplacian-finish",
@@ -3669,9 +3660,9 @@
       "title": "Flexi - psychenapping",
       "file": "/milkdrop-presets/butterchurn/flexi-psychenapping.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3698,7 +3689,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-science-fraction",
@@ -3710,7 +3701,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-self-similarity-7",
@@ -3729,9 +3720,9 @@
       "title": "Flexi - self-lubricating",
       "file": "/milkdrop-presets/butterchurn/flexi-self-lubricating.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3746,7 +3737,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-smashing-fractals-geiss-bas-relief-finish",
@@ -3758,7 +3749,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-smashing-fractals-acid-etching-mix",
@@ -3770,7 +3761,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-strangely-dynamic-world",
@@ -3782,7 +3773,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-supersonic",
@@ -3813,9 +3804,9 @@
       "title": "Flexi - the bouncer and the crasher [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3837,12 +3828,12 @@
       "title": "Flexi - the bouncer and the crasher [random mashup 4]",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher-random-mashup-4.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-the-bouncer-and-the-crasher-random-mashup",
@@ -3861,9 +3852,9 @@
       "title": "Flexi - the bouncer and the crasher",
       "file": "/milkdrop-presets/butterchurn/flexi-the-bouncer-and-the-crasher.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3878,7 +3869,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-truly-soft-piece-of-software-this-is-generic-texturing-jelly",
@@ -3890,7 +3881,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-using-jedi-forces",
@@ -3902,7 +3893,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-when-monopolies-were-the-future-simple-warp-non-reactive-moebius",
@@ -3938,16 +3929,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell",
       "title": "Flexi, BDRV, Aderrasi et al - Potion of Resurrection [rosswell]",
       "file": "/milkdrop-presets/butterchurn/flexi-bdrv-aderrasi-et-al-potion-of-resurrection-rosswell.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -3962,7 +3953,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-martin-phat-zylot-eo-s-one-way-trip-trap-proof-of-concept-epileptic-zoom-tunnel-edit",
@@ -3974,7 +3965,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-phat-zylot-eo-s-work-with-lines-of-code",
@@ -3986,7 +3977,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-rovastar-geiss-fractopia-vs-bas-relief",
@@ -3998,7 +3989,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-nitorami-shifter-shader-authoring-motivation-set",
@@ -4064,10 +4055,10 @@
       "id": "fumbling-foo-flexi-martin-orb-star-forge-v16",
       "title": "Fumbling_Foo & Flexi, Martin, Orb - Star Forge v16",
       "file": "/milkdrop-presets/butterchurn/fumbling-foo-flexi-martin-orb-star-forge-v16.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 1
@@ -4076,13 +4067,13 @@
       "id": "fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b",
       "title": "Fumbling_Foo & Flexi, Martin, Orb, Unchained - Star Nova v7b",
       "file": "/milkdrop-presets/butterchurn/fumbling-foo-flexi-martin-orb-unchained-star-nova-v7b.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "future-ligh-show-adamfx-2-martin-flexi-lodus-geiss-ludicrous-speed-baked-hexocollie-eos-suksma-adamfx-ft-che-fishbrain-bmelgren-4",
@@ -4473,9 +4464,9 @@
       "title": "Geiss - Bas Relief - mash0000 - restructure society one sheep at a time",
       "file": "/milkdrop-presets/butterchurn/geiss-bas-relief-mash0000-restructure-society-one-sheep-at-a-time.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -4946,7 +4937,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-reverse-jelly-v3",
@@ -4958,16 +4949,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-game-of-life-mix",
       "title": "Geiss - Cosmic Dust 2 - Game of Life mix",
       "file": "/milkdrop-presets/butterchurn/geiss-cosmic-dust-2-game-of-life-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -4982,7 +4973,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-tiny-reaction-diffusion-mix",
@@ -5042,7 +5033,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-desat-trails-2",
@@ -5054,7 +5045,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-desat-trails",
@@ -5066,7 +5057,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-cosmic-dust-2-quasistatic-noise-dual-pane-window",
@@ -5162,7 +5153,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-dancing-spirits",
@@ -5174,7 +5165,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-de-la-moutard-1",
@@ -5198,7 +5189,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-desert-rose-2",
@@ -5342,7 +5333,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-el-cubismo",
@@ -5541,9 +5532,9 @@
       "title": "Geiss - Game of Life 2",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -5553,9 +5544,9 @@
       "title": "Geiss - Game of Life 3",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -5565,9 +5556,9 @@
       "title": "Geiss - Game of Life",
       "file": "/milkdrop-presets/butterchurn/geiss-game-of-life.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6265,7 +6256,7 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": false,
+      "hasShaderBody": true,
       "diagnostics": 0
     },
     {
@@ -6578,7 +6569,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-soft",
@@ -6626,7 +6617,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-spiral-artifact",
@@ -6921,9 +6912,9 @@
       "title": "Geiss, Nitorami + MackTuesday - Twitchy Paint fact fuct nz+",
       "file": "/milkdrop-presets/butterchurn/geiss-nitorami-macktuesday-twitchy-paint-fact-fuct-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6933,9 +6924,9 @@
       "title": "Goody + flexi - Irdu Lili",
       "file": "/milkdrop-presets/butterchurn/goody-flexi-irdu-lili.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6945,45 +6936,45 @@
       "title": "Goody + martin - crystal palace - Aqua Lumens",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-aqua-lumens.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-martin-crystal-palace-ocular-anima",
       "title": "Goody + martin - crystal palace - Ocular Anima",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-ocular-anima.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics",
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - Darkening mathematics",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-darkening-mathematics.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one",
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom - mess2 nz+ i have no character and feel entitled to one",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-mess2-nz-i-have-no-character-and-feel-entitled-to-one.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -6993,12 +6984,12 @@
       "title": "Goody + martin - crystal palace - Schizotoxin - The Wild Iris Bloom",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-acid-angel-fallen-angel",
@@ -7034,7 +7025,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-clouded-reason-revisited",
@@ -7082,7 +7073,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-need-desire-remix",
@@ -7130,7 +7121,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-sonic-infection",
@@ -7226,7 +7217,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "hexcollie-cell-division",
@@ -7298,7 +7289,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "hexcollie-personal-mashup3-flexis-portal-mix",
@@ -7382,7 +7373,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "hexcollie-bdrv-n-unchained-the-hive",
@@ -7565,6 +7556,18 @@
       "diagnostics": 0
     },
     {
+      "id": "illusion-unchained-new-strategy",
+      "title": "Illusion & Unchained - New Strategy",
+      "file": "/milkdrop-presets/butterchurn/illusion-unchained-new-strategy.milk",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
+      "softUnknownKeys": [],
+      "evidenceCodes": [],
+      "unsupportedFeatures": [],
+      "hasShaderBody": false,
+      "diagnostics": 0
+    },
+    {
       "id": "illusion-dance-of-the-planets",
       "title": "Illusion - Dance Of The Planets",
       "file": "/milkdrop-presets/butterchurn/illusion-dance-of-the-planets.milk",
@@ -7617,9 +7620,9 @@
       "title": "Inside A Black Whole AdamFX 2 martin - another kind of groove (Ati Fix)Ft Raron Flexi and Rovastar (AdamFX Remix)Uh huh 6 ngorng",
       "file": "/milkdrop-presets/butterchurn/inside-a-black-whole-adamfx-2-martin-another-kind-of-groove-ati-fix-ft-raron-flexi-and-rovastar-adamfx-remix-uh-huh-6-ngorng.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -7658,7 +7661,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "jim-geiss-bass-zoom-symmetry-mash0000-the-god-damn-pen-is-rrrroyal-blue",
@@ -7741,7 +7744,7 @@
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
-      "hasShaderBody": false,
+      "hasShaderBody": true,
       "diagnostics": 0
     },
     {
@@ -7772,6 +7775,18 @@
       "id": "krash-illusion-spiral-movement",
       "title": "Krash + Illusion - Spiral Movement",
       "file": "/milkdrop-presets/butterchurn/krash-illusion-spiral-movement.milk",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
+      "softUnknownKeys": [],
+      "evidenceCodes": [],
+      "unsupportedFeatures": [],
+      "hasShaderBody": false,
+      "diagnostics": 0
+    },
+    {
+      "id": "krash-rovastar-cerebral-demons-phat-eo-s-stars-remix",
+      "title": "Krash + Rovastar - Cerebral Demons - Phat + Eo.S. Stars Remix",
+      "file": "/milkdrop-presets/butterchurn/krash-rovastar-cerebral-demons-phat-eo-s-stars-remix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -7893,9 +7908,9 @@
       "title": "Krash - interwoven (nightmare weft)_Phats_I_Wana_Fuck_Some_Candy_Kids... - mash0000 - elevator to the drugged up runaway penthouse",
       "file": "/milkdrop-presets/butterchurn/krash-interwoven-nightmare-weft-phats-i-wana-fuck-some-candy-kids-mash0000-elevator-to-the-drugged-up-runaway-penthouse.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -7934,7 +7949,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "luxxx-chillflower-blurface-ib",
@@ -7994,7 +8009,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "luxxx-fuck-your-code-ii",
@@ -8090,7 +8105,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "luxxx-melt-ur-face-i-b",
@@ -8210,7 +8225,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-diabolo",
@@ -8229,9 +8244,9 @@
       "title": "Martin - QBikal - Surface Turbulence II",
       "file": "/milkdrop-presets/butterchurn/martin-qbikal-surface-turbulence-ii.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8241,9 +8256,9 @@
       "title": "Martin - QBikal - Surface Turbulence IIb",
       "file": "/milkdrop-presets/butterchurn/martin-qbikal-surface-turbulence-iib.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8265,9 +8280,9 @@
       "title": "Martin - acid wiring",
       "file": "/milkdrop-presets/butterchurn/martin-acid-wiring.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8277,9 +8292,9 @@
       "title": "Martin - bombyx mori mix2",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-mix2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8373,9 +8388,9 @@
       "title": "Martin - underwater cathedral",
       "file": "/milkdrop-presets/butterchurn/martin-underwater-cathedral.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8409,21 +8424,21 @@
       "title": "Martin+Anandamide - Mandelbox_Explorer Quantum_Timepiece_remix",
       "file": "/milkdrop-presets/butterchurn/martin-anandamide-mandelbox-explorer-quantum-timepiece-remix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2",
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8433,9 +8448,9 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup 3]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8445,9 +8460,9 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8457,12 +8472,12 @@
       "title": "Martin, Fishbrain + Flexi - lasercutting binary trees",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-lasercutting-binary-trees.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "milk-artist-at-our-best-fed-slowfast-ft-adamfx-n-martin-hd-cosmofx",
@@ -8481,9 +8496,9 @@
       "title": "Milk King to the ExtreemFX flexi - divine struggle - Ft AdamFX n Martin - Picasso In Milk Molten Meltdown E",
       "file": "/milkdrop-presets/butterchurn/milk-king-to-the-extreemfx-flexi-divine-struggle-ft-adamfx-n-martin-picasso-in-milk-molten-meltdown-e.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -8570,7 +8585,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "nighthawk-eye-of-gawd-phat-spiral-edit-v2",
@@ -8762,7 +8777,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "orb-magma-pool",
@@ -8930,7 +8945,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "orb-waaa",
@@ -8942,7 +8957,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "phat-eo-s-data-swimmer",
@@ -9077,9 +9092,9 @@
       "diagnostics": 0
     },
     {
-      "id": "phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt",
+      "id": "phat-eo-s-rainbow-bubble-mid3-f-me-dood",
       "title": "Phat_Eo.S. rainbow bubble_mid3-f. me dood",
-      "file": "/milkdrop-presets/butterchurn/phat-eo-s-rainbow-bubble-mid3-f-me-dood-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/phat-eo-s-rainbow-bubble-mid3-f-me-dood.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -9245,9 +9260,9 @@
       "diagnostics": 0
     },
     {
-      "id": "phat-zylot-eo-s-work-with-lines-alt",
+      "id": "phat-zylot-eo-s-work-with-lines",
       "title": "Phat_Zylot_Eo.S. work with lines",
-      "file": "/milkdrop-presets/butterchurn/phat-zylot-eo-s-work-with-lines-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/phat-zylot-eo-s-work-with-lines.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -9897,9 +9912,9 @@
       "title": "Rovastar + Loadus + Geiss - FractalDrop (Spinning Mix)",
       "file": "/milkdrop-presets/butterchurn/rovastar-loadus-geiss-fractaldrop-spinning-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -10028,6 +10043,18 @@
       "id": "rovastar-telek-altars-of-madness-rolling-oceans-mix",
       "title": "Rovastar + Telek - Altars of Madness (Rolling Oceans Mix)",
       "file": "/milkdrop-presets/butterchurn/rovastar-telek-altars-of-madness-rolling-oceans-mix.milk",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
+      "softUnknownKeys": [],
+      "evidenceCodes": [],
+      "unsupportedFeatures": [],
+      "hasShaderBody": false,
+      "diagnostics": 0
+    },
+    {
+      "id": "rovastar-unchained-ambrosia-mystic-dark-heart-mix",
+      "title": "Rovastar + Unchained - Ambrosia Mystic (Dark Heart Mix)",
+      "file": "/milkdrop-presets/butterchurn/rovastar-unchained-ambrosia-mystic-dark-heart-mix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -10634,7 +10661,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "rovastar-voov-s-light-pattern",
@@ -10893,9 +10920,9 @@
       "title": "ShadowHarlequin - Fitting Butterfly - v4 - [Loadus & Geiss - FractalDrop 22] v2v2v2v2newcolorsv2v2-22v2-NEWv222v2 bennett",
       "file": "/milkdrop-presets/butterchurn/shadowharlequin-fitting-butterfly-v4-loadus-geiss-fractaldrop-22-v2v2v2v2newcolorsv2v2-22v2-newv222v2-bennett.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -10982,7 +11009,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-adamfx-eo-s-flexi-geiss-phat-rovastar-zylot-fractopia-kaleidoscope",
@@ -10994,7 +11021,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-aderrasi-eo-s-geiss-fishbrain-prickly-abyss",
@@ -11018,7 +11045,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-a-feat-hexcollie",
@@ -11030,7 +11057,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-b",
@@ -11042,7 +11069,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-aderrasi-flexi-rovastar-fractal-twist-g",
@@ -11054,7 +11081,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-benski-fvese-geiss-rovastar-voyager-spark-call-jester-s-smashing-atoms-rmx-1",
@@ -11078,7 +11105,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-relief-block-mix",
@@ -11090,7 +11117,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-boz-eo-s-geiss-phat-rovastar-zylot-machine-code-jelly",
@@ -11102,7 +11129,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-che-geiss-illusion-unchained-shifty-jelly-v2",
@@ -11126,7 +11153,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-eo-s-geiss-orb-phat-fruitsticks-flexi-tex-shader",
@@ -11270,7 +11297,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-geiss-mashup-16-seizure-inducing-confetti-kaleidoscope-rmx",
@@ -11378,7 +11405,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-fishbrain-geiss-martin-flowercraft",
@@ -11402,7 +11429,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-flexi-geiss-rovastar-shifter-even-more-fractals-for-hexcollie-reflecto-fcukup",
@@ -11414,7 +11441,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-flexi-geiss-rovastar-shifter-fractal-feedback-for-hexcollie",
@@ -11426,7 +11453,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-flexi-geiss-martin-rovastar-tides-martin-s-metallics",
@@ -11462,7 +11489,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-flexi-psychotic-flower-gelatine-burst",
@@ -11474,7 +11501,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-geiss-martin-ouboros-metal-finish-2",
@@ -11486,16 +11513,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess",
       "title": "Stahlregen + Geiss - Old school, baby (Flower V2)_1 - lack-of-torture torture mess",
       "file": "/milkdrop-presets/butterchurn/stahlregen-geiss-old-school-baby-flower-v2-1-lack-of-torture-torture-mess.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -11534,7 +11561,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "stahlregen-dots-pixels-blocky-jelly-v2",
@@ -11657,6 +11684,18 @@
       "diagnostics": 0
     },
     {
+      "id": "techno-sandstorm-psychodelic-highway",
+      "title": "TEcHNO + SandStorm - Psychodelic Highway",
+      "file": "/milkdrop-presets/butterchurn/techno-sandstorm-psychodelic-highway.milk",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
+      "softUnknownKeys": [],
+      "evidenceCodes": [],
+      "unsupportedFeatures": [],
+      "hasShaderBody": false,
+      "diagnostics": 0
+    },
+    {
       "id": "tag-cradle-of-life-remix-of-yin-315",
       "title": "Tag - Cradle of Life(remix of yin 315)",
       "file": "/milkdrop-presets/butterchurn/tag-cradle-of-life-remix-of-yin-315.milk",
@@ -11738,7 +11777,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "tonymilkdrop-magellan-s-nebula-flexi-fancy-this-shall-not-retain",
@@ -11750,7 +11789,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "tonymilkdrop-magellan-s-nebula-flexi-grind-this-shall-not-retain",
@@ -11786,7 +11825,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "tripgnosis-negative-photon-burn",
@@ -12506,7 +12545,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "various-artists-goo",
@@ -12614,19 +12653,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "zylot-age-of-science-seeking-truth-mix",
       "title": "Zylot - Age of Science (seeking truth mix)",
       "file": "/milkdrop-presets/butterchurn/zylot-age-of-science-seeking-truth-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "zylot-block-of-sound-abstract-architecture-mix",
@@ -12674,7 +12713,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "zylot-crossing-over-paint-spatter-mix",
@@ -12686,7 +12725,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "zylot-digiscape-advanced-processor",
@@ -12729,9 +12768,9 @@
       "title": "Zylot - Heaven Bloom nz+",
       "file": "/milkdrop-presets/butterchurn/zylot-heaven-bloom-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -12801,9 +12840,9 @@
       "title": "Zylot - Paint Spill (Music Reactive Paint Mix)",
       "file": "/milkdrop-presets/butterchurn/zylot-paint-spill-music-reactive-paint-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -12890,7 +12929,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "aderrasi-wanderer-in-curved-space-mash0000-faclempt-kibitzing-meshuggana-schmaltz-geiss-color-mix",
@@ -12953,16 +12992,16 @@
       "diagnostics": 0
     },
     {
-      "id": "eo-s-zylot-skylight-stained-glass-majesty-mix-alt",
+      "id": "eo-s-zylot-skylight-stained-glass-majesty-mix",
       "title": "_Eo.S. + Zylot - skylight (Stained Glass Majesty mix)",
-      "file": "/milkdrop-presets/butterchurn/eo-s-zylot-skylight-stained-glass-majesty-mix-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/eo-s-zylot-skylight-stained-glass-majesty-mix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "eo-s-glowsticks-v2-02-geiss-hpf",
@@ -12974,7 +13013,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-mindblob-where-it-s-at-now-broth-mix",
@@ -13265,9 +13304,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-confetti-kaleidoscope-mix-alt",
+      "id": "geiss-confetti-kaleidoscope-mix",
       "title": "_Geiss - Confetti (Kaleidoscope Mix)",
-      "file": "/milkdrop-presets/butterchurn/geiss-confetti-kaleidoscope-mix-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-confetti-kaleidoscope-mix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13289,9 +13328,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-desert-rose-2-alt",
+      "id": "geiss-desert-rose-2",
       "title": "_Geiss - Desert Rose 2",
-      "file": "/milkdrop-presets/butterchurn/geiss-desert-rose-2-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-desert-rose-2.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13337,9 +13376,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-kaleidoscope-1-alt",
+      "id": "geiss-kaleidoscope-1",
       "title": "_Geiss - Kaleidoscope 1",
-      "file": "/milkdrop-presets/butterchurn/geiss-kaleidoscope-1-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-kaleidoscope-1.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13397,9 +13436,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-reaction-diffusion-relief-mix-alt",
+      "id": "geiss-reaction-diffusion-relief-mix",
       "title": "_Geiss - Reaction Diffusion (Relief Mix)",
-      "file": "/milkdrop-presets/butterchurn/geiss-reaction-diffusion-relief-mix-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-reaction-diffusion-relief-mix.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13421,9 +13460,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-reducto-absurdum-alt",
+      "id": "geiss-reducto-absurdum",
       "title": "_Geiss - Reducto Absurdum",
-      "file": "/milkdrop-presets/butterchurn/geiss-reducto-absurdum-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-reducto-absurdum.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13457,9 +13496,9 @@
       "diagnostics": 0
     },
     {
-      "id": "geiss-skin-dots-multi-layer-3-alt",
+      "id": "geiss-skin-dots-multi-layer-3",
       "title": "_Geiss - Skin Dots Multi-layer 3",
-      "file": "/milkdrop-presets/butterchurn/geiss-skin-dots-multi-layer-3-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/geiss-skin-dots-multi-layer-3.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -13478,7 +13517,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-spiral-artifact-filament-mix-beat-dots-mix",
@@ -13490,7 +13529,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-spiral-artifact-filament-mix-rad8-mix",
@@ -13502,7 +13541,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-beetle-bore-color-invert-mirror-animated",
@@ -13529,9 +13568,9 @@
       "diagnostics": 0
     },
     {
-      "id": "krash-eo-s-photographic-sentinel-alt",
+      "id": "krash-eo-s-photographic-sentinel",
       "title": "_Krash + Eo.S. - Photographic Sentinel",
-      "file": "/milkdrop-presets/butterchurn/krash-eo-s-photographic-sentinel-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/krash-eo-s-photographic-sentinel.milk",
       "webglStatus": "supported",
       "webgpuStatus": "supported",
       "softUnknownKeys": [],
@@ -14330,7 +14369,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "geiss-flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-emboss",
@@ -14433,9 +14472,9 @@
       "title": "a crappy reality = you did well",
       "file": "/milkdrop-presets/butterchurn/a-crappy-reality-you-did-well.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14493,9 +14532,9 @@
       "title": "amandio c - fume",
       "file": "/milkdrop-presets/butterchurn/amandio-c-fume.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14553,9 +14592,9 @@
       "title": "amandio c - pole - shf fab candiria pull ap5+ made to believe i don′t matter",
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-made-to-believe-i-don-t-matter.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14565,9 +14604,9 @@
       "title": "amandio c - pole - shf fab candiria pull ap5+ selectro-electronic afield asquid",
       "file": "/milkdrop-presets/butterchurn/amandio-c-pole-shf-fab-candiria-pull-ap5-selectro-electronic-afield-asquid.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14829,9 +14868,9 @@
       "title": "beta106.S. + Phat - sentinel linearity b nz+ mbinistre ov mbajiq",
       "file": "/milkdrop-presets/butterchurn/beta106-s-phat-sentinel-linearity-b-nz-mbinistre-ov-mbajiq.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14889,9 +14928,9 @@
       "title": "beta106i - Airhandler (Radial Dreamers) - mash0000 - unload stones into black market torture houses",
       "file": "/milkdrop-presets/butterchurn/beta106i-airhandler-radial-dreamers-mash0000-unload-stones-into-black-market-torture-houses.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -14925,9 +14964,9 @@
       "title": "beta106i - Have at You (Spin Strike) - mash0000 - more the game of death, jesus conway",
       "file": "/milkdrop-presets/butterchurn/beta106i-have-at-you-spin-strike-mash0000-more-the-game-of-death-jesus-conway.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15050,7 +15089,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-flexi-cartune-extrusion-machine-mix-inside-the-hive",
@@ -15081,9 +15120,9 @@
       "title": "cope + flexi - cartune (extrusion machine mix) [spiral out]",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-cartune-extrusion-machine-mix-spiral-out.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15093,21 +15132,21 @@
       "title": "cope + flexi - colorful marble (ghost mix) - rand wave 4 nz+",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-colorful-marble-ghost-mix-rand-wave-4-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz",
       "title": "cope + flexi - mother-of-whirl [composition from fractopia] roam3 nz+",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-mother-of-whirl-composition-from-fractopia-roam3-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15242,7 +15281,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-strange-attractor-flexis-let-it-grow-mix-stahlregens-jelly-after-burner",
@@ -15254,7 +15293,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-strange-attractor-flexis-let-it-grow-mix-jelly-5-56-volume-noise-zoom-in",
@@ -15266,7 +15305,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-the-drain-to-heaven",
@@ -15285,12 +15324,12 @@
       "title": "cope, flexi + martin - cartune [reinventing the scene]",
       "file": "/milkdrop-presets/butterchurn/cope-flexi-martin-cartune-reinventing-the-scene.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "cope-martin-flexi-the-slickery-of-alternative-varnish",
@@ -15338,7 +15377,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "ech0-liquid-firesticks-i",
@@ -15362,7 +15401,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "eo-s-phat-chasers-11-sentinel-c-jelly-v4-x",
@@ -15374,7 +15413,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fed-slowfast-1-1-geiss-composite-remix",
@@ -15405,12 +15444,12 @@
       "title": "felix capacitor",
       "file": "/milkdrop-presets/butterchurn/felix-capacitor.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-eo-s-phat-starburst-totem-pole",
@@ -15494,7 +15533,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-witchcraft-glow-mix",
@@ -15518,7 +15557,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix-3",
@@ -15530,7 +15569,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix-3c-finally-mirrored-mash0000-rituals-on-water-skin",
@@ -15542,7 +15581,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-witchcraft-grow-mix",
@@ -15554,7 +15593,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-witchcraft-stahl-s-mirror-crossfire-mix",
@@ -15566,7 +15605,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-a-quiet-death",
@@ -15782,7 +15821,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-geiss-stahlregen-orb-witchcraft-yabm-tiled",
@@ -15794,7 +15833,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "fishbrain-flexi-stitchcraft",
@@ -15818,7 +15857,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic-random-mashup-2",
@@ -15830,7 +15869,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic-random-mashup",
@@ -15857,64 +15896,64 @@
       "diagnostics": 0
     },
     {
-      "id": "flexi-amandio-c-organic12-3d-2-alt",
+      "id": "flexi-amandio-c-organic12-3d-2",
       "title": "flexi + amandio c - organic12-3d-2",
-      "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2-alt.milk",
+      "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic12-3d3",
       "title": "flexi + amandio c - organic12-3d3",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic12-3d4-2",
       "title": "flexi + amandio c - organic12-3d4-2",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d4-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic12-3d4",
       "title": "flexi + amandio c - organic12-3d4",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic12-3d4.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-amandio-c-organic4-columns",
       "title": "flexi + amandio c - organic4-columns",
       "file": "/milkdrop-presets/butterchurn/flexi-amandio-c-organic4-columns.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bdrv-acid-etching-jelly-v5-5",
@@ -15933,9 +15972,9 @@
       "title": "flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+ wrepwrimindloss w8",
       "file": "/milkdrop-presets/butterchurn/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz-wrepwrimindloss-w8.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15945,9 +15984,9 @@
       "title": "flexi + cope - i blew you a soap bubble now what - feel the projection you are, connected to it all nz+",
       "file": "/milkdrop-presets/butterchurn/flexi-cope-i-blew-you-a-soap-bubble-now-what-feel-the-projection-you-are-connected-to-it-all-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -15974,7 +16013,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-warpcraft-random-mashup-2",
@@ -15986,7 +16025,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-warpcraft-random-mashup-3",
@@ -16034,7 +16073,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-warpcraft",
@@ -16058,7 +16097,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-witchcraft-complex-terraforming",
@@ -16070,7 +16109,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-redi-jedi-stahlregen-thumbdrum-tokamak-crossfiring-aftermath-mashup",
@@ -16101,9 +16140,9 @@
       "title": "flexi + geiss - infused with the spiral (Heavy Oil Mix) nz+ rapery",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-infused-with-the-spiral-heavy-oil-mix-nz-rapery.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16113,9 +16152,9 @@
       "title": "flexi + geiss - pogo cubes vs. tokamak vs. game of life [stahls jelly 4.5 finish]",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-vs-tokamak-vs-game-of-life-stahls-jelly-4-5-finish.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16130,19 +16169,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2",
       "title": "flexi + geiss - pogo-cubes on tokamak matter [mind over matter remix]2",
       "file": "/milkdrop-presets/butterchurn/flexi-geiss-pogo-cubes-on-tokamak-matter-mind-over-matter-remix-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-geiss-tokamak-fallout-repellor",
@@ -16154,16 +16193,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-goody-the-prayerwheel-misplaced-prayers",
       "title": "flexi + goody - the prayerwheel - misplaced prayers",
       "file": "/milkdrop-presets/butterchurn/flexi-goody-the-prayerwheel-misplaced-prayers.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16178,7 +16217,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-nitorami-beat-explorer-cn-bc-jelly-4",
@@ -16214,7 +16253,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-gimme-color-spinner-mix-v2",
@@ -16226,7 +16265,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-gimme-color-spinner-mix",
@@ -16238,7 +16277,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-jelly-spin-off",
@@ -16250,7 +16289,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-jelly-strike",
@@ -16262,7 +16301,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-jewelry-tiles",
@@ -16274,7 +16313,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-julian-tiles-3-mirror-mode-eo-s-spiral-chaos",
@@ -16334,7 +16373,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-alien-canvas-learning",
@@ -16358,7 +16397,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-alien-canvas",
@@ -16394,7 +16433,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-alien-web-bouncer-edit-for-hexcollie",
@@ -16406,7 +16445,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-black-holes-sucking-fractals-for-breakfast",
@@ -16418,16 +16457,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-blame-moebius",
       "title": "flexi - blame moebius",
       "file": "/milkdrop-presets/butterchurn/flexi-blame-moebius.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16442,7 +16481,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bouncing-balls-double-mindblob-gastrointestinal-mix",
@@ -16454,7 +16493,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bouncing-balls-double-mindblob-neon-mix",
@@ -16466,7 +16505,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bouncing-balls-grafitti-mix",
@@ -16490,7 +16529,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-bouncing-balls-neon-mix",
@@ -16502,19 +16541,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-can-t-think-of-mosaic-cages",
       "title": "flexi - can′t think of mosaic cages",
       "file": "/milkdrop-presets/butterchurn/flexi-can-t-think-of-mosaic-cages.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-color-strike",
@@ -16526,7 +16565,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-crank-prototype",
@@ -16538,7 +16577,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-flow",
@@ -16550,7 +16589,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fractal-descent",
@@ -16562,7 +16601,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fractal-seafood",
@@ -16574,7 +16613,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-gimme-color-bc-cn-jelly-4",
@@ -16586,7 +16625,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-gimme-color",
@@ -16598,7 +16637,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-gravitational-chaos",
@@ -16622,7 +16661,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-hyperspaceflight-bn-cn-jelly-4",
@@ -16670,7 +16709,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-jelly-fish-mandala",
@@ -16682,7 +16721,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-island-output-stage",
@@ -16694,7 +16733,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-set-illuminating-example-parameter-play",
@@ -16706,7 +16745,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-set-illuminating-example",
@@ -16718,7 +16757,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-set-shader-neocortex-wiretapping",
@@ -16742,7 +16781,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-set-shader-example-2",
@@ -16754,7 +16793,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julia-set-shader-example",
@@ -16778,7 +16817,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-julian-affairs-bc-cn-jelly-v4",
@@ -16802,7 +16841,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-lollipop-overkill-bccn-jelly-v4",
@@ -16869,9 +16908,9 @@
       "title": "flexi - lorenz chaser [accidental shader-lock mashup] (ripples)2 nz+ discombobule lose",
       "file": "/milkdrop-presets/butterchurn/flexi-lorenz-chaser-accidental-shader-lock-mashup-ripples-2-nz-discombobule-lose.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -16886,7 +16925,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-mindblob-2-0-bc-cn-jelly-4",
@@ -16910,19 +16949,19 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-mom-why-the-sky-looks-different-today",
       "title": "flexi - mom, why the sky looks different today",
       "file": "/milkdrop-presets/butterchurn/flexi-mom-why-the-sky-looks-different-today.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-patternton-district-of-media-capitol-of-the-united-abstractions-of-fractopia",
@@ -16934,7 +16973,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-predator-prey-seminar-paper-visualization-05-mathematical-biology-concepts-reaction-diffusion-on-predator-prey-spirals",
@@ -16958,7 +16997,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-romanesco-fantasies",
@@ -16970,7 +17009,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-smouldering",
@@ -17001,9 +17040,9 @@
       "title": "flexi - swing out on the spiral",
       "file": "/milkdrop-presets/butterchurn/flexi-swing-out-on-the-spiral.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17030,16 +17069,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-the-prayerwheel",
       "title": "flexi - the prayerwheel",
       "file": "/milkdrop-presets/butterchurn/flexi-the-prayerwheel.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17049,9 +17088,9 @@
       "title": "flexi - trickster zenarchy",
       "file": "/milkdrop-presets/butterchurn/flexi-trickster-zenarchy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17078,7 +17117,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-undercurrents-3-psychodelic-mix-mash0001-planck-based-dematerializer",
@@ -17102,16 +17141,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template",
       "title": "flexi - what to do with the inside of a torus [easily customizable moebius spiral template]",
       "file": "/milkdrop-presets/butterchurn/flexi-what-to-do-with-the-inside-of-a-torus-easily-customizable-moebius-spiral-template.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17126,16 +17165,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-why-random-mashups-should-be-forbidden",
       "title": "flexi - why random mashups should be forbidden",
       "file": "/milkdrop-presets/butterchurn/flexi-why-random-mashups-should-be-forbidden.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17150,7 +17189,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-fishbrain-stahlregen-witchcraft-jelly5-5",
@@ -17186,7 +17225,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-martin-indoctrinutrition",
@@ -17198,7 +17237,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "flexi-stahlregen-geiss-tobias-wolfboi-space-gelatine-burst-mash0000-chromatidal-pool-mirror-blasphemy",
@@ -17217,9 +17256,21 @@
       "title": "geiss + martin - mandelbox explorer - high speed demo version (fire mix)",
       "file": "/milkdrop-presets/butterchurn/geiss-martin-mandelbox-explorer-high-speed-demo-version-fire-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
+      "unsupportedFeatures": [],
+      "hasShaderBody": true,
+      "diagnostics": 1
+    },
+    {
+      "id": "geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix",
+      "title": "geiss + mstress - Cleaning a path - Painterly Crossfire (Crisp Emboss Mix)",
+      "file": "/milkdrop-presets/butterchurn/geiss-mstress-cleaning-a-path-painterly-crossfire-crisp-emboss-mix.milk",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
+      "softUnknownKeys": [],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17277,12 +17328,12 @@
       "title": "goody + martin - crystal palace - schizotoxin - the wild iris bloom - 16 iterations",
       "file": "/milkdrop-presets/butterchurn/goody-martin-crystal-palace-schizotoxin-the-wild-iris-bloom-16-iterations.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader-fixed",
@@ -17294,7 +17345,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "goody-shadowharlequin-red-blue-chase-megatrip-geiss-aurora-2-v22-2222-v2-shader",
@@ -17306,7 +17357,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "had-to-cum-that-jaben",
@@ -17337,9 +17388,9 @@
       "title": "hexcollie(1), goody(3), stahlregen(3), fed(1) - 2nd collaboration(ps2.0) - 8",
       "file": "/milkdrop-presets/butterchurn/hexcollie-1-goody-3-stahlregen-3-fed-1-2nd-collaboration-ps2-0-8.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17349,9 +17400,9 @@
       "title": "high-altitude basket unraveling - singh grooves nitrogen argon nz+",
       "file": "/milkdrop-presets/butterchurn/high-altitude-basket-unraveling-singh-grooves-nitrogen-argon-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17385,9 +17436,9 @@
       "title": "lit claw (explorers grid) - i don′t have either a belfry or bats bitch",
       "file": "/milkdrop-presets/butterchurn/lit-claw-explorers-grid-i-don-t-have-either-a-belfry-or-bats-bitch.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17397,21 +17448,21 @@
       "title": "martin  - mandelbox explorer - high speed demo  [flexi's complex polynomial version]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-flexi-s-complex-polynomial-version.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-flexi-bombyx-mori-mix2-in-the-beehive",
       "title": "martin + flexi - bombyx mori mix2 in the beehive",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-bombyx-mori-mix2-in-the-beehive.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17433,21 +17484,21 @@
       "title": "martin + flexi - mandelbox explorer - high speed oversustained bipolar",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-mandelbox-explorer-high-speed-oversustained-bipolar.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix",
       "title": "martin + flexi - mandelbox stepper mix [kinetic triangles gossip matrix]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-mandelbox-stepper-mix-kinetic-triangles-gossip-matrix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17469,9 +17520,9 @@
       "title": "martin + stahlregen - martin in da mash 10 (infinity mix)",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-10-infinity-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17481,9 +17532,9 @@
       "title": "martin + stahlregen - martin in da mash 11",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-11.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17493,9 +17544,9 @@
       "title": "martin + stahlregen - martin in da mash 12",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-12.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17505,9 +17556,9 @@
       "title": "martin + stahlregen - martin in da mash 12a",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-12a.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17541,9 +17592,9 @@
       "title": "martin + stahlregen - martin in da mash 18",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-18.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17553,9 +17604,9 @@
       "title": "martin + stahlregen - martin in da mash 3",
       "file": "/milkdrop-presets/butterchurn/martin-stahlregen-martin-in-da-mash-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17618,7 +17669,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-thinking-about-you",
@@ -17661,9 +17712,9 @@
       "title": "martin - alien grand theft water",
       "file": "/milkdrop-presets/butterchurn/martin-alien-grand-theft-water.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17781,9 +17832,9 @@
       "title": "martin - bombyx mori [flexi′s logarithmic edit]",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori-flexi-s-logarithmic-edit.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17793,9 +17844,9 @@
       "title": "martin - bombyx mori",
       "file": "/milkdrop-presets/butterchurn/martin-bombyx-mori.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17822,7 +17873,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-carpet-weaver",
@@ -17834,16 +17885,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-castle-in-the-air",
       "title": "martin - castle in the air",
       "file": "/milkdrop-presets/butterchurn/martin-castle-in-the-air.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17877,9 +17928,9 @@
       "title": "martin - cherry brain 2",
       "file": "/milkdrop-presets/butterchurn/martin-cherry-brain-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17901,9 +17952,9 @@
       "title": "martin - city of shadows",
       "file": "/milkdrop-presets/butterchurn/martin-city-of-shadows.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17925,9 +17976,9 @@
       "title": "martin - cope - laser dome",
       "file": "/milkdrop-presets/butterchurn/martin-cope-laser-dome.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17949,9 +18000,9 @@
       "title": "martin - crystal palace nz+",
       "file": "/milkdrop-presets/butterchurn/martin-crystal-palace-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17961,9 +18012,9 @@
       "title": "martin - crystal palace",
       "file": "/milkdrop-presets/butterchurn/martin-crystal-palace.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -17996,13 +18047,13 @@
       "id": "martin-diamond-cutter",
       "title": "martin - diamond cutter",
       "file": "/milkdrop-presets/butterchurn/martin-diamond-cutter.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-disco-mix-1",
@@ -18069,9 +18120,9 @@
       "title": "martin - dont drink and drive (police mix)",
       "file": "/milkdrop-presets/butterchurn/martin-dont-drink-and-drive-police-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18080,13 +18131,13 @@
       "id": "martin-dune-racer",
       "title": "martin - dune racer",
       "file": "/milkdrop-presets/butterchurn/martin-dune-racer.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-electric-pool",
@@ -18105,9 +18156,9 @@
       "title": "martin - elusive impressions mix1",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix1.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18117,9 +18168,9 @@
       "title": "martin - elusive impressions mix2 - flacc mess proph nz+2",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix2-flacc-mess-proph-nz-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18129,9 +18180,9 @@
       "title": "martin - elusive impressions mix2",
       "file": "/milkdrop-presets/butterchurn/martin-elusive-impressions-mix2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18165,9 +18216,9 @@
       "title": "martin - flexi - laser dome [bipolar focus intent]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-laser-dome-bipolar-focus-intent.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18189,12 +18240,12 @@
       "title": "martin - frosty caves 2",
       "file": "/milkdrop-presets/butterchurn/martin-frosty-caves-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-fruit-machine",
@@ -18249,9 +18300,9 @@
       "title": "martin - girlie affairs",
       "file": "/milkdrop-presets/butterchurn/martin-girlie-affairs.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18296,22 +18347,22 @@
       "id": "martin-hardcore-mix-1",
       "title": "martin - hardcore mix 1",
       "file": "/milkdrop-presets/butterchurn/martin-hardcore-mix-1.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function", "shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-hardcore-mix-2",
       "title": "martin - hardcore mix 2",
       "file": "/milkdrop-presets/butterchurn/martin-hardcore-mix-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18333,9 +18384,9 @@
       "title": "martin - infinity (2008)",
       "file": "/milkdrop-presets/butterchurn/martin-infinity-2008.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18345,9 +18396,9 @@
       "title": "martin - infinity (2010 update)",
       "file": "/milkdrop-presets/butterchurn/martin-infinity-2010-update.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18357,9 +18408,9 @@
       "title": "martin - infinity",
       "file": "/milkdrop-presets/butterchurn/martin-infinity.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18393,9 +18444,9 @@
       "title": "martin - jellyfish dance",
       "file": "/milkdrop-presets/butterchurn/martin-jellyfish-dance.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18405,9 +18456,9 @@
       "title": "martin - liquid gold",
       "file": "/milkdrop-presets/butterchurn/martin-liquid-gold.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18441,9 +18492,9 @@
       "title": "martin - ludicrous speed",
       "file": "/milkdrop-presets/butterchurn/martin-ludicrous-speed.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18453,9 +18504,9 @@
       "title": "martin - mandelbox explorer - high speed demo version [Flexi's diffuse wave] [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18465,33 +18516,33 @@
       "title": "martin - mandelbox explorer - high speed demo version [Flexi's diffuse wave]",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version-flexi-s-diffuse-wave.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-mandelbox-explorer-high-speed-demo-version",
       "title": "martin - mandelbox explorer - high speed demo version",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-explorer-high-speed-demo-version.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-mandelbox-stepper",
       "title": "martin - mandelbox stepper",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbox-stepper.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18500,13 +18551,13 @@
       "id": "martin-mandelbulb-slideshow",
       "title": "martin - mandelbulb slideshow",
       "file": "/milkdrop-presets/butterchurn/martin-mandelbulb-slideshow.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function", "shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 8
+      "diagnostics": 1
     },
     {
       "id": "martin-moonlight-splash",
@@ -18549,9 +18600,9 @@
       "title": "martin - musicogenic epilepsy",
       "file": "/milkdrop-presets/butterchurn/martin-musicogenic-epilepsy.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18596,13 +18647,13 @@
       "id": "martin-night-cathedral",
       "title": "martin - night cathedral",
       "file": "/milkdrop-presets/butterchurn/martin-night-cathedral.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function", "shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-night-in-the-forest",
@@ -18621,9 +18672,9 @@
       "title": "martin - on silent paths",
       "file": "/milkdrop-presets/butterchurn/martin-on-silent-paths.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18633,9 +18684,9 @@
       "title": "martin - orbit trap playground",
       "file": "/milkdrop-presets/butterchurn/martin-orbit-trap-playground.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18669,9 +18720,9 @@
       "title": "martin - purple pulsator",
       "file": "/milkdrop-presets/butterchurn/martin-purple-pulsator.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18693,9 +18744,9 @@
       "title": "martin - resonant twister - steel spring",
       "file": "/milkdrop-presets/butterchurn/martin-resonant-twister-steel-spring.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18777,9 +18828,9 @@
       "title": "martin - silversmith",
       "file": "/milkdrop-presets/butterchurn/martin-silversmith.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18789,9 +18840,9 @@
       "title": "martin - skywards",
       "file": "/milkdrop-presets/butterchurn/martin-skywards.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18825,9 +18876,9 @@
       "title": "martin - sparky caleidoscope",
       "file": "/milkdrop-presets/butterchurn/martin-sparky-caleidoscope.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18866,7 +18917,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-starfield-sectors",
@@ -18957,9 +19008,9 @@
       "title": "martin - the Dome ps3",
       "file": "/milkdrop-presets/butterchurn/martin-the-dome-ps3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -18993,9 +19044,9 @@
       "title": "martin - the forge of isengard [flexi′s moebius transformation vs. logarithmic spiral mix]",
       "file": "/milkdrop-presets/butterchurn/martin-the-forge-of-isengard-flexi-s-moebius-transformation-vs-logarithmic-spiral-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19052,13 +19103,13 @@
       "id": "martin-tunnel-race",
       "title": "martin - tunnel race",
       "file": "/milkdrop-presets/butterchurn/martin-tunnel-race.milk",
-      "webglStatus": "partial",
-      "webgpuStatus": "partial",
+      "webglStatus": "supported",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["unknown-function", "shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 1
+      "diagnostics": 0
     },
     {
       "id": "martin-unholy-amulet-2",
@@ -19113,9 +19164,9 @@
       "title": "martin - witchcraft reloaded",
       "file": "/milkdrop-presets/butterchurn/martin-witchcraft-reloaded.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19137,9 +19188,9 @@
       "title": "martin, fishbrain + flexi - mandelbox explorer v1 Eo.S. optimize [bipolar witchcraft mix]",
       "file": "/milkdrop-presets/butterchurn/martin-fishbrain-flexi-mandelbox-explorer-v1-eo-s-optimize-bipolar-witchcraft-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19149,21 +19200,21 @@
       "title": "martin, flexi + sto - traumflug",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-sto-traumflug.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-flexi-fishbrain-sto-enterstate-random-mashup-2",
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup 2]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup-2.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19173,9 +19224,9 @@
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup 3]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup-3.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19185,33 +19236,33 @@
       "title": "martin, flexi, fishbrain + sto - enterstate [random mashup]",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate-random-mashup.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "martin-flexi-fishbrain-sto-enterstate",
       "title": "martin, flexi, fishbrain + sto - enterstate",
       "file": "/milkdrop-presets/butterchurn/martin-flexi-fishbrain-sto-enterstate.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "massive-crack-hit-maggot-trace",
       "title": "massive crack hit maggot trace",
       "file": "/milkdrop-presets/butterchurn/massive-crack-hit-maggot-trace.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19221,9 +19272,9 @@
       "title": "menstruating in reverse in reverse time max out crap roam3 nz+",
       "file": "/milkdrop-presets/butterchurn/menstruating-in-reverse-in-reverse-time-max-out-crap-roam3-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19262,7 +19313,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "nil-did-you-speak-with-the-orb",
@@ -19293,12 +19344,12 @@
       "title": "no good rnz",
       "file": "/milkdrop-presets/butterchurn/no-good-rnz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "orb-fireworks-fusion",
@@ -19526,16 +19577,16 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "random-mash-up-round-47",
       "title": "random mash-up round 47",
       "file": "/milkdrop-presets/butterchurn/random-mash-up-round-47.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19550,7 +19601,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "raron-a-grayish-blob-mash0000-pungent-gastric-automata-cloud-fumes",
@@ -19581,21 +19632,21 @@
       "title": "rce-ordinary + flexi - far away distance (custom beat detection + bipolar colour ghost mix)",
       "file": "/milkdrop-presets/butterchurn/rce-ordinary-flexi-far-away-distance-custom-beat-detection-bipolar-colour-ghost-mix.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "rediculator-qrem-glob",
       "title": "rediculator qrem glob",
       "file": "/milkdrop-presets/butterchurn/rediculator-qrem-glob.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -19610,7 +19661,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "schglasmia-danqueer",
@@ -19658,7 +19709,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "shadowharlequin-cope-alternative-energy-antimatter-mod-1-rave-dreams",
@@ -19682,7 +19733,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "shifter-aderrasi-airhandler-sadako",
@@ -19965,9 +20016,9 @@
       "title": "shifter - liquid circuitry",
       "file": "/milkdrop-presets/butterchurn/shifter-liquid-circuitry.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20157,21 +20208,21 @@
       "title": "skipper skipper kiss me hard - if it weren′t for you wonderful role playing ′people′ parts of my solipsistic overmind, i′d be ungrateful",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-if-it-weren-t-for-you-wonderful-role-playing-people-parts-of-my-solipsistic-overmind-i-d-be-ungrateful.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn",
       "title": "skipper skipper kiss me hard - thank god for martin nitorami - tgfmn",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-tgfmn.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20181,9 +20232,9 @@
       "title": "skipper skipper kiss me hard - thank god for martin nitorami nz",
       "file": "/milkdrop-presets/butterchurn/skipper-skipper-kiss-me-hard-thank-god-for-martin-nitorami-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20277,9 +20328,9 @@
       "title": "suksma + aderassi geiss - the sick assumptions you make about my car [shifter′s esc shader] nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-aderassi-geiss-the-sick-assumptions-you-make-about-my-car-shifter-s-esc-shader-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20354,7 +20405,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "suksma-blatantic-emissarial-crotch",
@@ -20433,9 +20484,9 @@
       "title": "suksma - eternal pain and misery is a small price to pay for being able to say i destroyed you - masticate my bowels like you′re bored",
       "file": "/milkdrop-presets/butterchurn/suksma-eternal-pain-and-misery-is-a-small-price-to-pay-for-being-able-to-say-i-destroyed-you-masticate-my-bowels-like-you-re-bored.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20457,12 +20508,12 @@
       "title": "suksma - fiShbRaiN - white sceam firefly - mash0000 - liquid oxygen, jet fuel, and maybe some plutonium too",
       "file": "/milkdrop-presets/butterchurn/suksma-fishbrain-white-sceam-firefly-mash0000-liquid-oxygen-jet-fuel-and-maybe-some-plutonium-too.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "suksma-flexi-lorenz-chaser-heretical-tribal-necklace",
@@ -20517,9 +20568,9 @@
       "title": "suksma - in madness i purposely convince myself of all your lies, then slice you open and eat your lungs only nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-in-madness-i-purposely-convince-myself-of-all-your-lies-then-slice-you-open-and-eat-your-lungs-only-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20558,7 +20609,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "suksma-question-authority-take-what-you-want-be-a-nihilist",
@@ -20601,9 +20652,9 @@
       "title": "suksma - sun pod gambit couch nz+2 satangastriq",
       "file": "/milkdrop-presets/butterchurn/suksma-sun-pod-gambit-couch-nz-2-satangastriq.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20654,7 +20705,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "suksma-water-cooled-red-uranium-vs-dotes-freeenergynow-net",
@@ -20673,9 +20724,9 @@
       "title": "suksma - yin - 100 - Through the ether - Bitcore Tweak - mash0000 - dmt eye rub spher nz+",
       "file": "/milkdrop-presets/butterchurn/suksma-yin-100-through-the-ether-bitcore-tweak-mash0000-dmt-eye-rub-spher-nz.milk",
       "webglStatus": "supported",
-      "webgpuStatus": "partial",
+      "webgpuStatus": "supported",
       "softUnknownKeys": [],
-      "evidenceCodes": ["shader-text-translated"],
+      "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
       "diagnostics": 0
@@ -20714,7 +20765,7 @@
       "evidenceCodes": [],
       "unsupportedFeatures": [],
       "hasShaderBody": true,
-      "diagnostics": 0
+      "diagnostics": 1
     },
     {
       "id": "yin-030-dance-with-the-ocean",

--- a/src/js/milkdrop/compiler/parity.ts
+++ b/src/js/milkdrop/compiler/parity.ts
@@ -284,8 +284,8 @@ export function buildBackendSupport({
   }
 
   // When the other backend executes this preset's shader programs directly
-  // but this one falls back to extracted scalar controls (e.g. the packed
-  // sampler_fc_main gap on WebGPU), the translation is a real visual
+  // but this one falls back to extracted scalar controls (e.g. a `mat3`
+  // element write the WebGPU node executor cannot represent), the translation is a real visual
   // approximation and must surface as backend evidence instead of silently
   // reporting full support. Symmetric 'translated' (control-syntax shader
   // text with no direct programs) is the designed exact path and stays

--- a/src/js/milkdrop/compiler/shader-analysis.ts
+++ b/src/js/milkdrop/compiler/shader-analysis.ts
@@ -1649,34 +1649,47 @@ export function clearShaderAnalysisCaches() {
 }
 
 const MATRIX_DECLARATION_PATTERN =
-  /^(?:const\s+)?mat[234]\s+([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)/u;
+  /^(?:const\s+)?(mat[234])\s+([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)/u;
 
-/** Names declared `mat2`/`mat3`/`mat4` anywhere in this body. */
-function collectMatrixLocals(lines: string[]): Set<string> {
-  const names = new Set<string>();
+type MatrixLocalKind = 'mat2' | 'mat3' | 'mat4';
+
+/** Names declared `mat2`/`mat3`/`mat4` anywhere in this body, by size. */
+function collectMatrixLocals(lines: string[]): Map<string, MatrixLocalKind> {
+  const locals = new Map<string, MatrixLocalKind>();
   for (const line of lines) {
     const match = line.match(MATRIX_DECLARATION_PATTERN);
     if (!match) {
       continue;
     }
-    for (const name of (match[1] ?? '').split(',')) {
-      names.add(name.trim());
+    const kind = match[1] as MatrixLocalKind;
+    for (const name of (match[2] ?? '').split(',')) {
+      locals.set(name.trim(), kind);
     }
   }
-  return names;
+  return locals;
 }
 
 /**
- * True for an assignment that writes one element of a matrix local —
- * `tmpvar_1[int(0)].x = q20`. The statement grammar parses these, but only the
- * raw-GLSL backends can execute them.
+ * True for an assignment that writes one element of a matrix local the WebGPU
+ * node executor cannot represent — `tmpvar_1[int(0)].x = q20` where
+ * `tmpvar_1` is a `mat3` or `mat4`. The statement grammar parses these, but
+ * only the raw-GLSL backend can execute them.
+ *
+ * `mat2` writes are NOT matched: the executor packs a mat2 as a vec4 of its
+ * two columns and handles column (`M[i] = v`) and component (`M[i].x = s`)
+ * writes, products, and constructors on it. Measured over the bundled corpus,
+ * 87 of the 107 shader bodies with matrix element writes touch only mat2.
  */
-function isMatrixElementAssignment(
+function isUnexecutableMatrixElementAssignment(
   target: string,
-  matrixLocals: Set<string>,
+  matrixLocals: Map<string, MatrixLocalKind>,
 ): boolean {
   const bracket = target.indexOf('[');
-  return bracket > 0 && matrixLocals.has(target.slice(0, bracket).trim());
+  if (bracket <= 0) {
+    return false;
+  }
+  const kind = matrixLocals.get(target.slice(0, bracket).trim());
+  return kind === 'mat3' || kind === 'mat4';
 }
 
 export function extractShaderControls(
@@ -1741,14 +1754,19 @@ export function extractShaderControls(
   normalized.forEach((line) => {
     const parsedStatement = parseShaderStatementCached(line);
     if (parsedStatement) {
-      if (isMatrixElementAssignment(parsedStatement.target, matrixLocals)) {
+      if (
+        isUnexecutableMatrixElementAssignment(
+          parsedStatement.target,
+          matrixLocals,
+        )
+      ) {
         // The statement parser accepts `tmpvar_1[int(0)].x = q20`, but the
-        // WebGPU node executor has no way to write one matrix element, and
-        // what it builds instead is unbounded: martin-city-of-shadows, whose
-        // warp body opens with nine of these, compiled to a WGSL
-        // `objectStruct` of 44641 mat3x3 members behind a 2.1 MB uniform
-        // binding — past both the 16383-member and 65536-byte limits — and
-        // took the GPU process down with it.
+        // WebGPU node executor has no way to write one element of a mat3 or
+        // mat4, and what it builds instead is unbounded: martin-city-of-
+        // shadows, whose warp body opens with nine of these on a mat3,
+        // compiled to a WGSL `objectStruct` of 44641 mat3x3 members behind a
+        // 2.1 MB uniform binding — past both the 16383-member and 65536-byte
+        // limits — and took the GPU process down with it.
         //
         // Recording it as unparsed is what keeps the preset honest: WebGL
         // still runs the raw GLSL, which handles the write fine, and WebGPU

--- a/src/js/milkdrop/feedback-manager-webgpu-composite.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-composite.ts
@@ -514,6 +514,14 @@ export function createCompositeUniforms(
     signalTime: uniform(0),
     signalFrame: uniform(0),
     signalFps: uniform(60),
+    // MilkDrop per-frame registers (`tele`, `hordist`, …) that a directly
+    // executed shader body reads without ever assigning. WebGL declares each
+    // as `uniform float` and drives it from the VM's frame state; here the
+    // executor binds one uniform node per name on first read (see
+    // getShaderEnvValue in feedback-manager-webgpu-tsl.ts) and the manager
+    // writes the values every frame next to the q/t banks. Cleared when the
+    // composite graph is rebuilt for a new preset.
+    perFrameVariables: new Map<string, ReturnType<typeof uniform>>(),
     // q/t register banks packed four-per-vec4 (q1..q4 in [0], q5..q8 in [1],
     // …), matching the WebGL path's _qa.._qh packing: 16 uniform nodes and 16
     // per-frame writes instead of 64 scalars.

--- a/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
@@ -653,6 +653,35 @@ function parseShaderIndex(expression: string): number | null {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
+/**
+ * Column index of a read like `M[0]` or `M[int(0)]`. The HLSL normalizer
+ * rewrites `uint(0)` to `int(0)`, so every indexed read in a native body
+ * arrives as an `int(...)` call around a literal; the write side already
+ * accepts that shape through `parseShaderIndex`, and reads were dropping the
+ * whole statement on it.
+ */
+function resolveShaderIndexExpression(
+  index: MilkdropShaderExpressionNode | null | undefined,
+): number | null {
+  if (!index) {
+    return null;
+  }
+  const literal =
+    index.type === 'literal'
+      ? index
+      : index.type === 'call' &&
+          (index.name === 'int' || index.name === 'uint') &&
+          index.args.length === 1 &&
+          index.args[0]?.type === 'literal'
+        ? index.args[0]
+        : null;
+  if (!literal) {
+    return null;
+  }
+  const value = Number(literal.value);
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
 /** mat2 * v and v * mat2 and mat2 * mat2 column-major products. */
 function multiplyMat2(
   operator: '*' | '/' | '%',
@@ -1311,11 +1340,8 @@ export function compileShaderExpressionNode(
       if (object?.kind !== 'mat2') {
         return null;
       }
-      if (node.index?.type !== 'literal') {
-        return null;
-      }
-      const index = Number(node.index.value);
-      if (!Number.isInteger(index) || index < 0 || index > 1) {
+      const index = resolveShaderIndexExpression(node.index);
+      if (index === null || index > 1) {
         return null;
       }
       return shaderMat2Column(object, index);
@@ -2136,7 +2162,13 @@ function resolveSwizzleAssignmentKind(
   return 'vec2';
 }
 
-function runShaderProgram(
+/**
+ * Execute a direct shader program statement by statement against `env`,
+ * building the TSL node for each right-hand side and assigning it to the
+ * statement's target. Exported for the headless executor tests: they run a
+ * body through this and inspect the value kinds the env ends up holding.
+ */
+export function runShaderProgram(
   statements: MilkdropShaderStatement[],
   env: ShaderNodeEnv,
 ) {

--- a/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu-tsl.ts
@@ -1056,9 +1056,27 @@ function setShaderEnvValue(
   env.values.set(key.toLowerCase(), value);
 }
 
+/**
+ * A name that, when a directly executed body reads it without ever having
+ * assigned it, is a MilkDrop per-frame register the VM owns (`tele`,
+ * `hordist`, `vshift`, …) rather than anything this executor could resolve
+ * on its own. Sampler identifiers are the one other thing that reaches the
+ * scalar env unresolved — `tex2d(currentTex, uv)` compiles its arguments
+ * before the sampler name is looked up in the binding table — so those are
+ * excluded by shape.
+ */
+function isPerFrameVariableCandidate(name: string): boolean {
+  return (
+    /^[a-z][a-z0-9_]*$/u.test(name) &&
+    !name.endsWith('tex') &&
+    !name.startsWith('sampler_')
+  );
+}
+
 function getShaderEnvValue(
   env: ShaderNodeEnv,
   key: string,
+  options: { bindPerFrameVariable?: boolean } = {},
 ): ShaderNodeValue | null {
   const normalized = key.toLowerCase();
   const existing = env.values.get(normalized);
@@ -1281,9 +1299,32 @@ function getShaderEnvValue(
       ? registerUniforms[Math.floor(registerIndex / 4)]
       : null;
   const registerComponent = (['x', 'y', 'z', 'w'] as const)[registerIndex % 4];
-  const resolved = registerVector
+  let resolved = registerVector
     ? shaderFloat(registerVector[registerComponent])
     : (uniformMap[normalized]?.() ?? null);
+  // A read of a name nothing above supplies is a per-frame register the VM
+  // computes (martin-adrift-on-a-dead-planet reads `tele` and `hordist` in
+  // its warp body). WebGL declares these as `uniform float` and drives them
+  // from the frame state; do the same here with one uniform node per name.
+  // Only reads bind — assignShaderTarget passes bindPerFrameVariable: false,
+  // so a body's own scratch locals never turn into uniforms, matching the
+  // WebGL classifier's "first occurrence is an assignment ⇒ scratch" rule.
+  const perFrameVariables = env.uniforms.perFrameVariables as
+    | Map<string, ReturnType<typeof uniform>>
+    | undefined;
+  if (
+    !resolved &&
+    options.bindPerFrameVariable !== false &&
+    perFrameVariables instanceof Map &&
+    isPerFrameVariableCandidate(normalized)
+  ) {
+    let node = perFrameVariables.get(normalized);
+    if (!node) {
+      node = uniform(0);
+      perFrameVariables.set(normalized, node);
+    }
+    resolved = shaderFloat(node);
+  }
   if (resolved) {
     env.values.set(normalized, resolved);
   } else {
@@ -2011,7 +2052,11 @@ function assignShaderTarget(
     rawTarget === 'return' ? (env.values.has('ret') ? 'ret' : 'uv') : rawTarget;
   const segments = target.split('.');
   const baseKey = segments[0] ?? target;
-  const baseValue = getShaderEnvValue(env, baseKey);
+  // A write never binds a per-frame register: the base lookup is only for
+  // compound assignment and swizzle writes into an existing value.
+  const baseValue = getShaderEnvValue(env, baseKey, {
+    bindPerFrameVariable: false,
+  });
   const nextValue =
     statement.operator === '=' || !baseValue
       ? value
@@ -2033,7 +2078,9 @@ function assignShaderTarget(
     if (index === null) {
       return;
     }
-    const matrixValue = getShaderEnvValue(env, matrixName);
+    const matrixValue = getShaderEnvValue(env, matrixName, {
+      bindPerFrameVariable: false,
+    });
     if (segments.length === 1) {
       setShaderEnvValue(
         env,
@@ -3398,6 +3445,13 @@ class WebGPUMilkdropFeedbackManager
       state.perPixelVariables,
     );
     if (compositeStateIdentityChanged(this.compositeIdentity, state)) {
+      // The bound per-frame registers belong to the outgoing preset's
+      // bodies; the rebuild below re-binds whatever the new ones read.
+      (
+        this.compositeMaterial.uniforms.perFrameVariables as
+          | Map<string, unknown>
+          | undefined
+      )?.clear();
       this.compositeIdentity = {
         shaderExecution: state.shaderExecution,
         warp: state.shaderPrograms.warp,
@@ -3576,6 +3630,19 @@ class WebGPUMilkdropFeedbackManager
         perPixelVariables?.[`t${base + 3}`] ?? 0,
         perPixelVariables?.[`t${base + 4}`] ?? 0,
       );
+    }
+    // Per-frame registers the directly executed bodies read (`tele`,
+    // `hordist`, …), bound by the executor on first read. Same source and
+    // same zero default as the WebGL path's per-frame uniforms; non-finite
+    // values are clamped to 0 for the same reason the warp bases below are.
+    const perFrameVariableUniforms = this.compositeMaterial.uniforms
+      .perFrameVariables as Map<string, { value: number }> | undefined;
+    if (perFrameVariableUniforms) {
+      for (const [name, node] of perFrameVariableUniforms) {
+        const value = perPixelVariables?.[name];
+        node.value =
+          typeof value === 'number' && Number.isFinite(value) ? value : 0;
+      }
     }
     // Per-frame bases for the warp variables the per-pixel program may
     // overwrite. Read off the same variable bag q/t come from rather than

--- a/src/js/milkdrop/feedback-manager-webgpu.ts
+++ b/src/js/milkdrop/feedback-manager-webgpu.ts
@@ -4,4 +4,5 @@ export {
   resolveDirectShaderConstructorPattern,
   resolveDirectShaderSamplerBinding,
   resolveDirectShaderSwizzle,
+  runShaderProgram,
 } from './feedback-manager-webgpu-tsl.ts';

--- a/src/js/milkdrop/shader-execution-mode.ts
+++ b/src/js/milkdrop/shader-execution-mode.ts
@@ -27,9 +27,12 @@
  *                   known-lossy at parse time.
  *
  * Measured over the bundled corpus (1750 presets, 1201 carrying shader text)
- * on 2026-08-22: WebGL is 'direct' for all 1201; WebGPU is 'direct' for 1182
- * and 'translated' for 19. Approximation is rare, which is exactly why it
- * needs reporting — 19 quietly-wrong presets do not show up in an average.
+ * on 2026-09-02 with shipped defaults: WebGL is 'direct' for all 1201; WebGPU
+ * is 'direct' for 1032 and 'translated' for 169 (50 with the gated
+ * `shaderBranchDesugar` rewrite on). Approximation is the minority, which is
+ * exactly why it needs reporting — quietly-wrong presets do not show up in
+ * an average. tests/corpus/butterchurn-corpus-support.test.ts pins the
+ * counts.
  */
 import type {
   MilkdropFeatureAnalysis,

--- a/src/js/milkdrop/webgpu-optimization-flags.ts
+++ b/src/js/milkdrop/webgpu-optimization-flags.ts
@@ -103,9 +103,9 @@ export const DEFAULT_MILKDROP_WEBGPU_OPTIMIZATION_FLAGS = Object.freeze({
   // Opt in with ?milkdrop-webgpu-compute-vm=1.
   gpuComputeVM: false,
   renderBundles: false,
-  // Measured OFF (2026-08-22). Flattening `if`/`else` into masked assignments
-  // and unrolling bounded `for` loops moves ~150 shader bodies off the
-  // uniform-only approximation and onto direct WebGPU execution. The rewrite
+  // Measured OFF (2026-09-02). Flattening `if`/`else` into masked assignments
+  // and unrolling bounded `for` loops moves 119 shader bodies (169 → 50) off
+  // the uniform-only approximation and onto direct WebGPU execution. The rewrite
   // itself is sound — see the module docstring in
   // compiler/shader-branch-desugar.ts — but it hands those bodies to the
   // WebGPU node executor for the first time, and the executor still has gaps.

--- a/tests/corpus/butterchurn-corpus-support.test.ts
+++ b/tests/corpus/butterchurn-corpus-support.test.ts
@@ -65,29 +65,30 @@ describe('butterchurn preset corpus support', () => {
       });
       expect(unexplainedPartials.map(({ file }) => file)).toEqual([]);
 
-      // Measured baseline (2026-08-22): 226 presets execute shader programs
+      // Measured baseline (2026-09-02): 169 presets execute shader programs
       // directly on WebGL but fall back to extracted scalar controls on
-      // WebGPU, and 9 presets reference EEL identifiers the expression VM
+      // WebGPU, and 8 presets reference EEL identifiers the expression VM
       // evaluates to 0.
       //
       // This number is a SHIPPED-DEFAULT number, and most of the reach it
       // reports as missing is gated rather than lost. Flattening `if`/`else`
       // into masked assignments and unrolling bounded `for` loops takes it to
-      // 19, but that work is behind the `shaderBranchDesugar` flag
+      // 50, but that work is behind the `shaderBranchDesugar` flag
       // (`?milkdrop-webgpu-branch-desugar=1`), off by default while the WebGPU
-      // executor gaps it exposes are closed — one of them kills the GPU
-      // process. Turn the flag on and this assertion is expected to fail; the
-      // desugar's own coverage in
+      // executor gaps it exposes are closed. Turn the flag on and this
+      // assertion is expected to fail; the desugar's own coverage in
       // tests/unit/milkdrop-compiler-shader-analysis.test.ts enables it
       // explicitly so the rewrite stays exercised either way.
       //
-      // Of the 226, 168 is what this was before the desugar existed at all —
-      // 7 `while (true)` bodies, 7 loops whose trip count is a runtime value,
-      // and the branchy bodies the statement model cannot express. The other
-      // 58 are bodies that assign to a `mat2`/`mat3`/`mat4` element, which is
-      // NOT gated: the node executor has no way to express that write, and
-      // what it built instead was a 44641-member WGSL uniform struct that
-      // took the GPU process down.
+      // Of the 169: 149 are bodies the statement model cannot express at all
+      // without the desugar — 7 `while (true)` bodies, 7 loops whose trip
+      // count is a runtime value, and branchy bodies — and 20 assign to an
+      // element of a `mat3` (19 of them also branch). Those are NOT gated:
+      // the node executor has no mat3/mat4 representation, and what it built
+      // instead was a 44641-member WGSL uniform struct that took the GPU
+      // process down. `mat2` element writes used to be counted here too (57
+      // presets, until 2026-09-02) but the executor packs a mat2 as a vec4 of
+      // its columns and runs them directly, so the gate no longer covers them.
       //
       // These counts moving DOWN means gaps were closed — update the
       // baseline. Moving UP means a regression introduced new degradation.
@@ -96,7 +97,7 @@ describe('butterchurn preset corpus support', () => {
           (entry) => entry.code === 'shader-text-translated',
         ),
       );
-      expect(translatedOnWebgpu.length).toBe(226);
+      expect(translatedOnWebgpu.length).toBe(169);
 
       const missingIdentifiers = corpus.filter(
         ({ compiled }) =>
@@ -105,14 +106,15 @@ describe('butterchurn preset corpus support', () => {
       expect(missingIdentifiers.length).toBe(8);
 
       // Everything else stays fully supported on both backends. Measured on
-      // the same corpus: 1578 with the branch desugar gated off and matrix
-      // element writes still claiming to be executable, 1521 once the matrix
-      // gate lands, and 1612 with `shaderBranchDesugar` turned on as well.
+      // the same corpus: 1578 with the branch desugar gated off and every
+      // matrix element write still claiming to be executable, 1521 once the
+      // matrix gate landed on all sizes, 1577 with the gate narrowed to
+      // mat3/mat4, and 1693 with `shaderBranchDesugar` turned on as well.
       const fullySupported = corpus.filter(({ compiled }) => {
         const { webgl, webgpu } = compiled.ir.compatibility.backends;
         return webgl.status === 'supported' && webgpu.status === 'supported';
       });
-      expect(fullySupported.length).toBe(1521);
+      expect(fullySupported.length).toBe(1577);
     },
     { timeout: 30000 },
   );

--- a/tests/unit/milkdrop-compiler-shader-analysis.test.ts
+++ b/tests/unit/milkdrop-compiler-shader-analysis.test.ts
@@ -573,7 +573,7 @@ describe('branch flattening for direct shader execution', () => {
     expect(analysis.nativeBodyUnparsedLines.length).toBeGreaterThan(0);
   });
 
-  test('keeps a matrix element write, and off the WebGPU direct path', () => {
+  test('keeps a mat2 element write on the WebGPU direct path', () => {
     // The desugar's assignment pattern is narrower than the statement parser's
     // — it does not match an indexed target — and dropping what it cannot
     // match corrupted the preset silently: the body still looked fully parsed,
@@ -581,11 +581,9 @@ describe('branch flattening for direct shader execution', () => {
     // and never assigned. A corpus sweep found 49 presets losing 469 such
     // statements, several rendering black. So the write is passed through.
     //
-    // Passing it through is not the same as being able to run it. The WebGPU
-    // node executor cannot write one matrix element, and what it built for a
-    // body full of them was a 44641-member WGSL uniform struct that crashed
-    // the GPU process, so the line is recorded as unparsed: WebGL keeps
-    // running the raw GLSL and WebGPU falls back to scalar controls.
+    // For a mat2 that is also enough to run it: the WebGPU node executor packs
+    // a mat2 as a vec4 of its columns and handles column and component writes
+    // on it, so the statement stays on the direct program.
     const analysis = extractShaderControls(
       nativeBody(`
           mat2 basis_1;
@@ -602,6 +600,30 @@ describe('branch flattening for direct shader execution', () => {
     // The HLSL-to-GLSL normalizer rewrites `uint(0)` to `int(0)` on the way
     // through; what matters is that the matrix write survives at all.
     const matrixWrite = /^basis_1\[[^\]]+\] = vec2\(1\.0, 0\.0\)$/u;
+    expect(analysis.nativeBodyUnparsedLines).toEqual([]);
+    expect(
+      analysis.directProgramLines.some((line) => matrixWrite.test(line)),
+    ).toBe(true);
+  });
+
+  test('keeps a mat3 element write, and off the WebGPU direct path', () => {
+    // Passing a matrix write through is not the same as being able to run
+    // it. The WebGPU node executor has no mat3/mat4 representation, and what
+    // it built for a body full of mat3 element writes was a 44641-member WGSL
+    // uniform struct that crashed the GPU process, so the line is recorded
+    // as unparsed: WebGL keeps running the raw GLSL and WebGPU falls back to
+    // scalar controls.
+    const analysis = extractShaderControls(
+      nativeBody(`
+          mat3 basis_1;
+          vec3 ret_2;
+          ret_2 = texture(sampler_pw_main, uv).xyz;
+          basis_1[uint(0)].x = q20;
+          ret = ret_2;
+        `),
+    );
+
+    const matrixWrite = /^basis_1\[[^\]]+\]\.x = q20$/u;
     expect(
       analysis.nativeBodyUnparsedLines.some((line) => matrixWrite.test(line)),
     ).toBe(true);

--- a/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
+++ b/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
@@ -231,6 +231,7 @@ describe('milkdrop WebGPU TSL mat2 element writes', () => {
     // The shared env seeds `uv` with a placeholder object, which is enough
     // for the intrinsic tests above but not for arithmetic on it.
     env.values.set('uv', { kind: 'vec2', node: vec2(0.25, 0.75) });
+    env.unresolvedNames = new Set<string>();
     const statements = lines.map((line) => {
       const statement = parseMilkdropShaderStatement(line);
       if (!statement) {
@@ -249,6 +250,30 @@ describe('milkdrop WebGPU TSL mat2 element writes', () => {
     }
     return env;
   }
+
+  test('binds a per-frame register read as a uniform, never a scratch local', () => {
+    // martin-adrift-on-a-dead-planet-lard-mix reads `tele` and `hordist`
+    // in its warp body: per_frame code writes them, the shader only reads
+    // them. WebGL declares those as `uniform float`; the executor has to
+    // bind them too, or the statements silently vanish. A name the body
+    // assigns before reading is its own scratch variable and must not become
+    // a uniform, and a sampler identifier must not either.
+    const env = runBody([
+      'xlat_mutableuv2 = ((uv * aspect.xy) * tele)',
+      'tmpvar_7 = (32.0 * hordist)',
+      'foo = 1.0',
+      'foo = (foo + tmpvar_7)',
+      'ret_1 = texture2D(currentTex, xlat_mutableuv2).xyz',
+      'ret = (ret_1 * foo)',
+    ]);
+    const bound = env.uniforms.perFrameVariables as Map<string, unknown>;
+    expect([...bound.keys()].sort()).toEqual(['hordist', 'tele']);
+    // The diagnostics set also records first-write base lookups and sampler
+    // identifiers by design; what must not be there is a bound register.
+    expect(env.unresolvedNames?.has('tele')).toBe(false);
+    expect(env.unresolvedNames?.has('hordist')).toBe(false);
+    expect(env.values.get('ret')?.kind).toBe('vec3');
+  });
 
   test('builds a mat2 column by column and multiplies uv through it', () => {
     const env = runBody([

--- a/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
+++ b/tests/unit/milkdrop-shader-tsl-intrinsics.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { Texture } from 'three';
-import { compileShaderExpressionNode } from '../../src/js/milkdrop/feedback-manager-webgpu.ts';
+import { getCurrentStack, setCurrentStack, stack, vec2 } from 'three/tsl';
+import {
+  compileShaderExpressionNode,
+  runShaderProgram,
+} from '../../src/js/milkdrop/feedback-manager-webgpu.ts';
 import {
   createCompositeUniforms,
   createSampleAuxTextureNode,
@@ -211,5 +215,70 @@ describe('milkdrop WebGPU TSL extended intrinsics', () => {
       expect(value, source).not.toBeNull();
       expect(sampledNodeType(value), source).toMatch(/^Texture(3D)?Node$/);
     }
+  });
+});
+
+describe('milkdrop WebGPU TSL mat2 element writes', () => {
+  // The shader-analysis gate lets `mat2` element writes through to this
+  // executor (only `mat3`/`mat4` writes are held back — see
+  // isUnexecutableMatrixElementAssignment in compiler/shader-analysis.ts),
+  // so every form the bundled corpus uses has to build a node here rather
+  // than silently drop the statement: column writes, component writes on a
+  // bare-declared matrix, matrix products in both orders, and the mat2
+  // constructor. 87 of the 107 gap presets with matrix writes are mat2-only.
+  function runBody(lines: string[]) {
+    const env = buildShaderEnv() as unknown as ShaderNodeEnv;
+    // The shared env seeds `uv` with a placeholder object, which is enough
+    // for the intrinsic tests above but not for arithmetic on it.
+    env.values.set('uv', { kind: 'vec2', node: vec2(0.25, 0.75) });
+    const statements = lines.map((line) => {
+      const statement = parseMilkdropShaderStatement(line);
+      if (!statement) {
+        throw new Error(`Failed to parse: ${line}`);
+      }
+      return statement;
+    });
+    // Component writes go through TSL `.toVar().assign()`, which needs the
+    // stack a `Fn()` body provides in production; open one here.
+    const previous = getCurrentStack();
+    setCurrentStack(stack());
+    try {
+      runShaderProgram(statements, env);
+    } finally {
+      setCurrentStack(previous);
+    }
+    return env;
+  }
+
+  test('builds a mat2 column by column and multiplies uv through it', () => {
+    const env = runBody([
+      'tmpvar_16[int(0)] = vec2(1.0, 0.0)',
+      'tmpvar_16[1] = vec2(0.0, 1.0)',
+      'xlat_mutableuv6 = (uv * tmpvar_16)',
+      'ret = vec3(xlat_mutableuv6, 0.0)',
+    ]);
+    expect(env.values.get('tmpvar_16')?.kind).toBe('mat2');
+    expect(env.values.get('xlat_mutableuv6')?.kind).toBe('vec2');
+    expect(env.values.get('ret')?.kind).toBe('vec3');
+  });
+
+  test('builds a mat2 component by component from a bare declaration', () => {
+    // `mat2 tmpvar_13;` carries no statement; the first component write has
+    // to materialise the matrix on its own.
+    const env = runBody([
+      'tmpvar_13[int(0)].x = 1.0',
+      'tmpvar_13[int(0)].y = -0.0',
+      'tmpvar_13[1].x = 0.0',
+      'tmpvar_13[1].y = 1.0',
+      'xlat_mutablerss = (tmpvar_13 * mat2(0.7, -0.7, 0.7, 0.7))',
+      'zz_1 = (((uv - vec2(0.5, 0.5)) * 0.01) * xlat_mutablerss)',
+      'ofs = (tmpvar_13 * 2.0)',
+      'ret = vec3(zz_1, ofs[int(0)].x)',
+    ]);
+    expect(env.values.get('tmpvar_13')?.kind).toBe('mat2');
+    expect(env.values.get('xlat_mutablerss')?.kind).toBe('mat2');
+    expect(env.values.get('zz_1')?.kind).toBe('vec2');
+    expect(env.values.get('ofs')?.kind).toBe('mat2');
+    expect(env.values.get('ret')?.kind).toBe('vec3');
   });
 });


### PR DESCRIPTION
## Summary

First slice of the roadmap item "Close the WebGPU shader-translation gap".

The shader-analysis gate that keeps matrix element writes off the WebGPU direct path treated every matrix size the same, but the node executor already packs a `mat2` as a vec4 of its columns and handles column writes (`M[i] = v`), component writes (`M[i].x = s`), products in both orders, and the `mat2(...)` constructor. Only `mat3`/`mat4` have no representation (that is where the 44,641-member uniform struct that crashed the GPU process came from). The gate now covers those two sizes only.

Measured over the bundled corpus (`tests/corpus/butterchurn-corpus-support.test.ts`, shipped defaults):

| | before | after |
| --- | --- | --- |
| Presets whose shaders run directly on WebGL but fall back to scalar controls on WebGPU | 226 | **169** |
| Fully supported on both backends | 1521 | **1577** |
| Same, with the gated `shaderBranchDesugar` rewrite on | 135 → | **50** |

87 of the 107 gap presets with matrix element writes are mat2-only. What remains in the 169: 149 bodies the statement model cannot express without the desugar (`while (true)`, runtime-bound loops, branches) and 20 that write a `mat3` element.

Two executor gaps found by running those bodies headlessly, both fixed here:

- **Read-side index form.** `M[int(0)].x` on the right-hand side returned null because column reads accepted only a bare literal index, while the write side already accepted `int(N)` (what the HLSL normalizer turns `uint(N)` into). Reads now resolve the same forms.
- **Per-frame registers (from review).** A body that reads a MilkDrop per-frame register it never assigns (`tele`, `hordist` in martin-adrift-on-a-dead-planet) compiled the read to null and silently dropped the statement and everything downstream. WebGL declares such names as `uniform float` driven from the VM frame state; the WebGPU executor now binds one uniform node per name on first read (never on a write, matching WebGL's first-occurrence-is-an-assignment rule), the manager syncs them every frame next to the q/t banks, and the set is cleared on graph rebuild. 8 bundled presets hit this: 3 among the mat2 bodies above and 5 that were already direct before this PR.

`runShaderProgram` is exported so the executor tests can drive a body end to end and check the value kinds it leaves behind.

Also corrected while here: the roadmap's first bullet (packed `sampler_fc_main` / `sampler_fw_main` binding) is already done in code — both resolve to real WebGPU bindings with tests — so the roadmap now says so; the counts in `shader-execution-mode.ts`, `webgpu-optimization-flags.ts` and the corpus test comments were stale desugar-on numbers presented as current state and now carry the measured shipped-default figures.

## Testing

- `bun run check` — full gate green: **2824 pass, 0 fail** on the final head. (An earlier run hit the known parallel-load flake in `tests/corpus/preset-flash-risk.test.ts`, "Target page, context or browser has been closed"; that test passes alone and is unrelated to compiler changes.)
- New executor tests in `tests/unit/milkdrop-shader-tsl-intrinsics.test.ts` run bodies through `runShaderProgram` headlessly: mat2 column build, component build from a bare declaration, `uv * M`, `M * mat2(...)`, `M * 2.0`, `M[int(0)].x` read, and per-frame register binding (`tele`/`hordist` bound, a scratch local and a sampler identifier not) — 10 pass.
- `tests/unit/milkdrop-compiler-shader-analysis.test.ts` — mat2 write now on the direct program, mat3 write still recorded as unparsed — 30 pass.
- Corpus counts re-measured with a script and pinned in the corpus test (169 / 8 / 1577; 50 / 1693 with the desugar on).
- Not verified here: pixels on a real WebGPU device. Headless Chromium in this container cannot initialise a WebGPU adapter (`lab:backend-diff` captures the launch shell instead of the preset), so the WebGPU side was validated by the executor's node-graph construction, not by rendering. `bun run lab:backend-diff -- --preset martin-adrift-on-a-dead-planet-lard-mix` on a machine with WebGPU is the right spot check; it exercises both the mat2 writes and the per-frame binding.

## Docs touched

- `docs/ROADMAP.md` (gap section: counts, sampler bullet done, matrix and desugar bullets restated)
- `CHANGELOG.md` (Unreleased → Changed, two entries)

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic (`resolveShaderIndexExpression` returns null on anything but a literal or `int`/`uint`(literal); the gate returns false for non-indexed targets; per-frame values fall back to 0 when missing or non-finite)
- [x] Async/lifecycle state transitions reviewed (bound register set is cleared on composite graph rebuild, so it cannot grow across preset switches)
- [x] Existing shared helper/module checked before introducing duplicate logic (write side's `parseShaderIndex` accepts the same forms; the per-frame sync sits beside the existing q/t sync and reads the same bag)
- [x] New visual literals use existing design tokens — n/a
- [x] Behavior change is covered by tests (analysis gate, executor bodies, corpus counts)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` — not run; no build/runtime output changed beyond source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnArzDp9goG1aJA4MnnBLz