### PR TITLE
fix: twelve defects found auditing the runtime, shell and test scheduling

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -28,6 +28,15 @@ const TEST_FILE_PATTERN = /\.test\.(?:ts|tsx|js|jsx)$/;
  * - `serial` runs in its own pass with `--max-concurrency=1`. Browser-backed
  *   tests contend for GPU and port resources, and time out when interleaved
  *   with the rest of the suite.
+ *
+ * `serial` is a property of a *file*, though, and marking whole categories
+ * only covered the case where every file in one is browser-backed. `corpus`
+ * is not that: two of its fourteen files drive real Chromium and the rest are
+ * CPU-heavy compute, so the browser pair got fanned out by `--parallel`
+ * alongside them and lost exactly the contention this trait exists to
+ * prevent — `preset-flash-risk` failed every corpus run while passing alone.
+ * `isBrowserBackedTest` therefore lifts those files out of the parallel pass
+ * on their own merits, whatever category they live in.
  */
 const CATEGORY_TRAITS = {
   unit: { slow: false, serial: false },
@@ -70,6 +79,37 @@ async function listTestFiles(dir: string): Promise<string[]> {
 async function listCategoryFiles(category: Category): Promise<string[]> {
   const dir = path.join(TEST_DIR, category);
   return listTestFiles(dir);
+}
+
+/**
+ * True when a test file drives a real browser.
+ *
+ * Keyed on `browserTest` rather than a hand-maintained list of paths, for the
+ * same reason categories are keyed on folders: a new browser-backed test must
+ * land in the serial pass by existing, not by someone remembering to add it.
+ * The marker is exact — `tests/test-helpers.ts` exports `browserTest` as the
+ * gate for "a real Chromium is installed", so a file that imports it is a file
+ * that launches one, and nothing else in the suite mentions it.
+ */
+async function isBrowserBackedTest(file: string): Promise<boolean> {
+  try {
+    const source = await fs.readFile(file, 'utf8');
+    return /\bbrowserTest\b/.test(source);
+  } catch {
+    // Unreadable here means bun test will fail on it in a moment and say so
+    // properly. Treating it as ordinary keeps that the reported failure.
+    return false;
+  }
+}
+
+/** Splits a file list into [browserBacked, rest], preserving order. */
+async function partitionBrowserBacked(
+  files: string[],
+): Promise<[string[], string[]]> {
+  const flags = await Promise.all(files.map(isBrowserBackedTest));
+  const browserBacked = files.filter((_, index) => flags[index]);
+  const rest = files.filter((_, index) => !flags[index]);
+  return [browserBacked, rest];
 }
 
 /**
@@ -355,9 +395,10 @@ async function main() {
   const parallel = categories.filter((c) => !CATEGORY_TRAITS[c].serial);
   const serial = categories.filter((c) => CATEGORY_TRAITS[c].serial);
 
-  const parallelFiles = (
-    await Promise.all(parallel.map(listCategoryFiles))
-  ).flat();
+  const [browserBackedParallelFiles, parallelFiles] =
+    await partitionBrowserBacked(
+      (await Promise.all(parallel.map(listCategoryFiles))).flat(),
+    );
 
   // Watch mode can only drive one bun process, so keep it to a single pass.
   if (watch) {
@@ -374,6 +415,16 @@ async function main() {
       // unbuffered output, no worker pool.
       ...(parallel === 1 ? {} : { parallel }),
     });
+    if (exitCode !== 0) {
+      process.exit(exitCode);
+    }
+  }
+
+  // Browser-backed files from otherwise-parallel categories get the serial
+  // treatment their contention needs: one process each, and only once the
+  // parallel pass has released its CPU.
+  if (browserBackedParallelFiles.length > 0) {
+    const exitCode = await runSerialCategory(browserBackedParallelFiles);
     if (exitCode !== 0) {
       process.exit(exitCode);
     }

--- a/src/css/AudioStatusControl.module.css
+++ b/src/css/AudioStatusControl.module.css
@@ -232,3 +232,16 @@
     display: none;
   }
 }
+
+/* The dock's siblings (.navBtn/.menuBtn in StageControls.module.css) get
+   bumped to 44px on coarse pointers; this module never did, so the one
+   control that answers "why is there no sound?" was the smallest thing in
+   the bar — roughly 35x32 once .label is hidden — wedged between 44px
+   neighbours. */
+@media (pointer: coarse) {
+  .trigger {
+    min-width: 44px;
+    height: 44px;
+    padding: 0 10px;
+  }
+}

--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -1341,6 +1341,14 @@ body[data-page="workspace"][data-live="true"] {
   .stims-shell__launch-center {
     display: grid;
     justify-items: start;
+    /* This column sits in a stage panel taller than its content, and
+       `align-content` defaults to stretch, so every auto row silently
+       absorbed an equal share of the leftover height — about 40px onto each
+       of seven rows on the first-visit page, pushing a two-button decision
+       to the bottom of a phone screen. That whitespace was leftover height
+       being redistributed, not spacing anyone chose, so the gap below is
+       the only spacing here and it means what it says. */
+    align-content: start;
     gap: 10px;
     width: min(52rem, 100%);
   }
@@ -1419,21 +1427,8 @@ body[data-page="workspace"][data-live="true"] {
      establish what it looks like (the old strip was prominent enough to cost
      space but too shallow to do that) and no taller: title, card, Resume,
      the other sources and Browse should all fit one phone screen. */
-  .stims-shell__launch-center[data-variant="resume"] {
-    /* The launch column is a grid inside a stage panel taller than its
-       content, and `align-content` defaults to stretch — so every auto row
-       absorbed an equal share of the leftover height. On this variant that
-       was ~42px added to each of eight rows, which is why the page read as
-       a short interface floating in a screen and a half of nothing: the
-       whitespace was leftover height being redistributed, not spacing
-       anyone chose. Packing the rows to the start makes the gaps below the
-       real ones, so the whole decision fits one phone screen. */
-    align-content: start;
-    gap: 10px;
-  }
-
   .stims-shell__launch-center[data-variant="resume"]
-    .stims-shell__launch-title {
+  .stims-shell__launch-title {
     font-size: clamp(2.25rem, 5vw, 3.5rem);
   }
 
@@ -4406,6 +4401,29 @@ main.stims-shell[data-sheet-open="true"] [class*="toast"] {
   /* No hover to reveal it on touch. */
   .stims-preset-grid__fav {
     opacity: 1;
+  }
+}
+
+@media (pointer: coarse) {
+  /* The star is a 26px disc layered on the full-tile "open preset" button,
+     so a near-miss does not do nothing — it opens and starts playing a
+     different preset, which is a bad surprise mid-set. The 44px bump in
+     chrome.css targets `.ctl-preset__fav`, the list-view star, and never
+     matched this one: the grid button only carries that class on its inner
+     icon span.
+
+     The hit area grows, not the disc. A 44px opaque circle on top of the
+     artwork is a much heavier mark than this needs; the pseudo-element is
+     part of the button's own box, so it takes the taps without changing
+     anything the eye sees. */
+  .stims-preset-grid__fav::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/js/core/modal-utils.ts
+++ b/src/js/core/modal-utils.ts
@@ -32,11 +32,52 @@ export function getFocusableElements(container: HTMLElement) {
   });
 }
 
+/**
+ * Duck-typed rather than `instanceof Node`.
+ *
+ * `instanceof` compares against one realm's constructor, so it answers false
+ * for a node that came from another document — an iframe, or a test DOM whose
+ * globals are not the ones this module closed over — and the focus trap then
+ * silently stops enforcing instead of failing loudly. `nodeType` is the part
+ * `Node.prototype.contains` actually needs.
+ */
+function isNode(value: unknown): value is Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Node).nodeType === 'number'
+  );
+}
+
+/**
+ * Every trap currently installed, outermost first.
+ *
+ * Only the innermost one may act. `handleFocusIn` below is a document-level
+ * listener that pulls focus back into its own panel whenever focus lands
+ * outside it, and nothing stopped two of those existing at once: opening the
+ * shortcuts dialog (or the command palette) over an already-trapped Settings
+ * panel left the panel mounted, so the dialog pulled focus in, the panel's
+ * handler saw a target outside itself and pulled it back, and that dispatched
+ * another focusin — synchronously, with no settling state. The tab locks up.
+ *
+ * A stack rather than a single "current" reference, because traps do not
+ * always unwind in order: closing the outer panel first must leave the dialog
+ * still enforcing.
+ */
+const activeFocusTraps: HTMLElement[] = [];
+
+function isInnermostTrap(panel: HTMLElement) {
+  return activeFocusTraps[activeFocusTraps.length - 1] === panel;
+}
+
 export function trapFocusWithin(panel: HTMLElement) {
   const focusable = () => getFocusableElements(panel);
 
   const handleKeydown = (event: KeyboardEvent) => {
     if (event.key !== 'Tab') return;
+    // A nested trap's panel may sit inside this one, in which case its Tab
+    // events bubble up here too. The innermost trap owns them.
+    if (!isInnermostTrap(panel)) return;
 
     const items = focusable();
     if (items.length === 0) {
@@ -62,7 +103,8 @@ export function trapFocusWithin(panel: HTMLElement) {
   };
 
   const handleFocusIn = (event: FocusEvent) => {
-    if (!(event.target instanceof Node) || panel.contains(event.target)) {
+    if (!isInnermostTrap(panel)) return;
+    if (!isNode(event.target) || panel.contains(event.target)) {
       return;
     }
 
@@ -74,10 +116,15 @@ export function trapFocusWithin(panel: HTMLElement) {
     }
   };
 
+  activeFocusTraps.push(panel);
   panel.addEventListener('keydown', handleKeydown);
   panel.ownerDocument.addEventListener('focusin', handleFocusIn);
 
   return () => {
+    const index = activeFocusTraps.lastIndexOf(panel);
+    if (index !== -1) {
+      activeFocusTraps.splice(index, 1);
+    }
     panel.removeEventListener('keydown', handleKeydown);
     panel.ownerDocument.removeEventListener('focusin', handleFocusIn);
   };

--- a/src/js/core/services/external-display-service.ts
+++ b/src/js/core/services/external-display-service.ts
@@ -66,6 +66,16 @@ let state: ExternalDisplayState = { mode: null, target: null, error: null };
 const listeners = new Set<Listener>();
 let connection: PresentationConnectionLike | null = null;
 let externalWindow: Window | null = null;
+/**
+ * The id of the 1Hz "did they close the popup?" poll.
+ *
+ * Module scope, because the poll cannot cancel itself on the stop path: it
+ * exits only when it observes `externalWindow.closed`, and
+ * `stopExternalDisplay` clears that reference first, so the condition could
+ * never become true again and every send-then-stop cycle left another timer
+ * running for the life of the page.
+ */
+let externalWindowPoll: number | null = null;
 
 function setState(next: Partial<ExternalDisplayState>): void {
   state = { ...state, ...next };
@@ -207,9 +217,10 @@ export async function openOnSecondScreen(receiverUrl: string): Promise<void> {
   externalWindow = opened;
   // A closed window leaves no event on the opener, so poll — cheaply, and
   // only while one is open.
-  const poll = window.setInterval(() => {
+  stopExternalWindowPoll();
+  externalWindowPoll = window.setInterval(() => {
     if (externalWindow?.closed) {
-      window.clearInterval(poll);
+      stopExternalWindowPoll();
       externalWindow = null;
       if (state.mode === 'window') setState({ mode: null, target: null });
     }
@@ -237,6 +248,13 @@ export async function presentToExternalDisplay(
   await startCast(receiverUrl);
 }
 
+function stopExternalWindowPoll(): void {
+  if (externalWindowPoll !== null) {
+    window.clearInterval(externalWindowPoll);
+    externalWindowPoll = null;
+  }
+}
+
 export function stopExternalDisplay(): void {
   if (connection) {
     try {
@@ -246,6 +264,7 @@ export function stopExternalDisplay(): void {
     }
     connection = null;
   }
+  stopExternalWindowPoll();
   if (externalWindow && !externalWindow.closed) {
     externalWindow.close();
   }
@@ -256,6 +275,7 @@ export function stopExternalDisplay(): void {
 export const __externalDisplayTestUtils = {
   reset(): void {
     connection = null;
+    stopExternalWindowPoll();
     externalWindow = null;
     state = { mode: null, target: null, error: null };
     listeners.clear();

--- a/src/js/frontend/AudioSourcePanel.tsx
+++ b/src/js/frontend/AudioSourcePanel.tsx
@@ -15,7 +15,9 @@ import {
   AUDIO_FILE_ACCEPT,
   canProbablyPlay,
   createFileAudioStream,
-  type FileAudioHandle,
+  disposeActiveFileAudio,
+  getActiveFileAudioName,
+  setActiveFileAudio,
 } from './file-audio.ts';
 import { UiIcon } from './UiIcon.tsx';
 import { useWorkspace } from './workspace-context.tsx';
@@ -116,12 +118,17 @@ export function AudioSourcePanel({
 
   const fileCardId = `${sourcePanelId}-file-card`;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const fileHandleRef = useRef<FileAudioHandle | null>(null);
+  // Seeded from the session, not from nothing: this panel mounts twice and
+  // the Settings copy is remounted on every open, so starting empty made it
+  // offer to pick a track that was already playing.
   const [fileState, setFileState] = useState<{
     name: string;
     error: string | null;
     loading: boolean;
-  } | null>(null);
+  } | null>(() => {
+    const playing = getActiveFileAudioName();
+    return playing ? { name: playing, error: null, loading: false } : null;
+  });
   const [dragActive, setDragActive] = useState(false);
 
   // One handle at a time: picking a second track must tear the first one's
@@ -136,11 +143,10 @@ export function AudioSourcePanel({
       return;
     }
     setFileState({ name: file.name, error: null, loading: true });
-    fileHandleRef.current?.dispose();
-    fileHandleRef.current = null;
+    disposeActiveFileAudio();
     try {
       const handle = await createFileAudioStream(file);
-      fileHandleRef.current = handle;
+      setActiveFileAudio(handle);
       // Commit the route *and* pass it as launchState, the same way the
       // Strudel bridge starts a stream source. Calling startAudioSource
       // alone leaves routeState.audioSource null, so the engine snapshot
@@ -155,8 +161,7 @@ export function AudioSourcePanel({
       setFileState({ name: handle.name, error: null, loading: false });
       ui.setStatusMessage(`Playing ${handle.name}`);
     } catch (error) {
-      fileHandleRef.current?.dispose();
-      fileHandleRef.current = null;
+      disposeActiveFileAudio();
       setFileState({
         name: file.name,
         error: error instanceof Error ? error.message : 'Could not play file.',
@@ -164,14 +169,6 @@ export function AudioSourcePanel({
       });
     }
   };
-
-  useEffect(
-    () => () => {
-      fileHandleRef.current?.dispose();
-      fileHandleRef.current = null;
-    },
-    [],
-  );
 
   const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState('');

--- a/src/js/frontend/HudOverlay.tsx
+++ b/src/js/frontend/HudOverlay.tsx
@@ -220,11 +220,7 @@ export function HudOverlay() {
   const energyPercent = Math.round(Math.min(1, Math.max(0, audioEnergy)) * 100);
 
   return (
-    <aside
-      className="stims-shell__debug-hud"
-      role="status"
-      aria-label="GPU debug HUD"
-    >
+    <aside className="stims-shell__debug-hud" aria-label="GPU debug HUD">
       <header className="stims-shell__debug-hud-header">
         <span className="stims-shell__debug-hud-title">Debug HUD</span>
         <button

--- a/src/js/frontend/LiveParameterHud.tsx
+++ b/src/js/frontend/LiveParameterHud.tsx
@@ -117,11 +117,7 @@ export function LiveParameterHud() {
   }
 
   return (
-    <div
-      className="stims-shell__midi-hud"
-      role="status"
-      aria-label="Live parameter status"
-    >
+    <aside className="stims-shell__midi-hud" aria-label="Live parameter status">
       {targets.map((target) => {
         const state = describeParameterState({
           target,
@@ -153,13 +149,15 @@ export function LiveParameterHud() {
             </span>
             {/* `title` is hover-only, and these chips are deliberately not
                 focusable — they are a status readout, not controls — so a
-                tooltip would reach nobody using a screen reader. The wrapper
-                is role="status", so text placed here is announced as part of
-                it. */}
+                tooltip would reach nobody using a screen reader. This text
+                carries the same detail for anyone reading the region. It is
+                deliberately NOT inside a live region: the values retick on
+                every incoming MIDI CC, so announcing each change made a
+                swept knob talk over everything else. */}
             <span className="stims-shell__sr-only">{state.summary}</span>
           </span>
         );
       })}
-    </div>
+    </aside>
   );
 }

--- a/src/js/frontend/PerformSurface.tsx
+++ b/src/js/frontend/PerformSurface.tsx
@@ -89,18 +89,35 @@ export function PerformSurface() {
   // Re-seed each fader from the incoming preset's own literal on every preset
   // change. Without this the faders keep the outgoing preset's positions and
   // silently misreport where the new preset actually sits.
+  //
+  // A field pinned *during* a preset needs the same treatment, and used not to
+  // get it: the effect listed `pinned` but returned early unless the preset id
+  // had changed, so a newly pinned target stayed absent from `values` and the
+  // row below rendered the range midpoint. Pinning warp on a preset that warps
+  // at 0.01 showed 1.0, and the first nudge jumped the value — a visible lurch
+  // mid-set, which is exactly what this effect exists to prevent. So: reseed
+  // everything on a preset change, and seed only the newly pinned targets
+  // otherwise, leaving positions the performer has already set alone.
   const seededForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!activeSource || seededForRef.current === activePresetId) return;
+    if (!activeSource) return;
+    const presetChanged = seededForRef.current !== activePresetId;
     seededForRef.current = activePresetId;
-    const seeded: Record<string, number> = {};
-    for (const target of pinned) {
-      const field = describePinnableField(target);
-      if (!field) continue;
-      const literal = readMilkdropField(activeSource, target);
-      seeded[target] = literal ?? (field.min + field.max) / 2;
-    }
-    setValues(seeded);
+    setValues((current) => {
+      const seeded: Record<string, number> = presetChanged
+        ? {}
+        : { ...current };
+      let changed = presetChanged;
+      for (const target of pinned) {
+        if (!presetChanged && seeded[target] !== undefined) continue;
+        const field = describePinnableField(target);
+        if (!field) continue;
+        const literal = readMilkdropField(activeSource, target);
+        seeded[target] = literal ?? (field.min + field.max) / 2;
+        changed = true;
+      }
+      return changed ? seeded : current;
+    });
   }, [activeSource, activePresetId, pinned]);
 
   const move = useCallback(

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -185,10 +185,12 @@ export function StageControls({
       ? syncSession.room
       : null;
 
-  const { visible, signalActivity } = useAutoHideActivity(3000, true);
+  const [showMenu, setShowMenu] = useState(false);
+  // An open menu holds the bar up. The menu renders as a sibling of the bar,
+  // so the bar's own `:focus-within` reprieve cannot see focus inside it.
+  const { visible, signalActivity } = useAutoHideActivity(3000, true, showMenu);
   const transition = usePresetTransition();
   const pip = usePictureInPicture(ui.stageRef);
-  const [showMenu, setShowMenu] = useState(false);
   const energyRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuBtnRef = useRef<HTMLButtonElement>(null);
@@ -724,10 +726,14 @@ export function StageControls({
             className={styles.titleBtn}
             data-action="open-browse"
             data-active={String(panel === 'browse')}
+            // The visible text is the preset title, so the name has to
+            // start with it: a name that replaces the visible label outright
+            // leaves voice-control users unable to activate the button by the
+            // words they can see (WCAG 2.5.3 Label in Name).
             aria-label={
               shaderApproximation
-                ? `Browse presets. ${shaderApproximation.detail}`
-                : 'Browse presets'
+                ? `${presetTitle}. Browse presets. ${shaderApproximation.detail}`
+                : `${presetTitle}. Browse presets`
             }
             title={
               shaderApproximation

--- a/src/js/frontend/engine/milkdrop-engine-session.ts
+++ b/src/js/frontend/engine/milkdrop-engine-session.ts
@@ -391,7 +391,20 @@ export function createMilkdropEngineAdapter() {
       await setMilkdropCapturedVideoStream(request.stream, {
         cropTarget: request.cropTarget ?? container,
       });
-      await activeRuntime.startAudio({ stream: request.stream });
+      // Tab and YouTube capture come from getDisplayMedia, so the tracks are
+      // a live screen share the browser advertises with its own "sharing"
+      // bar. `acquireAudioHandle` defaults `stopStreamOnCleanup` to
+      // `!reuseMicrophone`, i.e. false, so without this the teardown only
+      // unregistered the stream: "Stop audio" said audio had stopped, the
+      // dock showed no source, and the tab went on being captured until the
+      // page was closed. Nothing else stops these tracks —
+      // `clearMilkdropCapturedVideoStream` (called by performStopAudio, and
+      // when switching to any other source) drops the texture and its
+      // listeners but never touches the tracks.
+      await activeRuntime.startAudio({
+        stream: request.stream,
+        stopStreamOnCleanup: true,
+      });
       audioActive = true;
       audioSource = request.source;
       setAudioActive(true, request.source);

--- a/src/js/frontend/file-audio.ts
+++ b/src/js/frontend/file-audio.ts
@@ -117,3 +117,52 @@ export async function createFileAudioStream(
     },
   };
 }
+
+/**
+ * The file currently feeding the engine, owned here rather than by a
+ * component.
+ *
+ * It used to live in a ref inside `AudioSourcePanel`, disposed on unmount.
+ * But that panel mounts twice — once in the home hero, which stays mounted
+ * all session, and once in the Settings sheet, which is conditionally
+ * rendered — so closing Settings tore down the graph and the context while
+ * the engine's audio session, `routeState.audioSource` and `audioActive` all
+ * carried on: the music stopped and the analyser flatlined, while the dock
+ * still showed the file chip and the stage kept animating on silence.
+ *
+ * The mirror case was worse. From the home copy, which never unmounts,
+ * "Stop audio" tore down the engine side and left this handle untouched — and
+ * the element loops, so the track played on, audibly, forever, after the UI
+ * said audio had stopped.
+ *
+ * Playback belongs to the audio session, so its lifetime is tied to the
+ * session's: `setActiveFileAudio` on play, `disposeActiveFileAudio` when the
+ * session stops or switches to another source.
+ */
+let activeFileAudio: FileAudioHandle | null = null;
+
+/**
+ * Adopts `handle` as the playing file, disposing whichever one it replaces.
+ * One at a time: two live graphs would both feed the analyser and both be
+ * audible.
+ */
+export function setActiveFileAudio(handle: FileAudioHandle | null): void {
+  if (activeFileAudio && activeFileAudio !== handle) {
+    activeFileAudio.dispose();
+  }
+  activeFileAudio = handle;
+}
+
+/** Stops and tears down the playing file, if any. Safe to call repeatedly. */
+export function disposeActiveFileAudio(): void {
+  setActiveFileAudio(null);
+}
+
+/**
+ * The playing file's name, or null. Lets a freshly mounted copy of the audio
+ * panel report what is actually playing instead of offering to pick a track
+ * that is already playing.
+ */
+export function getActiveFileAudioName(): string | null {
+  return activeFileAudio?.name ?? null;
+}

--- a/src/js/frontend/hooks/useAutoHideActivity.ts
+++ b/src/js/frontend/hooks/useAutoHideActivity.ts
@@ -1,8 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+/**
+ * @param holdVisible While true, nothing auto-hides: the deadline is dropped
+ * and `visible` is pinned. For UI that is *open* rather than merely recently
+ * touched — the stage overflow menu is rendered as a sibling of the bar, so
+ * the bar's `:focus-within` reprieve never sees focus sitting in the menu,
+ * and after three still seconds of reading it the bar went
+ * `visibility: hidden` underneath. Escape then restored focus to a hidden
+ * button, which is not focusable, so focus fell to `<body>` and the keyboard
+ * user had to tab in from the top of the document.
+ */
 export function useAutoHideActivity(
   delayMs = 3000,
   initiallyVisible = true,
+  holdVisible = false,
 ): {
   visible: boolean;
   signalActivity: () => void;
@@ -10,6 +21,10 @@ export function useAutoHideActivity(
   const [visible, setVisible] = useState(initiallyVisible);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastActivityRef = useRef(Date.now());
+  // Read inside `signalActivity`, which must stay referentially stable for
+  // the listeners built on it.
+  const holdVisibleRef = useRef(holdVisible);
+  holdVisibleRef.current = holdVisible;
 
   const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -35,6 +50,7 @@ export function useAutoHideActivity(
   const signalActivity = useCallback(() => {
     lastActivityRef.current = Date.now();
     setVisible(true);
+    if (holdVisibleRef.current) return;
     // Keep the existing deadline during an activity burst. When it arrives,
     // the callback above moves it forward once from the most recent activity
     // instead of allocating a fresh timeout for every pointer event.
@@ -42,12 +58,20 @@ export function useAutoHideActivity(
   }, [scheduleHide]);
 
   useEffect(() => {
+    if (holdVisible) {
+      // Drop any deadline already in flight, then stay up until released.
+      clearTimer();
+      setVisible(true);
+      return;
+    }
     if (initiallyVisible) {
+      // Releasing the hold starts a fresh countdown rather than resuming a
+      // stale one, so the bar does not vanish the instant a menu closes.
       lastActivityRef.current = Date.now();
       scheduleHide();
     }
     return clearTimer;
-  }, [initiallyVisible, clearTimer, scheduleHide]);
+  }, [holdVisible, initiallyVisible, clearTimer, scheduleHide]);
 
   return { visible, signalActivity };
 }

--- a/src/js/frontend/preset-queue.ts
+++ b/src/js/frontend/preset-queue.ts
@@ -75,14 +75,31 @@ export function usePersistentPresetQueue(catalog: PresetCatalogEntry[]) {
     });
   }, []);
 
+  /**
+   * Reads the head from the rendered state, not from inside the updater.
+   *
+   * This used to assign its return value inside `setPresetIds` and return it
+   * afterwards. React only runs an updater during dispatch on the eager-state
+   * path, which needs the owning fiber to have no pending lanes — and this
+   * queue lives in the workspace provider, which re-renders every frame while
+   * audio plays. So in the one situation the cue deck is even mounted, the
+   * updater was deferred, `popNext()` returned null while still queueing the
+   * removal, and "Take" dropped the cued preset and reported "Nothing is
+   * cued". `queue-skip` already read `presetIds[0]` directly; this now does
+   * the same.
+   *
+   * The updater re-checks the head so a queue that changed in between loses
+   * nothing: it removes the entry this call actually returned, or removes
+   * nothing at all.
+   */
   const popNext = useCallback(() => {
-    let nextId: string | null = null;
-    setPresetIds((current) => {
-      nextId = current[0] ?? null;
-      return current.slice(1);
-    });
+    const nextId = presetIds[0] ?? null;
+    if (nextId === null) return null;
+    setPresetIds((current) =>
+      current[0] === nextId ? current.slice(1) : current,
+    );
     return nextId;
-  }, []);
+  }, [presetIds]);
 
   return { presetIds, entries, add, remove, clear, move, popNext };
 }

--- a/src/js/frontend/workspace-shell-hooks.ts
+++ b/src/js/frontend/workspace-shell-hooks.ts
@@ -23,6 +23,7 @@ import type {
   SessionRouteState,
 } from './contracts.ts';
 import type { EngineSnapshot } from './engine/milkdrop-engine-adapter.ts';
+import { disposeActiveFileAudio } from './file-audio.ts';
 import { buildCanonicalUrl } from './url-state.ts';
 import {
   buildStarterPresets,
@@ -437,6 +438,15 @@ export function useWorkspaceShellOrchestration({
     if (audioStartInProgressRef.current) return;
     audioStartInProgressRef.current = true;
 
+    // Starting any other source replaces file playback, and the file element
+    // loops, so without this it would keep playing underneath the new source.
+    // `'file'` is excluded because that path runs `startAudioSource` directly
+    // after adopting its own handle; disposing here would tear it straight
+    // back down.
+    if (source !== 'file') {
+      disposeActiveFileAudio();
+    }
+
     // Pre-warm the shared Three.js AudioContext while we're still inside
     // the user gesture (click/tap). On iOS Safari, AudioContext.resume()
     // called outside a user gesture stays suspended — the context is
@@ -603,6 +613,10 @@ export function useWorkspaceShellOrchestration({
   };
 
   const handleAudioStop = () => {
+    // The engine side is torn down by the route change, but a playing file is
+    // ours: it is an <audio> element with `loop = true`, so leaving it alone
+    // meant the track carried on audibly after the UI said audio had stopped.
+    disposeActiveFileAudio();
     commitRoute({ ...routeState, audioSource: null });
     setStatusMessage('Audio stopped.');
   };

--- a/tests/unit/file-audio-session-ownership.test.tsx
+++ b/tests/unit/file-audio-session-ownership.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { AudioSourcePanel } from '../../src/js/frontend/AudioSourcePanel.tsx';
+import {
+  disposeActiveFileAudio,
+  type FileAudioHandle,
+  getActiveFileAudioName,
+  setActiveFileAudio,
+} from '../../src/js/frontend/file-audio.ts';
+import { renderWorkspace } from '../frontend-harness.tsx';
+
+/**
+ * File playback belongs to the audio session, not to whichever copy of the
+ * audio panel happens to be mounted.
+ *
+ * The panel renders twice at once — the home hero keeps one for the whole
+ * session, the Settings sheet mounts another each time it opens — and the
+ * handle used to live in a ref there, disposed on unmount. Closing Settings
+ * therefore stopped the music while the engine, the route and the dock all
+ * still reported a file playing; and from the home copy, which never
+ * unmounts, "Stop audio" left the element looping audibly forever.
+ */
+
+function makeHandle(name: string) {
+  let disposed = 0;
+  const handle: FileAudioHandle = {
+    // The engine only ever reads `.stream`, and nothing in these tests gets
+    // that far, so a bare object stands in for a MediaStream that happy-dom
+    // cannot construct.
+    stream: {} as MediaStream,
+    element: {} as HTMLAudioElement,
+    name,
+    dispose: () => {
+      disposed += 1;
+    },
+  };
+  return {
+    handle,
+    get disposed() {
+      return disposed;
+    },
+  };
+}
+
+afterEach(() => {
+  disposeActiveFileAudio();
+});
+
+describe('file audio session ownership', () => {
+  test('adopting a second file disposes the first', () => {
+    const first = makeHandle('first.mp3');
+    const second = makeHandle('second.mp3');
+
+    setActiveFileAudio(first.handle);
+    expect(first.disposed).toBe(0);
+    expect(getActiveFileAudioName()).toBe('first.mp3');
+
+    setActiveFileAudio(second.handle);
+
+    // Two live graphs would both be audible and both feed the analyser.
+    expect(first.disposed).toBe(1);
+    expect(second.disposed).toBe(0);
+    expect(getActiveFileAudioName()).toBe('second.mp3');
+  });
+
+  test('disposing clears the session and is safe to repeat', () => {
+    const only = makeHandle('only.mp3');
+    setActiveFileAudio(only.handle);
+
+    disposeActiveFileAudio();
+    expect(only.disposed).toBe(1);
+    expect(getActiveFileAudioName()).toBeNull();
+
+    disposeActiveFileAudio();
+    expect(only.disposed).toBe(1);
+  });
+
+  test('re-adopting the same handle does not dispose it', () => {
+    const same = makeHandle('same.mp3');
+    setActiveFileAudio(same.handle);
+    setActiveFileAudio(same.handle);
+
+    expect(same.disposed).toBe(0);
+    expect(getActiveFileAudioName()).toBe('same.mp3');
+  });
+
+  test('unmounting the audio panel leaves playback alone', () => {
+    const playing = makeHandle('set.mp3');
+    setActiveFileAudio(playing.handle);
+
+    const rendered = renderWorkspace(<AudioSourcePanel showHelp={false} />);
+    rendered.dispose();
+
+    // Closing the Settings sheet unmounts a copy of this panel. It must not
+    // take the music with it.
+    expect(playing.disposed).toBe(0);
+    expect(getActiveFileAudioName()).toBe('set.mp3');
+  });
+
+  test('a freshly mounted panel reports the file already playing', () => {
+    setActiveFileAudio(makeHandle('already-playing.mp3').handle);
+
+    const rendered = renderWorkspace(<AudioSourcePanel showHelp={false} />);
+    try {
+      // Not "Pick a track" — that offered to start something already started.
+      expect(rendered.text()).toContain('Playing already-playing.mp3');
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('with nothing playing the panel offers to pick a track', () => {
+    const rendered = renderWorkspace(<AudioSourcePanel showHelp={false} />);
+    try {
+      expect(rendered.text()).toContain('Pick a track');
+    } finally {
+      rendered.dispose();
+    }
+  });
+});

--- a/tests/unit/focus-trap-stacking.test.ts
+++ b/tests/unit/focus-trap-stacking.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { trapFocusWithin } from '../../src/js/core/modal-utils.ts';
+
+/**
+ * A focus trap installs a document-level `focusin` listener that pulls focus
+ * back into its own panel whenever focus lands outside it. Two of those can be
+ * live at once in the real app — the shortcuts dialog and the command palette
+ * both open *over* a Settings panel that stays mounted — and before traps were
+ * stacked, both answered the same event: each pulled focus into itself, which
+ * in a browser dispatches another `focusin`, which the other answered, with no
+ * state either could settle in. The tab locks up.
+ *
+ * The property under test is therefore "exactly one trap responds, and it is
+ * the innermost one". That is asserted directly rather than through the DOM,
+ * because happy-dom ignores a `focus()` call made during focus dispatch: the
+ * recursion that makes this fatal in a browser cannot be staged here, and a
+ * test that watched `document.activeElement` would pass against the old code
+ * for reasons that have nothing to do with the fix.
+ */
+
+/**
+ * Elements this test created, so `recordFocusCalls` can spy on them.
+ *
+ * Spied per element rather than on `HTMLElement.prototype`: the `HTMLElement`
+ * visible to this module is not the constructor happy-dom's document builds
+ * its nodes from, so a prototype patch records nothing at all.
+ */
+let tracked: HTMLElement[] = [];
+
+function track<T extends HTMLElement>(element: T): T {
+  tracked.push(element);
+  return element;
+}
+
+/**
+ * Records who each trap tries to pull focus to, without actually moving focus.
+ * Suppressing the real move is what keeps the recording honest: it isolates
+ * "which traps responded to this one event" from any follow-on events a real
+ * focus change would produce.
+ */
+function recordFocusCalls(act: () => void): string[] {
+  const calls: string[] = [];
+  for (const element of tracked) {
+    element.focus = () => {
+      calls.push(element.id || element.tagName.toLowerCase());
+    };
+  }
+  try {
+    act();
+  } finally {
+    for (const element of tracked) {
+      // Drop the own property so the prototype's real focus is back.
+      delete (element as Partial<HTMLElement>).focus;
+    }
+  }
+  return calls;
+}
+
+function buildPanel(id: string) {
+  const panel = track(document.createElement('div'));
+  panel.id = id;
+  panel.tabIndex = -1;
+  for (const label of ['first', 'second']) {
+    const button = track(document.createElement('button'));
+    button.id = `${id}-${label}`;
+    button.textContent = label;
+    panel.appendChild(button);
+  }
+  document.body.appendChild(panel);
+  return panel;
+}
+
+/** A control outside every trap, standing in for "focus escaped". */
+function buildStray() {
+  const stray = track(document.createElement('button'));
+  stray.id = 'stray';
+  document.body.appendChild(stray);
+  return stray;
+}
+
+/**
+ * A plain bubbling `Event`, not a `FocusEvent`: the handler under test reads
+ * only `event.target`, and happy-dom does not put `FocusEvent` on the global
+ * scope the way a browser does.
+ */
+function announceFocusIn(target: HTMLElement) {
+  target.dispatchEvent(new Event('focusin', { bubbles: true }));
+}
+
+afterEach(() => {
+  tracked = [];
+  document.body.innerHTML = '';
+});
+
+describe('trapFocusWithin stacking', () => {
+  test('only the innermost trap answers focus escaping', () => {
+    const outer = buildPanel('outer');
+    const inner = buildPanel('inner');
+    const stray = buildStray();
+
+    const releaseOuter = trapFocusWithin(outer);
+    const releaseInner = trapFocusWithin(inner);
+
+    try {
+      const calls = recordFocusCalls(() => announceFocusIn(stray));
+
+      // Before stacking this was ['outer-first', 'inner-first'] — the two
+      // traps pulling in opposite directions, which is the lockup.
+      expect(calls).toEqual(['inner-first']);
+    } finally {
+      releaseInner();
+      releaseOuter();
+    }
+  });
+
+  test('a trap ignores focus that is already inside it', () => {
+    const inner = buildPanel('inner');
+    const release = trapFocusWithin(inner);
+
+    try {
+      const calls = recordFocusCalls(() => {
+        const target = document.getElementById('inner-second');
+        if (target) announceFocusIn(target);
+      });
+
+      expect(calls).toEqual([]);
+    } finally {
+      release();
+    }
+  });
+
+  test('the outer trap resumes once the inner one is released', () => {
+    const outer = buildPanel('outer');
+    const inner = buildPanel('inner');
+    const stray = buildStray();
+
+    const releaseOuter = trapFocusWithin(outer);
+    const releaseInner = trapFocusWithin(inner);
+
+    try {
+      releaseInner();
+
+      expect(recordFocusCalls(() => announceFocusIn(stray))).toEqual([
+        'outer-first',
+      ]);
+    } finally {
+      releaseOuter();
+    }
+  });
+
+  test('traps released out of order leave the survivor enforcing', () => {
+    const outer = buildPanel('outer');
+    const inner = buildPanel('inner');
+    const stray = buildStray();
+
+    const releaseOuter = trapFocusWithin(outer);
+    const releaseInner = trapFocusWithin(inner);
+
+    try {
+      // Closing the panel *underneath* first is legal: the dialog above it is
+      // still open and must keep enforcing.
+      releaseOuter();
+
+      expect(recordFocusCalls(() => announceFocusIn(stray))).toEqual([
+        'inner-first',
+      ]);
+    } finally {
+      releaseInner();
+    }
+  });
+
+  test('a lone trap still enforces', () => {
+    const panel = buildPanel('solo');
+    const stray = buildStray();
+
+    const release = trapFocusWithin(panel);
+    try {
+      expect(recordFocusCalls(() => announceFocusIn(stray))).toEqual([
+        'solo-first',
+      ]);
+    } finally {
+      release();
+    }
+  });
+
+  test('releasing every trap stops all enforcement', () => {
+    const panel = buildPanel('solo');
+    const stray = buildStray();
+
+    trapFocusWithin(panel)();
+
+    expect(recordFocusCalls(() => announceFocusIn(stray))).toEqual([]);
+  });
+
+  test('a trap with nothing focusable falls back to the panel itself', () => {
+    const empty = track(document.createElement('div'));
+    empty.id = 'empty';
+    empty.tabIndex = -1;
+    document.body.appendChild(empty);
+    const stray = buildStray();
+
+    const release = trapFocusWithin(empty);
+    try {
+      expect(recordFocusCalls(() => announceFocusIn(stray))).toEqual(['empty']);
+    } finally {
+      release();
+    }
+  });
+});

--- a/tests/unit/preset-queue-pop.test.tsx
+++ b/tests/unit/preset-queue-pop.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { useState } from 'react';
+import { usePersistentPresetQueue } from '../../src/js/frontend/preset-queue.ts';
+import { renderWorkspace } from '../frontend-harness.tsx';
+
+const STORAGE_KEY = 'stims:preset-queue:v1';
+
+/**
+ * `popNext` has to return the preset it removed, because "Take" loads that
+ * preset and announces it.
+ *
+ * It used to read its own return value out of a `setPresetIds` updater. React
+ * only runs an updater during dispatch on the eager-state path, which needs
+ * the owning fiber to have no pending lanes — and the queue lives in the
+ * workspace provider, which re-renders every frame while audio plays, i.e.
+ * exactly when the cue deck is on screen. So the updater was deferred,
+ * `popNext()` returned null while still queueing the removal, and Take
+ * dropped the cued preset and reported "Nothing is cued".
+ *
+ * The tests below stage that by dirtying the fiber first: another queue
+ * update in the same handler leaves a pending lane, which is what closes the
+ * eager path.
+ */
+
+function Probe({
+  dirtyFirst,
+  popTwice = false,
+}: {
+  dirtyFirst: boolean;
+  popTwice?: boolean;
+}) {
+  const queue = usePersistentPresetQueue([]);
+  const [taken, setTaken] = useState<string>('none');
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-take="true"
+        onClick={() => {
+          // A pending update on this fiber before the pop is what the real
+          // provider always has while audio is playing.
+          if (dirtyFirst) queue.add('dirty-entry');
+          const first = queue.popNext();
+          const second = popTwice ? queue.popNext() : null;
+          setTaken(popTwice ? `${first},${second}` : String(first));
+        }}
+      >
+        take
+      </button>
+      <span data-taken="true">{taken}</span>
+      <span data-remaining="true">{queue.presetIds.join('|')}</span>
+    </div>
+  );
+}
+
+function readText(container: HTMLElement, attribute: string) {
+  return container.querySelector(`[${attribute}]`)?.textContent ?? '';
+}
+
+beforeEach(() => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ presetIds: ['alpha', 'beta', 'gamma'] }),
+  );
+});
+
+afterEach(() => {
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+describe('preset queue popNext', () => {
+  test('returns the head even with an update already pending', () => {
+    const rendered = renderWorkspace(<Probe dirtyFirst />);
+    try {
+      rendered.click(rendered.container.querySelector('[data-take]'));
+
+      // The defect returned 'null' here while still removing the entry.
+      expect(readText(rendered.container, 'data-taken')).toBe('alpha');
+      expect(readText(rendered.container, 'data-remaining')).toBe(
+        'beta|gamma|dirty-entry',
+      );
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('returns the head on a clean fiber too', () => {
+    const rendered = renderWorkspace(<Probe dirtyFirst={false} />);
+    try {
+      rendered.click(rendered.container.querySelector('[data-take]'));
+
+      expect(readText(rendered.container, 'data-taken')).toBe('alpha');
+      expect(readText(rendered.container, 'data-remaining')).toBe('beta|gamma');
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('removes exactly one entry when popped twice in one handler', () => {
+    const rendered = renderWorkspace(<Probe dirtyFirst={false} popTwice />);
+    try {
+      rendered.click(rendered.container.querySelector('[data-take]'));
+
+      // Both calls see the same rendered head, so the second is a repeat
+      // rather than a second removal. Returning the same id twice is
+      // recoverable; removing two presets while naming one is not.
+      expect(readText(rendered.container, 'data-taken')).toBe('alpha,alpha');
+      expect(readText(rendered.container, 'data-remaining')).toBe('beta|gamma');
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('an empty queue yields null and stays empty', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ presetIds: [] }));
+    const rendered = renderWorkspace(<Probe dirtyFirst={false} />);
+    try {
+      rendered.click(rendered.container.querySelector('[data-take]'));
+
+      expect(readText(rendered.container, 'data-taken')).toBe('null');
+      expect(readText(rendered.container, 'data-remaining')).toBe('');
+    } finally {
+      rendered.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Twelve defects, found by auditing the frontend runtime, the shell's accessibility and mobile layout, and the test runner. Each was verified in the code before it was fixed, and the ones with a stateable contract carry regression tests that fail against the old implementation. Eight commits, grouped so they can be read one at a time.

**Audio sessions outlived their teardown, two ways** (`e2ddc0c`)

- Tab and YouTube capture come from `getDisplayMedia`. The microphone branch passes `stopStreamOnCleanup`; this one did not, and the default resolves to false, so teardown only unregistered the stream. "Stop audio" reported audio stopped and the dock showed no source while the browser kept its sharing bar up and the tab went on being captured. Only closing the tab ended it.
- File playback was owned by `AudioSourcePanel`, disposed on unmount. That panel mounts twice: the home hero keeps one all session, the Settings sheet mounts another per open. So closing Settings stopped the music while the engine, the route and the dock all still reported a file playing. From the home copy, which never unmounts, the mirror case was worse: Stop audio left the handle alone and the element loops, so the track played on after the interface said it had stopped. Ownership now sits in `file-audio.ts` and is tied to the audio session.

**Take silently dropped the cued preset** (`23074c4`)

`popNext` read its return value out of a `setState` updater. React runs an updater during dispatch only on the eager-state path, which needs the owning fiber to have no pending lanes, and the queue lives in the provider that re-renders every frame while audio plays. That is the only time the cue deck is mounted, so the updater was always deferred: the head was removed, `null` was returned, and the palette announced "Nothing is cued". It now reads the head from rendered state, as `queue-skip` already did.

**Two focus traps could fight over the same focus** (`dcaded4`)

The trap installs a document-level `focusin` listener that pulls focus back into its own panel, with no stacking. Opening the shortcuts dialog or the command palette over a trapped Settings panel left both live, each pulling focus from the other, with no state either could settle in. Traps are stacked now and only the innermost acts. The node check is duck-typed rather than `instanceof Node`, so a node from another realm no longer makes a trap quietly stop enforcing.

**Debug overlays announced themselves continuously; stage focus could be dropped** (`e976c72`)

Both overlays wrapped a continuously updating readout in `role="status"`. The HUD resamples twice a second, so a screen-reader user who enabled it had it announced at least that often, indefinitely, with the dismiss button inside the region doing the shouting. Separately, the stage overflow menu renders as a sibling of the control bar, so the bar auto-hid underneath it and Escape restored focus to a hidden button, dropping focus to `<body>`. An open menu now holds the bar up. The dock's title button also names itself with the visible preset title, so voice control can reach it.

**Two touch targets, and the launch column's dead space** (`bd7cfe8`)

The dock audio-status trigger had no coarse-pointer rule at all, and the browse grid's save star sits on the full-tile open button, so a near-miss opens a different preset. The grid star's hit area grows via a pseudo-element rather than the disc, since a 44px opaque circle over the artwork is a heavier mark than this needs.

| Control | Before | After |
| --- | --- | --- |
| Audio status trigger | 35 x 32 | 44 x 44 |
| Grid save star hit area | 26 x 26 | 44 x 44 |

The launch column is a grid in a panel taller than its content, and `align-content` defaults to stretch, so every auto row absorbed a share of the leftover height. The returning-visitor variant was packed already; this lifts it to both.

| First-visit page at 412x915 | Before | After |
| --- | --- | --- |
| Bottom of the last element | 881px | 561px |

**Smaller two** (`8a80a89`, `a47c325`)

A performance fader pinned mid-session was never seeded, so it rendered its range midpoint and lurched on the first nudge. And the second-screen poll could never reach its own `clearInterval`, because the stop path cleared the window reference first, so each send-then-stop cycle leaked a timer.

**Browser-backed corpus tests were mis-scheduled** (`15cdbe9`)

The runner's serial trait exists because browser tests contend for GPU and port resources, but it is applied per category and only end-to-end has it. Two corpus files drive real Chromium and were fanned out alongside twelve CPU-heavy ones. Detection now keys on the `browserTest` helper rather than a path list, so a new browser-backed test lands in the serial pass by existing.

| Corpus profile | Result |
| --- | --- |
| Before | failed 3 of 3 runs |
| Single process | failed, 256s |
| After | all pass, 44s |

## Testing

- `bun run check` — **3021 pass, 0 fail** in the parallel pass, then both browser-backed corpus files pass in their own processes. Zero failures anywhere.
- Three new unit files, 17 tests: focus-trap stacking, file-audio session ownership, and queue pop.
- Each new suite was confirmed to catch its defect. Reverting the focus-trap guard fails one test; reverting `popNext` fails two, including the pending-lane case that is the real-world condition.
- Verified in a real browser at 412x915: the first-visit launch page renders with no console or page errors and its content ends at 561px.
- The two findings I could not put behind an automated assertion are the stage-menu focus restore and the debug-overlay live regions. Both are structural, and the reasoning is in the commit messages.

## Docs touched

- None. Each fix carries its reasoning in a comment beside the code it explains.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (no build/runtime output change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8pDEgkTvpbDDUSwwZ8WYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8pDEgkTvpbDDUSwwZ8WYF)_