### PR TITLE
Cut duplicated CI work, and repair the guard that should have caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,41 @@ permissions:
   contents: read
 
 jobs:
+  # Which of the jobs below are worth spending a runner on. Measured over the
+  # last 40 commits on main, 9 of them touched nothing under src/, tests/,
+  # scripts/ or functions/ — docs and agent playbooks, mostly — and each one
+  # still paid for three browser matrix jobs, the parity corpus and a
+  # production build. That is roughly a quarter of runs spending ~470 job
+  # seconds to prove that prose did not break Chromium.
+  #
+  # Written as "everything, minus documentation" rather than a list of code
+  # paths, so it fails open: a directory nobody thought of counts as code and
+  # runs the full suite. The quality gate itself is deliberately NOT gated on
+  # this — half its guards read the docs (doc references, README claims,
+  # guardrail and skill-index freshness, SEO), so a docs-only change is
+  # exactly when several of them have something to say.
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Classify changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!.agent/**'
+              - '!.claude/**'
+              - '!LICENSE'
+
   # Commit-message hygiene was left to the local commit-msg hook alone, on the
   # assumption that every commit passes through it. It does not: 20+ commits
   # whose subjects this guard rejects are on main, including a run of GitHub
@@ -83,13 +118,37 @@ jobs:
       - name: Run quality gate
         run: bun run check -- --no-tests
 
-  # The postflight half of `bun run check`, split onto its own runner. No
-  # Playwright here, exactly as when this ran inside the quality gate job: the
-  # two browser-backed corpus tests skip without it, and the `parity` job
-  # below runs them with a browser.
+      # Folded in from the job this used to be. Pure gate: deploys moved to
+      # Cloudflare Workers Builds (see docs/DEPLOYMENT.md), which builds and
+      # deploys on push independently of Actions, so nothing downstream waits
+      # on it. On its own runner it spent 8s checking out and 18s installing
+      # to do 2s of work — 26s of setup per run to amortise nothing. Here it
+      # rides a checkout and an install that already happened.
+      - name: Build production bundle
+        run: bun run build
+
+      # The budget guard needs dist/, which is why it never ran inside the
+      # gate proper (see the script's docblock). It was added with the lazy
+      # EditorPanel work and then never wired to anything, which left the
+      # startup payload unguarded against step-change regressions.
+      - name: Check bundle-size budget
+        run: bun run check:bundle-size
+
+  # The postflight half of `bun run check`, split onto its own runner.
+  #
+  # Runs the `fast` profile (unit + compat), not `gate`. `gate` also includes
+  # tests/corpus/, which the `parity` job below runs in full — and runs
+  # *better*, because it provisions Playwright, while this job deliberately
+  # does not and so skipped the two browser-backed corpus tests anyway. The
+  # duplicate cost ~44s of runner time every run and covered strictly less
+  # than the job it duplicated. Category coverage is unchanged and asserted by
+  # scripts/check-ci-config.ts: unit and compat here, corpus in `parity`, e2e
+  # in the matrix.
   gate-tests:
     name: Gate test suite
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       # The runner must read the local composite action's action.yml from
       # disk before it can run it, so the repository has to be checked out
@@ -105,11 +164,13 @@ jobs:
           checkout: 'false'
 
       - name: Run gate test suite
-        run: bun run test:gate
+        run: bun run test:fast
 
   parity:
     name: Parity corpus
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     # tests/corpus/ holds the MilkDrop/projectM parity certification corpus,
     # the compiler/IR/codegen goldens and the pixel-diff suite. The
     # dual-backend boundary they cover is the repo's densest source of
@@ -149,39 +210,11 @@ jobs:
       - name: Run parity corpus
         run: bun run test:corpus
 
-  build:
-    name: Production build
-    runs-on: ubuntu-latest
-    # Pure gate: deploys moved to Cloudflare Workers Builds (see
-    # docs/DEPLOYMENT.md), which builds and deploys on push independently of
-    # Actions. This job only proves the production bundle still builds.
-    steps:
-      # The runner must read the local composite action's action.yml from
-      # disk before it can run it, so the repository has to be checked out
-      # in the workflow itself — a local action can never perform the first
-      # checkout (newer runner versions fail the job at action-resolution
-      # time otherwise).
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-stims
-        with:
-          checkout: 'false'
-
-      - name: Build production bundle
-        run: bun run build
-
-      # The budget guard needs dist/, so it runs here rather than in the
-      # quality gate (see the script's docblock). It was added with the lazy
-      # EditorPanel work and then never wired to anything, which left the
-      # startup payload unguarded against step-change regressions.
-      - name: Check bundle-size budget
-        run: bun run check:bundle-size
-
   integration:
     name: Browser end-to-end tests (${{ matrix.file }})
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     # Each e2e file gets its own runner. They used to share one job's 2 vCPUs
     # sequentially — a fresh `bun test` process per file (see run-tests.ts)
     # stopped in-process leaks from accumulating, but everything still
@@ -308,35 +341,42 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [check, gate-tests, parity, build, integration, commit-messages]
+    needs: [changes, check, gate-tests, parity, integration, commit-messages]
     if: always()
     steps:
       - name: Verify all required jobs passed
         run: |
-          # commit-messages is pull_request-only, so it reports "skipped" on
-          # push/merge_group runs. Skipped is a pass here; only an actual
-          # failure should block.
+          # Two jobs here legitimately report "skipped": commit-messages is
+          # pull_request-only, and the test jobs are gated on the `changes`
+          # filter, so a docs-only run skips all three. Skipped is a pass;
+          # only failure or cancellation should block. `check` is the one job
+          # that always runs, so it stays an exact success check — if the
+          # filter ever mis-fires and skips everything, that is still a real
+          # gate rather than a vacuous green.
+          passed() {
+            [ "$1" != "failure" ] && [ "$1" != "cancelled" ]
+          }
+
+          changes_outcome="${{ needs.changes.result }}"
           commit_outcome="${{ needs['commit-messages'].result }}"
           check_outcome="${{ needs.check.result }}"
           gate_tests_outcome="${{ needs['gate-tests'].result }}"
           parity_outcome="${{ needs.parity.result }}"
-          build_outcome="${{ needs.build.result }}"
           integration_outcome="${{ needs.integration.result }}"
 
-          echo "Commit Messages: $commit_outcome"
-          echo "Quality Gate: $check_outcome"
-          echo "Gate Test Suite: $gate_tests_outcome"
-          echo "Parity Corpus: $parity_outcome"
-          echo "Production Build: $build_outcome"
+          echo "Changed paths:     $changes_outcome"
+          echo "Commit Messages:   $commit_outcome"
+          echo "Quality Gate:      $check_outcome"
+          echo "Gate Test Suite:   $gate_tests_outcome"
+          echo "Parity Corpus:     $parity_outcome"
           echo "Integration Tests: $integration_outcome"
 
-          if [ "$commit_outcome" != "failure" ] && \
-             [ "$commit_outcome" != "cancelled" ] && \
-             [ "$check_outcome" = "success" ] && \
-             [ "$gate_tests_outcome" = "success" ] && \
-             [ "$parity_outcome" = "success" ] && \
-             [ "$build_outcome" = "success" ] && \
-             [ "$integration_outcome" = "success" ]; then
+          if [ "$check_outcome" = "success" ] && \
+             passed "$changes_outcome" && \
+             passed "$commit_outcome" && \
+             passed "$gate_tests_outcome" && \
+             passed "$parity_outcome" && \
+             passed "$integration_outcome"; then
             echo "All CI jobs passed successfully."
             exit 0
           else

--- a/scripts/check-ci-config.ts
+++ b/scripts/check-ci-config.ts
@@ -131,33 +131,70 @@ if (
  * notices CI stopped looking at them. Assert the coverage instead of trusting
  * it, so dropping a category from CI has to be a deliberate edit here.
  */
-const ciWorkflow = readText(join(ROOT, '.github/workflows/ci.yml'));
-if (ciWorkflow) {
+/**
+ * Which test categories a CI workflow actually runs.
+ *
+ * Exported so the rules below can be tested against synthetic workflows
+ * rather than only against this repo's own — the two ways this check used to
+ * pass for the wrong reason were both invisible to a test that just asserted
+ * the current tree is clean.
+ */
+export function coveredTestCategories(
+  ciWorkflow: string,
+  scripts: Record<string, string> = {},
+): Set<string> {
   const profileFor = (script: string) =>
-    pkg.scripts?.[script]?.match(/--profile\s+([a-z]+)/)?.[1] ?? null;
+    scripts[script]?.match(/--profile\s+([a-z]+)/)?.[1] ?? null;
 
-  // Which npm scripts does ci.yml actually invoke?
-  const invoked = new Set(
-    [...ciWorkflow.matchAll(/\bbun run (?!--)([A-Za-z0-9:_-]+)/g)].map(
-      (match) => match[1] as string,
-    ),
-  );
+  // Comments are not commands. Scanning the raw file counted `bun run check`
+  // where it appeared in explanatory prose — this workflow has two such
+  // mentions — so the coverage requirement below was satisfied by English,
+  // and stayed satisfied no matter what the steps actually ran. Strip
+  // whole-line YAML comments before looking for invocations.
+  const ciCommands = ciWorkflow
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
 
-  // `check` runs the quality gate, which runs the `fast` profile.
+  // Which npm scripts does ci.yml invoke, and with what arguments? The flags
+  // matter: `bun run check -- --no-tests` runs no tests at all, and crediting
+  // it with a profile anyway is the other half of how this passed for the
+  // wrong reason (see below).
+  const invocations = [
+    ...ciCommands.matchAll(/\bbun run (?!--)([A-Za-z0-9:_-]+)([^\n]*)/g),
+  ].map((match) => ({ script: match[1] as string, args: match[2] ?? '' }));
+  const invoked = new Set(invocations.map((invocation) => invocation.script));
+
   const coveredProfiles = new Set<string>();
-  if (invoked.has('check')) coveredProfiles.add('fast');
+
+  // `check` runs the quality gate, whose postflight suite is `test:gate` — not
+  // `fast`, which is what this said for long enough for both halves to drift:
+  // ci.yml passes `--no-tests` here (the suite moved to its own job), so the
+  // profile it was credited with was one it did not run, of a suite it was not
+  // running either. Meanwhile `test:gate` had no entry in the map below at
+  // all, so the job actually covering unit and compat contributed nothing.
+  // Coverage was real but unattributed: deleting `gate-tests` would have left
+  // this green, which is the exact drift the check exists to catch.
+  const runsCheckWithTests = invocations.some(
+    (invocation) =>
+      invocation.script === 'check' && !/--no-tests\b/.test(invocation.args),
+  );
+  if (runsCheckWithTests) coveredProfiles.add('gate');
   if (invoked.has('check:all')) coveredProfiles.add('all');
   for (const script of invoked) {
     const profile = profileFor(script);
     if (profile) coveredProfiles.add(profile);
   }
 
-  // profile -> categories, mirroring PROFILES in scripts/run-tests.ts.
+  // profile -> categories, mirroring PROFILES in scripts/run-tests.ts. Keep
+  // the two in step: an entry missing here silently stops crediting the job
+  // that runs it, and an over-broad one credits coverage nothing provides.
   const PROFILE_CATEGORIES: Record<string, string[]> = {
     all: ['unit', 'compat', 'corpus', 'e2e'],
+    gate: ['unit', 'compat', 'corpus'],
     fast: ['unit', 'compat'],
     unit: ['unit'],
-    compat: ['compat', 'corpus'],
+    compat: ['compat'],
     corpus: ['corpus'],
     e2e: ['e2e'],
   };
@@ -169,8 +206,19 @@ if (ciWorkflow) {
   );
 
   // e2e is covered by the integration matrix, which names files directly
-  // rather than going through a profile.
-  if (/tests\/e2e\//.test(ciWorkflow)) coveredCategories.add('e2e');
+  // rather than going through a profile. Read from the comment-stripped copy
+  // for the same reason: a comment mentioning tests/e2e/ is not a test run.
+  if (/tests\/e2e\//.test(ciCommands)) coveredCategories.add('e2e');
+
+  return coveredCategories;
+}
+
+const ciWorkflow = readText(join(ROOT, '.github/workflows/ci.yml'));
+if (ciWorkflow) {
+  const coveredCategories = coveredTestCategories(
+    ciWorkflow,
+    pkg.scripts ?? {},
+  );
 
   for (const category of ['unit', 'compat', 'corpus', 'e2e']) {
     if (!coveredCategories.has(category)) {

--- a/tests/unit/check-ci-config.test.ts
+++ b/tests/unit/check-ci-config.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 /**
- * Smoke test for the CI config drift guard. The full logic is exercised
- * against the live repo; here we verify the script runs clean against the
- * current tree and fails on a planted npm-leaking workflow.
+ * Tests for the CI config drift guard.
+ *
+ * A smoke test that the script runs clean against the current tree, plus the
+ * category-coverage rules exercised against synthetic workflows. There is no
+ * planted npm-leaking workflow case, whatever this comment used to claim.
  */
 import { spawnSync } from 'node:child_process';
+import { coveredTestCategories } from '../../scripts/check-ci-config.ts';
 
 function runCiConfig(): number {
   const result = spawnSync('bun', ['run', 'scripts/check-ci-config.ts'], {
@@ -17,5 +20,94 @@ function runCiConfig(): number {
 describe('check-ci-config', () => {
   test('passes on the current repo', () => {
     expect(runCiConfig()).toBe(0);
+  });
+});
+
+/**
+ * The category-coverage rules, against synthetic workflows.
+ *
+ * The smoke test above cannot catch the failure mode this guard exists for:
+ * it asserts the current tree is clean, and the guard was clean for two
+ * reasons that had nothing to do with the jobs actually running.
+ */
+describe('test category coverage', () => {
+  const SCRIPTS = {
+    check: 'bun run scripts/run-quality-gate.ts',
+    'test:fast': 'bun run scripts/run-tests.ts --profile fast',
+    'test:gate': 'bun run scripts/run-tests.ts --profile gate',
+    'test:corpus': 'bun run scripts/run-tests.ts --profile corpus',
+  };
+
+  test('a comment mentioning a command does not count as running it', () => {
+    // This is how the guard came to pass while attributing nothing: two
+    // comments in ci.yml said "bun run check", and that was enough to credit
+    // the whole profile. Prose is not a job.
+    const workflow = [
+      'jobs:',
+      '  build:',
+      '    steps:',
+      '      # The postflight half of `bun run check`, split onto its own runner.',
+      '      - run: bun run build',
+    ].join('\n');
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)]).toEqual([]);
+  });
+
+  test('a gate invoked with --no-tests covers nothing', () => {
+    // ci.yml hands the suite to its own job and runs the checks only here.
+    // Crediting this with the profile it would have run is how a deleted test
+    // job could have gone unnoticed.
+    const workflow = '      - run: bun run check -- --no-tests';
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)]).toEqual([]);
+  });
+
+  test('a gate invoked for real covers what its profile covers', () => {
+    const workflow = '      - run: bun run check';
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)].sort()).toEqual([
+      'compat',
+      'corpus',
+      'unit',
+    ]);
+  });
+
+  test('the profile map mirrors run-tests, so every job is attributed', () => {
+    // `gate` had no entry at all, so the one job covering unit and compat
+    // contributed nothing to the tally it was supposed to satisfy.
+    const workflow = '      - run: bun run test:gate';
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)].sort()).toEqual([
+      'compat',
+      'corpus',
+      'unit',
+    ]);
+  });
+
+  test('compat does not silently carry corpus with it', () => {
+    // The map claimed compat included corpus; run-tests.ts has not agreed
+    // since the parity job stopped duplicating it.
+    const workflow = '      - run: bun run test:fast';
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)].sort()).toEqual([
+      'compat',
+      'unit',
+    ]);
+  });
+
+  test('the shape this repo actually uses covers all four categories', () => {
+    const workflow = [
+      '      - run: bun run check -- --no-tests',
+      '      - run: bun run test:fast',
+      '      - run: bun run test:corpus',
+      '      - run: bun test tests/e2e/${{ matrix.file }}',
+    ].join('\n');
+
+    expect([...coveredTestCategories(workflow, SCRIPTS)].sort()).toEqual([
+      'compat',
+      'corpus',
+      'e2e',
+      'unit',
+    ]);
   });
 });


### PR DESCRIPTION
Measured on run [34236933371](https://github.com/zz-plant/stims/actions/runs/34236933371): ~85s wall, ~470 job-seconds across 9 jobs. Wall clock is already fine and barely moves here — the critical path was `gate-tests` at 84s and becomes the e2e matrix at 83s. **The savings are billed minutes.**

## The guard was passing on prose

`check-ci-config` asserts every test category reaches CI, because a category can silently stop running and nothing signals it — its own docblock calls that "invisible drift". It scanned `ci.yml` as raw text, and this workflow contains two comments that mention `bun run check`:

> `# The postflight half of `bun run check`, split onto its own runner.`
> `# `bun run check` now runs them too, via the `gate` profile …`

Either one satisfied the coverage requirement on its own. English, not jobs — and it stayed satisfied no matter what the steps actually ran. The same flaw let a comment mentioning `tests/e2e/` stand in for the browser matrix.

Two smaller drifts on top:

- It credited `bun run check` with a profile, but `ci.yml` invokes `bun run check -- --no-tests`, which runs none.
- Its profile map had **no `gate` entry at all**, so `gate-tests` — the job actually covering unit and compat — contributed nothing to the tally. Its `compat` entry also still claimed corpus, which `run-tests.ts` stopped agreeing with when the parity job was de-duplicated.

Net: coverage was real, but entirely unattributed. Deleting `gate-tests` would have left this green.

Comments are stripped before scanning now, the map mirrors `PROFILES`, and the coverage logic is exported as `coveredTestCategories()` so it can be tested against synthetic workflows rather than only against a tree that happens to pass. Six new tests pin each failure mode, including the comment one.

Verified by mutation — neutering each job now produces the right error, where before all four stayed green:

| neutered | before | after |
|---|---|---|
| `test:fast` (unit + compat) | ✅ passed | ✖ unit, compat |
| `test:corpus` | ✅ passed | ✖ corpus |
| e2e matrix path | ✅ passed | ✖ e2e |

## Then the three savings

**Corpus ran twice.** `gate-tests` ran the `gate` profile (unit + compat + corpus) and `parity` ran corpus again. The duplicate was also the *worse* of the two — `gate-tests` deliberately provisions no Playwright, so it skipped the browser-backed corpus tests `parity` actually runs. Now `fast` there: ~44s of runner time back, that job 84s → ~40s, coverage unchanged and now genuinely asserted.

**Production build was 93% setup.** 8s checkout + 18s install to do 2s of work, on a runner amortising nothing — deploys go through Workers Builds, so no job waits on it. Folded into the quality gate, which has already paid for both.

**Docs-only runs booked the full matrix.** 9 of the last 40 commits on main touched nothing under `src/`, `tests/`, `scripts/` or `functions/`, and each still paid for three browser jobs, the parity corpus and a build. A `dorny/paths-filter` job gates those. Written as "everything, minus documentation" so an unfamiliar directory counts as code and runs the full suite — it fails open, not closed.

The quality gate itself is deliberately **not** gated: half its guards read the docs (doc references, README claims, guardrail and skill-index freshness, SEO), so a docs-only change is exactly when they have something to say.

## ci-status

Now treats skipped as a pass for the gated jobs, the way it already did for the `pull_request`-only `commit-messages` job — but keeps requiring an exact `success` from the quality gate, so a mis-firing filter cannot produce a vacuous green.

No branch protection or ruleset enforces status checks on this repo today (the one ruleset is `disabled`), so removing the `Production build` job breaks no required check. Worth knowing if protection is ever turned on: the contexts changed.

## Verification

`bun run check` green — exit 0, 3004 tests across 318 files. This PR's own CI run is the first real exercise of the filter and the skipped-job handling.

## Not done

The `node_modules` cache may be counterproductive under `linker = "isolated"` — restoring a tarball of thousands of symlinks against a warm `~/.bun/install/cache`. Setup time varies 10s–18s between jobs, which is consistent with that but doesn't establish it. Left alone; it needs a measurement, not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
