### PR TITLE
Catch camel-case z-index declarations in check:z-layers

### DIFF
--- a/scripts/check-z-layers.ts
+++ b/scripts/check-z-layers.ts
@@ -68,8 +68,15 @@ function walk(dir: string): string[] {
   return out;
 }
 
-/** Matches both `z-index: 40;` in CSS and `'z-index:80'` in an inline style. */
-const Z_INDEX = /z-index\s*:\s*([^;'"`,}\n]+)/g;
+/**
+ * Every spelling a layer gets declared in: `z-index: 40` in CSS and in inline
+ * style strings, `zIndex: 40` in a JSX style prop or style object, and
+ * `el.style.zIndex = '80'` imperatively. The first version of this matched
+ * only the hyphenated form, so the camel-case ones — the normal way to do it
+ * in a component — passed straight through a guard that advertised scanning
+ * .ts/.tsx.
+ */
+const Z_INDEX = /\bz-?index\s*[:=]\s*([^;,}\n]+)/gi;
 
 const offences: Offence[] = [];
 
@@ -82,7 +89,11 @@ for (const root of ROOTS) {
       Z_INDEX.lastIndex = 0;
       let match: RegExpExecArray | null = Z_INDEX.exec(line);
       while (match !== null) {
-        const raw = match[1].trim();
+        // `zIndex: '80'` and `z-index: 80` should read the same.
+        const raw = match[1]
+          .trim()
+          .replace(/^['"`]|['"`]$/g, '')
+          .trim();
         if (!raw.includes('var(--z-')) {
           const value = Number.parseInt(raw, 10);
           if (

--- a/scripts/check-z-layers.ts
+++ b/scripts/check-z-layers.ts
@@ -78,6 +78,21 @@ function walk(dir: string): string[] {
  */
 const Z_INDEX = /\bz-?index\s*[:=]\s*([^;,}\n]+)/gi;
 
+/**
+ * The layer a declaration actually resolves to, or NaN if it is not a number.
+ *
+ * Both halves are load-bearing. `Number` is first because `parseInt(_, 10)`
+ * reads the JavaScript literal forms wrong rather than rejecting them —
+ * `1e3` comes back 1 and `0x28` comes back 0, so `zIndex: 1e3` would sail
+ * under a floor it is two orders of magnitude above. `parseInt` is the
+ * fallback because `Number` rejects a trailing qualifier outright, and
+ * `z-index: 40 !important` is still a 40.
+ */
+function resolveLayer(raw: string): number {
+  const exact = Number(raw);
+  return Number.isFinite(exact) ? exact : Number.parseInt(raw, 10);
+}
+
 const offences: Offence[] = [];
 
 for (const root of ROOTS) {
@@ -95,7 +110,7 @@ for (const root of ROOTS) {
           .replace(/^['"`]|['"`]$/g, '')
           .trim();
         if (!raw.includes('var(--z-')) {
-          const value = Number.parseInt(raw, 10);
+          const value = resolveLayer(raw);
           if (
             !Number.isNaN(value) &&
             Math.abs(value) >= GLOBAL_SCALE_FLOOR &&

--- a/tests/unit/check-z-layers.test.ts
+++ b/tests/unit/check-z-layers.test.ts
@@ -100,6 +100,29 @@ describe('check:z-layers', () => {
     expect(code).toBe(0);
   });
 
+  // Also Codex, on the follow-up: parseInt(_, 10) misreads JavaScript numeric
+  // literals rather than rejecting them, so `1e3` came back 1 and `0x28` came
+  // back 0 — both sailing under a floor they are well above.
+  test('resolves exponential and hexadecimal literals before the floor', () => {
+    const { code, output } = runGuard({
+      'x.ts':
+        'export const a = { zIndex: 1e3 };\nexport const b = { zIndex: 0x28 };\n',
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('1e3');
+    expect(output).toContain('0x28');
+  });
+
+  test('still reads a value carrying a trailing qualifier', () => {
+    // The reason resolveLayer falls back to parseInt: Number('40 !important')
+    // is NaN, and dropping to Number alone would have lost this.
+    const { code, output } = runGuard({
+      'y.css': '.a {\n  z-index: 40 !important;\n}\n',
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('40 !important');
+  });
+
   test('accepts a token', () => {
     const { code } = runGuard({
       'fixture.css': '.panel {\n  z-index: var(--z-lab-panel);\n}\n',

--- a/tests/unit/check-z-layers.test.ts
+++ b/tests/unit/check-z-layers.test.ts
@@ -62,6 +62,44 @@ describe('check:z-layers', () => {
     expect(output).toContain('z-index:80');
   });
 
+  // Codex caught this on review: the first version matched only the
+  // hyphenated `z-index:` spelling, so the normal ways to set a layer from a
+  // component went straight through a guard that advertised scanning .tsx.
+  test('rejects a raw value in a JSX style prop', () => {
+    const { code, output } = runGuard({
+      'Comp.tsx':
+        'export function Comp() {\n' +
+        "  return <div style={{ position: 'fixed', zIndex: 40 }} />;\n" +
+        '}\n',
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('zIndex: 40');
+  });
+
+  test('rejects a raw value assigned to element.style.zIndex', () => {
+    const { code, output } = runGuard({
+      'imperative.ts':
+        "const el = document.createElement('div');\nel.style.zIndex = '80';\n",
+    });
+    expect(code).toBe(1);
+    expect(output).toContain('zIndex');
+  });
+
+  test('accepts a token in camel-case form too', () => {
+    const { code } = runGuard({
+      'Comp.tsx':
+        "const style = { zIndex: 'var(--z-lab-panel)' };\nexport default style;\n",
+    });
+    expect(code).toBe(0);
+  });
+
+  test('a zIndex type annotation is not a declaration', () => {
+    const { code } = runGuard({
+      'types.ts': 'export type Props = {\n  zIndex?: number;\n};\n',
+    });
+    expect(code).toBe(0);
+  });
+
   test('accepts a token', () => {
     const { code } = runGuard({
       'fixture.css': '.panel {\n  z-index: var(--z-lab-panel);\n}\n',


### PR DESCRIPTION
## Summary

Follow-up to #1180. That PR squash-merged as `dd50127`, which took only its **first** commit — the guard fix pushed to the same branch a minute before the merge did not land. Main got the layer fixes but kept the original `check:z-layers` regex, 7 tests, and the hole still open. This re-applies it on top of main, plus a second hole found in review here.

### Hole 1 — camel-case declarations (found on #1180)

The guard's docblock says scanning `.ts`/`.tsx` is deliberate, citing the promote overlay's `'z-index:80'` inside an inline style string. But the pattern only matched the hyphenated CSS spelling, so the two normal ways a component sets a layer went straight through it:

```tsx
<div style={{ zIndex: 40 }} />
el.style.zIndex = '80';
```

Both are exactly how the StrudelLabPanel/modal-backdrop collision that motivated the guard would be reintroduced. Verified before fixing: a fixture containing each exited 0 against main's version.

The pattern now covers `z-index:`, `zIndex:` and `.style.zIndex =`, and strips quotes so `zIndex: '80'` reads the same as `z-index: 80`.

### Hole 2 — numeric literals (found on this PR)

`Number.parseInt(raw, 10)` does not *reject* JavaScript's numeric literal forms, it **misreads** them:

```
parseInt('1e3', 10)  → 1     (actual: 1000)
parseInt('0x28', 10) → 0     (actual: 40)
```

So `zIndex: 1e3` declared layer 1000 and the guard measured it as 1. And `0x28` is exactly the 40 that tied with `--z-modal-backdrop` and started this whole thread. Verified before fixing: a fixture with both exited 0.

`resolveLayer` now tries `Number` first, which reads both correctly, and falls back to `parseInt`. **The fallback is load-bearing in the other direction** — `Number('40 !important')` is `NaN`, so switching to `Number` alone would have *stopped* catching a qualified declaration `parseInt` handled fine. Both directions have fixtures.

**No repository code changes in either fix.** There were no camel-case or exotic-literal z-index declarations to fix; only the check that claimed to cover them.

Some fixtures guard against over-matching rather than under-matching: a camel-case token (`zIndex: 'var(--z-lab-panel)'`) must still pass, and `zIndex?: number` is a type annotation rather than a declaration — its value resolves to NaN, and a fixture keeps it that way.

## Testing

- `bun run check -- --no-tests` — all static checks pass, exit 0, on top of current main.
- `bun test tests/unit/check-z-layers.test.ts` — **13 pass, 0 fail** (main has 7).
- `unit` profile — 2804 pass, 0 fail.
- Both gaps confirmed closed against live fixtures: `style={{ zIndex: 40 }}`, `zIndex: 1e3` and `zIndex: 0x28` each exit 1 where they exited 0 before; `z-index: 40 !important` still exits 1.
- `bun run check:z-layers` against the repo — clean, so neither the wider pattern nor the wider parsing produces false positives on real source.
- CI green on both heads (runs 4026 and 4027), including the Quality gate job that runs the guard over all of `src/`.

Not run to completion: the full local `bun run check`. It fails on `tests/corpus/preset-flash-risk.test.ts` under full-suite load in this sandbox — but that reproduces identically on `d4fe1bc`, a commit CI already proved green, which I confirmed by stashing back to it. The test passes standalone here. This diff touches only a check script and its test.

## Docs touched

None. `docs/GUARDRAILS.md` is generated from the script's summary line, which is unchanged.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic — `resolveLayer` returns NaN for non-numeric captures, which is what keeps type annotations and `var()` values passing
- [x] Async/lifecycle state transitions reviewed — n/a, synchronous check script
- [x] Existing shared helper/module checked before introducing duplicate logic — same script, widened pattern and parsing
- [x] New visual literals use existing design tokens — n/a
- [x] Behavior change is covered by tests — six new fixtures, including two for cases that must keep passing

## Quality checklist

- [x] `bun run check:quick`
- [ ] `bun run check` — static half green; the one test failure is the pre-existing sandbox issue described above, reproduced on a known-green commit
- [ ] `bun run build` — not run; a check script and its test, nothing in the bundle

---

Two notes for the merge:

**Squash carefully.** This branch has two commits. #1180 squashed only its first and silently dropped the second — CI still reported green, because it had run on the earlier head. That is the reason this PR exists.

**Three review rounds, three holes, all in the guard rather than the fixes.** The z-index changes in #1180 were right the first time; what kept being wrong was the check meant to protect them. Worth weighing whether a guard this fiddly to get right earns its place, or whether the token scale is better enforced some other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CumbQsUSHhVm4Aw4TaZQsR