### PR TITLE
fix(audio): detect the gesture gate Chrome hides behind a running context

### DIFF
--- a/src/js/core/audio-handler.ts
+++ b/src/js/core/audio-handler.ts
@@ -1073,21 +1073,51 @@ const stateChangeHandlers = new WeakMap<AudioContext, () => void>();
 let resumeOnVisibleInstalled = false;
 
 /**
+ * Whether the page has ever been interacted with.
+ *
+ * `true` when the browser cannot tell us: a false "tap for sound" on a
+ * browser without this API would be worse than staying quiet, and every
+ * engine that withholds audio this way implements it.
+ */
+function hasHadUserActivation(): boolean {
+  const activation =
+    typeof navigator === 'undefined' ? undefined : navigator.userActivation;
+  return activation ? activation.hasBeenActive : true;
+}
+
+/**
  * Publish "audio is set up but silent, waiting for a gesture" so the UI can
- * say so. A suspended context looks exactly like a working one from the
+ * say so. A gesture-gated context looks exactly like a working one from the
  * outside — the session is active, the analyser just returns zeros — and the
  * deep-link path deliberately starts audio without a click, so without this
  * the visitor gets silence with no explanation. See audio-gesture-gate.ts.
+ *
+ * Two signals, because a suspended context is only one of the two shapes this
+ * takes. Measured in Chrome 2026-09-08 on the `?audio=demo` arrival: both
+ * contexts report `state: 'running'` with `currentTime` advancing, and the
+ * analyser still reads exactly zero until the first real click — after which
+ * it reads 0.59 with nothing else changed. A gate watching only for
+ * 'suspended' therefore reported "nothing is waiting" during precisely the
+ * silence it exists to explain, and `SilentAudioNotice` stayed hidden.
+ *
+ * The activation check is deliberately not a substitute for the state check:
+ * a context can also be suspended long after the visitor has interacted (a
+ * backgrounded tab on mobile), which `hasBeenActive` would call fine.
  */
 function publishGestureGate() {
-  let suspended = false;
+  if (activeContexts.size === 0) {
+    reportAudioAwaitingGesture(false);
+    return;
+  }
+
   for (const context of activeContexts) {
     if (context.state === 'suspended') {
-      suspended = true;
-      break;
+      reportAudioAwaitingGesture(true);
+      return;
     }
   }
-  reportAudioAwaitingGesture(suspended);
+
+  reportAudioAwaitingGesture(!hasHadUserActivation());
 }
 
 function tryResumeAllActiveContexts() {
@@ -1122,6 +1152,10 @@ function installResumeOnVisible() {
 
   const handleUserGesture = () => {
     tryResumeAllActiveContexts();
+    // `navigator.userActivation` fires no event of its own, so the gate has
+    // to be re-published here; a context that was never suspended produces no
+    // `statechange` to ride on, and the notice would outlive the silence.
+    publishGestureGate();
   };
 
   document.addEventListener('pointerdown', handleUserGesture, {

--- a/tests/unit/audio-gesture-gate.test.ts
+++ b/tests/unit/audio-gesture-gate.test.ts
@@ -115,4 +115,109 @@ describe('audio gesture gate wiring', () => {
     unregisterAudioContext(fakeContext);
     expect(isAudioAwaitingGesture()).toBe(false);
   });
+
+  test('a running context still counts as gated before the first interaction', () => {
+    // Measured in Chrome 2026-09-08 on the `?audio=demo` arrival: both
+    // contexts report `state: 'running'` with `currentTime` advancing, and
+    // the analyser reads exactly zero until the first real click — then 0.59
+    // with nothing else changed. Watching only for 'suspended' reported
+    // "nothing is waiting" during the exact silence this gate exists to
+    // explain, and SilentAudioNotice stayed hidden the whole time.
+    withUserActivation(false, () => {
+      const context = fakeContext('running');
+      registerAudioContext(context);
+      expect(isAudioAwaitingGesture()).toBe(true);
+      unregisterAudioContext(context);
+    });
+  });
+
+  test('a running context after an interaction is simply working audio', () => {
+    withUserActivation(true, () => {
+      const context = fakeContext('running');
+      registerAudioContext(context);
+      expect(isAudioAwaitingGesture()).toBe(false);
+      unregisterAudioContext(context);
+    });
+  });
+
+  test('a suspended context is gated even long after an interaction', () => {
+    // The activation check adds to the state check rather than replacing it:
+    // a backgrounded tab on mobile suspends a context the visitor has already
+    // interacted with, and `hasBeenActive` would call that fine.
+    withUserActivation(true, () => {
+      const context = fakeContext('suspended');
+      registerAudioContext(context);
+      expect(isAudioAwaitingGesture()).toBe(true);
+      unregisterAudioContext(context);
+    });
+  });
+
+  test('no contexts means nothing is waiting, whatever the activation state', () => {
+    withUserActivation(false, () => {
+      expect(isAudioAwaitingGesture()).toBe(false);
+    });
+  });
+
+  test('a browser without the activation API is never told to tap', () => {
+    // Claiming a pending gesture on a browser that cannot report one would
+    // put "click for sound" over audio that is already playing.
+    withoutUserActivation(() => {
+      const context = fakeContext('running');
+      registerAudioContext(context);
+      expect(isAudioAwaitingGesture()).toBe(false);
+      unregisterAudioContext(context);
+    });
+  });
 });
+
+function fakeContext(state: AudioContextState): AudioContext {
+  return {
+    state,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as AudioContext;
+}
+
+/** Runs `body` with `navigator.userActivation.hasBeenActive` forced. */
+function withUserActivation(hasBeenActive: boolean, body: () => void) {
+  const target = navigator as unknown as Record<string, unknown>;
+  const had = Object.hasOwn(target, 'userActivation');
+  const previous = target.userActivation;
+  Object.defineProperty(target, 'userActivation', {
+    value: { hasBeenActive, isActive: hasBeenActive },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    body();
+  } finally {
+    if (had) {
+      Object.defineProperty(target, 'userActivation', {
+        value: previous,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      delete target.userActivation;
+    }
+  }
+}
+
+/** Runs `body` on a browser that does not implement the activation API. */
+function withoutUserActivation(body: () => void) {
+  const target = navigator as unknown as Record<string, unknown>;
+  const had = Object.hasOwn(target, 'userActivation');
+  const previous = target.userActivation;
+  delete target.userActivation;
+  try {
+    body();
+  } finally {
+    if (had) {
+      Object.defineProperty(target, 'userActivation', {
+        value: previous,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+}


### PR DESCRIPTION
`SilentAudioNotice` has not been appearing on the arrival it was written
for. The gate behind it asks "is any registered AudioContext suspended?",
and on the `?audio=demo` path in Chrome the answer is no while the visitor
still hears nothing.

Measured 2026-09-08, patching the AudioContext constructor before boot so
every context the app creates could be inspected: both report
`state: 'running'` with `currentTime` advancing, and the analyser returns
exactly 0. One real click — nothing else changed — and it reads 0.86. A
synthetic dispatchEvent does not do it; only a trusted gesture does. So the
silence is real, it is gesture-gated, and `state` never says so.

The gate now consults `navigator.userActivation.hasBeenActive` as well.
The two checks are not redundant: a context can also be suspended long
after the visitor has interacted (a backgrounded tab on mobile), which
activation alone would call fine. Where the API is missing the answer is
"activated", so no browser is falsely told to tap over audio that is
already playing.

Activation fires no event of its own, so the existing user-gesture handler
republishes the gate — a context that was never suspended produces no
statechange to ride on, and the notice would otherwise outlive the silence
it describes.

Found while verifying the stage audio-status control from #1182, which
reported this state as "No signal" and told the visitor to check their
system volume. Both consumers are correct now: the control reads "Tap for
sound" before the gesture and "Demo" after, and the notice appears and
clears with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>