### PR TITLE
ci: cut the font download and cold caches off the critical path

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -13,16 +13,61 @@ runs:
         restore-keys: |
           ${{ runner.os }}-playwright-
 
-    # On an exact cache hit only the apt-installed system libraries are
-    # missing (the runner image doesn't guarantee them and they can't be
-    # cached), so skip the ~150 MB browser download and install just the
-    # deps.
+    # Deliberately not `--with-deps`. That apt-installs Chromium's runtime
+    # libraries *and* a 21 MB CJK/Cyrillic/Thai font bundle. On ubuntu-latest
+    # every library it names is already on the image — the whole list comes
+    # back "libnss3 is already the newest version", xvfb included — so those
+    # nine font packages are the only thing it actually downloads, and they
+    # come from Azure's Ubuntu mirror, which throttles hard when the run's
+    # jobs hit it at once:
+    #
+    #   run 33646723575  parity  "Fetched 21.1 MB in 10min 36s (33.2 kB/s)"
+    #   run 33666962720  parity  Setup Playwright 8m34s
+    #
+    # Those two runs took 12min and 9min against a ~2min median, and this step
+    # sits on the critical path of four of the five jobs, so every run gets
+    # four chances to draw a throttled mirror. Nothing that gates a PR renders
+    # CJK text: chrome-visual-contract asserts computed styles and layout
+    # rather than pixels, precisely because font rasterisation is not portable
+    # across platforms. The fonts buy this repo nothing at up to 11 minutes a
+    # run.
     - name: Install Playwright Chromium
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: bunx playwright install --with-deps chromium
+      run: bunx playwright install chromium
 
-    - name: Install Playwright system deps
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
+    # The safety net the apt install used to provide, for about a second
+    # instead of minutes: start the browser for real. A cache restored from a
+    # prefix key can hold a build that does not match the pinned Playwright
+    # version, and a future runner image could drop a library Chromium links
+    # against — this repairs both, escalating to the full dependency install
+    # only when something is genuinely missing, rather than failing the test
+    # run with an opaque launch error.
+    - name: Verify Chromium launches
       shell: bash
-      run: bunx playwright install-deps chromium
+      run: |
+        smoke="$(mktemp -d)/smoke.png"
+        try_smoke() {
+          bunx playwright screenshot --browser chromium about:blank "$smoke" \
+            >/dev/null 2>&1
+        }
+
+        if try_smoke; then
+          echo 'Chromium launches; skipped the apt dependency install.'
+          exit 0
+        fi
+
+        echo '::group::Repairing the Chromium install'
+        bunx playwright install chromium || true
+        if try_smoke; then
+          echo '::endgroup::'
+          echo 'Chromium launches after re-downloading the browser.'
+          exit 0
+        fi
+
+        # Only now has apt earned its cost: a library is missing from the image.
+        bunx playwright install-deps chromium
+        echo '::endgroup::'
+        bunx playwright screenshot --browser chromium about:blank "$smoke" \
+          >/dev/null
+        echo 'Chromium launches after installing system dependencies.'

--- a/.github/actions/setup-stims/action.yml
+++ b/.github/actions/setup-stims/action.yml
@@ -6,6 +6,13 @@ inputs:
     description: 'Whether to check out the repository'
     required: false
     default: 'true'
+  cache-compute:
+    description: >-
+      Cache node_modules/.cache, where `typecheck` and `check:architecture`
+      keep their incremental state. Enable it only in a job that actually runs
+      those checks — see the step below for why.
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -38,3 +45,32 @@ runs:
     - name: Install dependencies
       shell: bash
       run: bun install --frozen-lockfile
+
+    # `typecheck` (tsBuildInfoFile) and `check:architecture` (dependency-cruiser)
+    # both keep their incremental state in node_modules/.cache, which the
+    # node_modules entry above nominally covers — except that entry is keyed on
+    # bun.lock and actions/cache skips the save on an exact key hit ("Cache hit
+    # occurred on the primary key …, not saving cache"). So the compute caches
+    # are frozen at whatever the first run for a given lockfile happened to
+    # produce, and that race is normally won by the build job, which runs
+    # neither check. Both steps therefore start cold on essentially every run.
+    # Measured on this repo, cold vs. warm:
+    #
+    #   check:architecture   21.9s -> 1.6s
+    #   typecheck            12.0s -> 1.7s
+    #
+    # A key that rotates per commit always saves; restore-keys picks up the
+    # most recent entry. Restored after the install so it wins over any stale
+    # copy inside the node_modules tarball.
+    #
+    # Enable this only in the job that runs those checks: the first job to
+    # finish writes the entry, so a job that ran neither would publish an empty
+    # cache and keep every later run cold — the bug this works around.
+    - name: Cache typecheck and dependency-cruiser state
+      if: inputs.cache-compute == 'true'
+      uses: actions/cache@v6
+      with:
+        path: node_modules/.cache
+        key: ${{ runner.os }}-compute-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-compute-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
         uses: ./.github/actions/setup-stims
         with:
           checkout: 'false'
+          # The only job that runs `typecheck` and `check:architecture`, so the
+          # only one that should publish their incremental caches.
+          cache-compute: 'true'
 
       # Fails on high/critical advisories against the lockfile. Moderate and
       # below only report locally via `bun audit`; gate them here once the


### PR DESCRIPTION
## Summary

I measured where CI time actually goes before changing anything. Two findings, both on the critical path; the production build turned out not to be worth touching.

**Baseline** (n=23 successful `ci.yml` runs): p50 **125s**, p90 162s, **max 724s**. The median is fine; the tail is 6x worse, and it has a single cause.

### 1. `playwright install-deps` downloads a 21 MB font bundle

`--with-deps` apt-installs Chromium's runtime libraries *and* a CJK/Cyrillic/Thai font set. On `ubuntu-latest` every library it names is already on the image — the whole list comes back `already the newest version`, xvfb included — so the nine font packages are the only thing it actually downloads, from Azure's Ubuntu mirror, which throttles when the run's jobs hit it together:

| run | job | step |
|---|---|---|
| [33646723575](https://github.com/zz-plant/stims/actions/runs/33646723575) | Parity corpus | `Fetched 21.1 MB in 10min 36s (33.2 kB/s)` |
| [33666962720](https://github.com/zz-plant/stims/actions/runs/33666962720) | Parity corpus | Setup Playwright **8m34s** |

Those runs took 12min and 9min. In the first, the parity job's *tests* took 27s and its Playwright setup took **10m54s**, while the same step in sibling jobs of the same run finished in 17–29s — same work, different mirror luck. The step runs in four of the five jobs, so each run gets four chances to draw a throttled mirror.

Nothing that gates a PR renders CJK text. `chrome-visual-contract` asserts computed styles and layout rather than pixels — its own docblock says baselines drift on font rasterisation alone — so the fonts buy nothing here at up to 11 minutes a run.

Replaced with a real launch (`playwright screenshot about:blank`, ~1s) that escalates to re-downloading the browser, and then to the full dependency install, only when the browser actually fails to start. That still covers the case the apt step existed for — a library missing from a future runner image — and additionally covers one the old step did not: a prefix-matched (`restore-keys`) cache holding a browser build that doesn't match the pinned Playwright version.

### 2. The typecheck and dependency-cruiser caches never warm

Both keep incremental state in `node_modules/.cache`, nominally covered by the `node_modules` cache entry — except that entry is keyed on `bun.lock`, and `actions/cache` skips the save on an exact key hit (`Cache hit occurred on the primary key …, not saving cache`, visible in the logs). Its contents are therefore frozen at whatever the first run for a given lockfile produced, and that race is normally won by the **build** job, which runs neither check. Both start cold on essentially every run.

Measured cold vs. warm on this repo:

| step | cold | warm |
|---|---|---|
| `check:architecture` | 21.9s | 1.6s |
| `typecheck` | 12.0s | 1.7s |

Now cached under a key that rotates per commit (so it always saves), restored after the install, and enabled only in the job that runs those checks — otherwise a job that ran neither would publish an empty entry and reintroduce the bug.

### Not changed: the build

`bun run build` is **2s** in CI (10s cold locally) and `check:bundle-size` is sub-second; the whole `build` job is ~24s end to end, nearly all setup. There is no meaningful win there, so I left it alone.

### Expected effect

Tail 724s → ~2min (the font download leaves the critical path entirely); median ~125s → ~105s. The remaining critical path is the Quality gate job, whose long pole is then the gate test suite — see the note at the end.

## Testing

- `bun run check:quick` — passes. Also confirms the warm-cache numbers above (`Architecture boundary check (1699ms)`, `TypeScript typecheck (1756ms)`, against 21928ms / 11987ms cold on the first run in a fresh tree).
- `bun run check:ci-config` — `✔ CI config is consistent`.
- All three YAML files parse (`yaml.safe_load`), and the new inline script passes `bash -n`.
- New "Verify Chromium launches" step exercised end to end against the real browser: **1s**, `Chromium launches; skipped the apt dependency install.`
- Escalation paths driven with a stubbed `bunx` under `bash -eo pipefail`, matching the runner's shell flags:
  - stale browser cache → re-downloads, recovers, exit 0
  - missing system library → re-downloads, then `install-deps`, recovers, exit 0
  - unrecoverable → exits 1 rather than proceeding into the tests
- `bun run build` — succeeds, 10s cold.
- `bun run check` was not run to completion locally: `tests/corpus/preset-flash-risk.test.ts` fails in this sandbox on Chromium version skew (the container links a different Chromium build than Playwright pins). That test passes in CI — it's green in the run logs cited above — and this branch touches no test or source code. CI will run the full gate.

## Docs touched

None. The reasoning lives in comments next to each step, with the run IDs and measurements, since that's where the next person will look before re-adding `--with-deps`.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic — both changes are in the existing composite actions
- [x] New visual literals use existing design tokens (or include a new named token) — n/a, no UI change
- [x] Behavior change is covered by tests (or reason provided) — CI config only; validated by the guard, the YAML parse, and the stubbed-path runs above

## Quality checklist

- [x] `bun run check:quick`
- [ ] `bun run check` — blocked locally by the sandbox Chromium skew described under Testing; no JS/TS changed
- [x] `bun run build`

---

One thing I found but did not change, for you to decide on: the `gate` test profile is `unit + compat + corpus`, and the separate `parity` job runs `test:corpus` too, so corpus runs twice per CI run. It's cheap in the Quality gate job (the two browser-driven corpus tests skip there — no Playwright installed), so this is a few seconds, not the 20–30s it first looks like. The larger remaining lever is splitting the gate test suite out of the Quality gate job into its own parallel job, worth roughly 11s of critical path once the two fixes here land — small enough that I didn't want to restructure the gate's contract for it without asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR)_