### PR TITLE
fix(stage): stop the dock clipping its menu button off-screen on phones

### DIFF
--- a/src/css/AudioStatusControl.module.css
+++ b/src/css/AudioStatusControl.module.css
@@ -215,15 +215,20 @@
   font-weight: 700;
 }
 
-/* The dock is tight on phones; the source label carries the state there and
-   the meter alone would be ambiguous, so the word stays and the icon goes. */
+/* The dock is tight on phones. Measured at 375px: with the word kept this
+   control was 95px, the pill's content ran ~411px inside a 359px pill, and
+   Full screen and the overflow menu were clipped past the viewport edge —
+   the gateway to 25 actions, unreachable. The word goes and the icon stays:
+   the state colour and the icon still read at a glance, the accessible name
+   carries the whole sentence, and SilentAudioNotice already prints the
+   "tap for sound" case on the stage itself. */
 @media (max-width: 480px) {
   .trigger {
     padding: 0 6px;
-    gap: 4px;
+    gap: 3px;
   }
 
-  .trigger > :global(.stims-icon-slot) {
+  .label {
     display: none;
   }
 }

--- a/src/css/StageControls.module.css
+++ b/src/css/StageControls.module.css
@@ -104,6 +104,16 @@
    mute, full screen and the overflow menu, so the bar offered six equal
    affordances and no answer to "what do I press?". Bigger, brighter, and
    carrying a resting fill so they read as the bar's primary pair. */
+/* Nearby leaves the dock on phones and lives in the overflow menu instead.
+   The wandering trio is worth its slot on a desktop pill; at 375px its 44px
+   was part of what pushed the menu button off-screen, and swipe already
+   covers previous/next there. */
+@media (max-width: 480px) {
+  .navBtn[data-action="nearby-preset"] {
+    display: none;
+  }
+}
+
 .navBtn[data-primary="true"] {
   width: 38px;
   height: 38px;

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -417,6 +417,15 @@ export function StageControls({
       action: () => run(() => openPerformPicker()),
     },
     {
+      // Duplicated from the dock on purpose: the dock button is hidden at
+      // phone widths (StageControls.module.css), and a verb that vanishes
+      // with the viewport needs a second home. Same body, same id.
+      icon: 'nearby' as const,
+      label: 'Nearby preset',
+      actionId: 'nearby-preset',
+      action: () => run(() => handleNearby()),
+    },
+    {
       // The behaviour is as old as the MilkDrop keybindings and has always
       // been reachable by pressing L; what it never had was anything on
       // screen, so it could only be used by someone who already knew. It


### PR DESCRIPTION
## Summary
- At 375px the stage dock's content (~411px) overflowed its 359px pill, pushing **Full screen** and the **More actions** menu button off-screen — the only route to 25 actions was untappable, and the preset title was crushed to 20px.
- Cause: the audio-status control (95px with its label) and the Nearby button (44px) from #1182.
- Fix: audio status drops its word below 480px (meter + icon + state colour stay; the accessible name keeps the full sentence). Nearby leaves the dock below 480px and gets a menu entry with the same id and body.

## Verification
- Measured at 375px on dev: 341px of content in the 359px pill, nothing clipped, title 54px, Nearby present in the menu.
- `bun run test:gate` green; `app-shell-minimal-surfaces`, `accessibility-regression`, `mobile-viewport-matrix`, `app-shell-ui-simplification` all pass; `check:quick` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)