### PR TITLE
fix(milkdrop): draw both custom-wave lanes without double-drawing

### DIFF
--- a/src/js/frontend/engine/engine-snapshot.ts
+++ b/src/js/frontend/engine/engine-snapshot.ts
@@ -1,18 +1,23 @@
 import type { ToyRuntimeInstance } from '../../core/toy-runtime.ts';
-import type { createMilkdropExperience } from '../../milkdrop/runtime.ts';
+import type {
+  MilkdropExperienceController,
+  MilkdropExperienceSnapshot,
+} from '../../milkdrop/runtime-types.ts';
 import type { MilkdropShaderExecutionMode } from '../../milkdrop/shader-execution-mode.ts';
 import type { AudioSource } from '../contracts.ts';
 
-type ExperienceController = ReturnType<typeof createMilkdropExperience>;
-type ExperienceSnapshot = ReturnType<ExperienceController['getStateSnapshot']>;
+// Named directly rather than re-derived through
+// `ReturnType<typeof createMilkdropExperience>`: the shell depends on the
+// engine's declared contract, not on whatever the factory happens to infer.
+type ExperienceController = MilkdropExperienceController;
 
 export type EngineSnapshot = {
   activePresetId: string | null;
   backend: 'webgl' | 'webgpu' | null;
   status: string | null;
-  adaptiveQuality: ExperienceSnapshot['adaptiveQuality'] | null;
-  catalogEntries: ExperienceSnapshot['catalogEntries'];
-  sessionState: ExperienceSnapshot['sessionState'] | null;
+  adaptiveQuality: MilkdropExperienceSnapshot['adaptiveQuality'] | null;
+  catalogEntries: MilkdropExperienceSnapshot['catalogEntries'];
+  sessionState: MilkdropExperienceSnapshot['sessionState'] | null;
   currentSource: string;
   runtimeReady: boolean;
   audioActive: boolean;

--- a/src/js/milkdrop/renderer-adapter-core.ts
+++ b/src/js/milkdrop/renderer-adapter-core.ts
@@ -135,6 +135,14 @@ const reusableInterpolatedCustomWaves: {
   current: import('./types').MilkdropProceduralCustomWaveVisual;
 }[] = [];
 
+/** Frozen empty lists: a lane with nothing to draw still has to be rendered so
+ * it trims last frame's geometry instead of leaving it on screen. */
+const EMPTY_PROCEDURAL_CUSTOM_WAVES: MilkdropProceduralCustomWaveVisual[] = [];
+const EMPTY_INTERPOLATED_CUSTOM_WAVES: {
+  previous: MilkdropProceduralCustomWaveVisual;
+  current: MilkdropProceduralCustomWaveVisual;
+}[] = [];
+
 function lerpColorInto(
   out: MilkdropColor,
   previousColor: MilkdropColor,
@@ -262,6 +270,21 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     new Group(),
     getMilkdropLayerRenderOrder('custom-wave'),
   );
+  /**
+   * Per-custom-wave-group lanes: [procedural, cpu].
+   *
+   * Custom waves route per WAVE, not per preset. A wave whose per-point block
+   * failed to lower stays on the CPU path, and so does any wave drawing dots
+   * (the procedural path only draws lines, and `usedots` is a per-frame value,
+   * so the split can change mid-preset). Both lists therefore have to draw in
+   * the same frame. renderWaveGroup and renderProceduralCustomWaveGroup each
+   * own their group's children by index and trim the tail, so they cannot
+   * share one group — each gets a lane. Before this, the adapter picked one
+   * path for the whole group and the other path's waves were silently never
+   * drawn: 205 of the 2686 bundled presets mix the two.
+   */
+  private readonly customWaveLanes = new WeakMap<Group, [Group, Group]>();
+
   private readonly trailGroup = withRenderOrder(
     new Group(),
     getMilkdropLayerRenderOrder('trails'),
@@ -610,6 +633,51 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
       }
     }
     trimGroupChildren(group, waves.length);
+  }
+
+  /**
+   * The subset of `waves` the CPU lane should draw: everything when the
+   * procedural lane is inactive, and only the non-GPU-backed waves when it is.
+   *
+   * Filtered into a reusable scratch list (one per call site, keyed by slot)
+   * because this runs every frame and a fresh array per frame per lane is
+   * exactly the kind of allocation this renderer avoids.
+   */
+  private readonly cpuCustomWaveScratch: MilkdropWaveVisual[][] = [[], []];
+
+  private cpuOnlyCustomWaves(
+    waves: MilkdropWaveVisual[],
+    proceduralLaneActive: boolean,
+    slot: 0 | 1,
+  ): MilkdropWaveVisual[] {
+    if (!proceduralLaneActive) {
+      return waves;
+    }
+    const out = this.cpuCustomWaveScratch[slot];
+    let count = 0;
+    for (let i = 0; i < waves.length; i += 1) {
+      const wave = waves[i];
+      if (wave && !wave.proceduralBacked) {
+        out[count] = wave;
+        count += 1;
+      }
+    }
+    out.length = count;
+    return out;
+  }
+
+  /** The [procedural, cpu] lanes of a custom-wave group, attached on first
+   * use. Rebuilt when a clearGroup has detached them. */
+  private getCustomWaveLanes(group: Group): [Group, Group] {
+    const lanes = this.customWaveLanes.get(group);
+    if (lanes && lanes[0].parent === group && lanes[1].parent === group) {
+      return lanes;
+    }
+    const next: [Group, Group] = [new Group(), new Group()];
+    group.add(next[0]);
+    group.add(next[1]);
+    this.customWaveLanes.set(group, next);
+    return next;
   }
 
   private renderProceduralCustomWaveGroup(
@@ -1081,20 +1149,23 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         alphaMultiplier,
       );
     }
-    if (canProceduralCustom && gpu.customWaves.length > 0) {
-      this.renderProceduralCustomWaveGroup(
-        customWaveGroup,
-        gpu.customWaves,
-        interaction?.waves,
-      );
-    } else {
-      this.renderWaveGroup(
-        'custom-wave',
-        customWaveGroup,
-        customWaves,
-        alphaMultiplier,
-      );
-    }
+    const [proceduralCustomWaveLane, cpuCustomWaveLane] =
+      this.getCustomWaveLanes(customWaveGroup);
+    this.renderProceduralCustomWaveGroup(
+      proceduralCustomWaveLane,
+      canProceduralCustom ? gpu.customWaves : EMPTY_PROCEDURAL_CUSTOM_WAVES,
+      interaction?.waves,
+    );
+    this.renderWaveGroup(
+      'custom-wave',
+      cpuCustomWaveLane,
+      // Only the waves the procedural lane is NOT drawing. The VM publishes
+      // every enabled wave here (so a backend without a procedural path sees
+      // the full set), so handing this list over unfiltered while the
+      // procedural lane also draws would render the GPU-backed waves twice.
+      this.cpuOnlyCustomWaves(customWaves, canProceduralCustom, 0),
+      alphaMultiplier,
+    );
     if (canProcedural('trail-waves') && (gpu?.trailWaves?.length ?? 0) > 0) {
       this.renderProceduralWaveGroup(
         'trail-waves',
@@ -1181,10 +1252,11 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
           blend.alpha,
         );
       }
-      if (
-        canProcedural('custom-wave') &&
-        prev.gpuGeometry.customWaves.length > 0
-      ) {
+      const [blendProceduralCustomWaveLane, blendCpuCustomWaveLane] =
+        this.getCustomWaveLanes(this.blendCustomWaveGroup);
+      const blendProceduralLaneActive =
+        canProcedural('custom-wave') && prev.gpuGeometry.customWaves.length > 0;
+      if (blendProceduralLaneActive) {
         const interpolated = reusableInterpolatedCustomWaves;
         interpolated.length = prev.gpuGeometry.customWaves.length;
         for (let i = 0; i < prev.gpuGeometry.customWaves.length; i++) {
@@ -1204,7 +1276,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
             blendMix,
           );
         this.renderInterpolatedProceduralCustomWaveGroup(
-          this.blendCustomWaveGroup,
+          blendProceduralCustomWaveLane,
           interpolated,
           blendMix,
           blend.alpha,
@@ -1217,13 +1289,23 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
           },
         );
       } else {
-        this.renderWaveGroup(
-          'blend-custom-wave',
-          this.blendCustomWaveGroup,
-          prev.customWaves,
+        this.renderInterpolatedProceduralCustomWaveGroup(
+          blendProceduralCustomWaveLane,
+          EMPTY_INTERPOLATED_CUSTOM_WAVES,
+          blendMix,
           blend.alpha,
+          null,
         );
       }
+      // Outside the branch: the outgoing preset's CPU-path custom waves draw
+      // whether or not its GPU-path siblings do — minus the ones the
+      // procedural lane above is already drawing.
+      this.renderWaveGroup(
+        'blend-custom-wave',
+        blendCpuCustomWaveLane,
+        this.cpuOnlyCustomWaves(prev.customWaves, blendProceduralLaneActive, 1),
+        blend.alpha,
+      );
       renderParticleFieldGroupHelper({
         backend: this.backend,
         target: 'blend-particle-field',
@@ -1275,9 +1357,19 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
         blend.mode === 'cpu' ? [blend.mainWave] : [],
         alpha,
       );
+      const [blendProceduralLane, blendCpuLane] = this.getCustomWaveLanes(
+        this.blendCustomWaveGroup,
+      );
+      this.renderInterpolatedProceduralCustomWaveGroup(
+        blendProceduralLane,
+        EMPTY_INTERPOLATED_CUSTOM_WAVES,
+        0,
+        alpha,
+        null,
+      );
       this.renderWaveGroup(
         'blend-custom-wave',
-        this.blendCustomWaveGroup,
+        blendCpuLane,
         blend.mode === 'cpu' ? blend.customWaves : [],
         alpha,
       );
@@ -1439,6 +1531,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
   dispose() {
     clearGroup(this.mainWaveGroup);
     clearGroup(this.customWaveGroup);
+    this.customWaveLanes.delete(this.customWaveGroup);
     clearGroup(this.trailGroup);
     clearGroup(this.particleFieldGroup);
     clearGroup(this.shapesGroup);
@@ -1446,6 +1539,7 @@ class ThreeMilkdropAdapter implements MilkdropRendererAdapter {
     clearGroup(this.motionVectorGroup);
     clearGroup(this.blendWaveGroup);
     clearGroup(this.blendCustomWaveGroup);
+    this.customWaveLanes.delete(this.blendCustomWaveGroup);
     clearGroup(this.blendParticleFieldGroup);
     clearGroup(this.blendShapeGroup);
     clearGroup(this.blendBorderGroup);

--- a/src/js/milkdrop/renderer-types.ts
+++ b/src/js/milkdrop/renderer-types.ts
@@ -65,6 +65,19 @@ export type MilkdropWaveVisual = MilkdropPolyline & {
   blendMode?: 'subtractive' | 'multiplicative';
   pointSize: number;
   spectrum?: boolean;
+  /**
+   * True when this wave is also published on the procedural (GPU) path, so
+   * `positions` was never filled for this frame.
+   *
+   * Custom waves route per wave, not per preset: a wave drawing dots, or one
+   * whose per-point block did not lower, stays on the CPU path while its
+   * siblings go to the GPU. Every enabled wave is still published here so a
+   * backend with no procedural path can draw the complete set — which means a
+   * renderer that draws BOTH lists must skip these, or the GPU-backed waves
+   * are drawn twice (doubling their brightness and their feedback injection)
+   * from stale pooled positions.
+   */
+  proceduralBacked?: boolean;
 };
 
 /**

--- a/src/js/milkdrop/runtime-types.ts
+++ b/src/js/milkdrop/runtime-types.ts
@@ -1,8 +1,11 @@
+import type { AdaptiveQualityState } from '../core/services/adaptive-quality-controller.ts';
+import type { MilkdropCatalogEntry } from './catalog-types.ts';
 import type {
   MilkdropDiagnostic,
   MilkdropPresetSource,
 } from './common-types.ts';
 import type { MilkdropCompiledPreset } from './compiler-types.ts';
+import type { MilkdropShaderExecutionMode } from './shader-execution-mode.ts';
 
 export type MilkdropRuntimeSignals = {
   time: number;
@@ -237,3 +240,100 @@ export interface MilkdropEditorCompiler {
    */
   setShaderBranchDesugar(enabled: boolean): Promise<void>;
 }
+
+/**
+ * The snapshot the experience controller publishes for the shell to read.
+ * This is the engine ↔ shell seam contract: it is declared here so the shell
+ * can name it directly instead of chaining `ReturnType` through the adapter,
+ * which ends in `any`. A field renamed or removed in the engine must now fail
+ * to compile in the shell instead of silently vanishing at runtime.
+ *
+ * Concrete field types resolve the engine's own `ReturnType<...>` references
+ * (catalog coordinator entries, editor session state) to their named types so
+ * this lives at module scope rather than inside the factory that builds it.
+ */
+export interface MilkdropExperienceSnapshot {
+  activePresetId: string | null;
+  backend: 'webgl' | 'webgpu';
+  status: string | null;
+  adaptiveQuality: AdaptiveQualityState | null;
+  catalogEntries: MilkdropCatalogEntry[];
+  sessionState: MilkdropEditorSessionState;
+  audioEnergy: number;
+  audioBass: number;
+  audioMid: number;
+  audioTreble: number;
+  /**
+   * Estimated tempo, already adjudicated: a whole number of BPM when the
+   * beat clock is confident, null otherwise.
+   */
+  tempoBpm: number | null;
+  /** How the active preset's shader reaches the screen on the active backend. */
+  shaderExecution: MilkdropShaderExecutionMode | null;
+  autoplay: boolean;
+  transitionMode: 'blend' | 'cut';
+  blendDuration: number;
+}
+
+/**
+ * The public surface of a running milkdrop experience, as seen by the shell.
+ * Mirrors the object `buildExperienceController` returns in `runtime.ts`.
+ * Declared so the shell depends on a contract it can name — and swap or mock
+ * against — rather than an inferred `ReturnType<...>` that reads as `any`.
+ */
+export interface MilkdropExperienceController {
+  subscribe(
+    listener: (snapshot: MilkdropExperienceSnapshot) => void,
+  ): () => void;
+  getStateSnapshot(): MilkdropExperienceSnapshot;
+  getAudioLevels(): {
+    energy: number;
+    bass: number;
+    mid: number;
+    treble: number;
+  };
+  applyFields(updates: unknown): unknown;
+  getActiveCompiledPreset(): MilkdropCompiledPreset | null;
+  getActivePresetId(): string | null;
+  selectPreset(module: unknown, options?: unknown): Promise<unknown>;
+  goBackPreset(): Promise<unknown>;
+  setActiveCollectionTag(collectionTag: string | null): void;
+  openTab(
+    tab: 'browse' | 'editor' | 'inspector' | 'refine' | 'finder' | 'blend',
+  ): void;
+  setOverlayOpen(open: boolean): void;
+  getAutoplay(): boolean;
+  setAutoplay(enabled: boolean): void;
+  getTransitionMode(): 'blend' | 'cut';
+  setTransitionMode(mode: 'blend' | 'cut'): void;
+  startManualCrossfade(): void;
+  setCrossfade(position: number): void;
+  getCrossfade(): number | null;
+  getBlendDuration(): number;
+  setBlendDuration(value: number): void;
+  importPresetFiles(files: FileList | File[]): Promise<void>;
+  exportPreset(): void;
+  resizeForVideoExport(width: number, height: number): void;
+  duplicatePreset(): Promise<void>;
+  deleteActivePreset(): Promise<void>;
+  applyEditorSourceAwaited(source: string): Promise<MilkdropEditorSessionState>;
+  applyEditorFieldsAwaited(
+    updates: Record<string, string | number>,
+  ): Promise<MilkdropEditorSessionState>;
+  getEditorSessionState(): MilkdropEditorSessionState;
+  updateEditorSource(source: string): void;
+  revertEditorSource(): void;
+  updateInspectorField(key: string, value: string | number): void;
+  setLiveField(key: string, value: number): void;
+  setQualityPreset(presetId: string): unknown;
+  setStatus(message: string): void;
+  attachRuntime(nextRuntime: unknown): unknown;
+  update(frame: unknown, options?: unknown): void;
+  dispose(): void;
+}
+
+/** Dependencies the experience controller builder is wired with. Typed in
+ * step 2 of the seam migration; declared here so the builder can adopt it.
+ * The catch-all access is kept deliberately loose until then. */
+// biome-ignore lint/suspicious/noExplicitAny: builder pattern bundles runtime delegates
+export type ExperienceControllerDeps = Record<string, any>;

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -89,10 +89,12 @@ import { createMilkdropTraceRecorder } from './runtime/trace-recorder';
 import { createMilkdropTransitionController } from './runtime/transition-controller';
 import { installRequestedPresetListener } from './runtime/ui-bridge';
 import { createMilkdropSignalTracker } from './runtime-signals';
-import {
-  type MilkdropShaderExecutionMode,
-  resolveShaderExecutionMode,
-} from './shader-execution-mode.ts';
+import type {
+  ExperienceControllerDeps,
+  MilkdropExperienceController,
+  MilkdropExperienceSnapshot,
+} from './runtime-types.ts';
+import { resolveShaderExecutionMode } from './shader-execution-mode.ts';
 import type {
   MilkdropCompiledPreset,
   MilkdropFrameState,
@@ -131,39 +133,6 @@ export function createMilkdropExperience({
   initialPresetId?: string;
   previewMode?: boolean;
 }) {
-  type MilkdropExperienceSnapshot = {
-    activePresetId: string | null;
-    backend: 'webgl' | 'webgpu';
-    status: string | null;
-    adaptiveQuality: AdaptiveQualityState | null;
-    catalogEntries: ReturnType<typeof catalogCoordinator.getCatalogEntries>;
-    sessionState: ReturnType<typeof session.getState>;
-    audioEnergy: number;
-    audioBass: number;
-    audioMid: number;
-    audioTreble: number;
-    /**
-     * Estimated tempo, already adjudicated: a whole number of BPM when the
-     * beat clock is confident, null otherwise. One field rather than a
-     * value plus a confidence, so the "is this trustworthy" rule lives here
-     * instead of being re-decided by every consumer — and rounded, because
-     * the raw median jitters by fractions of a BPM and every change of this
-     * field republishes the engine snapshot to the UI.
-     */
-    tempoBpm: number | null;
-    /**
-     * Whether the active preset's shader text is executing as authored on the
-     * active backend, or being approximated from its controls. Lives on the
-     * snapshot rather than being re-derived per consumer because it changes on
-     * two independent axes — the preset and the backend — and every surface
-     * that reports it must agree.
-     */
-    shaderExecution: MilkdropShaderExecutionMode | null;
-    autoplay: boolean;
-    transitionMode: 'blend' | 'cut';
-    blendDuration: number;
-  };
-
   // Before ANY preset compiles — the deep-link prefetch below and the default
   // preset both compile, and a preset compiled under the wrong setting would
   // carry the wrong backend classification for the rest of the session.
@@ -1091,8 +1060,18 @@ export function createMilkdropExperience({
   } as any);
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: builder pattern bundles runtime delegates
-function buildExperienceController(deps: Record<string, any>) {
+/**
+ * Annotated with the declared seam contract rather than letting the return
+ * type be inferred. The deps bag is deliberately loose (the builder bundles
+ * ~40 runtime delegates), so an inferred return type resolved to `any` and
+ * carried that `any` all the way into the shell, where a field renamed here
+ * still compiled. Naming the contract stops the erasure at this boundary:
+ * the shell now reads a real type, and a method dropped from the object below
+ * fails to compile here instead of at runtime.
+ */
+function buildExperienceController(
+  deps: ExperienceControllerDeps,
+): MilkdropExperienceController {
   let rendererLifecycleUnsubscribe: (() => void) | null = null;
   return {
     subscribe(listener: unknown) {

--- a/src/js/milkdrop/vm/wave-builder.ts
+++ b/src/js/milkdrop/vm/wave-builder.ts
@@ -477,6 +477,10 @@ export function buildCustomWaves({
     }
 
     if (visualWave && (positions || useProcedural)) {
+      // Published even when the wave went to the GPU, so a backend without a
+      // procedural path still sees every enabled wave. Flagged so a renderer
+      // drawing both lists knows not to draw this one twice.
+      visualWave.proceduralBacked = useProcedural;
       visualWave.alpha = waveAlpha;
       visualWave.thickness = clamp(frameLocals.thick ?? 1, 1, 6);
       visualWave.drawMode = drawMode;

--- a/tests/unit/catalog-measurement-passthrough.test.ts
+++ b/tests/unit/catalog-measurement-passthrough.test.ts
@@ -5,19 +5,18 @@ import { mapRuntimeCatalogEntry } from '../../src/js/frontend/workspace-helpers.
 import type { MilkdropCatalogEntry } from '../../src/js/milkdrop/catalog-types.ts';
 
 /**
- * Lab measurements have to survive four hand-listed projections between
- * catalog.json and a rendered row: the fetch-boundary mapper in
- * catalog-bundled-pipeline, the two entry builders in
- * catalog-store-projection, and mapRuntimeCatalogEntry here.
+ * Catalog-projection contract: every measured field on a catalog entry must
+ * survive the four hand-listed projections between catalog.json and a rendered
+ * row: the fetch-boundary mapper in catalog-bundled-pipeline, the two entry
+ * builders in catalog-store-projection, and mapRuntimeCatalogEntry here.
  *
- * Every one of them constructs a fresh object instead of spreading, so a
- * field missing from any single layer vanishes with no type error and no test
+ * Each layer constructs a fresh object instead of spreading, so a field
+ * missing from any single layer vanishes with no type error and no test
  * failure — which is exactly how the reactivity band shipped reading a field
- * that never reached it. TypeScript cannot catch this: dropping a field from
- * an object literal is legal.
+ * that never reached it.
  *
- * These are the cheap end-to-end guards. If a new measurement is added to the
- * catalog, add it here too, or it will silently never arrive.
+ * If a new measurement or compatibility field is added to the catalog, add a
+ * survival assertion here, or it will silently never arrive at the browse row.
  */
 
 const PRESETS_DIR = join(
@@ -34,41 +33,146 @@ function readJson(name: string) {
   };
 }
 
-describe('mapRuntimeCatalogEntry carries measurements to the UI', () => {
-  const runtimeEntry = {
-    id: 'x',
-    title: 'X',
-    tags: [],
-    supports: {
-      webgl: { status: 'supported' },
-      webgpu: { status: 'supported' },
+const FULL_FIXTURE: MilkdropCatalogEntry = {
+  id: 'test-preset',
+  title: 'Test Preset',
+  author: 'Test Author',
+  authorUrl: 'https://example.com',
+  derivedFrom: [{ id: 'original', title: 'Original' }],
+  origin: 'bundled',
+  tags: ['test', 'fixture'],
+  curatedRank: 42,
+  similarity: { clusterId: 'cluster-1', duplicateOf: 'other-preset' },
+  isFavorite: true,
+  rating: 4,
+  lastOpenedAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  historyIndex: 3,
+  featuresUsed: ['motion-vectors'],
+  warnings: [],
+  supports: {
+    webgl: {
+      status: 'supported',
+      reasons: [],
+      evidence: [],
+      requiredFeatures: [],
+      unsupportedFeatures: [],
     },
-    quality: { score: 0.5, components: { measuredReactivity: 0.87 } },
-    sensoryProfile: {
-      flashRiskLevel: 'high',
-      maxTransitionsPerSecondEstimate: 5,
-      meanLuminance: 0.4,
-      maxLuminanceDelta: 0.2,
-      measuredAt: '2026-08-19T00:00:00.000Z',
+    webgpu: {
+      status: 'supported',
+      reasons: [],
+      evidence: [],
+      requiredFeatures: [],
+      unsupportedFeatures: [],
     },
-  } as unknown as MilkdropCatalogEntry;
+  },
+  fidelityClass: 'exact',
+  fidelityTier: 'measured-visual',
+  visualEvidenceTier: 'measured',
+  semanticSupport: {
+    fidelityClass: 'exact',
+    evidence: { compile: 'confirmed', runtime: 'confirmed' },
+  },
+  visualCertification: {
+    fidelityClass: 'exact',
+    visualEvidenceTier: 'measured',
+    measured: true,
+  },
+  evidence: {
+    compile: 'confirmed',
+    runtime: 'confirmed',
+    source: 'test',
+  },
+  certification: 'certified',
+  corpusTier: 'bundled',
+  parity: {
+    semanticSupport: {
+      fidelityClass: 'exact',
+      evidence: { compile: 'confirmed', runtime: 'confirmed' },
+    },
+    visualCertification: {
+      fidelityClass: 'exact',
+      visualEvidenceTier: 'measured',
+      measured: true,
+    },
+    evidence: { compile: 'confirmed', runtime: 'confirmed', source: 'test' },
+  },
+  quality: {
+    score: 0.75,
+    components: {
+      fidelity: 0.9,
+      evidence: 0.8,
+      measuredReactivity: 0.87,
+    },
+  },
+  sensoryProfile: {
+    flashRiskLevel: 'high',
+    maxTransitionsPerSecondEstimate: 5,
+    meanLuminance: 0.4,
+    maxLuminanceDelta: 0.2,
+    measuredAt: '2026-08-19T00:00:00.000Z',
+  },
+  preview: false,
+} as unknown as MilkdropCatalogEntry;
 
-  test('reactivity survives the runtime-to-frontend hop', () => {
-    const mapped = mapRuntimeCatalogEntry(runtimeEntry);
+describe('mapRuntimeCatalogEntry field-survival contract', () => {
+  test('quality scores survive the projection', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.quality?.score).toBe(0.75);
     expect(mapped.quality?.components?.measuredReactivity).toBe(0.87);
   });
 
-  test('the sensory profile survives the runtime-to-frontend hop', () => {
-    const mapped = mapRuntimeCatalogEntry(runtimeEntry);
+  test('the sensory profile (reactivity band + flash warning) survives', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
     expect(mapped.sensoryProfile?.flashRiskLevel).toBe('high');
+    expect(mapped.sensoryProfile?.maxTransitionsPerSecondEstimate).toBe(5);
+    expect(mapped.sensoryProfile?.meanLuminance).toBe(0.4);
+  });
+
+  test('visual certification survives', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.visualCertification?.fidelityClass).toBe('exact');
+    expect(mapped.visualCertification?.measured).toBe(true);
+  });
+
+  test('similarity (dedup cluster) survives', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.similarity?.clusterId).toBe('cluster-1');
+    expect(mapped.similarity?.duplicateOf).toBe('other-preset');
+  });
+
+  test('fidelity tier survives', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.fidelityTier).toBe('measured-visual');
+  });
+
+  test('expected fidelity class (legacy shell alias for fidelityClass) survives', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.expectedFidelityClass).toBe('exact');
+  });
+
+  test('supports (boolean-derived from status-object) is carried', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.supports?.webgl).toBe(true);
+    expect(mapped.supports?.webgpu).toBe(true);
+  });
+
+  test('all identity and metadata fields survive', () => {
+    const mapped = mapRuntimeCatalogEntry(FULL_FIXTURE);
+    expect(mapped.id).toBe('test-preset');
+    expect(mapped.title).toBe('Test Preset');
+    expect(mapped.author).toBe('Test Author');
+    expect(mapped.authorUrl).toBe('https://example.com');
+    expect(mapped.tags).toEqual(['test', 'fixture']);
+    expect(mapped.isFavorite).toBe(true);
+    expect(mapped.rating).toBe(4);
+    expect(mapped.historyIndex).toBe(3);
+    expect(mapped.lastOpenedAt).toBe(1_700_000_000_000);
   });
 });
 
 describe('the shipped catalogs actually carry the fields', () => {
-  test('starter-catalog.json carries reactivity for its presets', () => {
-    // The starter set is what browse shows first, and it is also — not
-    // coincidentally — almost exactly the set with measured reactivity. It
-    // previously omitted the field entirely, so the chip rendered for nobody.
+  test('starter-catalog.json carries reactivity for every preset', () => {
     const starter = readJson('starter-catalog.json');
     const measured = starter.presets.filter((p) => {
       const q = p.quality as

--- a/tests/unit/engine-seam-types.test.ts
+++ b/tests/unit/engine-seam-types.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Compile-time probe that the engine ↔ shell seam carries real types instead
+ * of `any`.
+ *
+ * The regression this guards against: `buildExperienceController` accepted
+ * `Record<string, any>` deps and `getStateSnapshot()` returned whatever
+ * `buildSnapshot` produced, so the shell read the engine snapshot through
+ * `ReturnType<...>` chains that resolved to `any`. A field renamed or removed
+ * in the engine then compiled clean in the shell and failed at runtime. This
+ * test asserts the seam types are declared (non-`any`) and the shell snapshot
+ * names them directly. It is a type-level probe: the value assignments only
+ * compile if the assertion holds, so a positive (`IsAny<T> = true`) line is
+ * what breaks when the seam erodes.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { EngineSnapshot } from '../../src/js/frontend/engine/engine-snapshot.ts';
+import type {
+  MilkdropExperienceController,
+  MilkdropExperienceSnapshot,
+} from '../../src/js/milkdrop/runtime-types.ts';
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+describe('engine seam types', () => {
+  test('the snapshot contract is a declared, non-any type', () => {
+    // The declared interface must never be `any`. If someone re-derives the
+    // seam through `ReturnType<...>` back to an erased type, this fails.
+    const notAny: IsAny<MilkdropExperienceSnapshot> = false;
+    expect(notAny).toBe(false);
+  });
+
+  test('the controller contract is a declared, non-any type', () => {
+    const notAny: IsAny<MilkdropExperienceController> = false;
+    expect(notAny).toBe(false);
+  });
+
+  test('the shell snapshot names the engine snapshot fields directly', () => {
+    // Field-level probes: each must resolve to the engine's declared type,
+    // never to `any` or `unknown`.
+    const catalogNotAny: IsAny<EngineSnapshot['catalogEntries']> = false;
+    const sessionNotAny: IsAny<NonNullable<EngineSnapshot['sessionState']>> =
+      false;
+    const adaptiveNotAny: IsAny<
+      NonNullable<EngineSnapshot['adaptiveQuality']>
+    > = false;
+    expect(catalogNotAny).toBe(false);
+    expect(sessionNotAny).toBe(false);
+    expect(adaptiveNotAny).toBe(false);
+  });
+
+  test('the snapshot type aliases the engine contract, not a ReturnType chain', () => {
+    // `EngineSnapshot['catalogEntries']` must equal the engine's contract
+    // array type. A structural check keeps the shell honest that it reads
+    // the engine's declared shape rather than a shadow copy.
+    const entriesAreEngineEntries:
+      | MilkdropExperienceSnapshot['catalogEntries']
+      | undefined = undefined as EngineSnapshot['catalogEntries'] | undefined;
+    expect(entriesAreEngineEntries).toBeUndefined();
+  });
+
+  test('the active-preset control is its declared non-any type', () => {
+    // Control: `activePresetId` was already `string | null` before this
+    // change. It must stay non-any; this is the negative control that proves
+    // the probe is checking (a real `any` field would compile true).
+    const control: IsAny<EngineSnapshot['activePresetId']> = false;
+    expect(control).toBe(false);
+  });
+});

--- a/tests/unit/milkdrop-renderer-adapter.test.ts
+++ b/tests/unit/milkdrop-renderer-adapter.test.ts
@@ -3386,6 +3386,146 @@ shapecode_0_a=0.9
     ).toBeCloseTo(0.175, 6);
   });
 
+  test('draws both lanes when one custom wave is GPU-routed and another is not', () => {
+    // wavecode_0 draws dots, which the procedural path does not do, so it
+    // stays on the CPU path. wavecode_1 draws lines and lowers cleanly, so it
+    // goes to the GPU. The adapter used to pick ONE path for the whole group
+    // and never draw the other wave at all — 205 bundled presets mix the two.
+    const preset = compileMilkdropPresetSource(
+      `
+title=Mixed Custom Wave Routing
+wavecode_0_enabled=1
+wavecode_0_samples=40
+wavecode_0_usedots=1
+wavecode_0_x=0.35
+wavecode_0_y=0.55
+wavecode_0_r=1
+wavecode_0_g=0.2
+wavecode_0_b=0.2
+wavecode_0_a=0.6
+wavecode_1_enabled=1
+wavecode_1_samples=40
+wavecode_1_usedots=0
+wavecode_1_x=0.55
+wavecode_1_y=0.45
+wavecode_1_r=0.2
+wavecode_1_g=1
+wavecode_1_b=0.4
+wavecode_1_a=0.8
+wave_1_per_point1=x = x + value1 * 0.1;
+      `.trim(),
+      { id: 'mixed-custom-wave-routing' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+    const frameState = vm.step(makeSignals({ frame: 4, time: 0.2 }));
+
+    // The GPU path takes only the line wave.
+    expect(frameState.gpuGeometry.customWaves).toHaveLength(1);
+    // The VM publishes BOTH waves on the CPU list — a backend with no
+    // procedural path has to be able to draw the complete set — and flags the
+    // one that also went to the GPU so a both-lane renderer can skip it.
+    expect(frameState.customWaves).toHaveLength(2);
+    const dotsWave = frameState.customWaves.find((w) => w.drawMode === 'dots');
+    const lineWave = frameState.customWaves.find((w) => w.drawMode === 'line');
+    expect(dotsWave?.proceduralBacked).toBeFalsy();
+    expect(dotsWave?.positions.length ?? 0).toBeGreaterThan(0);
+    expect(lineWave?.proceduralBacked).toBe(true);
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapterCore({
+      scene,
+      camera,
+      backend: 'webgpu',
+      batcher: null,
+      preset,
+    });
+    adapter.attach();
+    adapter.render({ frameState, blendState: null });
+
+    const [proceduralLane, cpuLane] = (
+      adapter as unknown as {
+        customWaveGroup: { children: Array<{ children: unknown[] }> };
+      }
+    ).customWaveGroup.children;
+
+    // Neither lane is empty: this is the assertion the old all-or-nothing
+    // switch could not satisfy. And the CPU lane holds exactly ONE child —
+    // the dots wave — not two: drawing the GPU-backed wave here as well would
+    // double its brightness and its injection into the feedback loop, from
+    // stale pooled positions the VM never filled this frame.
+    expect(proceduralLane?.children ?? []).toHaveLength(1);
+    expect(cpuLane?.children ?? []).toHaveLength(1);
+  });
+
+  test('does not redraw a wave on the CPU lane after it moves to the GPU lane', () => {
+    // `usedots` is a per-frame value, so a wave can be CPU-routed on one frame
+    // (dots, which the procedural path cannot draw) and GPU-routed on the
+    // next. The VM pools its visual object across frames, so the CPU-side
+    // `positions` from the dots frame are still sitting there on the line
+    // frame. Drawing both lists unfiltered would then paint that stale
+    // geometry underneath the correct GPU wave — doubling the wave's
+    // contribution to the additive blend and to the feedback loop.
+    const preset = compileMilkdropPresetSource(
+      `
+title=Custom Wave Changes Routing Mid-Preset
+wavecode_0_enabled=1
+wavecode_0_samples=40
+wavecode_0_usedots=1
+wavecode_0_x=0.5
+wavecode_0_y=0.5
+wavecode_0_r=1
+wavecode_0_g=0.5
+wavecode_0_b=0.2
+wavecode_0_a=0.8
+wave_0_per_frame1=usedots = below(frame, 5);
+wave_0_per_point1=x = x + value1 * 0.1;
+      `.trim(),
+      { id: 'custom-wave-routing-flip' },
+    );
+
+    const vm = createMilkdropVM(preset);
+    vm.setRenderBackend('webgpu');
+
+    const scene = new Scene();
+    const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 10);
+    const adapter = createMilkdropRendererAdapterCore({
+      scene,
+      camera,
+      backend: 'webgpu',
+      batcher: null,
+      preset,
+    });
+    adapter.attach();
+
+    // Frame 1: usedots is on, so the wave is CPU-routed and its pooled
+    // positions get filled in.
+    const dotsFrame = vm.step(makeSignals({ frame: 1, time: 0.1 }));
+    expect(dotsFrame.customWaves[0]?.drawMode).toBe('dots');
+    expect(dotsFrame.customWaves[0]?.positions.length ?? 0).toBeGreaterThan(0);
+    adapter.render({ frameState: dotsFrame, blendState: null });
+
+    // Frame 6: usedots is off, so the same wave now routes to the GPU — while
+    // the CPU list still carries it, positions and all.
+    const lineFrame = vm.step(makeSignals({ frame: 6, time: 0.6 }));
+    expect(lineFrame.gpuGeometry.customWaves).toHaveLength(1);
+    expect(lineFrame.customWaves[0]?.proceduralBacked).toBe(true);
+    expect(lineFrame.customWaves[0]?.positions.length ?? 0).toBeGreaterThan(0);
+    adapter.render({ frameState: lineFrame, blendState: null });
+
+    const [proceduralLane, cpuLane] = (
+      adapter as unknown as {
+        customWaveGroup: { children: Array<{ children: unknown[] }> };
+      }
+    ).customWaveGroup.children;
+
+    // The GPU lane draws it; the CPU lane must have let go of it.
+    expect(proceduralLane?.children ?? []).toHaveLength(1);
+    expect(cpuLane?.children ?? []).toHaveLength(0);
+  });
+
   test('keeps previous-only procedural custom waves visible when the current frame has fewer slots', async () => {
     const previousPreset = compileMilkdropPresetSource(
       `
@@ -3469,16 +3609,18 @@ wavecode_0_a=0.8
       },
     });
 
-    const blendCustomWaveGroup = (
+    // The blend group holds two lanes — [procedural, cpu] — because custom
+    // waves route per wave; the procedural lane is the first.
+    const blendProceduralLane = (
       adapter as unknown as {
         blendCustomWaveGroup: {
-          children: Array<{ material?: ShaderMaterial }>;
+          children: Array<{ children: Array<{ material?: ShaderMaterial }> }>;
         };
       }
-    ).blendCustomWaveGroup;
-    const extraBlendedWave = blendCustomWaveGroup.children[1];
+    ).blendCustomWaveGroup.children[0];
+    const extraBlendedWave = blendProceduralLane?.children[1];
 
-    expect(blendCustomWaveGroup.children).toHaveLength(2);
+    expect(blendProceduralLane?.children).toHaveLength(2);
     expect(extraBlendedWave?.material).toBeInstanceOf(NodeMaterial);
     const blendedUniforms = (
       extraBlendedWave?.material as ShaderMaterial | undefined
@@ -3716,7 +3858,7 @@ wavecode_0_thick=4
       children: Array<{ material?: unknown }>;
     };
     const customWaveGroup = root.children[3] as {
-      children: Array<{ material?: unknown }>;
+      children: Array<{ children?: Array<{ material?: unknown }> }>;
     };
     const motionVectorGroup = root.children[8] as {
       children: Array<{ children?: Array<{ material?: unknown }> }>;
@@ -3728,7 +3870,10 @@ wavecode_0_thick=4
     expect(frameState.gpuGeometry.motionVectorField).toBeNull();
     expect(meshLines.material).toBeInstanceOf(LineBasicMaterial);
     expect(mainWaveGroup.children).toHaveLength(0);
-    expect(customWaveGroup.children).toHaveLength(0);
+    // Both custom-wave lanes are empty: this preset batches its waves.
+    for (const lane of customWaveGroup.children) {
+      expect(lane.children ?? []).toHaveLength(0);
+    }
     expect(motionVectorGroup.children[0]?.children ?? []).toHaveLength(0);
 
     const tree = scene.children[0] as RenderTreeNode;

--- a/tests/unit/workspace-engine-snapshot-coarse.test.ts
+++ b/tests/unit/workspace-engine-snapshot-coarse.test.ts
@@ -4,6 +4,7 @@ import {
   type EngineSnapshot,
 } from '../../src/js/frontend/engine/engine-snapshot.ts';
 import { coarseEngineSnapshotEqual } from '../../src/js/frontend/workspace-context.tsx';
+import { makeCatalogEntry } from '../milkdrop-fixtures.ts';
 
 /**
  * The engine snapshot context memo republishes to useEngineSnapshot consumers
@@ -41,9 +42,7 @@ const CHANGED_VALUES: { [K in keyof EngineSnapshot]: EngineSnapshot[K] } = {
   backend: 'webgpu',
   status: 'changed status',
   adaptiveQuality: { qualityStep: 1 } as EngineSnapshot['adaptiveQuality'],
-  catalogEntries: [
-    { id: 'p', title: 'P', author: 'A', tags: [] },
-  ] as EngineSnapshot['catalogEntries'],
+  catalogEntries: [makeCatalogEntry({ id: 'p', title: 'P', author: 'A' })],
   sessionState: { source: 'x' } as EngineSnapshot['sessionState'],
   currentSource: 'x',
   runtimeReady: true,


### PR DESCRIPTION
## The gap

Custom waves route per **wave**, not per preset. A wave drawing dots, or one whose per-point block did not lower, stays on the CPU path while its siblings go to the GPU. The adapter picked one path for the whole group, so the other path's waves were never drawn at all — **205 of the 2686 bundled presets mix the two**.

The custom-wave group is now split into `[procedural, cpu]` lanes, both rendered every frame so each also trims last frame's geometry instead of leaving it on screen.

## The bug that fix would have introduced

Drawing both lists as-is swaps one defect for a subtler one.

The VM publishes *every* enabled wave on the CPU list — a backend with no procedural path has to be able to draw the complete set — so a GPU-backed wave appears in both lists. Its visual object is pooled across frames, so it still holds the positions from the last frame it was CPU-routed. And `usedots` is a per-frame value, so a wave genuinely does change lanes mid-preset.

Unfiltered, that paints stale geometry underneath the correct GPU wave: double brightness in the additive blend, and double injection into the feedback loop.

The VM now flags a wave it published on both lists (`proceduralBacked`), and the CPU lane skips those while the procedural lane is active. Where the procedural lane is deliberately rendered empty, the CPU lane stays unfiltered — otherwise those waves would go undrawn.

## Verification

Both defects have tests that were confirmed to **fail without their respective fix**:

- `draws both lanes when one custom wave is GPU-routed and another is not` — the mixed-routing gap.
- `does not redraw a wave on the CPU lane after it moves to the GPU lane` — the double-draw, exercised by stepping a wave from `usedots=1` to `usedots=0` so the stale pooled positions are real.

`bun run check` green: 2862 pass, 5 skip, 0 fail.

## Also: the engine seam contract is now load-bearing

`MilkdropExperienceController` was declared but never applied. `buildExperienceController` still returned an inferred type built from an `any` deps bag, so the shell read the snapshot through a `ReturnType` chain that erased to `any` — the exact erosion the contract was written to stop.

Annotating the builder with the declared contract closes it. Verified by negative control: renaming a method on the interface now fails to compile in `runtime.ts`, where before it compiled clean and failed at runtime.

## Dropped from this change

`feedback-composite-contract.ts` and its test. It claimed to be "the single owned list" of the shared feedback surface but listed 4 of ~52 uniforms, and its test checked the table against a hardcoded list inside the test itself. `applyCompositeUniformState` in `feedback-manager-shared.ts` already enforces that surface by construction — both backends call it — so the table was a redundant hand-maintained copy with no guard behind it. Worth revisiting only as live uniform introspection.

## Not included

The refreshed `screenshots/parity/suite/*.json` captures are left uncommitted. They were taken before this rendering fix, and certified presets use custom waves heavily (`eos-phat-cubetrace-v2` has 52 wavecode blocks), so committing them would assert numbers that do not match this code. A re-capture run hung on `aderrasi-potion-of-spirits` and was stopped; parity needs a clean re-run before those numbers are trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)