### PR TITLE
fix(tests): give the e2e teardown a real timeout

### DIFF
--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -236,10 +236,24 @@ function browserTest(
 }
 
 beforeAll(() => startServer(), { timeout: 60000 });
+/**
+ * 30s, not bun's 5s default for a hook.
+ *
+ * This teardown does two slow things — it shuts down a Chromium that has been
+ * software-rasterizing WebGL frames, then stops vite — while `beforeAll` above
+ * only starts vite and was still given 60s. That asymmetry was the bug: on the
+ * 2-core runner the close ran past 5s, bun cut the hook, and the whole job
+ * failed red with all six tests passing, leaving an orphaned
+ * `chrome-headless-shell` behind for the runner to reap.
+ *
+ * 30s matches what the two sibling suites that also close a browser here
+ * (`agent-integration`, `chrome-visual-contract`) already use; the suites left
+ * on the default only stop a server, which is cheap.
+ */
 afterAll(async () => {
   await releaseSharedBrowser();
-  stopServer();
-});
+  await stopServer();
+}, 30000);
 
 browserTest(
   'mounts engine, loads preset, and renders a silent preview frame',


### PR DESCRIPTION
## Summary

**main is red on 139a2a5** (the merge of #1168). Quality Gate, Parity Corpus and Production Build all pass. The only failing job is `Browser end-to-end tests (e2e-engine-mount.test.ts)`, and inside it every test passes:

```
 3 pass
 2 skip
 1 fail
(fail) (unnamed) [5004.33ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

The unnamed failure is `afterAll`. It shuts down a Chromium that has been software-rasterizing WebGL frames on a 2-core runner, then stops vite — on bun's 5s default hook budget, while `beforeAll` immediately above it, which only starts vite, was explicitly given 60s. On the slower runner the browser close ran past 5s, bun cut the hook, and the job went red with nothing actually broken. The runner then had to reap what the cut hook abandoned:

```
Terminate orphan process: pid (3062) (chrome-headless-shell)
```

Two fixes, both inside that hook.

**A 30s budget instead of the default.** This is the directory's existing convention, not a new number. `agent-integration` and `chrome-visual-contract` are the other two e2e suites whose teardown closes a browser, and both already carry `30000`:

| Suite | `afterAll` closes a browser | Timeout |
|---|---|---|
| agent-integration | yes | 30000 |
| chrome-visual-contract | yes | 30000 |
| **e2e-engine-mount** | **yes** | **default (5s)** |
| agent-boot-smoke | no, server only | default |
| preset-crossfade | no, server only | default |
| preset-visual-regression | no, server only | default |
| webgpu-engine-mount | no, server only | default |

`e2e-engine-mount` was the one suite that closes a browser without a budget, and it is the one that failed.

**`await stopServer()`.** It is `async` and was being called without `await`, so the hook could resolve while vite was still coming down. That is the other half of the `killed 2 dangling processes` the log reports on every run of this file.

This is not a skip, a disable, or a quarantine — all six tests still run and assert exactly as before. Only the teardown's budget changes.

## Testing

- `bun run test tests/e2e/e2e-engine-mount.test.ts` — passes, exit 0. Run on merged `main` both before and after this change, which is what establishes it as a budget problem rather than a behavioural break: the assertions were already green, the hook was not given time to finish.
- `bun run check:quick` — passes.
- Root cause traced from the CI logs rather than inferred: all three real tests report `(pass)`, the failure is timed at 5004ms against a 5000ms default, and the runner reports the orphaned `chrome-headless-shell` that a cut teardown leaves behind.

## Docs touched

None. The reasoning is a docblock on the hook itself, next to the 60s `beforeAll` it is now consistent with.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

On the last point: there is no new test, because the change adds no behaviour to test — the six existing tests in the file are the coverage, and the fix is what lets their teardown finish. The four suites left on the default budget were checked and only stop a server, so they are correct as they stand.

## Quality checklist

- [x] `bun run check:quick`
- [ ] `bun run check` — not re-run in full for this one-hook change; the gate profile deliberately excludes e2e, so it would not have exercised the file this touches. The suite itself was run directly instead, which is the relevant signal.
- [ ] `bun run build` — no build or runtime output changed; this is a test-harness timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRm36bXdSFXwH6DdB7Bi5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRm36bXdSFXwH6DdB7Bi5o)_