### PR TITLE
Put UI controls on the layer they claim, and enforce the z-index scale

### DIFF
--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -42,6 +42,7 @@ become fast feedback instead of a surprise at PR time.
 | [`check:test-source-greps`](#checktest-source-greps) | `check:quick` | Fails when a test reads a production source file as text. |
 | [`check:unused-exports`](#checkunused-exports) | on demand | Detect exported symbols with zero importers — the "remove dead code" pattern that recurred 12+ times in the last 400 commits. Codex PRs introduced exports that nothing imported; they survived merge and were purged weeks later in bulk. |
 | [`check:webgpu-target-sampling`](#checkwebgpu-target-sampling) | `check:quick` | Blocks a bare `.sample()` against one of the WebGPU feedback manager's own render targets. |
+| [`check:z-layers`](#checkz-layers) | `check:quick` | Fail on `z-index` values that opt out of the layer scale in tokens.css. |
 
 ---
 
@@ -632,6 +633,32 @@ Uploaded textures — noise, aura, video, the glyph atlas — are NOT flipped an
 are none of this guard's business.
 
 Run it directly: `bun run check:webgpu-target-sampling`
+
+## check:z-layers
+
+Fail on `z-index` values that opt out of the layer scale in tokens.css.
+
+The scale is a shared claim about what sits above what: a lab panel below a
+dialog, a toast above the dock, a skip link above all of it. A raw number
+makes that claim privately, and privately made claims collide. They had:
+StrudelLabPanel declared `z-index: 40`, which is exactly --z-modal-backdrop,
+so an open dialog's scrim and a floating tool panel occupied one layer and
+paint order fell to DOM order. It rendered correctly only by accident of
+which element happened to come last.
+
+Nothing caught it because a hand-picked z-index is valid CSS that looks
+right in the state you tested. It surfaces as one surface covering another
+in a combination nobody opened — the same reason check-css-scale.ts exists
+for radius and type.
+
+The rule: at or above --z-nav (10), where the global chrome scale starts,
+use a token. Below that, a literal is fine and usually better — a `z-index:
+1` that lifts an image over its own tile is local stacking inside one
+component and makes no claim about the app's layers. Reaching for
+var(--z-stage-root) there would assert kinship with the stage from inside a
+browse panel, which is how the misleading ones got written.
+
+Run it directly: `bun run check:z-layers`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "check:ci-config": "bun run scripts/check-ci-config.ts",
     "check:commit-msg": "bun run scripts/check-commit-msg.ts",
     "check:css-scale": "bun run scripts/check-css-scale.ts",
+    "check:z-layers": "bun run scripts/check-z-layers.ts",
     "check:dead-code": "bun run scripts/check-dead-code.ts",
     "check:css-tokens": "bun run scripts/check-css-tokens.ts",
     "check:doc-references": "bun run scripts/check-doc-references.ts",

--- a/scripts/check-z-layers.ts
+++ b/scripts/check-z-layers.ts
@@ -1,0 +1,131 @@
+/**
+ * Fail on `z-index` values that opt out of the layer scale in tokens.css.
+ *
+ * The scale is a shared claim about what sits above what: a lab panel below a
+ * dialog, a toast above the dock, a skip link above all of it. A raw number
+ * makes that claim privately, and privately made claims collide. They had:
+ * StrudelLabPanel declared `z-index: 40`, which is exactly --z-modal-backdrop,
+ * so an open dialog's scrim and a floating tool panel occupied one layer and
+ * paint order fell to DOM order. It rendered correctly only by accident of
+ * which element happened to come last.
+ *
+ * Nothing caught it because a hand-picked z-index is valid CSS that looks
+ * right in the state you tested. It surfaces as one surface covering another
+ * in a combination nobody opened — the same reason check-css-scale.ts exists
+ * for radius and type.
+ *
+ * The rule: at or above --z-nav (10), where the global chrome scale starts,
+ * use a token. Below that, a literal is fine and usually better — a `z-index:
+ * 1` that lifts an image over its own tile is local stacking inside one
+ * component and makes no claim about the app's layers. Reaching for
+ * var(--z-stage-root) there would assert kinship with the stage from inside a
+ * browse panel, which is how the misleading ones got written.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+/**
+ * Roots to scan. Defaults to the app source; a caller may pass roots as
+ * arguments, which is how the test suite runs this against fixtures rather
+ * than re-implementing the matching and drifting from it.
+ */
+const ROOTS =
+  process.argv.slice(2).filter((a) => !a.startsWith('-')).length > 0
+    ? process.argv.slice(2).filter((a) => !a.startsWith('-'))
+    : ['src'];
+
+const SCANNED = new Set(['.css', '.ts', '.tsx']);
+
+/**
+ * The layer where the global scale begins (--z-nav). Below this, a literal is
+ * local stacking within one component and needs no token.
+ */
+const GLOBAL_SCALE_FLOOR = 10;
+
+/**
+ * Literals that are deliberately outside the scale, with the reason.
+ *
+ * Keep this short. An entry is a claim that the value orders siblings inside
+ * one component — not that picking a token was inconvenient.
+ */
+const ALLOWED: { file: string; value: number; reason: string }[] = [];
+
+type Offence = {
+  file: string;
+  line: number;
+  value: string;
+  context: string;
+};
+
+function walk(dir: string): string[] {
+  let out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out = out.concat(walk(full));
+    else if (SCANNED.has(extname(full))) out.push(full);
+  }
+  return out;
+}
+
+/** Matches both `z-index: 40;` in CSS and `'z-index:80'` in an inline style. */
+const Z_INDEX = /z-index\s*:\s*([^;'"`,}\n]+)/g;
+
+const offences: Offence[] = [];
+
+for (const root of ROOTS) {
+  for (const file of walk(root)) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      // A line that only talks about z-index in prose is not a declaration.
+      if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
+      Z_INDEX.lastIndex = 0;
+      let match: RegExpExecArray | null = Z_INDEX.exec(line);
+      while (match !== null) {
+        const raw = match[1].trim();
+        if (!raw.includes('var(--z-')) {
+          const value = Number.parseInt(raw, 10);
+          if (
+            !Number.isNaN(value) &&
+            Math.abs(value) >= GLOBAL_SCALE_FLOOR &&
+            !ALLOWED.some((a) => file.endsWith(a.file) && a.value === value)
+          ) {
+            offences.push({
+              file,
+              line: index + 1,
+              value: raw,
+              context: line.trim().slice(0, 72),
+            });
+          }
+        }
+        match = Z_INDEX.exec(line);
+      }
+    });
+  }
+}
+
+if (offences.length > 0) {
+  console.error(
+    `✖ ${offences.length} z-index value${offences.length === 1 ? '' : 's'} bypassing the layer scale:\n`,
+  );
+  for (const o of offences) {
+    console.error(`  ${o.file}:${o.line}  ${o.context}`);
+  }
+  console.error(
+    `\nAt or above ${GLOBAL_SCALE_FLOOR} the value is a claim about the app's layers,`,
+  );
+  console.error(
+    'so name it: use a --z-* token from src/css/tokens.css, or add one there',
+  );
+  console.error(
+    'in numeric order with a comment saying what it sits between. A value that',
+  );
+  console.error(
+    'only orders siblings inside one component belongs below the floor instead.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✔ every z-index at or above ${GLOBAL_SCALE_FLOOR} names its layer (src/css/tokens.css)`,
+);

--- a/scripts/run-quality-gate.ts
+++ b/scripts/run-quality-gate.ts
@@ -145,6 +145,10 @@ export function buildGatePlan(
         cmd: ['bun', 'run', 'check:css-scale'],
       },
       {
+        label: 'Z-index layer scale',
+        cmd: ['bun', 'run', 'check:z-layers'],
+      },
+      {
         label: 'Agent action id drift',
         cmd: ['bun', 'run', 'check:agent-action-ids'],
       },

--- a/src/css/StrudelLabPanel.module.css
+++ b/src/css/StrudelLabPanel.module.css
@@ -2,7 +2,7 @@
   position: absolute;
   top: calc(var(--stims-header-top, 62px) + 12px);
   right: 16px;
-  z-index: 40;
+  z-index: var(--z-lab-panel);
   display: grid;
   gap: 12px;
   width: min(360px, calc(100vw - 32px));
@@ -28,7 +28,7 @@
 }
 
 .panel[data-dragging="true"] {
-  z-index: 41;
+  z-index: calc(var(--z-lab-panel) + 1);
   user-select: none;
 }
 
@@ -202,7 +202,7 @@
   right: 16px;
   bottom: 16px;
   left: 16px;
-  z-index: 40;
+  z-index: var(--z-lab-panel);
   height: 112px;
   padding: 6px;
   border: 1px solid var(--stims-line-strong, rgba(255, 255, 255, 0.2));
@@ -218,7 +218,7 @@
 }
 
 .scopeStrip[data-dragging="true"] {
-  z-index: 41;
+  z-index: calc(var(--z-lab-panel) + 1);
   cursor: grabbing;
 }
 
@@ -252,7 +252,7 @@
   position: absolute;
   top: calc(var(--stims-header-top, 62px) + 12px);
   right: 16px;
-  z-index: 40;
+  z-index: var(--z-lab-panel);
   padding: 6px 14px;
   border: 1px solid var(--stims-line-strong, rgba(255, 255, 255, 0.2));
   border-radius: var(--radius-round);

--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -120,7 +120,7 @@ body[data-page="workspace"][data-live="true"] {
     position: fixed;
     right: max(0.75rem, env(safe-area-inset-right));
     bottom: max(0.75rem, env(safe-area-inset-bottom));
-    z-index: 12;
+    z-index: var(--z-embed-brand);
     display: inline-flex;
     align-items: center;
     min-height: 32px;
@@ -2024,7 +2024,10 @@ body[data-page="workspace"][data-live="true"] {
   .stims-shell__preset-preview-image {
     position: absolute;
     inset: 0;
-    z-index: var(--z-stage-root);
+    /* Local: raises the frame over the tile's own surface. It read
+       var(--z-stage-root) — the stage layer — which claimed kinship with the
+       stage from inside a browse panel. Nothing global is being asked for. */
+    z-index: 1;
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -2040,7 +2043,8 @@ body[data-page="workspace"][data-live="true"] {
   .stims-shell__preset-art-placeholder {
     position: absolute;
     inset: 0;
-    z-index: var(--z-stage-root);
+    /* Local to the tile, as above. */
+    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2257,7 +2261,7 @@ body[data-page="workspace"][data-live="true"] {
     position: fixed;
     right: 24px;
     bottom: 24px;
-    z-index: var(--z-audio-match);
+    z-index: var(--z-toast-floating);
     display: flex;
     flex-wrap: wrap;
     align-items: center;

--- a/src/css/editor-panel.css
+++ b/src/css/editor-panel.css
@@ -1431,7 +1431,9 @@ html.light .stims-editor {
   top: 8px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 30;
+  /* Local to the editor, above its menu (5) and proposal (4). It was 30,
+     which read as the global toast layer while being none of it. */
+  z-index: 6;
   width: min(320px, calc(100% - 24px));
   background: var(--ed-panel, #131a22);
   border: 1px solid var(--ed-line, rgba(255, 255, 255, 0.14));

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -54,7 +54,7 @@ canvas {
     box-shadow 0.2s ease,
     background 0.2s ease,
     border-color 0.2s ease;
-  z-index: var(--z-dropdown);
+  z-index: var(--z-skip-link);
   min-height: 46px;
   min-width: 44px;
   display: inline-flex;
@@ -558,7 +558,8 @@ body.tv-mode .content {
 
 .library {
   position: relative;
-  z-index: var(--z-stage-root);
+  /* Local: lifts the section over the page backdrop. */
+  z-index: 1;
 }
 
 /* UI polish v2: stronger hierarchy, better readability, and less cramped cards */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -303,15 +303,24 @@
   --z-frame-chrome: 3;
   --z-search-sticky: 6;
   --z-nav: 10;
+  /* Embed-mode branding badge: over stage chrome, under any panel. */
+  --z-embed-brand: 12;
   --z-panel: 15;
   --z-overlay: 18;
   --z-dropdown: 20;
   --z-dock: 25;
+  /* Floating lab panels (Strudel) — above the dock so stage chrome cannot
+     bury a tool the user is dragging, below toasts and modals so a notice or
+     a dialog still wins. Previously a raw 40, which tied exactly with
+     --z-modal-backdrop and left paint order to DOM order. */
+  --z-lab-panel: 26;
   --z-filter-bar: 28;
   --z-toast: 30;
   --z-alert: 35;
   --z-modal-backdrop: 40;
   --z-modal: 45;
+  /* Full-screen tile→stage promote animation; covers the UI for its duration. */
+  --z-promote-transition: 80;
   --z-shortcut-overlay: 100;
   --z-home-link: 1000;
   --z-control-panel: 1100;
@@ -322,7 +331,14 @@
   --z-settings-panel: 1250;
   --z-fullscreen-panel: 1260;
   --z-error-overlay: 2000;
-  --z-audio-match: 2100;
+  /* Named for the surface that uses it — the floating workspace toast. It was
+     --z-audio-match, whose only consumer was this toast; the audio-match toast
+     is a different component and lives in the toast stack at --z-toast. */
+  --z-toast-floating: 2100;
+  /* Nothing may cover the skip link while it is focused: it is the first
+     control a keyboard user reaches. It sat at --z-dropdown (20), under the
+     dock (25) and the toast stack (30). */
+  --z-skip-link: 2200;
   --z-loading: 9999;
 
   /* ── TV Mode Scaling ────────────────────────────────────────-- */

--- a/src/js/frontend/promote-transition.ts
+++ b/src/js/frontend/promote-transition.ts
@@ -97,7 +97,7 @@ export function runPresetPromoteTransition({
     `top:${from.top}px`,
     `width:${from.width}px`,
     `height:${from.height}px`,
-    'z-index:80',
+    'z-index:var(--z-promote-transition)',
     'pointer-events:none',
     'overflow:hidden',
     'background:#000',

--- a/tests/unit/check-z-layers.test.ts
+++ b/tests/unit/check-z-layers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Behavioural coverage for the z-index layer guard.
+ *
+ * The defect that prompted the guard is the one the first test pins: a
+ * floating lab panel declared `z-index: 40`, which is exactly
+ * --z-modal-backdrop, so a dialog's scrim and a tool panel shared one layer
+ * and paint order fell to whichever came last in the DOM. A guard that only
+ * read `.css` would have missed the other half of it — the promote transition
+ * builds its overlay in TypeScript with `'z-index:80'` inside an inline style
+ * string — so both forms are covered here.
+ *
+ * These run the actual script against fixtures rather than re-implementing
+ * its matching, so the test cannot drift from the guard the gate runs.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function runGuard(files: Record<string, string>): {
+  code: number;
+  output: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'z-layers-'));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(join(dir, name), content);
+    }
+    const result = Bun.spawnSync({
+      cmd: ['bun', 'run', 'scripts/check-z-layers.ts', dir],
+      cwd: process.cwd(),
+    });
+    return {
+      code: result.exitCode ?? 1,
+      output:
+        new TextDecoder().decode(result.stdout) +
+        new TextDecoder().decode(result.stderr),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('check:z-layers', () => {
+  test('rejects a raw value that silently occupies a named layer', () => {
+    // 40 is --z-modal-backdrop. Declared raw, it reads as an independent
+    // choice while actually tying with the scrim.
+    const { code, output } = runGuard({
+      'fixture.css': '.panel {\n  position: absolute;\n  z-index: 40;\n}\n',
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('z-index: 40');
+  });
+
+  test('rejects a raw value inside an inline style built in TypeScript', () => {
+    const { code, output } = runGuard({
+      'overlay.ts':
+        "const overlay = document.createElement('div');\n" +
+        "overlay.style.cssText = ['position:fixed', 'z-index:80'].join(';');\n",
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('z-index:80');
+  });
+
+  test('accepts a token', () => {
+    const { code } = runGuard({
+      'fixture.css': '.panel {\n  z-index: var(--z-lab-panel);\n}\n',
+    });
+    expect(code).toBe(0);
+  });
+
+  test('accepts a token arithmetic offset', () => {
+    // Dragging lifts the panel one step without leaving the scale.
+    const { code } = runGuard({
+      'fixture.css':
+        '.panel[data-dragging="true"] {\n  z-index: calc(var(--z-lab-panel) + 1);\n}\n',
+    });
+    expect(code).toBe(0);
+  });
+
+  test('allows low literals, which order siblings rather than layers', () => {
+    // The point of the floor: `z-index: 1` lifting an image over its own tile
+    // makes no claim about the app. Forcing a global token here is what
+    // produced the misleading var(--z-stage-root) inside a browse panel.
+    const { code } = runGuard({
+      'fixture.css':
+        '.image {\n  z-index: 1;\n}\n.hint {\n  z-index: 2;\n}\n.under {\n  z-index: -1;\n}\n',
+    });
+    expect(code).toBe(0);
+  });
+
+  test('ignores z-index mentioned in prose', () => {
+    const { code } = runGuard({
+      'fixture.css':
+        '/* This used to be z-index: 40 before the token existed. */\n.panel {\n  color: red;\n}\n',
+    });
+    expect(code).toBe(0);
+  });
+
+  test('the repository itself passes', () => {
+    const result = Bun.spawnSync({
+      cmd: ['bun', 'run', 'scripts/check-z-layers.ts'],
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`tokens.css` declares a semantic layer scale, and about half the app opted out of it — **18 raw `z-index` values against 14 token uses**, with 12 of the 26 tokens unused. A raw number makes a claim about what sits above what privately, and privately made claims collide.

One already had.

### The collision

`StrudelLabPanel` declared `z-index: 40` — which is exactly `--z-modal-backdrop`. Measured in the live DOM with the settings panel open:

| element | z-index | rect |
|---|---|---|
| settings panel | 45 | 800,0 560×900 |
| **Strudel lab panel** | **40** | 984,94 360×542 |
| **modal backdrop** | **40** | 0,0 1360×900 |

A dialog's dimming scrim and a floating tool panel occupied one layer, overlapping, so paint order fell to whichever came last in the DOM. It rendered correctly only by accident. `.reopenButton` — an actual control — sat there too.

The lab now uses `--z-lab-panel` (26): above the dock so stage chrome can't bury a tool being dragged, below toasts and modals so a notice or dialog still wins. Dragging is `calc(var(--z-lab-panel) + 1)` rather than a second magic number. Verified after: **26 / 40 / 45**.

### The other three

**Skip link** sat at `--z-dropdown` (20), under the dock (25) and toast stack (30) — both confirmed above it in the live DOM. It never actually bit, because it's top-left and those are bottom-anchored, but it's the first control a keyboard user reaches and nothing should be able to cover it. Now `--z-skip-link` (2200).

**`--z-audio-match` had exactly one consumer** — and it wasn't the audio-match toast. That component lives in the toast stack at `--z-toast`; the token was being used by the generic workspace toast. Renamed to `--z-toast-floating`. Same layer, no behaviour change.

**Stage tokens inside panels.** The preset tile's image and placeholder, and the landing page's `.library`, read `var(--z-stage-root)` while sitting in browse-panel content — claiming kinship with the stage from inside a sheet. They only ever needed to clear their own container, so they now say `z-index: 1`. `--z-stage-root` *is* 1, so rendering is identical; the token was the misleading part.

Plus tokens for the embed badge (raw 12) and the promote-transition overlay (which built `z-index:80` into an inline style string in TypeScript), and the editor's jump popover dropped from 30 — the global toast layer, which it isn't — to 6, alongside its own menu (5) and proposal (4).

### The guard

`check:z-layers` keeps the scale from eroding again: **at or above `--z-nav` (10) a value must name its layer.** Below that a literal is fine and usually better — a `z-index: 1` lifting an image over its own tile makes no claim about the app, and forcing a global token there is exactly how the misleading `var(--z-stage-root)` uses got written.

It scans `.ts`/`.tsx` as well as `.css` deliberately: the promote overlay is why a CSS-only guard would have missed half the problem.

## Testing

- `bun run check` — **passes, exit 0** (full gate including the test suite; 2884 tests).
- `tests/unit/check-z-layers.test.ts` (new, 7 tests) runs the real script against fixtures: rejects a raw 40 and a TypeScript inline `z-index:80`, accepts tokens and `calc()` offsets, allows low literals, ignores z-index in prose, and asserts the repo itself passes.
- Guard verified against the actual defect by reintroducing it: restoring `z-index: 40` in `StrudelLabPanel.module.css` and `'z-index:80'` in `promote-transition.ts` each failed the check; restoring the fixes passed.
- Browser-verified before and after across launch / browse / settings / editor / shortcuts / record / generate, including a live-DOM sweep that walks each positioned element to its nearest stacking-context ancestor.
- `docs/GUARDRAILS.md` regenerated (`check:guardrails-doc` clean) — 31 guards documented.

## Docs touched

`docs/GUARDRAILS.md`, regenerated from the new script's docblock. Reasoning otherwise sits in `tokens.css` next to each new token, saying what it sits between and what it replaced.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed — none touched; the changes are declarative layer values
- [x] Existing shared helper/module checked before introducing duplicate logic — the guard follows `check-css-scale.ts`, the closest analogue, including its fixture-driven test shape
- [x] New visual literals use existing design tokens — that is the whole change; the two remaining literals are deliberately local and documented
- [x] Behavior change is covered by tests

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [ ] `bun run build` — not run; no build-affecting change (CSS values, one inline style string, and a check script)

---

Worth flagging: three of the four findings were latent rather than broken — the skip link and the two token-naming issues render the same today. The Strudel/backdrop tie is the one that could actually have bitten, and even that was rendering correctly by DOM-order luck. So this is mostly buying back the scale's meaning and stopping the next collision, not fixing visible breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR)_