### PR TITLE
fix(lab): stop the flash-risk gate test losing Chrome's autoplay gate

### DIFF
--- a/scripts/preset-lab-flash-risk.ts
+++ b/scripts/preset-lab-flash-risk.ts
@@ -216,36 +216,31 @@ function maxTransitionsInRollingWindow(
   return maxCount;
 }
 
+/**
+ * `?audio=demo` starts demo audio as soon as the runtime is ready, so this
+ * is one bounded wait for the app's own signal.
+ *
+ * It used to fall back, after 5s, to clicking the stage canvas for a user
+ * gesture and posting `toil:set_audio`. Both were dead weight that cost 65s
+ * per failure. In the state the fallback was written for, the page is still
+ * in home mode and the launch overlay covers the canvas, so Playwright's
+ * click spent its full 30s waiting for the canvas to become hit-testable and
+ * never delivered a gesture; the agent bridge has no `onSetAudio` handler,
+ * so the message did nothing; and the 30s wait that followed could only
+ * time out. The autoplay gate that produced that state is now disabled at
+ * browser launch (see resolveLoopSweepChromiumArgs), and if audio still
+ * fails to start the report says so after AUDIO_ACTIVE_TIMEOUT_MS.
+ */
 async function waitForAudioActive(page: Page): Promise<boolean> {
   try {
     await page.waitForFunction(
       () => document.body.dataset.audioActive === 'true',
       undefined,
-      { timeout: 5_000 },
+      { timeout: AUDIO_ACTIVE_TIMEOUT_MS },
     );
     return true;
   } catch {
-    // If audio is delayed or blocked waiting for a user gesture under load,
-    // dispatch a trusted interaction and request demo audio via agent message.
-    try {
-      await page.click(STAGE_CANVAS_SELECTOR).catch(() => {});
-      await page
-        .evaluate(() => {
-          window.postMessage({ type: 'toil:set_audio', source: 'demo' }, '*');
-        })
-        .catch(() => {});
-    } catch {}
-
-    try {
-      await page.waitForFunction(
-        () => document.body.dataset.audioActive === 'true',
-        undefined,
-        { timeout: AUDIO_ACTIVE_TIMEOUT_MS },
-      );
-      return true;
-    } catch {
-      return false;
-    }
+    return false;
   }
 }
 
@@ -323,7 +318,7 @@ export async function runPresetFlashRiskLab({
       );
       audioActive = await waitForAudioActive(page);
       if (!audioActive) {
-        loadError = 'Demo audio did not activate within the timeout';
+        loadError = `Demo audio did not activate within ${AUDIO_ACTIVE_TIMEOUT_MS}ms`;
       }
       captureBackend = await probeCaptureBackend(page);
       series = await collectLuminanceSeries(

--- a/scripts/run-milkdrop-loop-visual-sweep.ts
+++ b/scripts/run-milkdrop-loop-visual-sweep.ts
@@ -293,12 +293,28 @@ export function softwareRenderRequested(): boolean {
   return process.env.STIMS_SOFTWARE_RENDER === '1';
 }
 
+/**
+ * Every harness sharing these args loads the page with `?audio=demo`, and
+ * the demo track is a Web Audio graph. Chrome's autoplay policy decides at
+ * AudioContext creation whether a page may start audio without a user
+ * gesture, and headless under `bun run test:gate` that decision came out
+ * differently from run to run. Measured 2026-09-08 on the flash-risk lab:
+ * failing runs logged "The AudioContext was not allowed to start" five
+ * times and both contexts stayed suspended for the entire 72s the lab
+ * waited; passing runs on the same machine, minutes apart, had audio live
+ * within 200ms of the preset. These harnesses measure presets, not Chrome's
+ * autoplay heuristics, so the policy is switched off — the same flag
+ * generate-thumbnails.ts and generate-readme-clips.ts already pass.
+ */
+const AUTOPLAY_ARGS = ['--autoplay-policy=no-user-gesture-required'];
+
 export function resolveLoopSweepChromiumArgs(
   renderer: SweepOptions['renderer'],
   _headless: boolean,
 ) {
   if (renderer === 'webgpu') {
     return [
+      ...AUTOPLAY_ARGS,
       '--enable-unsafe-webgpu',
       '--ignore-gpu-blocklist',
       '--enable-features=WebGPU,SharedArrayBuffer',
@@ -306,6 +322,7 @@ export function resolveLoopSweepChromiumArgs(
   }
   if (softwareRenderRequested()) {
     return [
+      ...AUTOPLAY_ARGS,
       '--use-angle=swiftshader',
       '--use-gl=angle',
       '--enable-webgl',
@@ -313,7 +330,7 @@ export function resolveLoopSweepChromiumArgs(
       '--ignore-gpu-blocklist',
     ];
   }
-  return ['--ignore-gpu-blocklist'];
+  return [...AUTOPLAY_ARGS, '--ignore-gpu-blocklist'];
 }
 
 /**

--- a/tests/corpus/preset-flash-risk.test.ts
+++ b/tests/corpus/preset-flash-risk.test.ts
@@ -80,6 +80,18 @@ describe('preset flash-risk lab', () => {
       expect(report.maxTransitionsPerSecondEstimate).toBeGreaterThanOrEqual(0);
       expect(fs.existsSync(report.artifacts.reportJson)).toBe(true);
     },
-    120_000,
+    // A hang guard, not a performance assertion. Measured 2026-09-08 on an
+    // M1 Max: 4.9s run alone, 6–7s to a live preset inside the parallel gate
+    // at load average 20. It sits above the sum of the lab's own waits (dev
+    // server 30s, browser launch 30s, navigation 30s, preset ready 60s, demo
+    // audio 30s, sampling 3s) so whichever of those gives up first reports
+    // why through `loadError`, which the assertion above prints, rather
+    // than bun reporting an opaque timeout. The gate flake that day looked
+    // like a timeout — 73–78s, roughly one run in three — but was the lab
+    // losing Chrome's autoplay gate and then spending 65s on a fallback that
+    // could not work; a longer budget alone would not have changed the
+    // verdict. Both are fixed in preset-lab-flash-risk.ts and the shared
+    // Chromium args in run-milkdrop-loop-visual-sweep.ts.
+    200_000,
   );
 });


### PR DESCRIPTION
## What was actually wrong

The task described this as a bun-timeout flake fixable by adding a per-test timeout. The test already had one: a 120 s budget on its own line after the closure since 09-04 (#1176), which a grep for `}, <ms>)` misses. The 77 s failures were assertion failures on `loadError`, not timeouts, so a budget change alone could not have fixed them.

Instrumenting `scripts/preset-lab-flash-risk.ts` and running it inside `bun run test:gate` reproduced the failure in 3 of 4 runs and gave this timeline:

| Phase | Failing run | Passing run |
|---|---|---|
| Dev server + browser + navigation | 5.6 s | 4.5 s |
| Preset ready (canvas + telemetry) | 7.0 s | 5.8 s |
| Demo audio active | never | 6.0 s |
| Fallback `page.click` on the stage canvas | 30.0 s, timed out | not reached |
| Second audio wait | 30.0 s, timed out | not reached |
| Total | 73–78 s | 7 s |

In the failing runs Chrome logged `The AudioContext was not allowed to start` five times and both demo AudioContexts stayed `suspended` at `currentTime` 0 for the entire wait. Passing runs minutes apart on the same machine had audio live within 200 ms of the preset. Boot speed was not the problem: under load average 20 the preset was ready in 6 to 7 s either way.

The lab's fallback then made every failure cost 65 s. The page is still in home mode when it runs, so the launch overlay (`.stims-shell__launch-center`) covers the canvas and Playwright's `page.click` spends its full default 30 s waiting for the element to become hit-testable before giving up. The `toil:set_audio` message posted afterwards has no handler: App.tsx never passes `onSetAudio` to `initAgentBridge`. So the second 30 s wait could only time out.

## The fix

- `resolveLoopSweepChromiumArgs` now passes `--autoplay-policy=no-user-gesture-required`, the flag `generate-thumbnails.ts` and `generate-readme-clips.ts` already use. Every harness sharing those args loads `?audio=demo`, so the loop sweep and `preset-lab-visual` lose the same latent race.
- The flash-risk lab's audio wait is a single bounded 30 s wait for the app's own `data-audio-active` signal. The obstructed click and the dead message are removed, and the `loadError` text names its budget.
- The test's budget is 200 s, sized above the sum of the lab's own hang guards (dev server 30, browser launch 30, navigation 30, preset ready 60, demo audio 30, sampling 3) so whichever guard fires first reports why through `loadError`, which the assertion prints, instead of bun reporting an opaque timeout. The comment records the measured idle and loaded durations. Assertions are unchanged and nothing is skipped.

## Verification

- `bun test tests/corpus/preset-flash-risk.test.ts`: passes in 5.0 s.
- `bun run test:gate`: four consecutive runs passed (27 s to 44 s each) at load averages 14 to 33, higher than during any observed failure.
- `bun run check`: passes.

## Notes for later

- The "Missing visualizer canvas" failures recorded on 09-07 were a different event: another session's edit to `StageControls.tsx` triggered a Vite hot reload mid-run. Not addressed here.
- `scripts/generate-readme-clips.ts` also posts `toil:set_audio`, which is equally unhandled. Left alone in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
