### PR TITLE
feat(ui): rank the returning-visitor launch page around one preset card

### DIFF
--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -1412,6 +1412,140 @@ body[data-page="workspace"][data-live="true"] {
     width: min(16rem, 100%);
   }
 
+  /* Returning visitor. The first screen used to spend itself explaining what
+     was being resumed — headline, "Continue with…" sentence, a strip of art —
+     before a decision that is small: this preset, or something else. The
+     preset is one card now, with its name on the artwork, tall enough to
+     establish what it looks like (the old strip was prominent enough to cost
+     space but too shallow to do that) and no taller: title, card, Resume,
+     the other sources and Browse should all fit one phone screen. */
+  .stims-shell__launch-center[data-variant="resume"] {
+    /* The launch column is a grid inside a stage panel taller than its
+       content, and `align-content` defaults to stretch — so every auto row
+       absorbed an equal share of the leftover height. On this variant that
+       was ~42px added to each of eight rows, which is why the page read as
+       a short interface floating in a screen and a half of nothing: the
+       whitespace was leftover height being redistributed, not spacing
+       anyone chose. Packing the rows to the start makes the gaps below the
+       real ones, so the whole decision fits one phone screen. */
+    align-content: start;
+    gap: 10px;
+  }
+
+  .stims-shell__launch-center[data-variant="resume"]
+    .stims-shell__launch-title {
+    font-size: clamp(2.25rem, 5vw, 3.5rem);
+  }
+
+  .stims-shell__launch-center[data-variant="resume"]
+    .stims-shell__launch-actions-minimal {
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  .stims-shell__launch-resume-card {
+    /* Clears the display headline, which sets its own optical space. */
+    margin-top: 4px;
+    width: min(24rem, 100%);
+    overflow: hidden;
+    border: 1px solid var(--stims-line-soft);
+    border-radius: var(--radius-xl);
+    background: var(--stims-white-04);
+    box-shadow: var(--stims-shadow-control);
+  }
+
+  .stims-shell__launch-resume-card .stims-shell__preset-art {
+    height: 140px;
+    min-height: 140px;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .stims-shell__launch-resume-card-copy {
+    display: grid;
+    gap: 2px;
+    padding: 10px 14px 12px;
+  }
+
+  .stims-shell__launch-resume-card-title {
+    margin: 0;
+    color: var(--stims-ink-strong);
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    overflow-wrap: anywhere;
+  }
+
+  .stims-shell__launch-resume-card-meta {
+    margin: 0;
+    color: var(--stims-muted);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+  }
+
+  /* Demo audio under Resume: an escape hatch for someone without their usual
+     source to hand, sized like one. */
+  .stims-shell__launch-demo-link {
+    align-self: flex-start;
+    padding: 6px 0;
+    border: 0;
+    background: none;
+    color: var(--stims-muted);
+    font: inherit;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    text-align: left;
+    text-decoration: underline;
+    text-decoration-color: var(--stims-line-strong);
+    text-underline-offset: 3px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: color var(--transition-fast);
+  }
+
+  .stims-shell__launch-demo-link:hover:not(:disabled) {
+    color: var(--stims-ink-strong);
+  }
+
+  .stims-shell__launch-demo-link:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .stims-shell__launch-demo-link:focus-visible {
+    outline: 2px solid var(--stims-accent);
+    outline-offset: 3px;
+    border-radius: var(--stims-radius-control);
+  }
+
+  /* The other sources, as chips, directly under Resume — no disclosure. */
+  .stims-shell__launch-sources-inline {
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  /* "Browse presets" on the returning-visitor page changes context; it is
+     not a second way to start, so it must not pair with Resume as an equal
+     outlined button. Doubled class: the 480px rule above stretches every
+     launch-secondary to full width. */
+  .stims-shell__launch-secondary.stims-shell__launch-secondary--quiet {
+    width: auto;
+    min-height: 40px;
+    padding: 8px 0;
+    border: 0;
+    background: none;
+    color: var(--stims-muted);
+    text-decoration: underline;
+    text-decoration-color: var(--stims-line-strong);
+    text-underline-offset: 3px;
+  }
+
+  .stims-shell__launch-secondary.stims-shell__launch-secondary--quiet:hover {
+    background: none;
+    color: var(--stims-ink-strong);
+  }
+
   .stims-shell__launch-explainer {
     margin: 4px 0 0;
     max-width: 34rem;
@@ -1776,6 +1910,69 @@ body[data-page="workspace"][data-live="true"] {
     color: var(--stims-muted);
     font-size: 0.8125rem;
     line-height: 1.35;
+  }
+
+  /* Chip layout (AudioSourcePanel layout="chips"): one line per source,
+     icon and name, wrapped. For surfaces where a primary button is already
+     on screen and these are its alternatives, so a card each would out-weigh
+     it. Flex, not the card grid: the 148px column minimum is a card's width,
+     and it left a lone chip stretched across the whole row. */
+  .stims-shell__source-grid--chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .stims-shell__source-card--chip {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 8px 14px;
+    border-radius: 999px;
+  }
+
+  .stims-shell__source-card--chip:hover:not(:disabled) {
+    transform: none;
+  }
+
+  .stims-shell__source-card--chip[aria-expanded="true"] {
+    border-color: rgba(119, 201, 255, 0.5);
+  }
+
+  .stims-shell__source-card--chip .stims-shell__source-card-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  .stims-shell__source-card--chip strong {
+    font-size: 0.875rem;
+  }
+
+  .stims-shell__source-panel--chips {
+    gap: 8px;
+  }
+
+  .stims-shell__source-panel--chips .stims-shell__section-label {
+    margin: 0;
+  }
+
+  .stims-shell__source-panel--chips .stims-shell__youtube-primary {
+    margin-top: 4px;
+  }
+
+  /* The file card's state line, moved out of the chip (a chip has no second
+     line) to sit under the row. */
+  .stims-shell__source-feedback {
+    margin: 0;
+    color: var(--stims-muted);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+  }
+
+  .stims-shell__source-feedback[data-state="error"] {
+    color: var(--stims-danger);
   }
 
   .stims-shell__source-card:disabled {

--- a/src/js/frontend/AudioSourcePanel.tsx
+++ b/src/js/frontend/AudioSourcePanel.tsx
@@ -20,8 +20,29 @@ import {
 import { UiIcon } from './UiIcon.tsx';
 import { useWorkspace } from './workspace-context.tsx';
 
+/** Every source the panel can offer, by the id its button starts. */
+export type AudioSourceId = 'demo' | 'microphone' | 'file' | 'tab' | 'youtube';
+
 type AudioSourcePanelProps = {
   showHelp?: boolean;
+  /**
+   * `cards` (default): one card per source with a line of copy, for the
+   * Settings sheet and the first-visit launch page.
+   * `chips`: one compact icon-and-name button per source, wrapped on one
+   * line. For surfaces where a primary button is already on screen and these
+   * are its alternatives — a card each with a subtitle would out-weigh it.
+   * The YouTube link field, which needs typing, opens from a chip of its
+   * own instead of sitting expanded above the others.
+   */
+  layout?: 'cards' | 'chips';
+  /** Section heading; "Audio source" unless the surface ranks these as alternatives. */
+  heading?: string;
+  /**
+   * Sources not to offer — a source the surrounding surface already starts
+   * from its own button (the returning visitor's "Resume with your mic")
+   * must not appear a second time a few lines down under another name.
+   */
+  omitSources?: readonly AudioSourceId[];
 };
 
 /**
@@ -56,8 +77,16 @@ function formatPlaybackTime(totalSeconds: number) {
     : `${minutes}:${paddedSeconds}`;
 }
 
-export function AudioSourcePanel({ showHelp = true }: AudioSourcePanelProps) {
+export function AudioSourcePanel({
+  showHelp = true,
+  layout = 'cards',
+  heading = 'Audio source',
+  omitSources = [],
+}: AudioSourcePanelProps) {
+  const chips = layout === 'chips';
+  const offers = (source: AudioSourceId) => !omitSources.includes(source);
   const sourcePanelId = useId();
+  const youtubeBlockId = `${sourcePanelId}-youtube-block`;
   const sourceHeadingId = `${sourcePanelId}-source-heading`;
   const engineStatusId = `${sourcePanelId}-engine-status`;
   const youtubeInputId = `${sourcePanelId}-youtube-url`;
@@ -209,20 +238,361 @@ export function AudioSourcePanel({ showHelp = true }: AudioSourcePanelProps) {
 
   const isAppBrowser = isInAppBrowser();
 
+  // In the chip layout the link field is closed until its chip is pressed —
+  // unless a link is already in flight, which must stay visible to be
+  // finished (paste-to-load, "Start capture", the transport).
+  const [youtubeOpened, setYoutubeOpened] = useState(false);
+  const offersYouTube = canCaptureDisplayAudio && offers('youtube');
+  const youtubeVisible =
+    offersYouTube &&
+    (!chips || youtubeOpened || youtubeReady || youtubeUrl.trim() !== '');
+  const cardClassName = chips
+    ? 'stims-shell__source-card stims-shell__source-card--chip'
+    : 'stims-shell__source-card';
+
+  const youtubeBlock = (
+    <div
+      id={youtubeBlockId}
+      className="stims-shell__youtube stims-shell__youtube-primary"
+      hidden={!youtubeVisible}
+    >
+      <label className="stims-shell__field-label" htmlFor={youtubeInputId}>
+        YouTube link
+      </label>
+      <div className="stims-shell__youtube-row">
+        <input
+          id={youtubeInputId}
+          className="stims-shell__input"
+          type="url"
+          placeholder="Paste a YouTube link…"
+          autoComplete="off"
+          inputMode="url"
+          spellCheck={false}
+          data-youtube-url-input="true"
+          aria-describedby={
+            !engineReady
+              ? `${youtubeFeedbackId} ${disabledDescription}`
+              : youtubeFeedbackId
+          }
+          aria-invalid={youtubeInputInvalid}
+          value={youtubeUrl}
+          onChange={(event) => onYoutubeUrlChange(event.target.value)}
+          onKeyDown={(e) =>
+            onYoutubeUrlKeyDown(e, () => onAudioStart('youtube'))
+          }
+          onPaste={handleYoutubeUrlPaste}
+        />
+        <button
+          id={`${sourcePanelId}-load-youtube`}
+          data-youtube-load-btn="true"
+          className="cta-button primary"
+          type="button"
+          disabled={!engineReady || !youtubeCanLoad || youtubeLoading}
+          aria-disabled={!engineReady || !youtubeCanLoad || youtubeLoading}
+          aria-describedby={!engineReady ? disabledDescription : undefined}
+          aria-busy={youtubeLoading}
+          onClick={handlePlayYouTube}
+        >
+          {youtubeLoading ? (
+            <>
+              <UiIcon name="spinner" className="stims-shell__button-icon" />
+              Loading…
+            </>
+          ) : youtubeReady ? (
+            'Start capture'
+          ) : (
+            'Load'
+          )}
+        </button>
+      </div>
+      <p
+        id={youtubeFeedbackId}
+        className="stims-shell__youtube-feedback"
+        data-state={
+          youtubeInputInvalid ? 'invalid' : youtubeReady ? 'ready' : 'idle'
+        }
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {youtubeFeedback}
+      </p>
+      {youtubeTransport ? (
+        <fieldset
+          className="stims-shell__youtube-transport"
+          aria-label="YouTube playback"
+        >
+          <button
+            type="button"
+            className="stims-shell__transport-button"
+            onClick={() => youtubeTransportControls.nudge(-10)}
+            aria-label="Back 10 seconds"
+          >
+            −10s
+          </button>
+          <button
+            type="button"
+            className="stims-shell__transport-button"
+            onClick={() =>
+              youtubeTransport.paused
+                ? youtubeTransportControls.play()
+                : youtubeTransportControls.pause()
+            }
+          >
+            {youtubeTransport.paused ? 'Play' : 'Pause'}
+          </button>
+          <button
+            type="button"
+            className="stims-shell__transport-button"
+            onClick={() => youtubeTransportControls.nudge(10)}
+            aria-label="Forward 10 seconds"
+          >
+            +10s
+          </button>
+          <input
+            className="stims-shell__transport-scrubber"
+            type="range"
+            min={0}
+            max={Math.floor(youtubeTransport.durationSeconds)}
+            value={Math.floor(youtubeTransport.currentSeconds)}
+            aria-label="Seek"
+            aria-valuetext={formatPlaybackTime(youtubeTransport.currentSeconds)}
+            onChange={(event) =>
+              youtubeTransportControls.seekTo(Number(event.target.value))
+            }
+          />
+          <span className="stims-shell__transport-time">
+            {formatPlaybackTime(youtubeTransport.currentSeconds)} /{' '}
+            {formatPlaybackTime(youtubeTransport.durationSeconds)}
+          </span>
+        </fieldset>
+      ) : null}
+      {recentYouTubeVideos.length > 0 ? (
+        <div className="stims-shell__youtube-recent">
+          <div className="stims-shell__youtube-recent-header">
+            <p className="stims-shell__field-label">Recent videos</p>
+            <button
+              type="button"
+              className="stims-shell__clear-filters stims-shell__clear-filters--compact"
+              onClick={engine.clearRecentYouTubeVideos}
+            >
+              Clear history
+            </button>
+          </div>
+          <div className="stims-shell__chip-list">
+            {recentYouTubeVideos.map((video) => (
+              <button
+                key={video.id}
+                type="button"
+                className="stims-shell__chip stims-shell__chip--media"
+                onClick={() => onLoadRecentYouTubeVideo(video.id)}
+              >
+                {video.thumbnail ? (
+                  <img
+                    className="stims-shell__chip-thumb"
+                    src={video.thumbnail}
+                    alt=""
+                    loading="lazy"
+                    decoding="async"
+                  />
+                ) : null}
+                <span className="stims-shell__chip-copy">
+                  <strong>{video.title}</strong>
+                  {video.author ? <span>{video.author}</span> : null}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      <div
+        id={youtubeContainerId}
+        ref={youtubePreviewRef}
+        className="stims-shell__youtube-preview"
+        hidden
+      >
+        <div data-youtube-player></div>
+      </div>
+    </div>
+  );
+
+  const fileCopy = fileState?.loading
+    ? 'Loading…'
+    : fileState?.error
+      ? fileState.error
+      : fileState
+        ? `Playing ${fileState.name}`
+        : 'Pick a track, or drop one here';
+
+  const sourceGrid = (
+    <div
+      className={
+        chips
+          ? 'stims-shell__source-grid stims-shell__source-grid--chips'
+          : 'stims-shell__source-grid'
+      }
+    >
+      {offers('demo') ? (
+        <button
+          id={`${sourcePanelId}-use-demo-audio-card`}
+          data-demo-audio-btn="true"
+          type="button"
+          className={cardClassName}
+          disabled={!engineReady}
+          aria-describedby={!engineReady ? disabledDescription : undefined}
+          onClick={() => onAudioStart('demo')}
+        >
+          <UiIcon
+            name="pulse"
+            className="stims-shell__source-card-icon stims-icon-slot"
+          />
+          <strong>Demo audio</strong>
+          {chips ? null : <span>No permission needed</span>}
+        </button>
+      ) : null}
+      {offers('microphone') ? (
+        <button
+          id={`${sourcePanelId}-start-audio-btn`}
+          data-mic-audio-btn="true"
+          type="button"
+          className={cardClassName}
+          disabled={!engineReady}
+          aria-describedby={!engineReady ? disabledDescription : undefined}
+          onClick={() =>
+            onAudioStart(
+              'microphone',
+              mobileDevice ? undefined : selectedDeviceId || undefined,
+            )
+          }
+        >
+          <UiIcon
+            name="mic"
+            className="stims-shell__source-card-icon stims-icon-slot"
+          />
+          <strong>Microphone</strong>
+          {chips ? null : <span>Whatever is playing in the room</span>}
+        </button>
+      ) : null}
+      {offers('microphone') && audioDevices.length > 1 ? (
+        <label className="stims-shell__device-select">
+          <span className="stims-shell__field-label">Microphone</span>
+          <select
+            className="stims-shell__input"
+            value={selectedDeviceId}
+            onChange={(e) => setSelectedDeviceId(e.target.value)}
+          >
+            {audioDevices.map((device) => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {device.label || `Microphone ${device.deviceId.slice(0, 8)}`}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+      <button
+        type="button"
+        // No hardcoded id: this panel mounts twice at once (home + Settings),
+        // so the sibling cards' fixed ids are already duplicated in the DOM.
+        // The data-attribute is the automation hook here, matching
+        // data-demo-audio-btn — which exists for exactly this reason.
+        id={fileCardId}
+        data-file-audio-btn="true"
+        className={cardClassName}
+        data-drag-active={dragActive || undefined}
+        disabled={!engineReady || fileState?.loading}
+        aria-describedby={!engineReady ? disabledDescription : undefined}
+        onClick={() => fileInputRef.current?.click()}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={(event) => {
+          event.preventDefault();
+          setDragActive(false);
+          const file = event.dataTransfer.files?.[0];
+          if (file) void playFile(file);
+        }}
+      >
+        <UiIcon
+          name="music"
+          className="stims-shell__source-card-icon stims-icon-slot"
+        />
+        <strong>Audio file</strong>
+        {chips ? null : <span>{fileCopy}</span>}
+      </button>
+      {/* Outside the button: a file input nested in a button swallows the
+            click that is meant to open the picker. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={AUDIO_FILE_ACCEPT}
+        className="stims-shell__sr-only"
+        tabIndex={-1}
+        aria-hidden="true"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          // Clear so re-picking the same file fires change again.
+          event.target.value = '';
+          if (file) void playFile(file);
+        }}
+      />
+      {canCaptureDisplayAudio && offers('tab') ? (
+        <button
+          type="button"
+          id={`${sourcePanelId}-use-tab-audio`}
+          data-tab-audio-btn="true"
+          className={cardClassName}
+          disabled={!engineReady}
+          aria-describedby={!engineReady ? disabledDescription : undefined}
+          onClick={() => onAudioStart('tab')}
+        >
+          <UiIcon
+            name="video"
+            className="stims-shell__source-card-icon stims-icon-slot"
+          />
+          <strong>This tab</strong>
+          {chips ? null : <span>Audio playing in this browser tab</span>}
+        </button>
+      ) : null}
+      {chips && offersYouTube ? (
+        <button
+          type="button"
+          className={cardClassName}
+          aria-expanded={youtubeVisible}
+          aria-controls={youtubeBlockId}
+          disabled={!engineReady}
+          aria-describedby={!engineReady ? disabledDescription : undefined}
+          onClick={() => setYoutubeOpened((open) => !open)}
+        >
+          <UiIcon
+            name="link"
+            className="stims-shell__source-card-icon stims-icon-slot"
+          />
+          <strong>YouTube</strong>
+        </button>
+      ) : null}
+    </div>
+  );
+
   return (
     <section
-      className="stims-shell__source-panel"
+      className={
+        chips
+          ? 'stims-shell__source-panel stims-shell__source-panel--chips'
+          : 'stims-shell__source-panel'
+      }
+      data-layout={layout}
       aria-labelledby={sourceHeadingId}
       aria-busy={!engineReady}
     >
       <div className="stims-shell__source-heading">
-        {/* "Audio source" in both cases. This heading names the whole
-            section — YouTube, microphone, a file and this tab — so labelling
-            it "YouTube playback" whenever tab capture happens to be available
-            named one of its four children and mis-described the other three,
-            which is also what a screen reader announced on entering it. */}
+        {/* This heading names the whole section — YouTube, microphone, a
+            file and this tab — so labelling it "YouTube playback" whenever
+            tab capture happens to be available named one of its four
+            children and mis-described the other three, which is also what
+            a screen reader announced on entering it. */}
         <h2 id={sourceHeadingId} className="stims-shell__section-label">
-          Audio source
+          {heading}
         </h2>
       </div>
       {isAppBrowser ? (
@@ -249,298 +619,19 @@ export function AudioSourcePanel({ showHelp = true }: AudioSourcePanelProps) {
           Audio engine is starting. Sources will unlock in a moment.
         </p>
       ) : null}
-      <div
-        className="stims-shell__youtube stims-shell__youtube-primary"
-        hidden={!canCaptureDisplayAudio}
-      >
-        <label className="stims-shell__field-label" htmlFor={youtubeInputId}>
-          YouTube link
-        </label>
-        <div className="stims-shell__youtube-row">
-          <input
-            id={youtubeInputId}
-            className="stims-shell__input"
-            type="url"
-            placeholder="Paste a YouTube link…"
-            autoComplete="off"
-            inputMode="url"
-            spellCheck={false}
-            data-youtube-url-input="true"
-            aria-describedby={
-              !engineReady
-                ? `${youtubeFeedbackId} ${disabledDescription}`
-                : youtubeFeedbackId
-            }
-            aria-invalid={youtubeInputInvalid}
-            value={youtubeUrl}
-            onChange={(event) => onYoutubeUrlChange(event.target.value)}
-            onKeyDown={(e) =>
-              onYoutubeUrlKeyDown(e, () => onAudioStart('youtube'))
-            }
-            onPaste={handleYoutubeUrlPaste}
-          />
-          <button
-            id={`${sourcePanelId}-load-youtube`}
-            data-youtube-load-btn="true"
-            className="cta-button primary"
-            type="button"
-            disabled={!engineReady || !youtubeCanLoad || youtubeLoading}
-            aria-disabled={!engineReady || !youtubeCanLoad || youtubeLoading}
-            aria-describedby={!engineReady ? disabledDescription : undefined}
-            aria-busy={youtubeLoading}
-            onClick={handlePlayYouTube}
-          >
-            {youtubeLoading ? (
-              <>
-                <UiIcon name="spinner" className="stims-shell__button-icon" />
-                Loading…
-              </>
-            ) : youtubeReady ? (
-              'Start capture'
-            ) : (
-              'Load'
-            )}
-          </button>
-        </div>
+      {/* Cards: the link field leads, the cards follow. Chips: the chips
+          lead and the field opens beneath them from its own chip. */}
+      {chips ? sourceGrid : youtubeBlock}
+      {chips ? youtubeBlock : sourceGrid}
+      {chips && fileState ? (
         <p
-          id={youtubeFeedbackId}
-          className="stims-shell__youtube-feedback"
-          data-state={
-            youtubeInputInvalid ? 'invalid' : youtubeReady ? 'ready' : 'idle'
-          }
+          className="stims-shell__source-feedback"
+          data-state={fileState.error ? 'error' : 'idle'}
           aria-live="polite"
-          aria-atomic="true"
         >
-          {youtubeFeedback}
+          {fileCopy}
         </p>
-        {youtubeTransport ? (
-          <fieldset
-            className="stims-shell__youtube-transport"
-            aria-label="YouTube playback"
-          >
-            <button
-              type="button"
-              className="stims-shell__transport-button"
-              onClick={() => youtubeTransportControls.nudge(-10)}
-              aria-label="Back 10 seconds"
-            >
-              −10s
-            </button>
-            <button
-              type="button"
-              className="stims-shell__transport-button"
-              onClick={() =>
-                youtubeTransport.paused
-                  ? youtubeTransportControls.play()
-                  : youtubeTransportControls.pause()
-              }
-            >
-              {youtubeTransport.paused ? 'Play' : 'Pause'}
-            </button>
-            <button
-              type="button"
-              className="stims-shell__transport-button"
-              onClick={() => youtubeTransportControls.nudge(10)}
-              aria-label="Forward 10 seconds"
-            >
-              +10s
-            </button>
-            <input
-              className="stims-shell__transport-scrubber"
-              type="range"
-              min={0}
-              max={Math.floor(youtubeTransport.durationSeconds)}
-              value={Math.floor(youtubeTransport.currentSeconds)}
-              aria-label="Seek"
-              aria-valuetext={formatPlaybackTime(
-                youtubeTransport.currentSeconds,
-              )}
-              onChange={(event) =>
-                youtubeTransportControls.seekTo(Number(event.target.value))
-              }
-            />
-            <span className="stims-shell__transport-time">
-              {formatPlaybackTime(youtubeTransport.currentSeconds)} /{' '}
-              {formatPlaybackTime(youtubeTransport.durationSeconds)}
-            </span>
-          </fieldset>
-        ) : null}
-        {recentYouTubeVideos.length > 0 ? (
-          <div className="stims-shell__youtube-recent">
-            <div className="stims-shell__youtube-recent-header">
-              <p className="stims-shell__field-label">Recent videos</p>
-              <button
-                type="button"
-                className="stims-shell__clear-filters stims-shell__clear-filters--compact"
-                onClick={engine.clearRecentYouTubeVideos}
-              >
-                Clear history
-              </button>
-            </div>
-            <div className="stims-shell__chip-list">
-              {recentYouTubeVideos.map((video) => (
-                <button
-                  key={video.id}
-                  type="button"
-                  className="stims-shell__chip stims-shell__chip--media"
-                  onClick={() => onLoadRecentYouTubeVideo(video.id)}
-                >
-                  {video.thumbnail ? (
-                    <img
-                      className="stims-shell__chip-thumb"
-                      src={video.thumbnail}
-                      alt=""
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  ) : null}
-                  <span className="stims-shell__chip-copy">
-                    <strong>{video.title}</strong>
-                    {video.author ? <span>{video.author}</span> : null}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        <div
-          id={youtubeContainerId}
-          ref={youtubePreviewRef}
-          className="stims-shell__youtube-preview"
-          hidden
-        >
-          <div data-youtube-player></div>
-        </div>
-      </div>
-      <div className="stims-shell__source-grid">
-        <button
-          id={`${sourcePanelId}-use-demo-audio-card`}
-          data-demo-audio-btn="true"
-          type="button"
-          className="stims-shell__source-card"
-          disabled={!engineReady}
-          aria-describedby={!engineReady ? disabledDescription : undefined}
-          onClick={() => onAudioStart('demo')}
-        >
-          <UiIcon
-            name="pulse"
-            className="stims-shell__source-card-icon stims-icon-slot"
-          />
-          <strong>Demo audio</strong>
-          <span>No permission needed</span>
-        </button>
-        <button
-          id={`${sourcePanelId}-start-audio-btn`}
-          data-mic-audio-btn="true"
-          type="button"
-          className="stims-shell__source-card"
-          disabled={!engineReady}
-          aria-describedby={!engineReady ? disabledDescription : undefined}
-          onClick={() =>
-            onAudioStart(
-              'microphone',
-              mobileDevice ? undefined : selectedDeviceId || undefined,
-            )
-          }
-        >
-          <UiIcon
-            name="mic"
-            className="stims-shell__source-card-icon stims-icon-slot"
-          />
-          <strong>Microphone</strong>
-          <span>Whatever is playing in the room</span>
-        </button>
-        {audioDevices.length > 1 ? (
-          <label className="stims-shell__device-select">
-            <span className="stims-shell__field-label">Microphone</span>
-            <select
-              className="stims-shell__input"
-              value={selectedDeviceId}
-              onChange={(e) => setSelectedDeviceId(e.target.value)}
-            >
-              {audioDevices.map((device) => (
-                <option key={device.deviceId} value={device.deviceId}>
-                  {device.label || `Microphone ${device.deviceId.slice(0, 8)}`}
-                </option>
-              ))}
-            </select>
-          </label>
-        ) : null}
-        <button
-          type="button"
-          // No hardcoded id: this panel mounts twice at once (home + Settings),
-          // so the sibling cards' fixed ids are already duplicated in the DOM.
-          // The data-attribute is the automation hook here, matching
-          // data-demo-audio-btn — which exists for exactly this reason.
-          id={fileCardId}
-          data-file-audio-btn="true"
-          className="stims-shell__source-card"
-          data-drag-active={dragActive || undefined}
-          disabled={!engineReady || fileState?.loading}
-          aria-describedby={!engineReady ? disabledDescription : undefined}
-          onClick={() => fileInputRef.current?.click()}
-          onDragOver={(event) => {
-            event.preventDefault();
-            setDragActive(true);
-          }}
-          onDragLeave={() => setDragActive(false)}
-          onDrop={(event) => {
-            event.preventDefault();
-            setDragActive(false);
-            const file = event.dataTransfer.files?.[0];
-            if (file) void playFile(file);
-          }}
-        >
-          <UiIcon
-            name="music"
-            className="stims-shell__source-card-icon stims-icon-slot"
-          />
-          <strong>Audio file</strong>
-          <span>
-            {fileState?.loading
-              ? 'Loading…'
-              : fileState?.error
-                ? fileState.error
-                : fileState
-                  ? `Playing ${fileState.name}`
-                  : 'Pick a track, or drop one here'}
-          </span>
-        </button>
-        {/* Outside the button: a file input nested in a button swallows the
-            click that is meant to open the picker. */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={AUDIO_FILE_ACCEPT}
-          className="stims-shell__sr-only"
-          tabIndex={-1}
-          aria-hidden="true"
-          onChange={(event) => {
-            const file = event.target.files?.[0];
-            // Clear so re-picking the same file fires change again.
-            event.target.value = '';
-            if (file) void playFile(file);
-          }}
-        />
-        {canCaptureDisplayAudio ? (
-          <button
-            type="button"
-            id={`${sourcePanelId}-use-tab-audio`}
-            data-tab-audio-btn="true"
-            className="stims-shell__source-card"
-            disabled={!engineReady}
-            aria-describedby={!engineReady ? disabledDescription : undefined}
-            onClick={() => onAudioStart('tab')}
-          >
-            <UiIcon
-              name="video"
-              className="stims-shell__source-card-icon stims-icon-slot"
-            />
-            <strong>This tab</strong>
-            <span>Audio playing in this browser tab</span>
-          </button>
-        ) : null}
-      </div>
+      ) : null}
       {showHelp ? (
         <details className="stims-shell__settings-advanced">
           <summary className="stims-shell__settings-summary">

--- a/src/js/frontend/NewHomePage.tsx
+++ b/src/js/frontend/NewHomePage.tsx
@@ -14,13 +14,25 @@ import { PresetArtwork } from './PresetArtwork.tsx';
 import { LaunchSignalTrace } from './SignalField.tsx';
 import { UiIcon } from './UiIcon.tsx';
 import { useWorkspace } from './workspace-context.tsx';
-import { STIMS_REPO_URL } from './workspace-helpers.ts';
+import { describePresetMood, STIMS_REPO_URL } from './workspace-helpers.ts';
 
 const RESUME_SOURCE_LABEL: Record<ResumableAudioSource, string> = {
   demo: 'demo audio',
   microphone: 'your mic',
   tab: "this tab's audio",
   youtube: 'YouTube audio',
+};
+
+/**
+ * The automation hook (`core/agent-api.ts`, `scripts/play-toy.ts`) for the
+ * source a button starts. The resume CTA used to carry `data-demo-audio-btn`
+ * whatever it resumed with, so `enableDemoAudio()` on a returning visitor's
+ * page asked for their microphone.
+ */
+const RESUME_SOURCE_HOOK: Partial<Record<ResumableAudioSource, string>> = {
+  demo: 'data-demo-audio-btn',
+  microphone: 'data-mic-audio-btn',
+  tab: 'data-tab-audio-btn',
 };
 
 /**
@@ -159,7 +171,10 @@ export function NewHomePage() {
       data-audio-controls
       aria-labelledby="stims-launch-title"
     >
-      <div className="stims-shell__launch-center">
+      <div
+        className="stims-shell__launch-center"
+        data-variant={resume ? 'resume' : deepLink ? 'deep-link' : 'launch'}
+      >
         <Header resume={resume} deepLink={deepLink} />
         <Actions
           resume={resume}
@@ -176,7 +191,19 @@ export function NewHomePage() {
             own.
           </p>
         )}
-        <AudioSources />
+        <AudioSources resume={resume} />
+        {/* Returning visitor: switching preset changes context, it is not
+            a second way to start, so it ranks below the sources as a quiet
+            text action rather than pairing with Resume as an equal. */}
+        {resume ? (
+          <button
+            type="button"
+            className="stims-shell__launch-secondary stims-shell__launch-secondary--quiet"
+            onClick={handleBrowsePresets}
+          >
+            Browse presets
+          </button>
+        ) : null}
         <ProjectMeta />
       </div>
     </section>
@@ -227,16 +254,26 @@ function Header({
     );
   }
   if (resume) {
+    // The preset is one object — its artwork with its name on it — not a
+    // headline, a "Continue with…" sentence and a strip of art each
+    // announcing the same thing. The decision on this page is small (this
+    // preset, or something else) and the layout should look it.
+    const { entry } = resume;
     return (
       <>
         <h1 id="stims-launch-title" className="stims-shell__launch-title">
           Welcome back
         </h1>
-        <p className="stims-shell__launch-tagline">
-          Continue with &ldquo;{resume.entry.title}&rdquo;
-        </p>
-        <div className="stims-shell__launch-resume-art">
-          <PresetArtwork entry={resume.entry} compact />
+        <div className="stims-shell__launch-resume-card">
+          <PresetArtwork entry={entry} compact />
+          <div className="stims-shell__launch-resume-card-copy">
+            <p className="stims-shell__launch-resume-card-title">
+              {entry.title}
+            </p>
+            <p className="stims-shell__launch-resume-card-meta">
+              {entry.author ? `by ${entry.author}` : describePresetMood(entry)}
+            </p>
+          </div>
         </div>
       </>
     );
@@ -299,13 +336,14 @@ function Actions({
       ctaRef.current?.focus();
     }
   }, [isEngineReady]);
+  const resumeHook = resume ? RESUME_SOURCE_HOOK[resume.session.source] : null;
   return (
     <div className="stims-shell__launch-actions-minimal">
       {resume ? (
         <button
           ref={ctaRef}
           id="use-demo-audio"
-          data-demo-audio-btn="true"
+          {...(resumeHook ? { [resumeHook]: 'true' } : {})}
           type="button"
           className="stims-shell__launch-cta"
           disabled={!isEngineReady || isStarting}
@@ -346,29 +384,64 @@ function Actions({
           Audio engine is starting. This will unlock in a moment.
         </p>
       ) : null}
-      <button
-        type="button"
-        className="stims-shell__launch-secondary"
-        onClick={onBrowsePresets}
-      >
-        Browse presets
-      </button>
+      {/* Demo audio is not the visitor's own audio, so it does not belong
+          among "use a different source". For someone resuming with a real
+          source it is the no-permission escape hatch, and lives here as a
+          small action under Resume. */}
+      {resume && resume.session.source !== 'demo' ? (
+        <button
+          type="button"
+          className="stims-shell__launch-demo-link"
+          data-demo-audio-btn="true"
+          disabled={!isEngineReady || isStarting}
+          onClick={onPlayDemo}
+        >
+          Try demo audio instead, no permission needed
+        </button>
+      ) : null}
+      {resume ? null : (
+        <button
+          type="button"
+          className="stims-shell__launch-secondary"
+          onClick={onBrowsePresets}
+        >
+          Browse presets
+        </button>
+      )}
     </div>
   );
 }
 
 /**
- * The alternatives to the primary CTA, behind a disclosure.
+ * The alternatives to the primary CTA.
  *
  * The pitch is "press one button and it plays" — but the YouTube field and
  * the four source cards rendered flat underneath the CTA at roughly equal
  * visual weight, so the page offered six ways to start and ranked none of
- * them. Collapsing them restores the ranking without removing anything: the
- * summary names every source inside, so nothing becomes undiscoverable, and
- * a returning visitor's usual source is already the primary button ("Resume
- * with your mic"), which is why this stays closed even for them.
+ * them. On a first visit they collapse behind a disclosure: the summary
+ * names every source inside, so nothing becomes undiscoverable.
+ *
+ * A returning visitor gets them as a row of compact chips instead. Their
+ * usual source is already the primary button ("Resume with your mic"), so
+ * the chips are ranked by size alone and need no disclosure — which also
+ * removes the page-length jump between its closed and open states, and the
+ * second "Microphone" that the open state used to show a few lines under
+ * "Resume with your mic". Demo audio is not their own audio and is offered
+ * under Resume instead (see `Actions`).
  */
-function AudioSources() {
+function AudioSources({ resume }: { resume: ResumeState }) {
+  if (resume) {
+    return (
+      <div className="stims-shell__launch-sources-inline">
+        <AudioSourcePanel
+          showHelp={false}
+          layout="chips"
+          heading="Use a different source"
+          omitSources={['demo', resume.session.source]}
+        />
+      </div>
+    );
+  }
   return (
     <details className="stims-shell__launch-source-minimal">
       <summary className="stims-shell__launch-sources-summary">

--- a/tests/e2e/e2e-engine-mount.test.ts
+++ b/tests/e2e/e2e-engine-mount.test.ts
@@ -417,16 +417,24 @@ browserTest(
 /**
  * Opens the home page's audio-source disclosure.
  *
- * The alternatives to the primary CTA (mic, tab, file, YouTube) now sit
- * behind a `<details>` so "Play demo" ranks above them, which means a real
- * user opens it before choosing mic — and a click on a collapsed
- * descendant does nothing. No-op when already open, or where the controls
- * render without the disclosure (the Settings panel).
+ * On a first visit the alternatives to the primary CTA (mic, tab, file,
+ * YouTube) sit behind a `<details>` so "Play demo" ranks above them, which
+ * means a real user opens it before choosing mic — and a click on a
+ * collapsed descendant does nothing. No-op when already open, or where the
+ * controls render without the disclosure: the Settings panel, and the
+ * returning-visitor launch page, which ranks the same sources as chips
+ * under "Resume with…" and so has nothing to open.
  */
 async function openAudioSourceDisclosure(
   page: import('playwright').Page,
   { attachTimeoutMs = 90000 }: { attachTimeoutMs?: number } = {},
 ) {
+  // The chips surface renders the same source buttons with no disclosure
+  // around them. Racing the two means this helper stays correct whichever
+  // launch variant the test's storage state produces, instead of timing out
+  // for 90s on a page where there is deliberately nothing to open.
+  const chipGrid = page.locator('.stims-shell__source-grid--chips');
+  if ((await chipGrid.count()) > 0) return;
   const details = page.locator('details.stims-shell__launch-source-minimal');
   // Wait for it rather than probing once: callers navigate with
   // `domcontentloaded`, and the home page is a lazy chunk, so an immediate
@@ -449,6 +457,9 @@ async function openAudioSourceDisclosure(
       .first()
       .waitFor({ state: 'attached', timeout: attachTimeoutMs });
   } catch {
+    // The chunk may have landed on the returning-visitor variant, which has
+    // chips and no disclosure. Check once more before blaming the chunk.
+    if ((await chipGrid.count()) > 0) return;
     throw new Error(
       'The audio-source disclosure never appeared. It lives inside the lazy ' +
         'NewHomePage chunk, so this usually means that chunk failed or was ' +

--- a/tests/unit/workspace-first-fold-actions.test.tsx
+++ b/tests/unit/workspace-first-fold-actions.test.tsx
@@ -1,9 +1,32 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { saveLastSession } from '../../src/js/core/state/last-session-store.ts';
 import { AudioSourcePanel } from '../../src/js/frontend/AudioSourcePanel.tsx';
 import { NewHomePage } from '../../src/js/frontend/NewHomePage.tsx';
-import { renderWorkspace } from '../frontend-harness.tsx';
+import { makePresetEntry, renderWorkspace } from '../frontend-harness.tsx';
+
+const LAST_SESSION_KEY = 'stims:last-session';
+
+/** Renders the "Welcome back" variant: a stored session whose preset the catalog resolves. */
+function renderReturningVisitor(source: 'microphone' | 'demo') {
+  const entry = makePresetEntry({
+    id: 'eo-s-phat-chasers',
+    title: 'eo.s. + phat - chasers 11',
+    author: 'eo.s.',
+  });
+  saveLastSession({ presetId: entry.id, presetTitle: entry.title, source });
+  const rendered = renderWorkspace(<NewHomePage />, {
+    engine: { catalog: [entry] },
+  });
+  return {
+    ...rendered,
+    dispose: () => {
+      rendered.dispose();
+      localStorage.removeItem(LAST_SESSION_KEY);
+    },
+  };
+}
 
 describe('workspace first-fold launch hierarchy', () => {
   test('the launch page renders real audio choices without demo generation', () => {
@@ -46,6 +69,129 @@ describe('workspace first-fold launch hierarchy', () => {
       expect(
         rendered.container.querySelector('.stims-shell__youtube-primary'),
       ).not.toBeNull();
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('a returning visitor gets one preset card, Resume, then the other sources as chips', () => {
+    // The hierarchy is: Welcome back → preset → Resume → change source →
+    // change preset. Not headline → sentence → art → two equal buttons →
+    // a disclosure that doubles the page when opened.
+    const rendered = renderReturningVisitor('microphone');
+    try {
+      const text = rendered.text();
+      const { container } = rendered;
+      expect(text).toContain('Welcome back');
+      expect(text).toContain('eo.s. + phat - chasers 11');
+      expect(text).not.toContain('Continue with');
+      // The preset name is part of the card, not a tagline above it.
+      expect(
+        container.querySelector(
+          '.stims-shell__launch-resume-card .stims-shell__launch-resume-card-title',
+        )?.textContent,
+      ).toBe('eo.s. + phat - chasers 11');
+      expect(
+        container.querySelector(
+          '.stims-shell__launch-resume-card .stims-shell__preset-art',
+        ),
+      ).not.toBeNull();
+      // The usual source is the primary button, and carries that source's
+      // automation hook — not the demo one.
+      const cta = container.querySelector<HTMLButtonElement>(
+        '.stims-shell__launch-cta',
+      );
+      expect(cta?.textContent).toBe('Resume with your mic');
+      expect(cta?.hasAttribute('data-mic-audio-btn')).toBe(true);
+      expect(cta?.hasAttribute('data-demo-audio-btn')).toBe(false);
+      // No disclosure: the other sources are chips directly under Resume …
+      expect(
+        container.querySelector('details.stims-shell__launch-source-minimal'),
+      ).toBeNull();
+      expect(text).not.toContain('Or use your own audio');
+      expect(text).toContain('Use a different source');
+      expect(
+        container.querySelector('.stims-shell__source-grid--chips'),
+      ).not.toBeNull();
+      // … and the source Resume already starts is not offered again under
+      // another name. The file picker still is.
+      expect(
+        container.querySelector(
+          '.stims-shell__source-card[data-mic-audio-btn]',
+        ),
+      ).toBeNull();
+      expect(
+        container.querySelector(
+          '.stims-shell__source-card[data-file-audio-btn]',
+        ),
+      ).not.toBeNull();
+      // Demo audio is not "your own audio": it is the small no-permission
+      // action under Resume, and the only demo hook on the page.
+      const demoButtons = container.querySelectorAll('[data-demo-audio-btn]');
+      expect(demoButtons.length).toBe(1);
+      expect(demoButtons[0].className).toContain(
+        'stims-shell__launch-demo-link',
+      );
+      // Browse presets changes context; it is a quiet action, not Resume's equal.
+      const browse = [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Browse presets',
+      );
+      expect(browse?.className).toContain(
+        'stims-shell__launch-secondary--quiet',
+      );
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('a visitor who last used demo audio gets the microphone chip and no demo shortcut', () => {
+    const rendered = renderReturningVisitor('demo');
+    try {
+      const { container } = rendered;
+      const cta = container.querySelector<HTMLButtonElement>(
+        '.stims-shell__launch-cta',
+      );
+      expect(cta?.textContent).toBe('Resume with demo audio');
+      expect(cta?.hasAttribute('data-demo-audio-btn')).toBe(true);
+      expect(
+        container.querySelector('.stims-shell__launch-demo-link'),
+      ).toBeNull();
+      expect(
+        container.querySelector(
+          '.stims-shell__source-card[data-mic-audio-btn]',
+        ),
+      ).not.toBeNull();
+      expect(
+        container.querySelector(
+          '.stims-shell__source-card[data-demo-audio-btn]',
+        ),
+      ).toBeNull();
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('the resume launch CSS still styles what the page renders', () => {
+    const rendered = renderReturningVisitor('microphone');
+    const appShellCss = readFileSync(
+      join(import.meta.dir, '..', '..', 'src', 'css', 'app-shell.css'),
+      'utf8',
+    );
+    try {
+      for (const className of [
+        'stims-shell__launch-resume-card',
+        'stims-shell__launch-resume-card-title',
+        'stims-shell__launch-demo-link',
+        'stims-shell__launch-sources-inline',
+        'stims-shell__source-grid--chips',
+        'stims-shell__source-card--chip',
+        'stims-shell__launch-secondary--quiet',
+      ]) {
+        expect(
+          rendered.container.querySelector(`.${className}`),
+        ).not.toBeNull();
+        expect(appShellCss).toContain(`.${className}`);
+      }
     } finally {
       rendered.dispose();
     }


### PR DESCRIPTION
## Summary

The "Welcome back" page had the right ingredients ranked backwards. It spent the first screen explaining what was being resumed — a headline, a "Continue with…" sentence and a strip of artwork, three hero elements for one piece of information — before a decision that is small: this preset, or something else. Underneath it, a disclosure whose open state roughly doubled the page length and offered "Microphone" as a card a few lines below "Resume with your mic".

The preset is now one object: artwork with the title and author on it, 140px tall so it actually establishes what the preset looks like. The old strip was prominent enough to cost space but too shallow to do that.

Under it the ranking is Resume → other sources → Browse:

- **Chips instead of a disclosure.** The alternatives render as compact icon-and-name buttons, so the page no longer has open and closed states that differ by a screen height. The YouTube link field, which needs typing, opens in place from its own chip rather than sitting expanded above everything else.
- **No duplicated source.** The source Resume already starts is omitted from those chips. It was previously offered twice under two names.
- **Demo audio moved out of "use your own audio"**, which it never was. It is a small no-permission action under Resume, shown only when the visitor is resuming with something else.
- **Browse presets is a quiet text action.** It changes context rather than being a second way to start, so it no longer pairs with Resume as an equal-weight outlined button.

The dead space in the old layout was not spacing anyone chose. The launch column is a grid inside a stage panel taller than its content, and `align-content` defaults to `stretch`, so every auto row absorbed an equal share of the leftover height — about 42px on each of eight rows. Packing the rows to the start on this variant is what removes it.

Measured at 412×915 (Pixel-class phone), the returning-visitor page before and after:

| Boundary | Before | After |
| --- | --- | --- |
| Bottom of "Browse presets" | 781px | 578px |
| Bottom of the GitHub link | 881px | 638px |

The first-visit page is deliberately untouched — its disclosure still ranks "Play demo" above the sources, and its layout is unchanged.

Also fixes a real bug found on the way: the resume CTA carried `data-demo-audio-btn` whatever source it resumed with, so the agent API's `enableDemoAudio()` asked a returning visitor for their microphone. It now carries the hook for the source it actually starts.

`AudioSourcePanel` gains three optional props (`layout`, `heading`, `omitSources`) and keeps its existing card layout as the default, so the Settings sheet and the first-visit page render exactly as before.

## Testing

- `bun run check` — **3012 pass, 0 fail** (the 3 new tests are the ones added here).
- `bun run check:quick` — clean.
- Three new unit tests in `tests/unit/workspace-first-fold-actions.test.tsx` render the real returning-visitor page through the workspace harness and assert the hierarchy against the DOM: the preset card carries the title, the CTA carries its own source's automation hook and not the demo one, there is no disclosure, the resumed source is absent from the chips, exactly one demo hook exists on the page, and Browse is the quiet variant. A second test covers the visitor whose last source *was* demo, where the microphone chip returns and the demo shortcut disappears.
- Verified in a real browser at 412×915 and 1440×900 with a seeded `stims:last-session`: no console or page errors, the YouTube chip expands its field in place with nothing above it moving, and the first-visit variant still renders its disclosure.
- `tests/corpus/preset-flash-risk.test.ts` is flaky in this container (browser crashes under software WebGL). It fails 3/3 on a clean tree under `--profile corpus`, so it is unrelated to this change; it passed in the full `bun run check` run reported above.

## Docs touched

- None. The behavior lives in component docblocks and CSS comments alongside the code it explains.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (no build/runtime output change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8pDEgkTvpbDDUSwwZ8WYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8pDEgkTvpbDDUSwwZ8WYF)_