### PR TITLE
feat(stage): name the audio state, add Nearby, surface the preset lock

### DIFF
--- a/functions/api/visual-search.ts
+++ b/functions/api/visual-search.ts
@@ -1,3 +1,7 @@
+import {
+  clampVisualSearchResults,
+  DEFAULT_VISUAL_SEARCH_RESULTS,
+} from '../../src/js/core/edge-contracts.ts';
 import { enforceAiRateLimit } from './_ai-guard.ts';
 
 interface Env {
@@ -81,11 +85,18 @@ export async function onRequest(context: { request: Request; env: Env }) {
     const body = (await request.json()) as {
       description: string;
       embedOnly?: boolean;
+      topK?: number;
     };
 
     if (!body.description || body.description.length < 3) {
       return new Response('Description too short', { status: 400 });
     }
+
+    // Clamped here, not trusted: this endpoint is public and Vectorize
+    // charges per queried vector.
+    const resultCount = clampVisualSearchResults(
+      body.topK ?? DEFAULT_VISUAL_SEARCH_RESULTS,
+    );
 
     let queryEmbedding: number[] = [];
 
@@ -117,7 +128,7 @@ export async function onRequest(context: { request: Request; env: Env }) {
     if (env.VECTOR_INDEX) {
       try {
         const vResult = await env.VECTOR_INDEX.query(queryEmbedding, {
-          topK: 5,
+          topK: resultCount,
           // Long preset slugs are stored under hashed vector ids; the real
           // preset id lives in metadata (see src/js/milkdrop/vectorize-id.ts).
           returnMetadata: 'all',
@@ -173,12 +184,15 @@ export async function onRequest(context: { request: Request; env: Env }) {
 
     scored.sort((a, b) => b.score - a.score);
 
-    return new Response(JSON.stringify({ results: scored.slice(0, 5) }), {
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
+    return new Response(
+      JSON.stringify({ results: scored.slice(0, resultCount) }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
       },
-    });
+    );
   } catch (error) {
     return new Response(
       JSON.stringify({

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -9,7 +9,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const TEST_DIR = path.resolve('tests');
-const TEST_FILE_PATTERN = /\.test\.(?:ts|js)$/;
+// React component tests are `.test.tsx`. Matching only ts/js silently
+// excluded 13 unit files from every profile — they ran only when a developer
+// pointed `bun test` at them by hand, so a guard could rot for a month and the
+// gate stayed green. Mirrors bun test's own default extension set.
+const TEST_FILE_PATTERN = /\.test\.(?:ts|tsx|js|jsx)$/;
 
 /**
  * Test categories are defined by the folder a test lives in, not by a
@@ -51,7 +55,7 @@ const PROFILES: Record<string, Category[]> = {
 
 async function listTestFiles(dir: string): Promise<string[]> {
   try {
-    const glob = new Bun.Glob('**/*.test.{ts,js}');
+    const glob = new Bun.Glob('**/*.test.{ts,tsx,js,jsx}');
     const files: string[] = [];
     const relDir = path.relative(process.cwd(), dir);
     for await (const file of glob.scan({ cwd: dir })) {

--- a/src/css/AudioStatusControl.module.css
+++ b/src/css/AudioStatusControl.module.css
@@ -1,0 +1,229 @@
+/* Audio status control — the dock's "is this thing on?" affordance.
+   Same opaque-panel language as the stage menu: no decorative gradients,
+   cool accent for a live/selected state, warm reserved for focus. */
+
+.wrap {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  margin: 0 4px 0 6px;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0 8px;
+  border: none;
+  border-radius: var(--radius-round);
+  background: transparent;
+  color: var(--ctl-ink-2);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.trigger:hover {
+  color: var(--ctl-ink);
+  background: var(--ctl-fill-hover);
+}
+
+.trigger:active {
+  transform: scale(0.94);
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--stims-accent);
+  outline-offset: 1px;
+}
+
+.trigger[aria-expanded="true"] {
+  color: var(--stims-cool, #77c9ff);
+  background: var(--ctl-accent-dim);
+}
+
+/* Signal arriving: the cool accent, matching every other "this is on and
+   selected" state in the chrome. */
+.trigger[data-signal="live"] {
+  color: var(--stims-cool, #77c9ff);
+}
+
+/* Connected and silent is the one state worth a warning colour — it is the
+   only one where something the visitor chose is not doing what they expect. */
+.trigger[data-signal="silent"],
+.trigger[data-signal="awaiting-gesture"] {
+  color: var(--stims-warm, #f47a54);
+}
+
+/* ── Meter ───────────────────────────────────────────────────────────
+   The old dock energy bar, kept at its original 6x22 footprint and
+   behaviour so the dock's audio-reactive signature does not change; what
+   is new is that it now sits inside something with a name. */
+.meter {
+  position: relative;
+  flex-shrink: 0;
+  width: 4px;
+  height: 20px;
+  border-radius: var(--radius-hairline);
+  background: var(--ctl-line, rgba(255, 255, 255, 0.09));
+  overflow: hidden;
+}
+
+.meterFill {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 100%;
+  border-radius: inherit;
+  background: currentColor;
+  transform-origin: 50% 100%;
+  transform: scaleY(calc(0.08 + var(--meter, 0) * 0.92));
+  opacity: calc(0.5 + var(--meter, 0) * 0.5);
+  transition:
+    transform 0.1s ease,
+    opacity 0.1s ease;
+}
+
+/* Nothing is running, so the meter must not imply a floor of signal. */
+.trigger[data-signal="off"] .meterFill {
+  transform: scaleY(0.08);
+  opacity: 0.35;
+}
+
+.label {
+  white-space: nowrap;
+}
+
+/* ── Popover ─────────────────────────────────────────────────────────
+   Anchored to the control rather than the dock corner: this one is about
+   the button you just pressed, unlike the overflow menu which is about the
+   whole session. */
+/* Left-aligned to the control, not centred on it. Centring put 87px of the
+   panel past the left edge of a 375px viewport — and the dock is fixed, so
+   nothing scrolls to reach it: the source list was simply unreachable on a
+   phone. The control sits at the left end of the pill, so aligning the two
+   left edges keeps the panel on screen at every width the dock supports. */
+.popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: var(--z-dock);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: max-content;
+  min-width: 200px;
+  max-width: min(280px, calc(100vw - 24px));
+  padding: 6px;
+  border-radius: var(--radius-lg);
+  background: var(--ctl-panel-bg, rgba(10, 14, 22, 0.97));
+  border: 1px solid var(--ctl-line, rgba(255, 255, 255, 0.09));
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+  animation: audio-status-in 0.16s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+@keyframes audio-status-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover {
+    animation: none;
+  }
+
+  .meterFill {
+    transition: none;
+  }
+}
+
+.detail {
+  margin: 0;
+  padding: 6px 8px 8px;
+  color: var(--ctl-ink-2);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.nextStep {
+  display: block;
+  margin-top: 4px;
+  color: var(--stims-warm, #f47a54);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-bottom: 2px;
+  margin-bottom: 2px;
+  border-bottom: 1px solid var(--ctl-line, rgba(255, 255, 255, 0.09));
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--ctl-ink-2);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.item:hover {
+  background: var(--ctl-fill-hover);
+  color: var(--ctl-ink);
+}
+
+.item:focus-visible {
+  outline: 2px solid var(--stims-accent);
+  outline-offset: -2px;
+}
+
+/* Same triple-encoded active state the stage menu uses — accent, inset lit
+   edge, and a check glyph — so it never rests on colour alone. */
+.item[data-active="true"] {
+  color: var(--stims-cool, #77c9ff);
+  background: var(--ctl-accent-dim);
+  box-shadow: inset 2px 0 0 var(--stims-cool, #77c9ff);
+}
+
+.item[data-active="true"]::after {
+  content: "✓" / "";
+  margin-left: auto;
+  font-weight: 700;
+}
+
+/* The dock is tight on phones; the source label carries the state there and
+   the meter alone would be ambiguous, so the word stays and the icon goes. */
+@media (max-width: 480px) {
+  .trigger {
+    padding: 0 6px;
+    gap: 4px;
+  }
+
+  .trigger > :global(.stims-icon-slot) {
+    display: none;
+  }
+}

--- a/src/css/StageControls.module.css
+++ b/src/css/StageControls.module.css
@@ -1,24 +1,3 @@
-/* Audio level meter. Widened from a 4px hairline: it is the bar's only
-   readout that the sound is actually reaching the visuals, which is the first
-   thing anyone checks when a preset looks inert, and at 4px it read as a
-   rendering artifact rather than a meter. */
-.energyBar {
-  flex-shrink: 0;
-  width: 6px;
-  height: 22px;
-  margin: 0 6px 0 10px;
-  border-radius: var(--radius-hairline);
-  background: var(--stims-cool, #77c9ff);
-  transform-origin: 50% 100%;
-  transform: scaleY(calc(0.3 + var(--energy, 0) * 0.7));
-  opacity: calc(0.55 + var(--energy, 0) * 0.45);
-  box-shadow: 0 0 12px rgba(119, 201, 255, calc(var(--energy, 0) * 0.95));
-  transition:
-    transform 0.1s ease,
-    opacity 0.1s ease,
-    box-shadow 0.1s ease;
-}
-
 .bar {
   position: fixed;
   bottom: 0;

--- a/src/js/core/accessibility-preferences.ts
+++ b/src/js/core/accessibility-preferences.ts
@@ -11,7 +11,25 @@ export type AccessibilityPreference = {
    * switch before the catalog stops handing them strobing presets.
    */
   reduceFlashing: boolean;
+  /**
+   * A ceiling on stage brightness, 0.3–1.
+   *
+   * A real limit, not a hint: it is applied as a CSS filter over the
+   * presented canvas, so it holds for every preset on either backend and
+   * cannot be undone by preset code. It composes with the flash governor's
+   * own clamp (see `stage-luminance.ts`) — whichever is darker wins, because
+   * they multiply.
+   */
+  stageBrightness: number;
 };
+
+/** Below this the stage is effectively black, which is not a comfort setting. */
+export const MIN_STAGE_BRIGHTNESS = 0.3;
+
+export function clampStageBrightness(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 1;
+  return Math.min(1, Math.max(MIN_STAGE_BRIGHTNESS, value));
+}
 
 type AccessibilitySubscriber = (preference: AccessibilityPreference) => void;
 
@@ -64,6 +82,7 @@ function readFromStorage(): AccessibilityPreference {
       highContrast: prefersMoreContrast(),
       freezeFrame: false,
       reduceFlashing: prefersReducedMotion(),
+      stageBrightness: 1,
     };
   }
   try {
@@ -78,6 +97,7 @@ function readFromStorage(): AccessibilityPreference {
         typeof parsed.reduceFlashing === 'boolean'
           ? parsed.reduceFlashing
           : prefersReducedMotion(),
+      stageBrightness: clampStageBrightness(parsed.stageBrightness),
     };
   } catch {
     return {
@@ -85,6 +105,7 @@ function readFromStorage(): AccessibilityPreference {
       highContrast: prefersMoreContrast(),
       freezeFrame: false,
       reduceFlashing: prefersReducedMotion(),
+      stageBrightness: 1,
     };
   }
 }

--- a/src/js/core/edge-contracts.ts
+++ b/src/js/core/edge-contracts.ts
@@ -79,7 +79,35 @@ export type VisualSearchRequest = {
   description: string;
   /** Returns the raw query embedding instead of running the vector search. */
   embedOnly?: boolean;
+  /**
+   * How many matches to return, 1–{@link MAX_VISUAL_SEARCH_RESULTS}.
+   *
+   * The finder panel shows a short list and wants the default. "Nearby"
+   * wants a deep one: it plays the best match that is not among the
+   * recently-played, so its usable supply is the result count minus the
+   * recency window — measured on the deployed index, a fixed five ran out
+   * after four presses.
+   */
+  topK?: number;
 };
+
+/** Default result count: the size of the finder panel's list. */
+export const DEFAULT_VISUAL_SEARCH_RESULTS = 5;
+
+/**
+ * Ceiling on requested matches. Vectorize charges per queried vector and the
+ * endpoint is rate-limited but public, so the count is clamped server-side
+ * rather than trusted from the client.
+ */
+export const MAX_VISUAL_SEARCH_RESULTS = 30;
+
+/** Clamps a requested count onto the supported range. */
+export function clampVisualSearchResults(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_VISUAL_SEARCH_RESULTS;
+  }
+  return Math.min(MAX_VISUAL_SEARCH_RESULTS, Math.max(1, Math.floor(value)));
+}
 
 export const VisualSearchRequestSchema = contractSchema<VisualSearchRequest>(
   (input) => {
@@ -90,9 +118,15 @@ export const VisualSearchRequestSchema = contractSchema<VisualSearchRequest>(
     if (input.embedOnly !== undefined && !isBoolean(input.embedOnly)) {
       return null;
     }
+    if (input.topK !== undefined && typeof input.topK !== 'number') {
+      return null;
+    }
     const result: VisualSearchRequest = { description: input.description };
     if (input.embedOnly !== undefined) {
       result.embedOnly = input.embedOnly;
+    }
+    if (input.topK !== undefined) {
+      result.topK = clampVisualSearchResults(input.topK);
     }
     return result;
   },

--- a/src/js/core/preset-lock.ts
+++ b/src/js/core/preset-lock.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether the visitor has asked to stay on the preset they are watching.
+ *
+ * The behaviour has shipped for as long as the MilkDrop keybindings have:
+ * `L` toggles it, and the runtime gates autoplay on it. What it never had
+ * was a way for the React shell to see it. The flag lived as a closure
+ * variable inside the runtime's interaction presenter, so the only route to
+ * it was a keystroke on a document handler — no button, no palette entry,
+ * and nothing in the chrome that could show it was on. Someone who settled
+ * into a preset and did not want it taken away had to know a letter.
+ *
+ * A module store rather than a value threaded through the engine adapter,
+ * for the same reason `audio-gesture-gate.ts` is one: both the runtime and
+ * the UI need it, neither owns the other, and the alternative is a prop
+ * drilled through every layer between them.
+ *
+ * Deliberately not persisted, unlike `live-performance-mode.ts`. Locking is
+ * about *this* preset in *this* sitting; restoring it on the next visit
+ * would silently disable autoplay for someone with no memory of asking.
+ */
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let locked = false;
+
+/** True while auto-advance is being held off by the visitor's request. */
+export function isPresetLocked(): boolean {
+  return locked;
+}
+
+export function subscribePresetLock(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function setPresetLocked(next: boolean): void {
+  if (next === locked) {
+    return;
+  }
+  locked = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Flips the lock and reports the new state, for callers that announce it. */
+export function togglePresetLock(): boolean {
+  setPresetLocked(!locked);
+  return locked;
+}
+
+/** Test seam: drop subscribers and the latched value between cases. */
+export function resetPresetLock(): void {
+  listeners.clear();
+  locked = false;
+}

--- a/src/js/core/services/flash-safety.ts
+++ b/src/js/core/services/flash-safety.ts
@@ -34,6 +34,7 @@ import {
   type FlashGovernorDecision,
 } from './flash-governor.ts';
 import { createFlashSampler, type FlashSampler } from './flash-sampler.ts';
+import { setStageLuminanceChannel } from './stage-luminance.ts';
 
 export type FlashSafetyOptions = {
   /** The presented canvas to observe. */
@@ -177,6 +178,10 @@ export function createFlashSafetyController(
  * The DOM half: applies a luminance scale to a stage element as a CSS
  * brightness filter.
  *
+ * Writes through `stage-luminance.ts` rather than touching `style.filter`
+ * directly: the visitor's comfort ceiling shares that one property, and this
+ * loop would overwrite it every frame.
+ *
  * Composited by the browser, so it costs nothing per frame and works
  * identically over a WebGL or a WebGPU canvas. CSS brightness multiplies
  * sRGB-encoded values rather than linear light, so the actual luminance
@@ -186,7 +191,6 @@ export function createFlashSafetyController(
  */
 export function createStageLuminanceApplier(stage: HTMLElement) {
   return (scale: number) => {
-    stage.style.filter =
-      scale >= 0.999 ? '' : `brightness(${scale.toFixed(3)})`;
+    setStageLuminanceChannel(stage, 'governor', scale);
   };
 }

--- a/src/js/core/services/stage-luminance.ts
+++ b/src/js/core/services/stage-luminance.ts
@@ -1,0 +1,61 @@
+/**
+ * The single owner of the stage's CSS brightness filter.
+ *
+ * Two things want to dim the stage, for unrelated reasons: the WCAG flash
+ * governor clamps it reactively when content strobes, and the visitor sets a
+ * comfort ceiling they expect to hold. Both used to be expressible only as
+ * `stage.style.filter = 'brightness(...)'`, which is one slot — and the
+ * governor writes it on a rAF loop, so a user ceiling written the same way
+ * would be overwritten within a frame and appear to do nothing.
+ *
+ * So the property has an owner. Callers set their own channel; this composes
+ * them and writes once. Multiplying is the right composition for the two
+ * meanings involved: the governor's clamp is "at most this much of what you
+ * asked for", and the ceiling is what was asked for.
+ */
+
+export type StageLuminanceChannel = 'governor' | 'ceiling';
+
+type Channels = { governor: number; ceiling: number };
+
+const channelsByStage = new WeakMap<HTMLElement, Channels>();
+
+function channelsFor(stage: HTMLElement): Channels {
+  let channels = channelsByStage.get(stage);
+  if (!channels) {
+    channels = { governor: 1, ceiling: 1 };
+    channelsByStage.set(stage, channels);
+  }
+  return channels;
+}
+
+/** The composed scale currently applied to a stage. Exported for tests. */
+export function stageLuminanceScale(stage: HTMLElement): number {
+  const { governor, ceiling } = channelsFor(stage);
+  return governor * ceiling;
+}
+
+export function setStageLuminanceChannel(
+  stage: HTMLElement,
+  channel: StageLuminanceChannel,
+  scale: number,
+): void {
+  const channels = channelsFor(stage);
+  const next = Number.isFinite(scale) ? Math.min(1, Math.max(0, scale)) : 1;
+  if (channels[channel] === next) return;
+  channels[channel] = next;
+
+  const composed = channels.governor * channels.ceiling;
+  // Clearing rather than writing brightness(1) keeps the stage off the
+  // filter path entirely in the overwhelmingly common case where neither
+  // channel is engaged — a filter, even an identity one, forces a
+  // compositing layer the renderer does not otherwise need.
+  stage.style.filter =
+    composed >= 0.999 ? '' : `brightness(${composed.toFixed(3)})`;
+}
+
+/** Test seam: forget a stage's channels between cases. */
+export function resetStageLuminance(stage: HTMLElement): void {
+  channelsByStage.delete(stage);
+  stage.style.filter = '';
+}

--- a/src/js/core/services/visual-embedding.ts
+++ b/src/js/core/services/visual-embedding.ts
@@ -228,6 +228,12 @@ export function describeFrame(stats: FrameStats): string {
 export async function searchByFrame(
   canvas: HTMLCanvasElement,
   signal?: AbortSignal,
+  /**
+   * How many matches to ask for. The finder's list wants the endpoint
+   * default; a caller that filters the results before using them (see
+   * `playNearbyPreset`) needs a deeper list than it intends to show.
+   */
+  topK?: number,
 ): Promise<Array<{ presetId: string; score: number }>> {
   const endpoint = resolveOptionalApiUrl('/api/visual-search');
   if (!endpoint) {
@@ -238,6 +244,9 @@ export async function searchByFrame(
   const description = describeFrame(stats);
 
   const request: VisualSearchRequest = { description };
+  if (topK !== undefined) {
+    request.topK = topK;
+  }
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -98,6 +98,7 @@ const NewHomePage = lazy(() =>
   })),
 );
 
+import { togglePresetLock } from '../core/preset-lock.ts';
 import { bindMidiToMilkdropControls } from './performance-hardware-controls.ts';
 import { ShortcutsDialog } from './ShortcutsDialog.tsx';
 import { SyncSessionBridge } from './SyncSessionBridge.tsx';
@@ -108,6 +109,7 @@ import { connectWakeLock } from './wake-lock.ts';
 import {
   endWatchParty,
   openRecordPanel,
+  playNearbyPreset,
   presentToExternalDisplayAction,
   setTransition,
   startAudioSource,
@@ -121,7 +123,7 @@ import {
   useWorkspace,
   WorkspaceProvider,
 } from './workspace-context.tsx';
-import { getToolLabel } from './workspace-helpers.ts';
+import { getToolLabel, recentlyOpenedPresetIds } from './workspace-helpers.ts';
 import {
   BROWSE_PANEL_FOCUS_SELECTOR,
   WorkspaceStagePanel,
@@ -531,6 +533,49 @@ function StimsWorkspaceAppShell() {
         label: 'Find similar presets',
         keywords: ['match', 'sound', 'look'],
         run: () => void engine.handleVisualSearch(),
+      },
+      {
+        // The small step next to next-preset's big one. Shares its body with
+        // the dock's Nearby button (workspace-actions.ts) so both mean the
+        // same thing.
+        id: 'nearby-preset',
+        group: 'Presets',
+        label: 'Nearby preset (looks like this one)',
+        keywords: ['similar', 'like', 'neighbour', 'neighbor'],
+        run: () =>
+          void playNearbyPreset({
+            canvas:
+              uiRef.current.stageRef.current?.querySelector('canvas') ?? null,
+            currentPresetId:
+              engineBridgeRef.current.selectedPreset?.id ??
+              engineBridgeRef.current.featuredPreset?.id ??
+              null,
+            recentPresetIds: recentlyOpenedPresetIds(
+              engineBridgeRef.current.catalog,
+            ),
+            isKnownPreset: (presetId) =>
+              engineBridgeRef.current.catalog.some(
+                (entry) => entry.id === presetId,
+              ),
+            play: (presetId) =>
+              engineBridgeRef.current.handlePresetSelection(presetId),
+            announce: uiRef.current.setStatusMessage,
+          }),
+      },
+      {
+        // Pauses auto-advance without touching the autoplay preference, so
+        // unlocking returns whatever the visitor had set. The MilkDrop
+        // keybinding layer's `L` flips the same store.
+        id: 'toggle-preset-lock',
+        group: 'Presets',
+        label: 'Stay on this preset',
+        keywords: ['lock', 'hold', 'stay', 'pin'],
+        run: () =>
+          uiRef.current.setStatusMessage(
+            togglePresetLock()
+              ? 'Staying on this preset. Auto-advance is paused.'
+              : 'Auto-advance on.',
+          ),
       },
       {
         id: 'open-editor',

--- a/src/js/frontend/AudioStatusControl.tsx
+++ b/src/js/frontend/AudioStatusControl.tsx
@@ -1,0 +1,268 @@
+/**
+ * The stage's answer to "is this thing on?".
+ *
+ * The dock has always carried an energy bar, but it was `aria-hidden`
+ * decoration: it moved with the music and said nothing about what was
+ * playing or why it had stopped moving. This is the same meter promoted
+ * into a control that names its own state and, when something is wrong,
+ * puts the fix one click away instead of three panels deep.
+ *
+ * It is deliberately not another copy of the audio setup panel. Sources that
+ * need an argument — a file to pick, a URL to paste — stay in that panel;
+ * what lives here is the mid-set subset that starts from a single click,
+ * matching the stage menu's own audio row, plus a door to the full panel.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import styles from '../../css/AudioStatusControl.module.css';
+import {
+  type AudioSignalState,
+  describeAudioSignal,
+  useAudioSignalState,
+} from './audio-signal-state.ts';
+import {
+  getAudioEnergy,
+  subscribeAudioEnergy,
+} from './engine-audio-energy-store.ts';
+import { pulseHaptic } from './haptics.ts';
+import { useListKeyboardNav } from './hooks/use-list-keyboard-nav.ts';
+import { UiIcon } from './UiIcon.tsx';
+import { startAudioSource, togglePanel } from './workspace-actions.ts';
+import { useEngineSnapshot, useWorkspace } from './workspace-context.tsx';
+
+/**
+ * Sources that start from one click. Kept in step with the stage menu's own
+ * audio row — the same three verbs, because a control that offered a
+ * different set depending on which surface you reached it from would be
+ * teaching two vocabularies for one job.
+ */
+const QUICK_SOURCES = [
+  { source: 'demo' as const, label: 'Demo track' },
+  { source: 'microphone' as const, label: 'Microphone' },
+  { source: 'tab' as const, label: 'This tab' },
+] satisfies ReadonlyArray<{
+  source: 'demo' | 'microphone' | 'tab';
+  label: string;
+}>;
+
+const SOURCE_NAMES: Record<string, string> = {
+  demo: 'Demo track',
+  microphone: 'Microphone',
+  tab: 'Tab audio',
+  file: 'Audio file',
+  youtube: 'YouTube',
+};
+
+/** Short enough for the dock at 375px, where the title already truncates. */
+const SOURCE_SHORT: Record<string, string> = {
+  demo: 'Demo',
+  microphone: 'Mic',
+  tab: 'Tab',
+  file: 'File',
+  youtube: 'YT',
+};
+
+function iconForState(state: AudioSignalState) {
+  if (state === 'off') return 'volume-off' as const;
+  if (state === 'silent') return 'warning' as const;
+  return 'pulse' as const;
+}
+
+/**
+ * What to do next, in the words of the state you are actually in. The silent
+ * case is the one that earns this control: it is the only state whose fix
+ * depends on which source is running.
+ */
+function nextStepFor(
+  state: AudioSignalState,
+  source: string | null,
+): string | null {
+  if (state !== 'silent') return null;
+  if (source === 'microphone') {
+    return 'Check the input device and that your mic is not muted.';
+  }
+  if (source === 'tab') {
+    return 'Check the shared tab is playing, and that you ticked "Share tab audio".';
+  }
+  if (source === 'youtube' || source === 'file') {
+    return 'Check playback is running and the volume is up.';
+  }
+  return 'Try another source, or check your system volume.';
+}
+
+export function AudioStatusControl() {
+  const { ui, engine } = useWorkspace();
+  const { engineSnapshot } = useEngineSnapshot();
+  const audioSource = engineSnapshot?.audioSource ?? null;
+  const state = useAudioSignalState(Boolean(audioSource));
+  const sourceName = audioSource ? (SOURCE_NAMES[audioSource] ?? null) : null;
+  const { label, detail } = describeAudioSignal(state, sourceName);
+  const nextStep = nextStepFor(state, audioSource);
+
+  const [open, setOpen] = useState(false);
+  const meterRef = useRef<HTMLSpanElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Written straight to a custom property rather than through state: this
+  // updates at audio rate, and a re-render per frame would cost the whole
+  // dock for one bar's height.
+  useEffect(() => {
+    const update = () => {
+      const energy = Math.min(1, Math.max(0, getAudioEnergy()));
+      meterRef.current?.style.setProperty('--meter', String(energy));
+    };
+    update();
+    return subscribeAudioEnergy(update);
+  }, []);
+
+  useListKeyboardNav(popoverRef, {
+    itemSelector: '[role^="menuitem"]',
+    orientation: 'vertical',
+    deps: [open],
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    popoverRef.current
+      ?.querySelector<HTMLElement>('[role^="menuitem"]')
+      ?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Element &&
+        (popoverRef.current?.contains(event.target) ||
+          buttonRef.current?.contains(event.target))
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.stopPropagation();
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const run = useCallback((fn: () => void) => {
+    pulseHaptic(10);
+    setOpen(false);
+    fn();
+    buttonRef.current?.focus();
+  }, []);
+
+  return (
+    <div className={styles.wrap}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={styles.trigger}
+        data-signal={state}
+        data-action="audio-status"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        // The visible label is a word or two; the accessible name is the
+        // whole sentence, because a screen reader user gets no help from the
+        // meter animation that carries half the meaning for everyone else.
+        aria-label={`Audio status. ${detail}${nextStep ? ` ${nextStep}` : ''}`}
+        title={detail}
+        onClick={() => {
+          pulseHaptic(10);
+          setOpen((current) => !current);
+        }}
+      >
+        <span ref={meterRef} className={styles.meter} aria-hidden="true">
+          <span className={styles.meterFill} />
+        </span>
+        <UiIcon
+          name={iconForState(state)}
+          className="stims-icon-slot stims-icon-slot--sm"
+        />
+        <span className={styles.label}>
+          {state === 'live' && audioSource
+            ? (SOURCE_SHORT[audioSource] ?? label)
+            : label}
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          ref={popoverRef}
+          className={styles.popover}
+          role="menu"
+          aria-label="Audio status and sources"
+        >
+          <p className={styles.detail}>
+            {detail}
+            {nextStep ? (
+              <span className={styles.nextStep}>{nextStep}</span>
+            ) : null}
+          </p>
+
+          {/* biome-ignore lint/a11y/useSemanticElements: role=group is the ARIA menu pattern for menuitemradio sets; fieldset carries form semantics a menu must not have */}
+          <div className={styles.group} role="group" aria-label="Audio source">
+            {QUICK_SOURCES.map((option) => (
+              <button
+                key={option.source}
+                type="button"
+                role="menuitemradio"
+                aria-checked={audioSource === option.source}
+                className={styles.item}
+                data-action={`audio-${option.source}`}
+                data-active={String(audioSource === option.source)}
+                onClick={() =>
+                  run(() => startAudioSource(engine, option.source))
+                }
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+
+          {audioSource ? (
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.item}
+              data-action="stop-audio"
+              onClick={() => run(() => engine.handleAudioStop())}
+            >
+              Stop audio
+            </button>
+          ) : null}
+
+          <button
+            type="button"
+            role="menuitem"
+            className={styles.item}
+            data-action="open-audio-setup"
+            onClick={() =>
+              run(() =>
+                togglePanel(
+                  {
+                    updatePanel: ui.updatePanel,
+                    routePanel: () => ui.routeState.panel ?? null,
+                  },
+                  'settings',
+                ),
+              )
+            }
+          >
+            Audio setup…
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/js/frontend/SettingsSheetPanel.tsx
+++ b/src/js/frontend/SettingsSheetPanel.tsx
@@ -6,7 +6,9 @@
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import {
   applyAccessibility,
+  clampStageBrightness,
   getActiveAccessibilityPreference,
+  MIN_STAGE_BRIGHTNESS,
   setAccessibilityPreference,
   type TextScale,
 } from '../core/accessibility-preferences.ts';
@@ -188,6 +190,42 @@ function AccessibilitySection({
           setAccessibilityPreference({ highContrast });
         }}
       />
+      {/* The three stage-comfort controls, gathered and labelled by what
+          they actually promise. They were previously interleaved with the
+          chrome settings above, which put a hard limit and a best-effort
+          mitigation side by side with nothing distinguishing them. */}
+      <p className="ctl-row__hint" id="comfort-note">
+        Brightness is a hard ceiling: it applies over every preset, on either
+        renderer. Reduce flashing is a mitigation, not a guarantee — it filters
+        the presets that have been measured and dims strobing as it is detected.
+      </p>
+      <div className="ctl-row">
+        <span className="ctl-row__text">
+          <label className="ctl-row__label" htmlFor="a11y-stage-brightness">
+            Stage brightness
+          </label>
+          <span className="ctl-row__hint">
+            Caps how bright the visuals can get. Carries across every preset.
+          </span>
+        </span>
+        <input
+          id="a11y-stage-brightness"
+          type="range"
+          min={MIN_STAGE_BRIGHTNESS}
+          max={1}
+          step={0.05}
+          value={prefs.stageBrightness}
+          aria-describedby="comfort-note"
+          aria-valuetext={`${Math.round(prefs.stageBrightness * 100)} percent`}
+          onChange={(event) => {
+            const stageBrightness = clampStageBrightness(
+              Number(event.target.value),
+            );
+            setPrefs((p) => ({ ...p, stageBrightness }));
+            setAccessibilityPreference({ stageBrightness });
+          }}
+        />
+      </div>
       <SwitchRow
         label="Freeze visuals"
         hint="Holds the current frame still so you can inspect it or reduce motion."

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -11,9 +11,15 @@ import {
   useSyncExternalStore,
 } from 'react';
 import styles from '../../css/StageControls.module.css';
+import {
+  isPresetLocked,
+  subscribePresetLock,
+  togglePresetLock,
+} from '../core/preset-lock.ts';
 import { splitPresetDisplay } from '../milkdrop/preset-credit.ts';
 import { describeShaderApproximation } from '../milkdrop/shader-execution-mode.ts';
 import type { UiIconName } from '../ui/icon-library.ts';
+import { AudioStatusControl } from './AudioStatusControl.tsx';
 import {
   getAudioEnergy,
   subscribeAudioEnergy,
@@ -31,6 +37,7 @@ import { UiIcon } from './UiIcon.tsx';
 import {
   endWatchParty,
   openRecordPanel,
+  playNearbyPreset,
   presentToExternalDisplayAction,
   setTransition,
   startAudioSource,
@@ -39,6 +46,7 @@ import {
   togglePanel,
 } from './workspace-actions.ts';
 import { useEngineSnapshot, useWorkspace } from './workspace-context.tsx';
+import { recentlyOpenedPresetIds } from './workspace-helpers.ts';
 
 type MenuItem = {
   icon: UiIconName;
@@ -162,6 +170,15 @@ export function StageControls({
   const syncSession = useSyncExternalStore(
     subscribeSyncSession,
     getSyncSessionState,
+  );
+
+  // Read through the store rather than local state: `L` on the MilkDrop
+  // keybinding layer toggles the same flag, and a control that only tracked
+  // its own clicks would sit there showing the wrong thing.
+  const presetLocked = useSyncExternalStore(
+    subscribePresetLock,
+    isPresetLocked,
+    () => false,
   );
   const hostingRoom =
     syncSession.role === 'host' && syncSession.status !== 'idle'
@@ -306,6 +323,33 @@ export function StageControls({
     void engine.handlePreviousPreset();
   }, [engine, signalActivity]);
 
+  // Nearby is the small step in the wandering trio: Back, Nearby, Surprise
+  // me. It reuses the visual-embedding index behind the finder's "by look"
+  // tab, so "similar" means one thing across the app.
+  const handleNearby = useCallback(() => {
+    signalActivity();
+    pulseHaptic(10);
+    void playNearbyPreset({
+      canvas: ui.stageRef.current?.querySelector('canvas') ?? null,
+      currentPresetId,
+      recentPresetIds: recentlyOpenedPresetIds(engine.catalog),
+      isKnownPreset: (presetId) =>
+        engine.catalog.some((entry) => entry.id === presetId),
+      play: (presetId) => engine.handlePresetSelection(presetId),
+      announce: ui.setStatusMessage,
+    });
+  }, [engine, ui, currentPresetId, signalActivity]);
+
+  const handleToggleLock = useCallback(() => {
+    signalActivity();
+    pulseHaptic(10);
+    ui.setStatusMessage(
+      togglePresetLock()
+        ? 'Staying on this preset. Auto-advance is paused.'
+        : 'Auto-advance on.',
+    );
+  }, [ui, signalActivity]);
+
   const handleBrowse = useCallback(() => {
     signalActivity();
     pulseHaptic(10);
@@ -371,6 +415,18 @@ export function StageControls({
       label: 'Performance controls',
       actionId: 'perform-pin',
       action: () => run(() => openPerformPicker()),
+    },
+    {
+      // The behaviour is as old as the MilkDrop keybindings and has always
+      // been reachable by pressing L; what it never had was anything on
+      // screen, so it could only be used by someone who already knew. It
+      // holds off auto-advance without touching the autoplay preference, so
+      // unlocking returns you to whatever you had set.
+      icon: 'pin' as const,
+      label: presetLocked ? 'Stop staying here' : 'Stay here',
+      actionId: 'toggle-preset-lock',
+      action: () => run(() => handleToggleLock()),
+      active: presetLocked,
     },
     {
       // Queueing is a mid-set verb — you spot something while browsing and
@@ -603,7 +659,7 @@ export function StageControls({
               }
             />
           ) : null}
-          <span className={styles.energyBar} aria-hidden="true" />
+          <AudioStatusControl />
           <button
             type="button"
             className={styles.navBtn}
@@ -616,6 +672,25 @@ export function StageControls({
           >
             <UiIcon
               name="arrow-left"
+              className="stims-icon-slot stims-icon-slot--sm"
+            />
+          </button>
+          {/* The wandering trio reads left to right as Back, Nearby,
+              Surprise me — one step back, a small step sideways, a big step
+              anywhere. Nearby is not primary: it is the considered move, and
+              giving all three the same weight would leave the bar with no
+              answer to "what do I press?" again. */}
+          <button
+            type="button"
+            className={styles.navBtn}
+            data-action="nearby-preset"
+            aria-label="Play a preset that looks like this one"
+            title={withHint('Nearby', 'nearby-preset')}
+            aria-keyshortcuts={ariaKeyShortcutsFor('nearby-preset')}
+            onClick={handleNearby}
+          >
+            <UiIcon
+              name="nearby"
               className="stims-icon-slot stims-icon-slot--sm"
             />
           </button>

--- a/src/js/frontend/audio-signal-state.ts
+++ b/src/js/frontend/audio-signal-state.ts
@@ -1,0 +1,194 @@
+/**
+ * Whether audio is not just *selected* but actually *arriving*.
+ *
+ * The stage has always shown an energy bar, and the bar has always been
+ * honest — but it answers a question nobody was asking. A flat bar means
+ * "nothing is coming through", and that single fact has at least three
+ * causes with three different fixes: no source is running at all; a source
+ * is running but the browser is still holding the AudioContext for a user
+ * gesture; or a source is genuinely connected and silent (wrong input
+ * device, muted tab, a paused track). Those are indistinguishable from a
+ * bar at rest, so the visitor is left to guess which one they are in.
+ *
+ * `audio-gesture-gate.ts` already reports the middle case. This module adds
+ * the third by watching the energy store over time, and collapses all of it
+ * into one value the UI can render and name.
+ *
+ * Nothing here starts, stops, or resumes audio — like the gesture gate, it
+ * only reports.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  isAudioAwaitingGesture,
+  subscribeAudioGestureGate,
+} from '../core/audio-gesture-gate.ts';
+import {
+  getAudioEnergy,
+  subscribeAudioEnergy,
+} from './engine-audio-energy-store.ts';
+
+export type AudioSignalState =
+  /** No source is running. */
+  | 'off'
+  /** A source is running, but the browser is holding it for a gesture. */
+  | 'awaiting-gesture'
+  /** A source is running and unblocked, and nothing is coming through. */
+  | 'silent'
+  /** Signal is arriving. */
+  | 'live';
+
+/**
+ * Energy below which a frame counts as "nothing came through".
+ *
+ * A judgment call, not a measurement, and deliberately well above the
+ * store's own 0.001 change dead zone: a connected-but-quiet microphone in a
+ * still room reads as small non-zero room noise, and calling that "live"
+ * would make the state useless exactly where it is most needed. Raising it
+ * further starts calling genuinely quiet passages silent, which is the worse
+ * error — this reads as reassurance, not as a fault light.
+ */
+export const SILENCE_ENERGY_FLOOR = 0.02;
+
+/**
+ * How long the signal must stay under the floor before we say so.
+ *
+ * Long enough to sit through a breakdown, a track gap, or the tail of a
+ * fade without the control flickering; short enough that someone who picked
+ * the wrong input device finds out while they are still looking at it.
+ */
+export const SILENCE_GRACE_MS = 4000;
+
+/** Cadence for re-evaluating elapsed silence. */
+const POLL_MS = 500;
+
+/**
+ * The "we last heard something at" mark, refreshed from the current level.
+ *
+ * Pulled out of the hook because the subtle half is here: the mark has to be
+ * recomputed from a *sample*, not merely carried forward. The energy store
+ * notifies on change only, so a level that is high but perfectly steady — a
+ * held tone, or a stalled pipeline repeating its last value — produces no
+ * events, and a mark that only advanced on notification goes stale under
+ * exactly the condition it is meant to detect.
+ */
+export function nextSignalMark(
+  energy: number,
+  previousMark: number | null,
+  now: number,
+): number | null {
+  return energy >= SILENCE_ENERGY_FLOOR ? now : previousMark;
+}
+
+export function classifyAudioSignal({
+  hasSource,
+  awaitingGesture,
+  msSinceSignal,
+  graceMs = SILENCE_GRACE_MS,
+}: {
+  hasSource: boolean;
+  awaitingGesture: boolean;
+  /** Time since energy was last at or above the floor; null if never. */
+  msSinceSignal: number | null;
+  graceMs?: number;
+}): AudioSignalState {
+  if (!hasSource) return 'off';
+  if (awaitingGesture) return 'awaiting-gesture';
+  if (msSinceSignal === null || msSinceSignal >= graceMs) return 'silent';
+  return 'live';
+}
+
+/** Plain-language state, shared by the visible label and the accessible name. */
+export function describeAudioSignal(
+  state: AudioSignalState,
+  sourceName: string | null,
+): { label: string; detail: string } {
+  switch (state) {
+    case 'off':
+      return {
+        label: 'No audio',
+        detail:
+          'Nothing is playing. Pick a source to give the visuals something to react to.',
+      };
+    case 'awaiting-gesture':
+      return {
+        label: 'Tap for sound',
+        detail: `${sourceName ?? 'Audio'} is ready, and your browser is holding it until you interact with the page.`,
+      };
+    case 'silent':
+      return {
+        label: 'No signal',
+        detail: `${sourceName ?? 'The source'} is connected, but nothing is coming through.`,
+      };
+    case 'live':
+      return {
+        label: sourceName ?? 'Audio',
+        detail: `${sourceName ?? 'Audio'} is playing and the visuals are reacting to it.`,
+      };
+  }
+}
+
+/**
+ * Live signal state for the current source.
+ *
+ * The energy store only notifies on change, so silence produces no events at
+ * all — the moment the level settles at zero, the last notification has
+ * already been delivered. Elapsed silence therefore has to be polled rather
+ * than derived from the subscription alone; the subscription's job is only to
+ * keep the "last time we heard something" mark fresh.
+ */
+export function useAudioSignalState(hasSource: boolean): AudioSignalState {
+  const [state, setState] = useState<AudioSignalState>(() =>
+    classifyAudioSignal({
+      hasSource,
+      awaitingGesture: isAudioAwaitingGesture(),
+      msSinceSignal: null,
+    }),
+  );
+  const lastSignalAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // A source change restarts the judgement: carrying the previous source's
+    // mark forward would report a fresh microphone as live on the strength of
+    // the demo track that preceded it.
+    lastSignalAtRef.current = null;
+
+    // Samples the level itself rather than trusting the subscription to have
+    // fired. The store only notifies on *change*, so a level that is high but
+    // perfectly steady — a held tone, or a stalled pipeline repeating its last
+    // value — delivers no events at all, and a version of this that only
+    // re-timed the previous mark reported "no signal" over a meter sitting at
+    // half scale. Reading here makes the subscription a latency optimisation
+    // instead of the only source of truth.
+    const evaluate = () => {
+      const now = Date.now();
+      lastSignalAtRef.current = nextSignalMark(
+        getAudioEnergy(),
+        lastSignalAtRef.current,
+        now,
+      );
+      const lastSignalAt = lastSignalAtRef.current;
+      setState(
+        classifyAudioSignal({
+          hasSource,
+          awaitingGesture: isAudioAwaitingGesture(),
+          msSinceSignal: lastSignalAt === null ? null : now - lastSignalAt,
+        }),
+      );
+    };
+
+    evaluate();
+    const unsubscribeEnergy = subscribeAudioEnergy(evaluate);
+    const unsubscribeGate = subscribeAudioGestureGate(evaluate);
+    // Only a running source can go silent, so an idle stage schedules nothing.
+    const timer = hasSource ? setInterval(evaluate, POLL_MS) : null;
+
+    return () => {
+      unsubscribeEnergy();
+      unsubscribeGate();
+      if (timer !== null) clearInterval(timer);
+    };
+  }, [hasSource]);
+
+  return state;
+}

--- a/src/js/frontend/hooks/use-flash-safety.ts
+++ b/src/js/frontend/hooks/use-flash-safety.ts
@@ -1,10 +1,15 @@
 import { useEffect, useRef } from 'react';
+import {
+  getActiveAccessibilityPreference,
+  subscribeToAccessibilityPreference,
+} from '../../core/accessibility-preferences.ts';
 import type { PresetSensoryProfile } from '../../core/sensory-profile.ts';
 import { primingHoldForProfile } from '../../core/services/flash-governor.ts';
 import {
   createFlashSafetyController,
   createStageLuminanceApplier,
 } from '../../core/services/flash-safety.ts';
+import { setStageLuminanceChannel } from '../../core/services/stage-luminance.ts';
 
 /**
  * Runs the WCAG flash governor over whatever the stage is currently showing.
@@ -83,4 +88,36 @@ export function useFlashSafety(
       controllerRef.current?.prime(hold);
     }
   }, [activeProfile]);
+}
+
+/**
+ * Holds the visitor's brightness ceiling on the stage.
+ *
+ * Separate from the governor's own effect and deliberately not gated on
+ * `reduceFlashing`: this one is a comfort preference someone set on purpose,
+ * and it applies whether or not they also asked for flash mitigation. Both
+ * write through `stage-luminance.ts`, which composes them.
+ */
+export function useStageBrightness(stageRef: {
+  current: HTMLDivElement | null;
+}) {
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+
+    const apply = (scale: number) =>
+      setStageLuminanceChannel(stage, 'ceiling', scale);
+
+    apply(getActiveAccessibilityPreference().stageBrightness);
+    const unsubscribe = subscribeToAccessibilityPreference((preference) =>
+      apply(preference.stageBrightness),
+    );
+
+    return () => {
+      unsubscribe();
+      // Leaving the ceiling engaged on a stage this hook no longer owns
+      // would dim a canvas nothing is watching.
+      apply(1);
+    };
+  }, [stageRef]);
 }

--- a/src/js/frontend/shortcut-registry.ts
+++ b/src/js/frontend/shortcut-registry.ts
@@ -20,6 +20,7 @@ export type ShortcutActionId =
   | 'close'
   | 'compile'
   | 'queue-add'
+  | 'preset-lock'
   | 'autoplay'
   | 'live-performance'
   | 'record'
@@ -131,6 +132,22 @@ export const SHORTCUT_REGISTRY: ShortcutDefinition[] = [
     // with independently of this registry. Confirmed unused there and here.
     defaultKeys: ['A'],
     paletteActionId: 'save-preset',
+  },
+  {
+    // Documented here, dispatched elsewhere. The MilkDrop keybinding layer
+    // (runtime/ui-bridge.ts) has owned 'l' for preset lock since long before
+    // this registry existed, and it preventDefault()s, so useKeyboardShortcuts
+    // never sees the key. The entry exists so the hint resolves — the dock's
+    // "Stay here" item can print its key like every other control — and so
+    // `setReservedShellKeys` stops the canvas from claiming it.
+    //
+    // Not configurable, precisely because this registry does not dispatch it:
+    // a rebind here would move the label and leave the behaviour on 'l'.
+    id: 'preset-lock',
+    label: 'Stay on this preset (pause auto-advance)',
+    defaultKeys: ['L'],
+    configurable: false,
+    paletteActionId: 'toggle-preset-lock',
   },
   {
     id: 'quick-select',

--- a/src/js/frontend/workspace-actions.ts
+++ b/src/js/frontend/workspace-actions.ts
@@ -188,3 +188,122 @@ export function presentToExternalDisplayAction(
     }
   })();
 }
+
+/**
+ * How many recently-played presets a nearby jump refuses to land on.
+ *
+ * Named `_LIMIT` on purpose: it is the bound on the exclusion Set built
+ * below, and `check-cache-bounds.ts` reads the name to prove that set cannot
+ * grow without one.
+ *
+ * Without this, "Nearby" against a strong match is a two-preset loop: the
+ * nearest neighbour of B is usually A, so the second press walks straight
+ * back. Wandering has to keep moving even when the neighbourhood is small.
+ */
+export const NEARBY_RECENT_EXCLUSION_LIMIT = 8;
+
+/**
+ * How many matches a nearby jump asks the index for.
+ *
+ * Must exceed {@link NEARBY_RECENT_EXCLUSION_LIMIT}, or the control is
+ * guaranteed to exhaust: every candidate ends up in the recency window and
+ * there is nothing left to play. Measured on the deployed index before this
+ * existed — the endpoint's default of five against an eight-deep exclusion
+ * ran dry after four presses, which reads as a broken button rather than a
+ * small neighbourhood.
+ */
+export const NEARBY_SEARCH_RESULTS = 25;
+
+export interface NearbyPresetRequest {
+  /** The stage canvas, which is the query — nearby means "looks like this". */
+  canvas: HTMLCanvasElement | null;
+  currentPresetId: string | null;
+  /** Most-recent-first; the head of this list is what we refuse to repeat. */
+  recentPresetIds: string[];
+  /** Guards against playing an id the index knows and this build does not. */
+  isKnownPreset: (presetId: string) => boolean;
+  play: (presetId: string) => void;
+  announce: (message: string) => void;
+  /**
+   * Test seam for the index lookup.
+   *
+   * An injected function rather than `mock.module`: mocking a module in this
+   * graph and re-importing it is a known way to hang `bun test` here, and the
+   * behaviour worth testing is the filtering around the lookup, not the fetch
+   * inside it.
+   */
+  searchByFrame?: (
+    canvas: HTMLCanvasElement,
+    signal?: AbortSignal,
+    topK?: number,
+  ) => Promise<Array<{ presetId: string; score: number }>>;
+}
+
+/**
+ * Play the nearest look-alike to what is on screen.
+ *
+ * This is the small step next to shuffle's big one: same wandering loop, but
+ * the next preset is chosen for resemblance instead of at random. It rides
+ * the visual-embedding index that already backs the finder's "by look" tab,
+ * so there is one definition of "similar" in the app rather than two.
+ *
+ * The index lives behind `/api/visual-search`, which the Vite dev server does
+ * not serve — `resolveOptionalApiUrl` returns null there and `searchByFrame`
+ * throws. That is a real limit of local development, not a failure state, and
+ * it is worth saying so plainly rather than reporting a broken feature.
+ */
+export async function playNearbyPreset({
+  canvas,
+  currentPresetId,
+  recentPresetIds,
+  isKnownPreset,
+  play,
+  announce,
+  searchByFrame: injectedSearch,
+}: NearbyPresetRequest): Promise<void> {
+  if (!canvas) {
+    announce('Nothing on the stage to match yet.');
+    return;
+  }
+
+  announce('Looking for something nearby…');
+
+  // Deferred so the embedding client and its schema stay out of the initial
+  // bundle; the dock button is on screen from the first frame, and almost
+  // nobody presses it before the stage is running.
+  const searchByFrame =
+    injectedSearch ??
+    (await import('../core/services/visual-embedding.ts')).searchByFrame;
+
+  let matches: Array<{ presetId: string; score: number }>;
+  try {
+    matches = await searchByFrame(canvas, undefined, NEARBY_SEARCH_RESULTS);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    announce(
+      message.includes('dev server')
+        ? 'Nearby needs the visual search index, which the dev server does not run. It works on the deployed site.'
+        : 'Could not reach the visual search index. Try again in a moment.',
+    );
+    return;
+  }
+
+  const excluded = new Set(
+    recentPresetIds.slice(0, NEARBY_RECENT_EXCLUSION_LIMIT),
+  );
+  if (currentPresetId) excluded.add(currentPresetId);
+
+  const next = matches.find(
+    (match) => !excluded.has(match.presetId) && isKnownPreset(match.presetId),
+  );
+
+  if (!next) {
+    // A neighbourhood can genuinely run out — a preset with few look-alikes,
+    // all of them just played. Saying so beats silently doing nothing, and
+    // names the control that does still have somewhere to go.
+    announce('No new neighbours for this one. Try Surprise me.');
+    return;
+  }
+
+  play(next.presetId);
+}

--- a/src/js/frontend/workspace-helpers.ts
+++ b/src/js/frontend/workspace-helpers.ts
@@ -911,6 +911,31 @@ export function pickRecentPresets(
     .slice(0, limit);
 }
 
+/**
+ * Presets opened recently enough that landing on one again would read as a
+ * loop rather than a discovery.
+ *
+ * `pickRecentPresets` cannot serve this: it caps at three for a UI list, and
+ * three is not enough to stop "Nearby" ping-ponging between a preset and its
+ * nearest neighbour — the nearest neighbour of B is usually A. The window
+ * matches the recency penalty in `handleShufflePreset`, so both wandering
+ * controls agree on what "just played" means.
+ */
+export function recentlyOpenedPresetIds(
+  entries: PresetCatalogEntry[],
+  { withinMs = 300_000, limit = 8, now = Date.now() } = {},
+): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        typeof entry.lastOpenedAt === 'number' &&
+        now - entry.lastOpenedAt <= withinMs,
+    )
+    .sort((left, right) => (right.lastOpenedAt ?? 0) - (left.lastOpenedAt ?? 0))
+    .slice(0, limit)
+    .map((entry) => entry.id);
+}
+
 export function pickFavoritePresets(
   entries: PresetCatalogEntry[],
   limit = 3,

--- a/src/js/frontend/workspace-hooks.ts
+++ b/src/js/frontend/workspace-hooks.ts
@@ -42,7 +42,10 @@ import {
 import { useAudioSourceSync } from './hooks/use-audio-source-sync.ts';
 import { useCatalogLoading } from './hooks/use-catalog-loading.ts';
 import { useDocumentDatasetSync } from './hooks/use-document-dataset-sync.ts';
-import { useFlashSafety } from './hooks/use-flash-safety.ts';
+import {
+  useFlashSafety,
+  useStageBrightness,
+} from './hooks/use-flash-safety.ts';
 import { usePresetPreviews } from './hooks/use-preset-previews.ts';
 import { usePresetRouteSync } from './hooks/use-preset-route-sync.ts';
 import { useStageCanvasSync } from './hooks/use-stage-canvas-sync.ts';
@@ -362,6 +365,7 @@ export function useWorkspaceSessionState({
     [fallbackCatalog, routeState.presetId],
   );
   useFlashSafety(stageRef, activeSensoryProfile);
+  useStageBrightness(stageRef);
 
   useEffect(() => {
     if (routeState.panel === 'browse') {

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -25,6 +25,7 @@ import {
 } from '../core/live-performance-mode.ts';
 import { createLogger } from '../core/logger.ts';
 import type { PostprocessingPipeline } from '../core/postprocessing.ts';
+import { isPresetLocked, togglePresetLock } from '../core/preset-lock.ts';
 import type {
   AdaptiveQualityController,
   AdaptiveQualityState,
@@ -187,7 +188,6 @@ export function createMilkdropExperience({
   let currentFrameState: MilkdropFrameState | null = null;
   const transitionController = createMilkdropTransitionController();
   let autoplay = preferences.getAutoplay();
-  let lockedPreset = false;
   let blendDuration = preferences.getBlendDuration(
     DEFAULT_BLEND_DURATION_SECONDS,
   );
@@ -791,10 +791,11 @@ export function createMilkdropExperience({
         void nudgeNumericField(args);
       },
       togglePresetLock: () => {
-        lockedPreset = !lockedPreset;
-        setOverlayStatus(lockedPreset ? 'Preset locked.' : 'Preset unlocked.');
+        setOverlayStatus(
+          togglePresetLock() ? 'Staying on this preset.' : 'Auto-advance on.',
+        );
       },
-      isPresetLocked: () => lockedPreset,
+      isPresetLocked,
     },
   });
 
@@ -884,7 +885,7 @@ export function createMilkdropExperience({
     transitionController,
     getBlendDuration: () => blendDuration,
     getTransitionMode: () => transitionMode,
-    getAutoplay: () => autoplay && !lockedPreset,
+    getAutoplay: () => autoplay && !isPresetLocked(),
     getLastPresetSwitchAt: () => lastPresetSwitchAt,
     updateAgentDebugSnapshot,
     agentModeEnabled,

--- a/src/js/ui/icon-library.ts
+++ b/src/js/ui/icon-library.ts
@@ -137,6 +137,19 @@ const ICON_NODES = {
     { tag: 'path', attrs: { d: 'M9 18c-4.51 2-5-2-7-2' } },
   ],
   spinner: [{ tag: 'path', attrs: { d: 'M21 12a9 9 0 1 1-6.219-8.56' } }],
+  /* Nearby: a filled centre with a ring around it — "this one, and what
+     sits next to it", distinct from shuffle's crossed arrows. */
+  nearby: [
+    { tag: 'circle', attrs: { cx: 12, cy: 12, r: 2.5 } },
+    { tag: 'path', attrs: { d: 'M12 4.5a7.5 7.5 0 0 1 7.5 7.5' } },
+    { tag: 'path', attrs: { d: 'M12 19.5A7.5 7.5 0 0 1 4.5 12' } },
+  ],
+  /* Stay here: a pin, matching the "pinned parameter" language the perform
+     surface already uses for "held in place on purpose". */
+  pin: [
+    { tag: 'path', attrs: { d: 'M12 17v4' } },
+    { tag: 'path', attrs: { d: 'M9 3h6l-1 6 3 3v2H7v-2l3-3-1-6Z' } },
+  ],
   shuffle: [
     {
       tag: 'path',

--- a/tests/unit/accessibility-regression.test.tsx
+++ b/tests/unit/accessibility-regression.test.tsx
@@ -22,11 +22,23 @@ describe('Accessibility regression guards', () => {
       }),
     );
 
-    const toggles = rendered.container.querySelectorAll('[aria-expanded]');
-    expect(toggles.length).toBeGreaterThan(0);
-    expect(rendered.container.querySelectorAll('[aria-pressed]').length).toBe(
-      0,
-    );
+    // Scoped to disclosure controls, not the whole bar. StageControls also
+    // holds genuine on/off toggles (full screen, save preset) whose state IS
+    // pressed-ness, and aria-pressed is right for those — the same pattern
+    // BrowseSheetPanel and PresetGrid use. What must never happen is a control
+    // that opens a menu or panel announcing "pressed" when the state a screen
+    // reader needs is collapsed/expanded.
+    const disclosures = [
+      ...rendered.container.querySelectorAll(
+        '[aria-expanded], [aria-haspopup]',
+      ),
+    ];
+    expect(disclosures.length).toBeGreaterThan(0);
+
+    for (const disclosure of disclosures) {
+      expect(disclosure.getAttribute('aria-expanded')).not.toBeNull();
+      expect(disclosure.getAttribute('aria-pressed')).toBeNull();
+    }
 
     rendered.dispose();
   });

--- a/tests/unit/audio-signal-state.test.ts
+++ b/tests/unit/audio-signal-state.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from 'bun:test';
+import {
+  classifyAudioSignal,
+  describeAudioSignal,
+  nextSignalMark,
+  SILENCE_GRACE_MS,
+} from '../../src/js/frontend/audio-signal-state.ts';
+
+test('no source reads as off, whatever the meter last said', () => {
+  expect(
+    classifyAudioSignal({
+      hasSource: false,
+      awaitingGesture: false,
+      msSinceSignal: 0,
+    }),
+  ).toBe('off');
+});
+
+test('the autoplay gate outranks silence, because it has a different fix', () => {
+  // Both states look identical at the analyser — zero energy — but only one
+  // is fixed by tapping the page, so the gate has to win.
+  expect(
+    classifyAudioSignal({
+      hasSource: true,
+      awaitingGesture: true,
+      msSinceSignal: null,
+    }),
+  ).toBe('awaiting-gesture');
+});
+
+test('a source that has never produced signal is silent immediately', () => {
+  expect(
+    classifyAudioSignal({
+      hasSource: true,
+      awaitingGesture: false,
+      msSinceSignal: null,
+    }),
+  ).toBe('silent');
+});
+
+test('a quiet passage inside the grace window still reads as live', () => {
+  expect(
+    classifyAudioSignal({
+      hasSource: true,
+      awaitingGesture: false,
+      msSinceSignal: SILENCE_GRACE_MS - 1,
+    }),
+  ).toBe('live');
+});
+
+test('silence past the grace window is reported', () => {
+  expect(
+    classifyAudioSignal({
+      hasSource: true,
+      awaitingGesture: false,
+      msSinceSignal: SILENCE_GRACE_MS,
+    }),
+  ).toBe('silent');
+});
+
+test('every state names the source it is describing', () => {
+  // The detail line is the control's accessible name, so a state that
+  // dropped the source name would leave a screen-reader user with "connected
+  // but nothing is coming through" and no way to tell which source.
+  for (const state of ['awaiting-gesture', 'silent', 'live'] as const) {
+    expect(describeAudioSignal(state, 'Microphone').detail).toContain(
+      'Microphone',
+    );
+  }
+});
+
+test('the off state does not invent a source it has no name for', () => {
+  const { detail } = describeAudioSignal('off', null);
+  expect(detail).not.toContain('undefined');
+  expect(detail).not.toContain('null');
+});
+
+test('a steady non-zero level keeps refreshing the mark', () => {
+  // The regression this exists for: the energy store notifies on change only,
+  // so a level pinned at half scale delivers no events. A mark that advanced
+  // only on notification went stale and the control said "No signal" over a
+  // meter sitting at 0.587 — confidently wrong in exactly the situation it
+  // was added to explain.
+  let mark = nextSignalMark(0.587, null, 1_000);
+  expect(mark).toBe(1_000);
+
+  mark = nextSignalMark(0.587, mark, 1_000 + SILENCE_GRACE_MS * 2);
+  expect(mark).toBe(1_000 + SILENCE_GRACE_MS * 2);
+
+  expect(
+    classifyAudioSignal({
+      hasSource: true,
+      awaitingGesture: false,
+      msSinceSignal: 0,
+    }),
+  ).toBe('live');
+});
+
+test('a level under the floor leaves the previous mark to age out', () => {
+  expect(nextSignalMark(0, 500, 9_000)).toBe(500);
+  expect(nextSignalMark(0, null, 9_000)).toBeNull();
+});

--- a/tests/unit/check-architecture.test.ts
+++ b/tests/unit/check-architecture.test.ts
@@ -185,6 +185,11 @@ describe('architecture boundary rules', () => {
     ).toBe(false);
   });
 
+  // The only test here that reads every file under src/js: 121ms on an idle
+  // machine, but seconds while the suite's parallel workers compete for the
+  // disk. Under bun's 5s default this test's verdict tracked machine load
+  // rather than the architecture rules it checks, so it gets a timeout sized
+  // to the I/O it does.
   test('scans tsx files when collecting architecture violations', async () => {
     const fixturePath = workspacePath(
       'src/js/utils/__tmp-architecture-violation-fixture.tsx',
@@ -211,5 +216,5 @@ describe('architecture boundary rules', () => {
     } finally {
       await fs.rm(fixturePath, { force: true });
     }
-  });
+  }, 30_000);
 });

--- a/tests/unit/nearby-preset.test.ts
+++ b/tests/unit/nearby-preset.test.ts
@@ -1,0 +1,165 @@
+import { expect, mock, test } from 'bun:test';
+import type { PresetCatalogEntry } from '../../src/js/frontend/contracts.ts';
+import {
+  NEARBY_RECENT_EXCLUSION_LIMIT,
+  NEARBY_SEARCH_RESULTS,
+  playNearbyPreset,
+} from '../../src/js/frontend/workspace-actions.ts';
+import { recentlyOpenedPresetIds } from '../../src/js/frontend/workspace-helpers.ts';
+
+function entry(id: string, lastOpenedAt?: number): PresetCatalogEntry {
+  return { id, title: id, lastOpenedAt };
+}
+
+test('the recency trail is most-recent-first and stops at the window', () => {
+  const now = 1_000_000;
+  const ids = recentlyOpenedPresetIds(
+    [
+      entry('old', now - 400_000),
+      entry('a', now - 1_000),
+      entry('never'),
+      entry('b', now - 10_000),
+    ],
+    { now },
+  );
+
+  expect(ids).toEqual(['a', 'b']);
+});
+
+test('the trail is long enough to break a two-preset ping-pong', () => {
+  const now = 1_000_000;
+  const many = Array.from({ length: 20 }, (_, index) =>
+    entry(`p${index}`, now - index),
+  );
+
+  // pickRecentPresets caps at 3, which is too short: the nearest neighbour of
+  // B is usually A, so a 3-deep exclusion still walks back within two presses.
+  expect(recentlyOpenedPresetIds(many, { now }).length).toBe(8);
+});
+
+test('a nearby jump skips the current preset and the recent trail', async () => {
+  const played: string[] = [];
+  const announcements: string[] = [];
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: 'current',
+    recentPresetIds: ['just-played'],
+    isKnownPreset: () => true,
+    play: (id) => played.push(id),
+    announce: (message) => announcements.push(message),
+    // Injected rather than reaching the network: the point under test is the
+    // filtering, not the index.
+    searchByFrame: async () => [
+      { presetId: 'current', score: 0.99 },
+      { presetId: 'just-played', score: 0.95 },
+      { presetId: 'fresh', score: 0.9 },
+    ],
+  });
+
+  expect(played).toEqual(['fresh']);
+});
+
+test('an id the index knows but this build does not is skipped, not played', async () => {
+  const played: string[] = [];
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: (id) => id === 'bundled',
+    play: (id) => played.push(id),
+    announce: () => {},
+    searchByFrame: async () => [
+      { presetId: 'retired-from-the-catalog', score: 0.99 },
+      { presetId: 'bundled', score: 0.8 },
+    ],
+  });
+
+  expect(played).toEqual(['bundled']);
+});
+
+test('an exhausted neighbourhood says so and points at the control that still moves', async () => {
+  const played: string[] = [];
+  const announcements: string[] = [];
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: 'current',
+    recentPresetIds: ['a'],
+    isKnownPreset: () => true,
+    play: (id) => played.push(id),
+    announce: (message) => announcements.push(message),
+    searchByFrame: async () => [
+      { presetId: 'current', score: 0.99 },
+      { presetId: 'a', score: 0.9 },
+    ],
+  });
+
+  expect(played).toEqual([]);
+  expect(announcements.at(-1)).toContain('Surprise me');
+});
+
+test('the dev server having no index is explained, not reported as a failure', async () => {
+  const announcements: string[] = [];
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: () => {},
+    announce: (message) => announcements.push(message),
+    searchByFrame: async () => {
+      throw new Error(
+        'Visual search API is unavailable in the Vite dev server.',
+      );
+    },
+  });
+
+  expect(announcements.at(-1)).toContain('deployed site');
+});
+
+test('a blank stage does not reach for the index at all', async () => {
+  const search = mock(async () => []);
+  const announcements: string[] = [];
+
+  await playNearbyPreset({
+    canvas: null,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: () => {},
+    announce: (message) => announcements.push(message),
+    searchByFrame: search,
+  });
+
+  expect(search).not.toHaveBeenCalled();
+  expect(announcements.at(-1)).toContain('Nothing on the stage');
+});
+
+test('nearby asks for a deeper list than it will exclude', () => {
+  // The invariant that keeps the control from exhausting: measured on the
+  // deployed index, the endpoint's default of 5 against an 8-deep exclusion
+  // ran dry after four presses.
+  expect(NEARBY_SEARCH_RESULTS).toBeGreaterThan(NEARBY_RECENT_EXCLUSION_LIMIT);
+});
+
+test('the requested depth is passed to the index, not silently defaulted', async () => {
+  let requestedTopK: number | undefined = -1;
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: () => {},
+    announce: () => {},
+    searchByFrame: async (_canvas, _signal, topK) => {
+      requestedTopK = topK;
+      return [{ presetId: 'anything', score: 0.9 }];
+    },
+  });
+
+  expect(requestedTopK).toBe(NEARBY_SEARCH_RESULTS);
+});

--- a/tests/unit/preset-lock.test.ts
+++ b/tests/unit/preset-lock.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  isPresetLocked,
+  resetPresetLock,
+  setPresetLocked,
+  subscribePresetLock,
+  togglePresetLock,
+} from '../../src/js/core/preset-lock.ts';
+
+afterEach(() => resetPresetLock());
+
+test('starts unlocked, so a fresh session auto-advances as configured', () => {
+  expect(isPresetLocked()).toBe(false);
+});
+
+test('toggle reports the state it moved to', () => {
+  expect(togglePresetLock()).toBe(true);
+  expect(isPresetLocked()).toBe(true);
+  expect(togglePresetLock()).toBe(false);
+});
+
+test('subscribers hear a change once, and not on a no-op set', () => {
+  let calls = 0;
+  const unsubscribe = subscribePresetLock(() => {
+    calls += 1;
+  });
+
+  setPresetLocked(true);
+  expect(calls).toBe(1);
+
+  // The dock button and the `L` keybinding both write this store; setting it
+  // to the value it already holds must not re-render every subscriber.
+  setPresetLocked(true);
+  expect(calls).toBe(1);
+
+  unsubscribe();
+  setPresetLocked(false);
+  expect(calls).toBe(1);
+});

--- a/tests/unit/stage-luminance.test.ts
+++ b/tests/unit/stage-luminance.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  resetStageLuminance,
+  setStageLuminanceChannel,
+  stageLuminanceScale,
+} from '../../src/js/core/services/stage-luminance.ts';
+
+function stage(): HTMLElement {
+  return document.createElement('div');
+}
+
+const created: HTMLElement[] = [];
+function trackedStage(): HTMLElement {
+  const element = stage();
+  created.push(element);
+  return element;
+}
+
+afterEach(() => {
+  for (const element of created.splice(0)) resetStageLuminance(element);
+});
+
+test('an unengaged stage carries no filter at all', () => {
+  const element = trackedStage();
+  setStageLuminanceChannel(element, 'governor', 1);
+  // Not `brightness(1)`: an identity filter still forces a compositing layer
+  // the renderer does not otherwise need.
+  expect(element.style.filter).toBe('');
+});
+
+test('the visitor ceiling survives a governor that writes every frame', () => {
+  const element = trackedStage();
+  setStageLuminanceChannel(element, 'ceiling', 0.5);
+  expect(element.style.filter).toBe('brightness(0.500)');
+
+  // This is the regression the module exists for: the governor ticks on rAF
+  // and, writing style.filter directly, used to erase the ceiling within a
+  // frame of it being set.
+  for (let i = 0; i < 5; i += 1) {
+    setStageLuminanceChannel(element, 'governor', 1);
+  }
+  expect(element.style.filter).toBe('brightness(0.500)');
+});
+
+test('the two channels multiply, so the darker intent wins', () => {
+  const element = trackedStage();
+  setStageLuminanceChannel(element, 'ceiling', 0.5);
+  setStageLuminanceChannel(element, 'governor', 0.4);
+  expect(stageLuminanceScale(element)).toBeCloseTo(0.2, 5);
+  expect(element.style.filter).toBe('brightness(0.200)');
+});
+
+test('releasing the governor restores the ceiling, not full brightness', () => {
+  const element = trackedStage();
+  setStageLuminanceChannel(element, 'ceiling', 0.6);
+  setStageLuminanceChannel(element, 'governor', 0.3);
+  setStageLuminanceChannel(element, 'governor', 1);
+  expect(element.style.filter).toBe('brightness(0.600)');
+});
+
+test('a nonsense scale falls back to unity rather than blacking the stage', () => {
+  const element = trackedStage();
+  setStageLuminanceChannel(element, 'ceiling', Number.NaN);
+  expect(stageLuminanceScale(element)).toBe(1);
+});
+
+test('channels are per-stage, so a second canvas does not inherit a clamp', () => {
+  const first = trackedStage();
+  const second = trackedStage();
+  setStageLuminanceChannel(first, 'governor', 0.2);
+  expect(second.style.filter).toBe('');
+  expect(stageLuminanceScale(second)).toBe(1);
+});


### PR DESCRIPTION
Three changes to how someone encounters the visuals, each built on wiring
that already shipped but had no way to be seen or reached.

Audio status. The dock's energy bar was aria-hidden decoration: it moved
with the music and said nothing about what was playing or why it had
stopped moving. A flat bar has three causes with three different fixes —
no source, a source held by the autoplay gate, or a source connected and
silent — and they were indistinguishable. It is now a control that names
its state and puts the fix one click away.

The subtle half is in audio-signal-state.ts. The energy store notifies on
*change* only, so a level that is high but perfectly steady delivers no
events at all; a first version that accumulated from the subscription
reported "No signal" over a meter sitting at 0.587. Elapsed silence is
sampled, not carried forward, and nextSignalMark exists so that rule has a
test.

Nearby. Back and Surprise me already shipped; this is the small step
between them, riding the same visual-embedding index as the finder's "by
look" tab so "similar" means one thing across the app. Two bounds matter
and both were measured on the deployed index, not guessed: recentPresets
caps at 3, too short to stop a two-preset ping-pong (the nearest neighbour
of B is usually A), so the exclusion is 8 on the same window shuffle uses;
and the endpoint's fixed topK of 5 against an 8-deep exclusion guaranteed
exhaustion after four presses, so the result count is now a request
parameter — 25 for wandering, the default 5 for the finder's list, clamped
server-side because the endpoint is public and Vectorize charges per
queried vector. Verified on a version preview: 12 hops, no stalls, no
ping-pong.

Preset lock. `L` has toggled it for as long as the MilkDrop keybindings
have existed, but the flag lived in a runtime closure, so the React shell
could not see it — no button, no palette entry, nothing showing it was on.
It is a shared store now, and both paths write it.

Stage brightness. Adding a comfort ceiling meant two writers on one CSS
property, and the flash governor ticks on rAF — it would have erased the
visitor's setting within a frame. stage-luminance.ts owns style.filter and
composes the two channels, so releasing the governor restores the ceiling
rather than full brightness. Grouped with freeze and reduce-flashing under
a note saying which is a hard limit and which is a mitigation.

No motion-intensity slider: there is no global motion lever in the
renderer, and a continuous control that moved without effect would be
worse than none.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>