### PR TITLE
Close the review findings on audio status, Nearby, and stage comfort

### DIFF
--- a/src/js/core/preset-lock.ts
+++ b/src/js/core/preset-lock.ts
@@ -17,6 +17,14 @@
  * Deliberately not persisted, unlike `live-performance-mode.ts`. Locking is
  * about *this* preset in *this* sitting; restoring it on the next visit
  * would silently disable autoplay for someone with no memory of asking.
+ *
+ * One store per document, which is the same scope `audio-gesture-gate.ts` and
+ * `live-performance-mode.ts` take and the same scope the shell's single stage
+ * has. A page running several experiences at once — the catalog tile lab,
+ * preview capture alongside the stage — shares one lock between them. That is
+ * why `createMilkdropExperience().dispose()` clears it: a module store does
+ * not die with the instance that set it, and inheriting a previous
+ * experience's lock reads as autoplay being broken.
  */
 
 type Listener = () => void;

--- a/src/js/core/services/flash-safety.ts
+++ b/src/js/core/services/flash-safety.ts
@@ -34,13 +34,27 @@ import {
   type FlashGovernorDecision,
 } from './flash-governor.ts';
 import { createFlashSampler, type FlashSampler } from './flash-sampler.ts';
-import { setStageLuminanceChannel } from './stage-luminance.ts';
+import {
+  setStageLuminanceChannel,
+  stageLuminanceScale,
+} from './stage-luminance.ts';
 
 export type FlashSafetyOptions = {
   /** The presented canvas to observe. */
   canvas: HTMLCanvasElement;
   /** Applies the mitigation. Called only when the value changes. */
   applyLuminanceScale: (scale: number) => void;
+  /**
+   * What the viewer is actually seeing, as a scale on the rendered pixels.
+   *
+   * Defaults to this controller's own last applied value, which is right
+   * only while the governor is the sole owner of the stage's brightness. It
+   * is not: the visitor's comfort ceiling multiplies into the same CSS
+   * filter, so a caller that composes channels must report the composed
+   * scale here or the feedback correction in `tick` under-counts the
+   * mitigation already in force (see `stage-luminance.ts`).
+   */
+  compositedScale?: () => number;
   /** Overridable for tests; defaults to the accessibility preference. */
   isEnabled?: () => boolean;
   /** Overridable for tests. */
@@ -79,6 +93,7 @@ export function createFlashSafetyController(
     scheduleFrame = (callback) => requestAnimationFrame(callback),
     cancelFrame = (handle) => cancelAnimationFrame(handle),
     sampler = createFlashSampler(),
+    compositedScale,
   } = options;
 
   const governor = createFlashGovernor();
@@ -111,9 +126,16 @@ export function createFlashSafetyController(
     // ceiling and stay there. Scaling the sample by the mitigation currently
     // in force reconstructs what the viewer is actually looking at, which is
     // the same thing tests/unit/flash-governor.test.ts feeds it.
-    if (lastApplied !== 1) {
+    //
+    // The scale to correct by is everything on the filter, not just this
+    // controller's contribution: with a visitor brightness ceiling of 0.5 the
+    // viewer sees half of what `lastApplied` claims, and correcting by
+    // `lastApplied` alone would leave the governor chasing brightness that is
+    // already gone.
+    const applied = compositedScale ? compositedScale() : lastApplied;
+    if (applied !== 1) {
       for (let i = 0; i < tiles.length; i += 1) {
-        tiles[i] = (tiles[i] as number) * lastApplied;
+        tiles[i] = (tiles[i] as number) * applied;
       }
     }
 
@@ -193,4 +215,13 @@ export function createStageLuminanceApplier(stage: HTMLElement) {
   return (scale: number) => {
     setStageLuminanceChannel(stage, 'governor', scale);
   };
+}
+
+/**
+ * The composed scale on that same stage, for the controller's feedback
+ * correction. Paired with the applier above so a caller cannot wire one
+ * without the other and leave the governor reading its own channel.
+ */
+export function createStageCompositedScale(stage: HTMLElement) {
+  return () => stageLuminanceScale(stage);
 }

--- a/src/js/core/services/stage-luminance.ts
+++ b/src/js/core/services/stage-luminance.ts
@@ -29,10 +29,17 @@ function channelsFor(stage: HTMLElement): Channels {
   return channels;
 }
 
-/** The composed scale currently applied to a stage. Exported for tests. */
+/**
+ * The composed scale currently applied to a stage.
+ *
+ * Reads without creating: a stage nobody has written to has no filter, and
+ * an accessor that registered one would populate this map for every element
+ * it is merely asked about. The flash governor calls this per frame to learn
+ * what the viewer is actually looking at, so it must stay a pure read.
+ */
 export function stageLuminanceScale(stage: HTMLElement): number {
-  const { governor, ceiling } = channelsFor(stage);
-  return governor * ceiling;
+  const channels = channelsByStage.get(stage);
+  return channels ? channels.governor * channels.ceiling : 1;
 }
 
 export function setStageLuminanceChannel(

--- a/src/js/core/services/visual-embedding.ts
+++ b/src/js/core/services/visual-embedding.ts
@@ -225,6 +225,20 @@ export function describeFrame(stats: FrameStats): string {
   return describeFrameParts(stats);
 }
 
+/**
+ * Thrown when this build has no visual-search endpoint to talk to at all —
+ * the Vite dev server does not serve `/api/visual-search`.
+ *
+ * A distinct type rather than a recognisable message: callers word the two
+ * cases differently for the user ("this environment has no index" versus
+ * "the index did not answer"), and a caller matching on message text breaks
+ * silently the first time the wording changes, telling people to retry
+ * something that can never succeed.
+ */
+export class VisualSearchUnavailableError extends Error {
+  readonly name = 'VisualSearchUnavailableError';
+}
+
 export async function searchByFrame(
   canvas: HTMLCanvasElement,
   signal?: AbortSignal,
@@ -237,7 +251,9 @@ export async function searchByFrame(
 ): Promise<Array<{ presetId: string; score: number }>> {
   const endpoint = resolveOptionalApiUrl('/api/visual-search');
   if (!endpoint) {
-    throw new Error('Visual search API is unavailable in the Vite dev server.');
+    throw new VisualSearchUnavailableError(
+      'Visual search API is unavailable in the Vite dev server.',
+    );
   }
 
   const stats = extractFrameStats(canvas);

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -108,6 +108,7 @@ import { buildRemixShareUrl, decodePresetCodeFromHash } from './url-state.ts';
 import { connectWakeLock } from './wake-lock.ts';
 import {
   endWatchParty,
+  nearbyPresetRequest,
   openRecordPanel,
   playNearbyPreset,
   presentToExternalDisplayAction,
@@ -123,7 +124,7 @@ import {
   useWorkspace,
   WorkspaceProvider,
 } from './workspace-context.tsx';
-import { getToolLabel, recentlyOpenedPresetIds } from './workspace-helpers.ts';
+import { getToolLabel } from './workspace-helpers.ts';
 import {
   BROWSE_PANEL_FOCUS_SELECTOR,
   WorkspaceStagePanel,
@@ -543,24 +544,19 @@ function StimsWorkspaceAppShell() {
         label: 'Nearby preset (looks like this one)',
         keywords: ['similar', 'like', 'neighbour', 'neighbor'],
         run: () =>
-          void playNearbyPreset({
-            canvas:
-              uiRef.current.stageRef.current?.querySelector('canvas') ?? null,
-            currentPresetId:
-              engineBridgeRef.current.selectedPreset?.id ??
-              engineBridgeRef.current.featuredPreset?.id ??
-              null,
-            recentPresetIds: recentlyOpenedPresetIds(
-              engineBridgeRef.current.catalog,
-            ),
-            isKnownPreset: (presetId) =>
-              engineBridgeRef.current.catalog.some(
-                (entry) => entry.id === presetId,
-              ),
-            play: (presetId) =>
-              engineBridgeRef.current.handlePresetSelection(presetId),
-            announce: uiRef.current.setStatusMessage,
-          }),
+          void playNearbyPreset(
+            nearbyPresetRequest({
+              stage: uiRef.current.stageRef.current,
+              catalog: engineBridgeRef.current.catalog,
+              currentPresetId:
+                engineBridgeRef.current.selectedPreset?.id ??
+                engineBridgeRef.current.featuredPreset?.id ??
+                null,
+              play: (presetId) =>
+                engineBridgeRef.current.handlePresetSelection(presetId),
+              announce: uiRef.current.setStatusMessage,
+            }),
+          ),
       },
       {
         // Pauses auto-advance without touching the autoplay preference, so

--- a/src/js/frontend/AudioStatusControl.tsx
+++ b/src/js/frontend/AudioStatusControl.tsx
@@ -90,7 +90,17 @@ function nextStepFor(
   return 'Try another source, or check your system volume.';
 }
 
-export function AudioStatusControl() {
+/**
+ * @param onActivity Keeps the dock awake. The bar auto-hides three seconds
+ * after the last signal, and this popover is the one piece of dock chrome a
+ * visitor is expected to stop and *read* — without this it would vanish
+ * mid-sentence for anyone not holding a mouse over it.
+ */
+export function AudioStatusControl({
+  onActivity,
+}: {
+  onActivity?: () => void;
+}) {
   const { ui, engine } = useWorkspace();
   const { engineSnapshot } = useEngineSnapshot();
   const audioSource = engineSnapshot?.audioSource ?? null;
@@ -148,19 +158,33 @@ export function AudioStatusControl() {
       buttonRef.current?.focus();
     };
     document.addEventListener('pointerdown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
+    // Capture phase, so stopPropagation actually holds. The competing Escape
+    // handlers (SidePanel, the overflow menu) are bubble-phase listeners on
+    // this same document, and stopPropagation from a listener registered
+    // alongside them cannot stop them — only stopImmediatePropagation can, and
+    // only for listeners registered later. Intercepting on the way down means
+    // one press closes the popover and nothing else.
+    document.addEventListener('keydown', onKeyDown, true);
     return () => {
       document.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keydown', onKeyDown, true);
     };
   }, [open]);
 
-  const run = useCallback((fn: () => void) => {
-    pulseHaptic(10);
-    setOpen(false);
-    fn();
-    buttonRef.current?.focus();
-  }, []);
+  const run = useCallback(
+    (fn: () => void, { keepFocus = true }: { keepFocus?: boolean } = {}) => {
+      pulseHaptic(10);
+      onActivity?.();
+      setOpen(false);
+      fn();
+      // Returning focus is right for the items that leave you standing in the
+      // dock. It is wrong for the one that hands off to another surface: the
+      // settings panel moves focus into itself on open, and pulling it back
+      // here leaves the panel open with the caret outside it.
+      if (keepFocus) buttonRef.current?.focus();
+    },
+    [onActivity],
+  );
 
   return (
     <div className={styles.wrap}>
@@ -179,6 +203,7 @@ export function AudioStatusControl() {
         title={detail}
         onClick={() => {
           pulseHaptic(10);
+          onActivity?.();
           setOpen((current) => !current);
         }}
       >
@@ -248,14 +273,16 @@ export function AudioStatusControl() {
             className={styles.item}
             data-action="open-audio-setup"
             onClick={() =>
-              run(() =>
-                togglePanel(
-                  {
-                    updatePanel: ui.updatePanel,
-                    routePanel: () => ui.routeState.panel ?? null,
-                  },
-                  'settings',
-                ),
+              run(
+                () =>
+                  togglePanel(
+                    {
+                      updatePanel: ui.updatePanel,
+                      routePanel: () => ui.routeState.panel ?? null,
+                    },
+                    'settings',
+                  ),
+                { keepFocus: false },
               )
             }
           >

--- a/src/js/frontend/SettingsSheetPanel.tsx
+++ b/src/js/frontend/SettingsSheetPanel.tsx
@@ -61,11 +61,18 @@ function SwitchRow({
   hint,
   checked,
   onChange,
+  describedById,
 }: {
   label: string;
   hint?: string;
   checked: boolean;
   onChange: (next: boolean) => void;
+  /**
+   * A note elsewhere on the panel that qualifies what this switch promises.
+   * Sighted users read it as an adjacent paragraph; without this it is not
+   * announced anywhere near the control it is about.
+   */
+  describedById?: string;
 }) {
   return (
     <label className="ctl-row">
@@ -77,6 +84,7 @@ function SwitchRow({
         type="checkbox"
         role="switch"
         aria-checked={checked}
+        aria-describedby={describedById}
         className="ctl-switch"
         checked={checked}
         onChange={(event) => onChange(event.target.checked)}
@@ -205,7 +213,8 @@ function AccessibilitySection({
             Stage brightness
           </label>
           <span className="ctl-row__hint">
-            Caps how bright the visuals can get. Carries across every preset.
+            Lowest setting is 30% — dark enough to rest against, still bright
+            enough to see.
           </span>
         </span>
         <input
@@ -238,6 +247,7 @@ function AccessibilitySection({
       <SwitchRow
         label="Reduce flashing"
         hint="Hides presets measured above the WCAG flash threshold. Presets that haven't been measured yet still appear, and say so."
+        describedById="comfort-note"
         checked={prefs.reduceFlashing}
         onChange={(reduceFlashing) => {
           setPrefs((p) => ({ ...p, reduceFlashing }));

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -36,6 +36,7 @@ import { getSyncSessionState, subscribeSyncSession } from './sync-session.ts';
 import { UiIcon } from './UiIcon.tsx';
 import {
   endWatchParty,
+  nearbyPresetRequest,
   openRecordPanel,
   playNearbyPreset,
   presentToExternalDisplayAction,
@@ -46,7 +47,6 @@ import {
   togglePanel,
 } from './workspace-actions.ts';
 import { useEngineSnapshot, useWorkspace } from './workspace-context.tsx';
-import { recentlyOpenedPresetIds } from './workspace-helpers.ts';
 
 type MenuItem = {
   icon: UiIconName;
@@ -329,15 +329,15 @@ export function StageControls({
   const handleNearby = useCallback(() => {
     signalActivity();
     pulseHaptic(10);
-    void playNearbyPreset({
-      canvas: ui.stageRef.current?.querySelector('canvas') ?? null,
-      currentPresetId,
-      recentPresetIds: recentlyOpenedPresetIds(engine.catalog),
-      isKnownPreset: (presetId) =>
-        engine.catalog.some((entry) => entry.id === presetId),
-      play: (presetId) => engine.handlePresetSelection(presetId),
-      announce: ui.setStatusMessage,
-    });
+    void playNearbyPreset(
+      nearbyPresetRequest({
+        stage: ui.stageRef.current,
+        catalog: engine.catalog,
+        currentPresetId,
+        play: (presetId) => engine.handlePresetSelection(presetId),
+        announce: ui.setStatusMessage,
+      }),
+    );
   }, [engine, ui, currentPresetId, signalActivity]);
 
   const handleToggleLock = useCallback(() => {
@@ -659,7 +659,7 @@ export function StageControls({
               }
             />
           ) : null}
-          <AudioStatusControl />
+          <AudioStatusControl onActivity={signalActivity} />
           <button
             type="button"
             className={styles.navBtn}

--- a/src/js/frontend/audio-signal-state.ts
+++ b/src/js/frontend/audio-signal-state.ts
@@ -80,6 +80,29 @@ export function nextSignalMark(
   return energy >= SILENCE_ENERGY_FLOOR ? now : previousMark;
 }
 
+/**
+ * Whether a sampled level can be believed yet for a freshly selected source.
+ *
+ * The energy store is not cleared when the source changes — it holds the last
+ * value the previous source published until the new one overwrites it. So
+ * nulling the mark on a source change is not enough on its own: the very next
+ * sample reads the old source's level and re-marks it, which is exactly the
+ * "fresh microphone reported live on the strength of the demo track" the reset
+ * exists to prevent.
+ *
+ * A level counts once it has moved off the value inherited at switch time.
+ * If a new source coincidentally publishes the identical level, this keeps
+ * withholding and the state settles on 'silent' after the grace window —
+ * the safe direction to be wrong in, since it prompts a check rather than
+ * asserting everything is fine.
+ */
+export function isInheritedLevel(
+  energy: number,
+  inherited: number | null,
+): boolean {
+  return inherited !== null && energy === inherited;
+}
+
 export function classifyAudioSignal({
   hasSource,
   awaitingGesture,
@@ -152,6 +175,11 @@ export function useAudioSignalState(hasSource: boolean): AudioSignalState {
     // mark forward would report a fresh microphone as live on the strength of
     // the demo track that preceded it.
     lastSignalAtRef.current = null;
+    // Nulling the mark alone does not achieve that, because the energy store
+    // keeps publishing the previous source's last value until the new one
+    // overwrites it. Hold the inherited level aside and disbelieve it until
+    // it moves; see isInheritedLevel.
+    let inherited: number | null = getAudioEnergy();
 
     // Samples the level itself rather than trusting the subscription to have
     // fired. The store only notifies on *change*, so a level that is high but
@@ -162,8 +190,10 @@ export function useAudioSignalState(hasSource: boolean): AudioSignalState {
     // instead of the only source of truth.
     const evaluate = () => {
       const now = Date.now();
+      const energy = getAudioEnergy();
+      if (!isInheritedLevel(energy, inherited)) inherited = null;
       lastSignalAtRef.current = nextSignalMark(
-        getAudioEnergy(),
+        inherited === null ? energy : 0,
         lastSignalAtRef.current,
         now,
       );

--- a/src/js/frontend/hooks/use-flash-safety.ts
+++ b/src/js/frontend/hooks/use-flash-safety.ts
@@ -7,6 +7,7 @@ import type { PresetSensoryProfile } from '../../core/sensory-profile.ts';
 import { primingHoldForProfile } from '../../core/services/flash-governor.ts';
 import {
   createFlashSafetyController,
+  createStageCompositedScale,
   createStageLuminanceApplier,
 } from '../../core/services/flash-safety.ts';
 import { setStageLuminanceChannel } from '../../core/services/stage-luminance.ts';
@@ -58,6 +59,9 @@ export function useFlashSafety(
       controller = createFlashSafetyController({
         canvas,
         applyLuminanceScale: createStageLuminanceApplier(stage),
+        // Reads the whole filter, not just the governor's share of it, so a
+        // visitor brightness ceiling does not make the loop over-clamp.
+        compositedScale: createStageCompositedScale(stage),
       });
       controllerRef.current = controller;
       controller.start();
@@ -101,23 +105,43 @@ export function useFlashSafety(
 export function useStageBrightness(stageRef: {
   current: HTMLDivElement | null;
 }) {
+  const appliedToRef = useRef<HTMLDivElement | null>(null);
+
+  // Deliberately no dependency array. The stage arrives through a ref, so
+  // there is no value whose change announces it — a version of this keyed on
+  // [stageRef] ran exactly once, and on any commit order where the stage
+  // mounts later it found null and never applied the ceiling again for the
+  // rest of the session. That is a silent failure of a setting the
+  // preference calls a real limit rather than a hint.
+  //
+  // Re-checking each commit is cheap: setStageLuminanceChannel early-returns
+  // when the channel has not moved, so the steady state is one comparison.
   useEffect(() => {
     const stage = stageRef.current;
     if (!stage) return;
-
-    const apply = (scale: number) =>
-      setStageLuminanceChannel(stage, 'ceiling', scale);
-
-    apply(getActiveAccessibilityPreference().stageBrightness);
-    const unsubscribe = subscribeToAccessibilityPreference((preference) =>
-      apply(preference.stageBrightness),
+    appliedToRef.current = stage;
+    setStageLuminanceChannel(
+      stage,
+      'ceiling',
+      getActiveAccessibilityPreference().stageBrightness,
     );
+  });
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAccessibilityPreference((preference) => {
+      const stage = stageRef.current ?? appliedToRef.current;
+      if (!stage) return;
+      setStageLuminanceChannel(stage, 'ceiling', preference.stageBrightness);
+    });
 
     return () => {
       unsubscribe();
       // Leaving the ceiling engaged on a stage this hook no longer owns
-      // would dim a canvas nothing is watching.
-      apply(1);
+      // would dim a canvas nothing is watching. Released against the stage we
+      // actually wrote to: by teardown the ref may already be null.
+      const stage = appliedToRef.current;
+      if (stage) setStageLuminanceChannel(stage, 'ceiling', 1);
+      appliedToRef.current = null;
     };
   }, [stageRef]);
 }

--- a/src/js/frontend/workspace-actions.ts
+++ b/src/js/frontend/workspace-actions.ts
@@ -11,12 +11,17 @@
  * call in.
  */
 
-import type { AudioSource, PanelState } from './contracts.ts';
+import type {
+  AudioSource,
+  PanelState,
+  PresetCatalogEntry,
+} from './contracts.ts';
 import {
   leaveSyncSession,
   setSyncUrlParam,
   startOrCopyWatchParty,
 } from './sync-session.ts';
+import { recentlyOpenedPresetIds } from './workspace-helpers.ts';
 
 export interface PanelSurface {
   updatePanel: (panel: PanelState) => void;
@@ -214,6 +219,20 @@ export const NEARBY_RECENT_EXCLUSION_LIMIT = 8;
  */
 export const NEARBY_SEARCH_RESULTS = 25;
 
+/**
+ * The nearby search currently on the wire, so a newer press can cancel it.
+ *
+ * Module-scoped because the control is module-scoped: the dock button and the
+ * palette entry are two doors onto one stage, and a press at either supersedes
+ * whatever the other started.
+ */
+let inFlightNearby: AbortController | null = null;
+
+/** Test seam: forget any in-flight search between cases. */
+export function resetNearbyPresetState(): void {
+  inFlightNearby = null;
+}
+
 export interface NearbyPresetRequest {
   /** The stage canvas, which is the query — nearby means "looks like this". */
   canvas: HTMLCanvasElement | null;
@@ -237,6 +256,38 @@ export interface NearbyPresetRequest {
     signal?: AbortSignal,
     topK?: number,
   ) => Promise<Array<{ presetId: string; score: number }>>;
+}
+
+/**
+ * Assembles a nearby request from the two things every caller actually has:
+ * the stage element and the catalog.
+ *
+ * Both entry points — the dock button and the command palette — used to build
+ * this object by hand, and had already drifted apart on how the current
+ * preset was derived, so one press could exclude a different preset depending
+ * on which control you reached it from.
+ */
+export function nearbyPresetRequest({
+  stage,
+  catalog,
+  currentPresetId,
+  play,
+  announce,
+}: {
+  stage: HTMLElement | null;
+  catalog: PresetCatalogEntry[];
+  currentPresetId: string | null;
+  play: (presetId: string) => void;
+  announce: (message: string) => void;
+}): NearbyPresetRequest {
+  return {
+    canvas: stage?.querySelector('canvas') ?? null,
+    currentPresetId,
+    recentPresetIds: recentlyOpenedPresetIds(catalog),
+    isKnownPreset: (presetId) => catalog.some((e) => e.id === presetId),
+    play,
+    announce,
+  };
 }
 
 /**
@@ -266,27 +317,51 @@ export async function playNearbyPreset({
     return;
   }
 
-  announce('Looking for something nearby…');
+  // A press supersedes the one before it. Two searches in flight both reach
+  // play(), and the slower one lands second with an exclusion set built
+  // before the first jump — so the stage moves twice and can land on the
+  // preset the recency window was there to avoid.
+  inFlightNearby?.abort();
+  const attempt = new AbortController();
+  inFlightNearby = attempt;
+  const superseded = () => attempt.signal.aborted;
 
-  // Deferred so the embedding client and its schema stay out of the initial
-  // bundle; the dock button is on screen from the first frame, and almost
-  // nobody presses it before the stage is running.
-  const searchByFrame =
-    injectedSearch ??
-    (await import('../core/services/visual-embedding.ts')).searchByFrame;
+  announce('Looking for something nearby…');
 
   let matches: Array<{ presetId: string; score: number }>;
   try {
-    matches = await searchByFrame(canvas, undefined, NEARBY_SEARCH_RESULTS);
+    // Deferred so the embedding client and its schema stay out of the initial
+    // bundle; the dock button is on screen from the first frame, and almost
+    // nobody presses it before the stage is running. Inside the try because a
+    // chunk that fails to load rejects here, and every caller invokes this as
+    // a bare `void` — an escape becomes an unhandled rejection with the status
+    // line stuck on "Looking for something nearby…".
+    const searchByFrame =
+      injectedSearch ??
+      (await import('../core/services/visual-embedding.ts')).searchByFrame;
+    matches = await searchByFrame(
+      canvas,
+      attempt.signal,
+      NEARBY_SEARCH_RESULTS,
+    );
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    if (superseded()) return;
+    // Matched on the error's declared `name`, not on its message: the class
+    // is exported from a module this one deliberately does not import
+    // statically, and `name` is a discriminant the type states rather than
+    // prose that reads as rewordable. Same shape as DOMException's AbortError.
+    const unavailable =
+      error instanceof Error && error.name === 'VisualSearchUnavailableError';
     announce(
-      message.includes('dev server')
+      unavailable
         ? 'Nearby needs the visual search index, which the dev server does not run. It works on the deployed site.'
         : 'Could not reach the visual search index. Try again in a moment.',
     );
     return;
   }
+
+  // A newer press already owns the stage; landing this one would undo it.
+  if (superseded()) return;
 
   const excluded = new Set(
     recentPresetIds.slice(0, NEARBY_RECENT_EXCLUSION_LIMIT),

--- a/src/js/milkdrop/runtime.ts
+++ b/src/js/milkdrop/runtime.ts
@@ -25,7 +25,11 @@ import {
 } from '../core/live-performance-mode.ts';
 import { createLogger } from '../core/logger.ts';
 import type { PostprocessingPipeline } from '../core/postprocessing.ts';
-import { isPresetLocked, togglePresetLock } from '../core/preset-lock.ts';
+import {
+  isPresetLocked,
+  setPresetLocked,
+  togglePresetLock,
+} from '../core/preset-lock.ts';
 import type {
   AdaptiveQualityController,
   AdaptiveQualityState,
@@ -1315,6 +1319,11 @@ function buildExperienceController(
       deps.getDisposeRequestedPresetListener?.()?.();
       deps.catalogCoordinator?.dispose();
       deps.disposeRuntimeSignalHub?.();
+      // The lock outlives this experience otherwise. It used to be a closure
+      // variable that died with the instance; as a module store it survives a
+      // teardown, so a backend switch or remount would come back with
+      // auto-advance still paused and no UI having asked for it.
+      setPresetLocked(false);
     },
   };
 }

--- a/tests/unit/audio-signal-state.test.ts
+++ b/tests/unit/audio-signal-state.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import {
   classifyAudioSignal,
   describeAudioSignal,
+  isInheritedLevel,
   nextSignalMark,
   SILENCE_GRACE_MS,
 } from '../../src/js/frontend/audio-signal-state.ts';
@@ -99,4 +100,17 @@ test('a steady non-zero level keeps refreshing the mark', () => {
 test('a level under the floor leaves the previous mark to age out', () => {
   expect(nextSignalMark(0, 500, 9_000)).toBe(500);
   expect(nextSignalMark(0, null, 9_000)).toBeNull();
+});
+
+test('a level inherited from the previous source is not believed', () => {
+  // The energy store is not cleared on a source change, so the first sample
+  // after switching still reads the old source's level. Believing it reports
+  // a microphone that has produced nothing as live, which is exactly what
+  // resetting the mark is supposed to prevent.
+  expect(isInheritedLevel(0.6, 0.6)).toBe(true);
+  // Once the new source publishes anything of its own, the hold is released.
+  expect(isInheritedLevel(0.61, 0.6)).toBe(false);
+  expect(isInheritedLevel(0, 0.6)).toBe(false);
+  // Nothing inherited (a first source in a fresh session) is never withheld.
+  expect(isInheritedLevel(0.6, null)).toBe(false);
 });

--- a/tests/unit/flash-safety.test.ts
+++ b/tests/unit/flash-safety.test.ts
@@ -76,6 +76,47 @@ describe('flash safety controller', () => {
     expect(hold).toBeGreaterThan(0);
   });
 
+  test('the feedback correction reads the whole filter, not just the governor', () => {
+    // The governor reconstructs what the viewer sees by scaling its sample by
+    // the mitigation in force. Once the visitor's brightness ceiling shares
+    // that same CSS filter, "in force" means the composed value: a ceiling of
+    // 0.5 has already halved the strobe before it reaches anyone's eyes.
+    //
+    // Correcting by the governor's own channel alone overstates what the
+    // viewer sees, so it keeps counting flashes that are already suppressed
+    // and clamps harder than the content warrants.
+    const uncorrected = harness(strobe);
+    // Mirrors stage-luminance's composition: the governor's own channel times
+    // the visitor's ceiling. Reporting a bare constant here would be wrong in
+    // a way worth naming — it drops the governor's own contribution, and the
+    // loop that converges only because it can see its own effect would
+    // escalate straight to the ceiling instead.
+    let governorChannel = 1;
+    const composed = createFlashSafetyController({
+      canvas: {} as HTMLCanvasElement,
+      sampler: scriptedSampler(strobe),
+      isEnabled: () => true,
+      applyLuminanceScale: (scale) => {
+        governorChannel = scale;
+      },
+      compositedScale: () => governorChannel * 0.25,
+      scheduleFrame: () => 1,
+      cancelFrame: () => {},
+    });
+
+    for (let i = 0; i < 600; i += 1) {
+      uncorrected.controller.tick(i * FRAME_MS);
+      composed.tick(i * FRAME_MS);
+    }
+
+    // Same content, but the viewer is already seeing a quarter of it, so the
+    // governor should hold back further than the uncorrected loop does.
+    expect(composed.getState().hold).toBeLessThan(
+      uncorrected.controller.getState().hold,
+    );
+    composed.stop();
+  });
+
   test('does nothing at all when the preference is off', () => {
     const { controller, applied } = harness(strobe, false);
     for (let i = 0; i < 120; i += 1) controller.tick(i * FRAME_MS);

--- a/tests/unit/nearby-preset.test.ts
+++ b/tests/unit/nearby-preset.test.ts
@@ -1,9 +1,11 @@
 import { expect, mock, test } from 'bun:test';
+import { VisualSearchUnavailableError } from '../../src/js/core/services/visual-embedding.ts';
 import type { PresetCatalogEntry } from '../../src/js/frontend/contracts.ts';
 import {
   NEARBY_RECENT_EXCLUSION_LIMIT,
   NEARBY_SEARCH_RESULTS,
   playNearbyPreset,
+  resetNearbyPresetState,
 } from '../../src/js/frontend/workspace-actions.ts';
 import { recentlyOpenedPresetIds } from '../../src/js/frontend/workspace-helpers.ts';
 
@@ -111,13 +113,94 @@ test('the dev server having no index is explained, not reported as a failure', a
     play: () => {},
     announce: (message) => announcements.push(message),
     searchByFrame: async () => {
-      throw new Error(
+      throw new VisualSearchUnavailableError(
         'Visual search API is unavailable in the Vite dev server.',
       );
     },
   });
 
   expect(announcements.at(-1)).toContain('deployed site');
+});
+
+test('a reworded message does not turn a missing index into a retry prompt', async () => {
+  const announcements: string[] = [];
+
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: () => {},
+    announce: (message) => announcements.push(message),
+    // Same condition, nothing recognisable in the prose. The branch reads the
+    // error's type, so the advice stays correct.
+    searchByFrame: async () => {
+      throw new VisualSearchUnavailableError('no endpoint configured');
+    },
+  });
+
+  expect(announcements.at(-1)).toContain('deployed site');
+});
+
+test('a second press supersedes the first, so the stage moves once', async () => {
+  resetNearbyPresetState();
+  const played: string[] = [];
+  let releaseFirst = () => {};
+  const firstSearchGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  const first = playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: (presetId) => played.push(presetId),
+    announce: () => {},
+    searchByFrame: async () => {
+      await firstSearchGate;
+      return [{ presetId: 'stale', score: 1 }];
+    },
+  });
+
+  // Second press lands while the first search is still out.
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: (presetId) => played.push(presetId),
+    announce: () => {},
+    searchByFrame: async () => [{ presetId: 'fresh', score: 1 }],
+  });
+
+  releaseFirst();
+  await first;
+
+  // The slower first press must not land on top of the newer one.
+  expect(played).toEqual(['fresh']);
+});
+
+test('a chunk that fails to load is reported, not left hanging', async () => {
+  resetNearbyPresetState();
+  const announcements: string[] = [];
+
+  // The real path resolves searchByFrame through a dynamic import; a rejected
+  // one used to escape the try entirely, leaving an unhandled rejection and
+  // the status line stuck on "Looking for something nearby…".
+  await playNearbyPreset({
+    canvas: {} as HTMLCanvasElement,
+    currentPresetId: null,
+    recentPresetIds: [],
+    isKnownPreset: () => true,
+    play: () => {},
+    announce: (message) => announcements.push(message),
+    searchByFrame: () =>
+      Promise.reject(new Error('Failed to fetch dynamically imported module')),
+  });
+
+  expect(announcements.at(-1)).toContain('Try again');
+  expect(announcements.at(-1)).not.toContain('Looking for');
 });
 
 test('a blank stage does not reach for the index at all', async () => {


### PR DESCRIPTION
Follow-up to #1182, which is already merged. That PR shipped the audio status control, Nearby, the preset lock surface and the stage brightness ceiling; this one carries the fifteen findings from reviewing it.

Rebased onto main so it contains only the unmerged work — one commit, 15 files.

## The two that change behaviour a user would notice

**The flash governor's feedback correction only read its own channel.** It reconstructs what the viewer sees by scaling its sample by the mitigation in force — but once the brightness ceiling multiplies into the same CSS filter, "in force" is the composed value. At a 0.5 ceiling the governor believed the viewer saw twice the light they did, so it kept counting flashes it had already suppressed and escalated toward its clamp ceiling. It now reads the composed scale through `createStageCompositedScale()`, paired with the applier so the two cannot be wired apart.

Writing the test for this surfaced why a naive fix fails, and the test says so: a *constant* composited scale drops the governor's own contribution, and the loop that converges precisely because it can see its own effect escalates straight to the ceiling instead.

**The audio signal state's source-change reset did not work.** Nulling the "last heard something" mark cannot restart the judgement while the energy store keeps publishing the previous source's level until the new one overwrites it — the very next sample re-marked it, so a fresh microphone read as live on the strength of the demo track before it. That is verbatim the failure the reset's own comment said it prevented. Levels inherited at switch time are now disbelieved until they move.

## The rest

- The lazy import in `playNearbyPreset` moved inside the `try` — it was escaping every caller's bare `void` as an unhandled rejection, leaving the status stuck on "Looking for something nearby…".
- A supersede-on-press guard with a real `AbortSignal`: two presses could both reach `play()`, the slower landing second from a stale exclusion set.
- The preset lock cleared on `dispose()` — as module state it no longer dies with the experience that set it, so a remount inherited a paused autoplay nothing had asked for.
- `useStageBrightness` re-checked per commit instead of once against a ref that may still be null, which silently dropped the ceiling entirely on some mount orders.
- `onActivity` on the audio popover, so the dock stops auto-hiding out from under its own open menu after three seconds.
- Focus no longer pulled back to the dock after the "Audio setup…" hand-off.
- Escape moved to the capture phase, where `stopPropagation` can actually hold against sibling `document` listeners.
- One shared `nearbyPresetRequest()` for two call sites that had already drifted on how the current preset was derived.
- `stageLuminanceScale` made a pure read, and given a production caller.
- The comfort note wired to the flashing switch it also describes.
- The dev-server branch no longer matches on error *message* text: `visual-embedding` exports `VisualSearchUnavailableError` and the branch reads its declared `name`, which keeps that module out of the initial bundle.
- Repeated settings copy replaced with the 30% floor, which nothing stated.

## Verification

`bun run check` green — exit 0, 2998 tests across 318 files, 0 failures. Five tests added: three to the Nearby suite (a second press superseding a slower first, a rejected import surfacing a retry rather than hanging, a reworded unavailable-error still giving the right advice), one each to flash-safety and audio-signal-state for the two findings above.

Two pre-existing load-flaky tests are unaffected by this branch and fail on a clean tree too: `tests/corpus/preset-flash-risk.test.ts` (~1 run in 3, `Missing visualizer canvas`) and `tests/unit/live-modulation.test.ts`.

## Note for reviewers

`AudioStatusControl` gains an `onActivity` prop. `StageControls` is the only caller today, but it is a signature change if anything else picks the component up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
