### PR TITLE
Fix the agent-driver timeout race, and split the gate test suite off the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,38 @@ jobs:
       - name: Audit dependencies
         run: bun audit --audit-level=high
 
+      # `--no-tests` leaves the checks and hands the gate test suite to the
+      # `gate-tests` job below. The two are independent, so running them in
+      # sequence here only made this job the workflow's critical path: it was
+      # the last job to finish on a normal run while four runners sat idle.
+      # Coverage is unchanged — the same `test:gate` runs over there, and
+      # `ci-status` gates on both.
       - name: Run quality gate
-        run: bun run check
+        run: bun run check -- --no-tests
+
+  # The postflight half of `bun run check`, split onto its own runner. No
+  # Playwright here, exactly as when this ran inside the quality gate job: the
+  # two browser-backed corpus tests skip without it, and the `parity` job
+  # below runs them with a browser.
+  gate-tests:
+    name: Gate test suite
+    runs-on: ubuntu-latest
+    steps:
+      # The runner must read the local composite action's action.yml from
+      # disk before it can run it, so the repository has to be checked out
+      # in the workflow itself — a local action can never perform the first
+      # checkout (newer runner versions fail the job at action-resolution
+      # time otherwise).
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-stims
+        with:
+          checkout: 'false'
+
+      - name: Run gate test suite
+        run: bun run test:gate
 
   parity:
     name: Parity corpus
@@ -278,7 +308,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [check, parity, build, integration, commit-messages]
+    needs: [check, gate-tests, parity, build, integration, commit-messages]
     if: always()
     steps:
       - name: Verify all required jobs passed
@@ -288,12 +318,14 @@ jobs:
           # failure should block.
           commit_outcome="${{ needs['commit-messages'].result }}"
           check_outcome="${{ needs.check.result }}"
+          gate_tests_outcome="${{ needs['gate-tests'].result }}"
           parity_outcome="${{ needs.parity.result }}"
           build_outcome="${{ needs.build.result }}"
           integration_outcome="${{ needs.integration.result }}"
 
           echo "Commit Messages: $commit_outcome"
           echo "Quality Gate: $check_outcome"
+          echo "Gate Test Suite: $gate_tests_outcome"
           echo "Parity Corpus: $parity_outcome"
           echo "Production Build: $build_outcome"
           echo "Integration Tests: $integration_outcome"
@@ -301,6 +333,7 @@ jobs:
           if [ "$commit_outcome" != "failure" ] && \
              [ "$commit_outcome" != "cancelled" ] && \
              [ "$check_outcome" = "success" ] && \
+             [ "$gate_tests_outcome" = "success" ] && \
              [ "$parity_outcome" = "success" ] && \
              [ "$build_outcome" = "success" ] && \
              [ "$integration_outcome" = "success" ]; then

--- a/scripts/run-quality-gate.ts
+++ b/scripts/run-quality-gate.ts
@@ -15,6 +15,10 @@
  * - `all`    — lint + typecheck + every profile including e2e (~5min+). Use
  *              before merging changes to the MilkDrop compiler, renderer
  *              adapter, or parity pipeline.
+ *
+ * `--no-tests` drops the test suite from any mode, leaving the checks. It
+ * exists for CI, which runs the suite as its own parallel job; locally,
+ * `bun run check` should stay the single command that runs everything.
  */
 type GateMode = 'quick' | 'full' | 'all';
 
@@ -53,6 +57,21 @@ export function parseExecutionMode(argv: string[]): GateExecutionMode {
   return argv.includes('--serial') ? 'serial' : 'parallel';
 }
 
+/**
+ * `--no-tests` drops the postflight test suite, leaving lint, guards and
+ * typecheck. Only CI passes it, so it can run the suite as its own parallel
+ * job instead of queueing it behind the concurrent lane in this one — the
+ * lane and the suite are independent, and serialising them made the Quality
+ * gate job the critical path of the whole workflow. Coverage is unchanged:
+ * the same `test:gate` command runs in that job, gated by `ci-status`.
+ *
+ * It stays off by default so a local `bun run check` is still the one command
+ * that runs everything before a push.
+ */
+export function parseSkipTests(argv: string[]): boolean {
+  return argv.includes('--no-tests');
+}
+
 export type OutputMode = 'text' | 'json';
 
 export function parseOutputMode(argv: string[]): OutputMode {
@@ -62,6 +81,7 @@ export function parseOutputMode(argv: string[]): OutputMode {
 export function buildGatePlan(
   mode: GateMode,
   executionMode: GateExecutionMode,
+  skipTests = false,
 ): GatePlan {
   return {
     mode,
@@ -212,7 +232,7 @@ export function buildGatePlan(
       },
     ],
     postflight:
-      mode === 'quick'
+      mode === 'quick' || skipTests
         ? []
         : mode === 'full'
           ? [
@@ -366,7 +386,7 @@ async function main() {
   const mode = parseMode(argv);
   const executionMode = parseExecutionMode(argv);
   const outputMode = parseOutputMode(argv);
-  const plan = buildGatePlan(mode, executionMode);
+  const plan = buildGatePlan(mode, executionMode, parseSkipTests(argv));
 
   await runStepListSerial(plan.preflight, outputMode);
 

--- a/src/js/core/agent-driver.ts
+++ b/src/js/core/agent-driver.ts
@@ -147,9 +147,18 @@ async function waitForDriverHandle(
       return handle;
     }
     if (Date.now() >= deadline) {
+      // Says "timed out" deliberately. ready() arms two timeouts on the same
+      // deadline — the withTimeout() below and this poll — and whichever
+      // trips first is the error the caller sees. The old wording ("the
+      // handle never registered") described the same timeout in words that
+      // shared no phrase with the other path, so a caller could not match on
+      // one message and CI could not either: the ready() timeout test asserts
+      // /timed out/ and failed whenever contention let this branch win the
+      // race. Both branches now agree, so which timer wins stops mattering.
       throw new Error(
-        'stims.agent: the milkdrop runtime driver handle never registered ' +
-          '(the runtime may not have mounted, or agent mode is off).',
+        'stims.agent: timed out waiting for the milkdrop runtime driver ' +
+          'handle to register (the runtime may not have mounted, or agent ' +
+          'mode is off).',
       );
     }
     await sleep(100);

--- a/tests/unit/agent-driver.test.ts
+++ b/tests/unit/agent-driver.test.ts
@@ -236,6 +236,34 @@ describe('stims.agent.selectPreset', () => {
 
     expect(order).toEqual(['startup-settled', 'selected:target-preset']);
   });
+
+  // The ready() timeout test above covers the same wording, but only when the
+  // outer withTimeout() wins a race against the driver-handle poll on the
+  // shared deadline — under CI contention the poll won instead and that test
+  // failed. selectPreset awaits waitForDriverHandle() unwrapped, so this
+  // reaches the poll's own error every time, with no race to lose.
+  test('times out with a matching message when no driver handle registers', async () => {
+    setAgentMode(true);
+    const { installAgentDriver } = await importFresh<
+      typeof import('../../src/js/core/agent-driver.ts')
+    >('src/js/core/agent-driver.ts');
+    installAgentDriver();
+
+    await expect(
+      (
+        globalThis as StimsGlobals & {
+          stims: {
+            agent: {
+              selectPreset: (
+                id: string,
+                o: { timeoutMs: number },
+              ) => Promise<unknown>;
+            };
+          };
+        }
+      ).stims.agent.selectPreset('any-preset', { timeoutMs: 50 }),
+    ).rejects.toThrow(/timed out/);
+  });
 });
 
 describe('stims.agent.waitForPreset', () => {

--- a/tests/unit/run-quality-gate.test.ts
+++ b/tests/unit/run-quality-gate.test.ts
@@ -3,6 +3,7 @@ import {
   buildGatePlan,
   parseExecutionMode,
   parseMode,
+  parseSkipTests,
 } from '../../scripts/run-quality-gate.ts';
 
 test('quick gate defaults to parallel execution', () => {
@@ -42,6 +43,32 @@ test('full gate plan runs the gate test suite after the concurrent lane', () => 
   // Not test:fast — corpus carries the parity and golden-snapshot tests, and
   // running them only in CI let a compiler change pass here and fail on push.
   expect(plan.postflight[0].cmd).toContain('test:gate');
+});
+
+test('--no-tests drops the suite without touching the checks', () => {
+  expect(parseSkipTests([])).toBe(false);
+  expect(parseSkipTests(['--no-tests'])).toBe(true);
+
+  const full = buildGatePlan('full', 'parallel');
+  const withoutTests = buildGatePlan('full', 'parallel', true);
+
+  expect(withoutTests.postflight).toHaveLength(0);
+
+  // The point of the flag is to move the suite to another CI job, not to
+  // check less: every check the full gate runs must still run here.
+  expect(withoutTests.preflight.map((step) => step.label)).toEqual(
+    full.preflight.map((step) => step.label),
+  );
+  expect(withoutTests.concurrent.map((step) => step.label)).toEqual(
+    full.concurrent.map((step) => step.label),
+  );
+});
+
+test('the gate runs tests unless it is asked not to', () => {
+  // A local `bun run check` passes no flags, so the default must keep the
+  // suite: CI opting out must never become the behaviour everyone gets.
+  expect(buildGatePlan('full', 'parallel').postflight).toHaveLength(1);
+  expect(buildGatePlan('all', 'parallel').postflight).toHaveLength(1);
 });
 
 test('all gate plan runs the complete test suite after the concurrent lane', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1171, which cut the font download and cold caches off the critical path. Two things it left behind.

### 1. The timeout race that turned #1171 red

`stims.agent.ready()` arms **two timeouts on the same deadline** — the `withTimeout()` wrapper and the poll inside `waitForDriverHandle()` — and whichever trips first is the error the caller sees. The two described the same timeout in words that shared no phrase:

| | message |
|---|---|
| outer | `stims.agent.ready() **timed out** waiting for the app shell, …` |
| inner | `stims.agent: the milkdrop runtime driver handle **never registered**…` |

So no caller could match on one message, and neither could CI. The `ready()` timeout test asserts `/timed out/` and failed whenever contention let the poll win the race — which it did on #1171, a run that touched no source at all: `2839 pass, 1 fail`, the failing assertion landing 317.83ms into a 300ms deadline.

The inner branch now says it timed out too, keeping the detail about *what* it was waiting for. Both paths agree, so which timer wins stops mattering — and the wording is more accurate, because that branch is a timeout.

The regression test goes through `selectPreset`, which awaits `waitForDriverHandle()` unwrapped and so reaches the poll's own error **deterministically**; the `ready()` test only reaches it by losing a race, which is exactly why it was an unreliable guard.

### 2. The gate test suite was serialised behind the checks

`bun run check` runs its checks concurrently and *then* the test suite, and CI ran both in one job. They are independent, so the sequence made **Quality gate the workflow's critical path** — last job to finish on a normal run, while four other runners sat idle. The imbalance measured locally:

| | slowest step |
|---|---|
| concurrent lane | ~4.5s |
| gate test suite | 115s |

`bun run check -- --no-tests` now drops the postflight suite, and a `gate-tests` job runs `test:gate` on its own runner alongside the checks. Coverage is unchanged: same command, and `ci-status` gates on **both**, so neither half can go missing without failing the run. No Playwright in the new job, exactly as when this ran inside the quality gate — the two browser-backed corpus tests skip without it, and `parity` runs them with a browser.

The flag defaults off, so a local `bun run check` remains the one command that runs everything before a push.

### Confirming #1171 in production

Main's merge commit `b7a56f6` ran green in **124s**, with `Setup Playwright` at 4–7s across all four browser jobs — against 10m54s and 8m34s in the two pathological runs before it. That run was also the first to *write* the compute cache (`actions/cache` only saves on success), so the warm `check:architecture` / `typecheck` timings land from the next run on.

## Testing

- `bun run check` — **passes, exit 0**, full gate including the test suite. (This also produced the 4.5s vs 115s split above.)
- `bun run check:quick` — passes.
- `bun run check:ci-config` — `✔ CI config is consistent`.
- `bun test tests/unit/agent-driver.test.ts tests/unit/run-quality-gate.test.ts` — 20 pass, 0 fail.
- Profiles individually: `unit` 2759 pass, `compat` 25 pass, `corpus` 61 pass, all 0 fail.
- **The regression test was verified to actually catch the bug**: reverted the message to the old wording and re-ran — `1 fail`, the new test. Restored, `14 pass`.
- `--no-tests` verified behaviourally, not just in unit tests: `bun run check -- --no-tests --json` emits no `Gate test suite` step while all 28 preflight/concurrent steps still run and report `ok:true`.
- Workflow graph parsed with `yaml.safe_load`; every `ci-status` `needs:` entry resolves to a defined job.

Note on the earlier `preset-flash-risk` failure I flagged on #1171: it was this sandbox's Chromium version skew, and the session's browser re-link cleared it. The corpus profile passes 61/0 here now.

## Docs touched

None. The reasoning sits in comments beside each change — the race in `waitForDriverHandle`, the split in `ci.yml` and the `parseSkipTests` docblock — since that is where someone would look before undoing either.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown) — the change is squarely in the timeout/poll lifecycle; both rejection paths traced
- [x] Existing shared helper/module checked before introducing duplicate logic — reuses `waitForDriverHandle` and `buildGatePlan` rather than adding parallel paths
- [x] New visual literals use existing design tokens (or include a new named token) — n/a
- [x] Behavior change is covered by tests (or reason provided) — deterministic regression test for the message; two tests for the flag, including that the default still runs tests

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [x] `bun run build` (unchanged by this diff; green in CI on the parent commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR)_