### PR TITLE
fix: give the overlay surfaces one dismissal and stacking policy

### DIFF
--- a/src/css/StageControls.module.css
+++ b/src/css/StageControls.module.css
@@ -293,6 +293,29 @@
   outline-offset: 1px;
 }
 
+/* Dims the stage behind the open menu.
+
+   The menu is 26 items and, on a phone, most of the screen. Without a scrim
+   it read as a slab dropped on top of live visuals with no indication that
+   the area around it was the way out, and its own translucent background had
+   to fight whatever the preset was doing underneath. */
+.menuScrim {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-stage-menu) - 1);
+  background: rgba(4, 7, 12, 0.55);
+  animation: menu-scrim-in 0.16s ease-out both;
+}
+
+@keyframes menu-scrim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .menu {
   position: fixed;
   bottom: calc(max(8px, env(safe-area-inset-bottom)) + 48px);
@@ -300,7 +323,9 @@
     max(12px, env(safe-area-inset-right)) +
     var(--stage-tool-inset, 0px)
   );
-  z-index: var(--z-dock);
+  /* Above the toast layer: this is what the user is pointing at, and an
+     ambient toast used to paint over its items. */
+  z-index: var(--z-stage-menu);
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -555,7 +580,13 @@
     left: max(8px, env(safe-area-inset-left));
     min-width: auto;
     bottom: calc(max(8px, env(safe-area-inset-bottom)) + 52px);
-    max-height: calc(100dvh - 80px);
+    /* Bounded so it reads as a panel over the stage rather than a takeover.
+       At `100dvh - 80px` it rendered 835px tall on a 915px screen, which is a
+       full-screen sheet wearing a menu's clothes — and it still scrolled, so
+       the extra height bought nothing but the impression that the app had
+       navigated somewhere. It stays anchored above the dock either way, so
+       the button that opened it is never covered. */
+    max-height: min(68dvh, calc(100dvh - 120px));
   }
 }
 

--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -2512,8 +2512,13 @@ body[data-page="workspace"][data-live="true"] {
      Both now sit above the modal layer and dodge upward, because the messages
      that matter most are raised from inside these panels: a failed preset
      import is reported from the Browse sheet. */
-  :scope[data-sheet-open="true"] .stims-shell__toast,
-  :scope[data-menu-open="true"] .stims-shell__toast {
+  /* `[data-tone]` is on every toast and buys this rule the specificity to
+     beat `:scope[data-mode="live"] .stims-shell__toast`, which sets `bottom`
+     again further down the sheet. Losing that leaves both `top` and `bottom`
+     set on a fixed, auto-height element, and the toast stretches down most of
+     the viewport instead of sitting compactly at the top. */
+  :scope[data-sheet-open="true"] .stims-shell__toast[data-tone],
+  :scope[data-bottom-overlay="true"] .stims-shell__toast[data-tone] {
     top: calc(max(12px, env(safe-area-inset-top, 0px)) + 12px);
     bottom: auto;
   }
@@ -3858,7 +3863,7 @@ body[data-page="workspace"][data-live="true"] {
 }
 
 main.stims-shell[data-sheet-open="true"] .stims-shell__toast-stack,
-main.stims-shell[data-menu-open="true"] .stims-shell__toast-stack {
+main.stims-shell[data-bottom-overlay="true"] .stims-shell__toast-stack {
   top: calc(max(12px, env(safe-area-inset-top, 0px)) + 12px);
   bottom: auto;
 }

--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -2500,15 +2500,22 @@ body[data-page="workspace"][data-live="true"] {
     color: #ffd6d1;
   }
 
-  :scope[data-sheet-open="true"] .stims-shell__toast {
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(8px);
-  }
+  /* A sheet no longer hides toasts; it moves them.
 
-  :scope[data-sheet-open="true"] [class*="toast"] {
-    opacity: 0;
-    pointer-events: none;
+     Hiding was the old policy and it failed in both directions. The status
+     toast has an entry animation, and an animation outranks a plain
+     declaration in the cascade, so it faded in over the sheet anyway — landing
+     on top of the sheet's own header. The ambient stack has no such animation,
+     so the rule did apply to it, and an audio match found while browsing was
+     invisible while its dismiss timer ran out.
+
+     Both now sit above the modal layer and dodge upward, because the messages
+     that matter most are raised from inside these panels: a failed preset
+     import is reported from the Browse sheet. */
+  :scope[data-sheet-open="true"] .stims-shell__toast,
+  :scope[data-menu-open="true"] .stims-shell__toast {
+    top: calc(max(12px, env(safe-area-inset-top, 0px)) + 12px);
+    bottom: auto;
   }
 
   .cta-button {
@@ -3125,7 +3132,10 @@ body[data-page="workspace"][data-live="true"] {
   );
   left: 50%;
   transform: translateX(-50%);
-  z-index: var(--z-toast);
+  /* The same layer as the status toast. At --z-toast this column sat below
+     --z-modal-backdrop, so an audio match found while a panel was open
+     rendered behind it and ran its dismiss timer out unseen. */
+  z-index: var(--z-toast-floating);
   display: flex;
   flex-direction: column-reverse;
   align-items: center;
@@ -3419,13 +3429,51 @@ body[data-page="workspace"][data-live="true"] {
 
 .stims-shell__credits-card {
   max-width: 640px;
-  max-height: min(84vh, 720px);
+  /* dvh, matching the shared card rule above. `vh` is the *largest* viewport
+     on iOS Safari, so with the URL bar showing an 84vh centred card ran past
+     the visible bottom and took its own Close button with it. */
+  max-height: min(84dvh, 720px);
   overflow-y: auto;
   padding: 36px;
 }
 
 .stims-shell__credits-card > .cta-button {
   margin-top: var(--space-lg, 1.5rem);
+}
+
+/* Phone: the two help dialogs become bottom sheets like every other overlay.
+   They were the only surfaces that stayed centred cards — 92% wide with 32px
+   of padding, which at 390px leaves under 300px of content for a three-column
+   shortcut grid — while the eight panels built on SidePanel all present as
+   sheets. Matching them means the dismissal a user has already learned here
+   (reach the bottom edge, or tap the dimmed area above) works on these too. */
+@media (max-width: 640px) {
+  .stims-shell__shortcut-overlay,
+  .stims-shell__credits-overlay {
+    align-items: flex-end;
+  }
+
+  .stims-shell__shortcut-card,
+  .stims-shell__credits-card {
+    width: 100%;
+    max-width: none;
+    max-height: 88dvh;
+    padding: 20px 16px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    animation: stims-modal-sheet-in 0.24s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+}
+
+@keyframes stims-modal-sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 @keyframes stims-modal-scale {
@@ -3809,9 +3857,10 @@ body[data-page="workspace"][data-live="true"] {
   gap: 8px;
 }
 
-main.stims-shell[data-sheet-open="true"] [class*="toast"] {
-  opacity: 0;
-  pointer-events: none;
+main.stims-shell[data-sheet-open="true"] .stims-shell__toast-stack,
+main.stims-shell[data-menu-open="true"] .stims-shell__toast-stack {
+  top: calc(max(12px, env(safe-area-inset-top, 0px)) + 12px);
+  bottom: auto;
 }
 
 /* ── Error Boundary & Skeleton Utilities ────────────────────────────── */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -309,12 +309,17 @@
   --z-overlay: 18;
   --z-dropdown: 20;
   --z-dock: 25;
+
   /* Floating lab panels (Strudel) — above the dock so stage chrome cannot
      bury a tool the user is dragging, below toasts and modals so a notice or
      a dialog still wins. Previously a raw 40, which tied exactly with
      --z-modal-backdrop and left paint order to DOM order. */
   --z-lab-panel: 26;
   --z-filter-bar: 28;
+  /* The stage overflow menu. Above the dock it belongs to and the floating
+     lab panels, below --z-modal-backdrop so opening a panel covers it. It sat
+     at --z-dock, tying with the bar it opens from. */
+  --z-stage-menu: 29;
   --z-toast: 30;
   --z-alert: 35;
   --z-modal-backdrop: 40;
@@ -331,9 +336,12 @@
   --z-settings-panel: 1250;
   --z-fullscreen-panel: 1260;
   --z-error-overlay: 2000;
-  /* Named for the surface that uses it — the floating workspace toast. It was
-     --z-audio-match, whose only consumer was this toast; the audio-match toast
-     is a different component and lives in the toast stack at --z-toast. */
+  /* Every toast, above every overlay. Both toast surfaces live here now: the
+     ambient stack used to sit at --z-toast, below --z-modal-backdrop, so an
+     audio match found while a panel was open rendered behind it and expired
+     unseen on its own timer. Being on top is only safe because a toast moves
+     out of the way of whatever occupies the bottom of the screen — see the
+     data-sheet-open / data-menu-open rules in app-shell.css. */
   --z-toast-floating: 2100;
   /* Nothing may cover the skip link while it is focused: it is the first
      control a keyboard user reaches. It sat at --z-dropdown (20), under the

--- a/src/js/core/modal-utils.ts
+++ b/src/js/core/modal-utils.ts
@@ -33,6 +33,64 @@ export function getFocusableElements(container: HTMLElement) {
 }
 
 /**
+ * Escape handlers for open overlays, outermost first.
+ *
+ * Escape used to be handled wherever each overlay felt like it. `SidePanel`
+ * listened on `document`; the help dialogs used a React `onKeyDown` on their
+ * backdrop, which React dispatches from the root container — *below*
+ * `document` in the tree, so it runs first only when the event originates
+ * inside that backdrop. Open the shortcuts dialog from inside Settings and
+ * press Escape and the sheet underneath took the keypress: the sheet closed,
+ * the dialog stayed open, and a second press did nothing because the sheet
+ * was already gone. The dialog could only be escaped with a mouse.
+ *
+ * One document-level listener, dispatching to the innermost overlay, makes
+ * Escape mean "close the thing in front of me" everywhere. It listens in the
+ * bubble phase deliberately: a React handler that calls `stopPropagation`
+ * still wins, which is what lets the Browse search field clear itself on
+ * Escape without also closing the panel around it.
+ */
+const escapeHandlers: Array<() => void> = [];
+let escapeListenerAttached = false;
+
+function handleDocumentEscape(event: KeyboardEvent) {
+  if (event.key !== 'Escape') return;
+  const innermost = escapeHandlers[escapeHandlers.length - 1];
+  if (!innermost) return;
+  event.preventDefault();
+  // Nothing further should act on a press that has closed something.
+  event.stopPropagation();
+  innermost();
+}
+
+/**
+ * Registers `handler` as the Escape action for an overlay, and returns the
+ * function that unregisters it. The most recently registered handler is the
+ * innermost overlay and the only one that runs.
+ */
+export function registerEscapeHandler(handler: () => void): () => void {
+  escapeHandlers.push(handler);
+  if (!escapeListenerAttached && typeof document !== 'undefined') {
+    document.addEventListener('keydown', handleDocumentEscape);
+    escapeListenerAttached = true;
+  }
+  return () => {
+    const index = escapeHandlers.lastIndexOf(handler);
+    if (index !== -1) {
+      escapeHandlers.splice(index, 1);
+    }
+    if (
+      escapeHandlers.length === 0 &&
+      escapeListenerAttached &&
+      typeof document !== 'undefined'
+    ) {
+      document.removeEventListener('keydown', handleDocumentEscape);
+      escapeListenerAttached = false;
+    }
+  };
+}
+
+/**
  * Duck-typed rather than `instanceof Node`.
  *
  * `instanceof` compares against one realm's constructor, so it answers false

--- a/src/js/core/modal-utils.ts
+++ b/src/js/core/modal-utils.ts
@@ -64,6 +64,19 @@ function handleDocumentEscape(event: KeyboardEvent) {
 }
 
 /**
+ * True while an overlay has claimed Escape.
+ *
+ * The global shortcut handler asks before acting: it registers on `document`
+ * when the shell mounts, i.e. before any overlay exists, so it runs first and
+ * neither `preventDefault` nor `stopPropagation` from here can reach back and
+ * cancel it. A user who rebinds Escape to an action would otherwise fire that
+ * action *and* dismiss the overlay with one press.
+ */
+export function escapeIsClaimed(): boolean {
+  return escapeHandlers.length > 0;
+}
+
+/**
  * Registers `handler` as the Escape action for an overlay, and returns the
  * function that unregisters it. The most recently registered handler is the
  * innermost overlay and the only one that runs.

--- a/src/js/frontend/CommandPalette.tsx
+++ b/src/js/frontend/CommandPalette.tsx
@@ -30,6 +30,7 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import styles from '../../css/CommandPalette.module.css';
+import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   buildPaletteResults,
   type CommandAction,
@@ -128,6 +129,18 @@ export function CommandPalette({
     initialFocusRef: inputRef,
   });
 
+  // The palette is the innermost overlay while it is open, so the shared
+  // stack closes it and nothing behind it. It used to stop the event itself,
+  // which worked only because React dispatches before the document listener.
+  //
+  // Gated on `open`: this component stays mounted while closed, so
+  // registering unconditionally put a no-op handler permanently on top of the
+  // stack and swallowed Escape for every panel underneath it.
+  useEffect(() => {
+    if (!open) return;
+    return registerEscapeHandler(onClose);
+  }, [open, onClose]);
+
   // Fresh palette each open; keyed on `open` so a reopened palette never
   // flashes the previous session's query/highlight.
   useEffect(() => {
@@ -223,21 +236,16 @@ export function CommandPalette({
   };
 
   return (
+    // The backdrop is the pointer affordance for dismiss. Keyboard users get
+    // Escape, dispatched to the innermost overlay by registerEscapeHandler
+    // above; focus is trapped in the card, so the backdrop never sees a key.
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard dismiss is Escape, handled above
     <div
       className={styles.backdrop}
       role="dialog"
       aria-modal="true"
       aria-label="Command palette"
       onClick={onClose}
-      onKeyDown={(event) => {
-        if (event.key === 'Escape') {
-          // Keep it from also reaching any global Escape/close handling —
-          // one press dismisses the palette only.
-          event.preventDefault();
-          event.stopPropagation();
-          onClose();
-        }
-      }}
     >
       {/* biome-ignore lint/a11y/noStaticElementInteractions: card is visual-only; the backdrop handles dismiss */}
       <div

--- a/src/js/frontend/CommandPalette.tsx
+++ b/src/js/frontend/CommandPalette.tsx
@@ -30,7 +30,6 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import styles from '../../css/CommandPalette.module.css';
-import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   buildPaletteResults,
   type CommandAction,
@@ -38,6 +37,7 @@ import {
   type PalettePresetResult,
   type PaletteResult,
 } from './command-palette-registry.ts';
+import { useEscapeHandler } from './hooks/use-escape-handler.ts';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 import {
   eventMatchesShortcut,
@@ -136,10 +136,7 @@ export function CommandPalette({
   // Gated on `open`: this component stays mounted while closed, so
   // registering unconditionally put a no-op handler permanently on top of the
   // stack and swallowed Escape for every panel underneath it.
-  useEffect(() => {
-    if (!open) return;
-    return registerEscapeHandler(onClose);
-  }, [open, onClose]);
+  useEscapeHandler(open, onClose);
 
   // Fresh palette each open; keyed on `open` so a reopened palette never
   // flashes the previous session's query/highlight.

--- a/src/js/frontend/CreditsDialog.tsx
+++ b/src/js/frontend/CreditsDialog.tsx
@@ -1,4 +1,6 @@
 import type { RefObject } from 'react';
+import { useEffect } from 'react';
+import { registerEscapeHandler } from '../core/modal-utils.ts';
 import { CreditsPanel } from './CreditsPanel.tsx';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 
@@ -16,31 +18,48 @@ export function CreditsDialog({
     autoFocus: true,
     restoreFocusOnUnmount: true,
     externalContainerRef: creditsRef,
+    // Land on the dialog itself rather than the first control inside it, as
+    // SidePanel does. Focusing a control scrolled the card to it, so the sheet
+    // opened part-way down with its own heading already scrolled off — and a
+    // screen reader announced that control instead of the dialog's name.
+    initialFocus: 'container',
   });
+
+  // See ShortcutsDialog: Escape is dispatched to the innermost overlay by the
+  // shared stack, so it cannot reach a sheet underneath this dialog.
+  useEffect(() => {
+    if (!open) return;
+    return registerEscapeHandler(onClose);
+  }, [open, onClose]);
 
   if (!open) return null;
 
   return (
+    // The backdrop is the pointer affordance for dismiss. Its keyboard
+    // equivalents are Escape, dispatched to the innermost overlay by
+    // registerEscapeHandler above, and the Close button inside the card. A
+    // keydown handler here would be dead code: focus is trapped in the card,
+    // so the backdrop never receives one.
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard dismiss is Escape, handled above
     <div
       className="stims-shell__credits-overlay"
       role="dialog"
       aria-modal="true"
       aria-label="About Stims and credits"
       onClick={onClose}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') onClose();
-      }}
     >
       {/* biome-ignore lint/a11y/noStaticElementInteractions: card is visual-only, backdrop handles dismiss */}
       <div
         ref={creditsRef}
         className="stims-shell__credits-card"
+        // Focusable only as a landing spot for the trap's initial focus, so
+        // the sheet opens at its heading rather than scrolled to a control.
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
-          // Let Escape bubble to the backdrop's close handler above — focus
-          // is trapped inside this card for the entire time it's open, so
-          // an unconditional stopPropagation here would make Escape a dead
-          // key while the dialog is up.
+          // Escape is deliberately let through to the document listener that
+          // closes the innermost overlay; everything else is contained so it
+          // cannot reach the global shortcut handler.
           if (e.key !== 'Escape') {
             e.stopPropagation();
           }

--- a/src/js/frontend/CreditsDialog.tsx
+++ b/src/js/frontend/CreditsDialog.tsx
@@ -1,7 +1,9 @@
 import type { RefObject } from 'react';
-import { useEffect } from 'react';
-import { registerEscapeHandler } from '../core/modal-utils.ts';
 import { CreditsPanel } from './CreditsPanel.tsx';
+import {
+  useBottomOverlaySignal,
+  useEscapeHandler,
+} from './hooks/use-escape-handler.ts';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 
 export function CreditsDialog({
@@ -27,10 +29,8 @@ export function CreditsDialog({
 
   // See ShortcutsDialog: Escape is dispatched to the innermost overlay by the
   // shared stack, so it cannot reach a sheet underneath this dialog.
-  useEffect(() => {
-    if (!open) return;
-    return registerEscapeHandler(onClose);
-  }, [open, onClose]);
+  useEscapeHandler(open, onClose);
+  useBottomOverlaySignal(open);
 
   if (!open) return null;
 

--- a/src/js/frontend/ShortcutsDialog.tsx
+++ b/src/js/frontend/ShortcutsDialog.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react';
 import { Fragment, useEffect, useState } from 'react';
+import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   availableStageKeyDocs,
   availableStageSignalKeys,
@@ -35,11 +36,25 @@ export function ShortcutsDialog({
     autoFocus: true,
     restoreFocusOnUnmount: true,
     externalContainerRef: shortcutsRef,
+    // Land on the dialog itself rather than the first control inside it, as
+    // SidePanel does. Focusing a control scrolled the card to it, so the sheet
+    // opened part-way down with its own heading already scrolled off — and a
+    // screen reader announced that control instead of the dialog's name.
+    initialFocus: 'container',
   });
 
   useEffect(() => {
     if (open) setOverrides(readShortcutOverrides());
   }, [open]);
+
+  // Escape goes through the shared stack, not this dialog's own backdrop
+  // handler. The backdrop only sees keys that originate inside it, so with
+  // focus anywhere else the sheet this dialog was opened from took the press
+  // instead — closing the sheet and leaving the dialog stranded.
+  useEffect(() => {
+    if (!open) return;
+    return registerEscapeHandler(onClose);
+  }, [open, onClose]);
 
   if (!open) return null;
 
@@ -84,28 +99,33 @@ export function ShortcutsDialog({
   };
 
   return (
+    // The backdrop is the pointer affordance for dismiss. Its keyboard
+    // equivalents are Escape, dispatched to the innermost overlay by
+    // registerEscapeHandler above, and the Close button inside the card. A
+    // keydown handler here would be dead code: focus is trapped in the card,
+    // so the backdrop never receives one.
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard dismiss is Escape, handled above
     <div
       className="stims-shell__shortcut-overlay"
       role="dialog"
       aria-modal="true"
       aria-label="Shortcuts and gestures"
       onClick={onClose}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') onClose();
-      }}
     >
       {/* biome-ignore lint/a11y/noStaticElementInteractions: card is visual-only, backdrop handles dismiss */}
       <div
         ref={shortcutsRef}
         className="stims-shell__shortcut-card"
+        // Focusable only as a landing spot for the trap's initial focus, so
+        // the sheet opens at its heading rather than scrolled to a control.
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
           // Suppress everything else from reaching the global shortcut
-          // listener (typing a new binding while editing shouldn't also
-          // trigger it), but let Escape bubble to the backdrop's close
-          // handler above — otherwise the dialog that documents "Esc
-          // closes" is the one dialog Esc can't close, since focus is
-          // trapped inside this card the entire time it's open.
+          // listener — typing a new binding while editing must not also fire
+          // the action it is bound to. Escape is deliberately let through, so
+          // it reaches the document listener that closes the innermost
+          // overlay; this dialog is registered there as long as it is open.
           if (e.key !== 'Escape') {
             e.stopPropagation();
           }

--- a/src/js/frontend/ShortcutsDialog.tsx
+++ b/src/js/frontend/ShortcutsDialog.tsx
@@ -1,12 +1,15 @@
 import type { RefObject } from 'react';
 import { Fragment, useEffect, useState } from 'react';
-import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   availableStageKeyDocs,
   availableStageSignalKeys,
   formatStageKey,
 } from '../core/unified-input.ts';
 import { isMobileDevice } from '../utils/browser/device-detect.ts';
+import {
+  useBottomOverlaySignal,
+  useEscapeHandler,
+} from './hooks/use-escape-handler.ts';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 import { STAGE_GESTURES } from './hooks/useStageGesture.ts';
 import {
@@ -51,10 +54,9 @@ export function ShortcutsDialog({
   // handler. The backdrop only sees keys that originate inside it, so with
   // focus anywhere else the sheet this dialog was opened from took the press
   // instead — closing the sheet and leaving the dialog stranded.
-  useEffect(() => {
-    if (!open) return;
-    return registerEscapeHandler(onClose);
-  }, [open, onClose]);
+  useEscapeHandler(open, onClose);
+  // On phones this dialog is a bottom sheet, and toasts now render above it.
+  useBottomOverlaySignal(open);
 
   if (!open) return null;
 

--- a/src/js/frontend/SidePanel.tsx
+++ b/src/js/frontend/SidePanel.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from 'react';
 import styles from '../../css/SidePanel.module.css';
+import { registerEscapeHandler } from '../core/modal-utils.ts';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 import { UiIcon } from './UiIcon.tsx';
 
@@ -310,16 +311,11 @@ export function SidePanel({
     }
   }, [open, onOpen]);
 
+  // Registered rather than listening directly, so a dialog opened *over* this
+  // panel takes Escape instead of the panel underneath taking it.
   useEffect(() => {
     if (!open || exiting) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        startClose();
-      }
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
+    return registerEscapeHandler(startClose);
   }, [open, exiting, startClose]);
 
   if (!open && !exiting) return null;

--- a/src/js/frontend/SidePanel.tsx
+++ b/src/js/frontend/SidePanel.tsx
@@ -15,7 +15,7 @@ import {
   useState,
 } from 'react';
 import styles from '../../css/SidePanel.module.css';
-import { registerEscapeHandler } from '../core/modal-utils.ts';
+import { useEscapeHandler } from './hooks/use-escape-handler.ts';
 import { useFocusTrap } from './hooks/use-focus-trap.ts';
 import { UiIcon } from './UiIcon.tsx';
 
@@ -313,10 +313,7 @@ export function SidePanel({
 
   // Registered rather than listening directly, so a dialog opened *over* this
   // panel takes Escape instead of the panel underneath taking it.
-  useEffect(() => {
-    if (!open || exiting) return;
-    return registerEscapeHandler(startClose);
-  }, [open, exiting, startClose]);
+  useEscapeHandler(open && !exiting, startClose);
 
   if (!open && !exiting) return null;
 

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -11,6 +11,7 @@ import {
   useSyncExternalStore,
 } from 'react';
 import styles from '../../css/StageControls.module.css';
+import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   isPresetLocked,
   subscribePresetLock,
@@ -195,6 +196,21 @@ export function StageControls({
   const menuRef = useRef<HTMLDivElement>(null);
   const menuBtnRef = useRef<HTMLButtonElement>(null);
 
+  // Toasts render above every overlay, so they have to know when something
+  // occupies the bottom of the screen and move out of its way. Sheets publish
+  // that as data-sheet-open on the shell root; this menu is bottom-anchored
+  // too, so it publishes the same kind of signal.
+  useEffect(() => {
+    const shell = document.getElementById('stims-main');
+    if (!shell) return;
+    if (!showMenu) {
+      shell.removeAttribute('data-menu-open');
+      return;
+    }
+    shell.setAttribute('data-menu-open', 'true');
+    return () => shell.removeAttribute('data-menu-open');
+  }, [showMenu]);
+
   // ARIA already promises menu semantics (role="menu"/"menuitem"); this
   // backs that up with the arrow-key traversal a screen reader user would
   // reasonably expect from it, instead of leaving Tab as the only path.
@@ -255,19 +271,29 @@ export function StageControls({
   useEffect(() => {
     if (!showMenu) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
+      // The menu pattern closes on Tab: focus is meant to leave the menu and
+      // continue through the page. Without this, Tab walked focus into the
+      // content the menu is covering while the menu stayed open on top of it.
+      // Focus is left where Tab sends it rather than pulled back to the
+      // button, which is the point of pressing Tab.
+      if (event.key === 'Tab') {
         setShowMenu(false);
-        menuBtnRef.current?.focus();
       }
     };
     const handleResize = () => setShowMenu(false);
+    // Escape goes through the shared overlay stack so the menu, as the
+    // innermost thing open, takes the press rather than a panel behind it.
+    const releaseEscape = registerEscapeHandler(() => {
+      setShowMenu(false);
+      menuBtnRef.current?.focus();
+    });
     document.addEventListener('keydown', handleKeyDown);
     window.addEventListener('resize', handleResize, { passive: true });
     window.addEventListener('orientationchange', handleResize, {
       passive: true,
     });
     return () => {
+      releaseEscape();
       document.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('orientationchange', handleResize);
@@ -859,6 +885,12 @@ export function StageControls({
           </button>
         </div>
       </div>
+
+      {showMenu ? (
+        // Presentational only: the document pointerdown listener above already
+        // closes the menu on any press outside it, and this sits underneath.
+        <div className={styles.menuScrim} aria-hidden="true" />
+      ) : null}
 
       {showMenu ? (
         <div

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -11,7 +11,6 @@ import {
   useSyncExternalStore,
 } from 'react';
 import styles from '../../css/StageControls.module.css';
-import { registerEscapeHandler } from '../core/modal-utils.ts';
 import {
   isPresetLocked,
   subscribePresetLock,
@@ -26,6 +25,10 @@ import {
   subscribeAudioEnergy,
 } from './engine-audio-energy-store.ts';
 import { pulseHaptic } from './haptics.ts';
+import {
+  useBottomOverlaySignal,
+  useEscapeHandler,
+} from './hooks/use-escape-handler.ts';
 import { useListKeyboardNav } from './hooks/use-list-keyboard-nav.ts';
 import { useAutoHideActivity } from './hooks/useAutoHideActivity.ts';
 import { usePictureInPicture } from './hooks/usePictureInPicture.ts';
@@ -198,18 +201,15 @@ export function StageControls({
 
   // Toasts render above every overlay, so they have to know when something
   // occupies the bottom of the screen and move out of its way. Sheets publish
-  // that as data-sheet-open on the shell root; this menu is bottom-anchored
-  // too, so it publishes the same kind of signal.
-  useEffect(() => {
-    const shell = document.getElementById('stims-main');
-    if (!shell) return;
-    if (!showMenu) {
-      shell.removeAttribute('data-menu-open');
-      return;
-    }
-    shell.setAttribute('data-menu-open', 'true');
-    return () => shell.removeAttribute('data-menu-open');
-  }, [showMenu]);
+  // that from the shell as data-sheet-open; this menu is bottom-anchored too.
+  useBottomOverlaySignal(showMenu);
+
+  // A stable registration: the menu must keep Escape while it is open, even
+  // as the shell re-renders around it.
+  useEscapeHandler(showMenu, () => {
+    setShowMenu(false);
+    menuBtnRef.current?.focus();
+  });
 
   // ARIA already promises menu semantics (role="menu"/"menuitem"); this
   // backs that up with the arrow-key traversal a screen reader user would
@@ -281,19 +281,12 @@ export function StageControls({
       }
     };
     const handleResize = () => setShowMenu(false);
-    // Escape goes through the shared overlay stack so the menu, as the
-    // innermost thing open, takes the press rather than a panel behind it.
-    const releaseEscape = registerEscapeHandler(() => {
-      setShowMenu(false);
-      menuBtnRef.current?.focus();
-    });
     document.addEventListener('keydown', handleKeyDown);
     window.addEventListener('resize', handleResize, { passive: true });
     window.addEventListener('orientationchange', handleResize, {
       passive: true,
     });
     return () => {
-      releaseEscape();
       document.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('orientationchange', handleResize);

--- a/src/js/frontend/WorkspaceToast.tsx
+++ b/src/js/frontend/WorkspaceToast.tsx
@@ -6,6 +6,7 @@ export function WorkspaceToast({
   toast: {
     message: string;
     tone: 'info' | 'warn' | 'error';
+    exiting?: boolean;
   } | null;
 }) {
   if (!toast) {
@@ -23,6 +24,9 @@ export function WorkspaceToast({
     <output
       className="stims-shell__toast"
       data-tone={toast.tone}
+      // Drives the `toast-exit` keyframe in app-shell.css, which had sat
+      // unused because nothing ever set this.
+      data-exit={toast.exiting ? 'true' : undefined}
       role={toast.tone === 'error' ? 'alert' : 'status'}
       aria-live={toast.tone === 'error' ? 'assertive' : 'polite'}
       aria-atomic="true"

--- a/src/js/frontend/hooks/use-escape-handler.ts
+++ b/src/js/frontend/hooks/use-escape-handler.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import { registerEscapeHandler } from '../../core/modal-utils.ts';
+
+/**
+ * Claims Escape for an overlay while `active`, as the innermost one open.
+ *
+ * The registration order *is* the nesting order, so it must not change for
+ * any reason other than an overlay opening or closing. Registering the
+ * handler directly makes that fragile: `SidePanel` takes an inline
+ * `onClose={() => ui.updatePanel(null)}`, a new function on every render of
+ * the shell, which would re-run the effect and push the panel back on top of
+ * the stack. The workspace provider re-renders every frame while audio plays,
+ * so with the stage editor and the overflow menu open together, Escape would
+ * start closing the editor underneath and leave the menu up.
+ *
+ * The handler is read through a ref and the effect depends only on `active`,
+ * so a re-render cannot reorder the stack.
+ */
+export function useEscapeHandler(active: boolean, handler: () => void): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    if (!active) return;
+    return registerEscapeHandler(() => handlerRef.current());
+  }, [active]);
+}
+
+/**
+ * How many overlays currently hold the bottom of the screen.
+ *
+ * Refcounted rather than a boolean because these can overlap — the stage menu
+ * can be open under a help dialog — and the last one to close must not clear
+ * a signal the other still needs.
+ */
+let bottomOverlayCount = 0;
+
+function setBottomOverlayAttribute() {
+  const shell = document.getElementById('stims-main');
+  if (!shell) return;
+  if (bottomOverlayCount > 0) {
+    shell.setAttribute('data-bottom-overlay', 'true');
+  } else {
+    shell.removeAttribute('data-bottom-overlay');
+  }
+}
+
+/**
+ * Announces that this overlay occupies the bottom of the screen while
+ * `active`, so toasts move out of its way.
+ *
+ * Toasts sit above every overlay, which is only safe because they dodge
+ * whatever holds the bottom. Sheets publish that as `data-sheet-open` from
+ * the shell itself. The stage overflow menu is bottom-anchored, and on phones
+ * the help dialogs are bottom sheets too, so they say so here.
+ */
+export function useBottomOverlaySignal(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    bottomOverlayCount += 1;
+    setBottomOverlayAttribute();
+    return () => {
+      bottomOverlayCount = Math.max(0, bottomOverlayCount - 1);
+      setBottomOverlayAttribute();
+    };
+  }, [active]);
+}

--- a/src/js/frontend/hooks/useKeyboardShortcuts.ts
+++ b/src/js/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { escapeIsClaimed } from '../../core/modal-utils.ts';
 import {
   NO_RESERVED_KEYS,
   setReservedShellKeys,
@@ -96,6 +97,10 @@ export function useKeyboardShortcuts({
       // resize, the warp gizmo's nudge) prevents default; firing the global
       // preset shortcuts on top of it double-acts the keystroke.
       if (event.defaultPrevented) return;
+      // An open overlay owns Escape. This listener is attached when the shell
+      // mounts, before any overlay exists, so it runs first; without this a
+      // rebound Escape would run its action and dismiss the overlay at once.
+      if (event.key === 'Escape' && escapeIsClaimed()) return;
       const shortcutOverrides = readShortcutOverrides();
       if (
         event.target instanceof HTMLInputElement ||

--- a/src/js/frontend/workspace-context.tsx
+++ b/src/js/frontend/workspace-context.tsx
@@ -55,6 +55,8 @@ export interface WorkspaceContextValue {
   toast: {
     message: string;
     tone: 'info' | 'warn' | 'error';
+    /** True while the exit animation plays, just before it unmounts. */
+    exiting?: boolean;
   } | null;
   dismissToast: () => void;
   toggleExtendedSources: () => void;

--- a/src/js/frontend/workspace-toast.ts
+++ b/src/js/frontend/workspace-toast.ts
@@ -3,6 +3,15 @@ import { resolvePresetId } from '../milkdrop/preset-id-resolution.ts';
 import type { SessionRouteState } from './contracts.ts';
 import type { EngineSnapshot } from './engine/milkdrop-engine-adapter.ts';
 
+/**
+ * How long the toast's exit animation runs, matching `toast-exit` in
+ * app-shell.css. The stylesheet has had that keyframe and a reduced-motion
+ * variant for a long time, both keyed on `data-exit="true"` — an attribute
+ * nothing ever set, so every toast animated in and then vanished between
+ * frames.
+ */
+const TOAST_EXIT_MS = 250;
+
 export function useWorkspaceToast({
   engineSnapshot,
   routeState,
@@ -15,11 +24,17 @@ export function useWorkspaceToast({
   const [toast, setToast] = useState<{
     message: string;
     tone: 'info' | 'warn' | 'error';
+    exiting?: boolean;
   } | null>(null);
   const toastTimerRef = useRef<number | null>(null);
+  const toastExitTimerRef = useRef<number | null>(null);
   const shownToastKeysRef = useRef(new Set<string>());
 
   const clearToastTimer = () => {
+    if (toastExitTimerRef.current !== null) {
+      window.clearTimeout(toastExitTimerRef.current);
+      toastExitTimerRef.current = null;
+    }
     if (toastTimerRef.current === null) {
       return;
     }
@@ -32,6 +47,9 @@ export function useWorkspaceToast({
     return () => {
       if (toastTimerRef.current !== null) {
         window.clearTimeout(toastTimerRef.current);
+      }
+      if (toastExitTimerRef.current !== null) {
+        window.clearTimeout(toastExitTimerRef.current);
       }
     };
   }, []);
@@ -51,8 +69,13 @@ export function useWorkspaceToast({
       // audio source substitution) — give visitors more time to read them.
       const duration = tone === 'info' ? 4200 : 7000;
       toastTimerRef.current = window.setTimeout(() => {
-        setToast(null);
         toastTimerRef.current = null;
+        // Mark it exiting, let the animation play, then drop it.
+        setToast((current) => (current ? { ...current, exiting: true } : null));
+        toastExitTimerRef.current = window.setTimeout(() => {
+          toastExitTimerRef.current = null;
+          setToast(null);
+        }, TOAST_EXIT_MS);
       }, duration);
     },
   );

--- a/tests/unit/escape-handler-hook.test.tsx
+++ b/tests/unit/escape-handler-hook.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { useState } from 'react';
+import { registerEscapeHandler } from '../../src/js/core/modal-utils.ts';
+import {
+  useBottomOverlaySignal,
+  useEscapeHandler,
+} from '../../src/js/frontend/hooks/use-escape-handler.ts';
+import { renderWorkspace } from '../frontend-harness.tsx';
+
+/**
+ * Escape registration order *is* overlay nesting order, so it must change only
+ * when an overlay opens or closes.
+ *
+ * That is easy to get wrong. `SidePanel` takes an inline
+ * `onClose={() => ui.updatePanel(null)}` — a new function on every render of
+ * the shell — so registering the handler directly re-ran the effect and pushed
+ * the panel back on top of the stack. The workspace provider re-renders every
+ * frame while audio plays, so with the stage editor and the overflow menu open
+ * together, Escape would drift to closing the editor underneath.
+ */
+
+function pressEscape() {
+  const event = new Event('keydown', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'key', { value: 'Escape' });
+  document.dispatchEvent(event);
+}
+
+/** An overlay whose handler identity changes on every render, like the real one. */
+function Overlay({
+  name,
+  calls,
+  revision,
+}: {
+  name: string;
+  calls: string[];
+  revision: number;
+}) {
+  useEscapeHandler(true, () => calls.push(`${name}@${revision}`));
+  return null;
+}
+
+function ReRenderingOverlay({ calls }: { calls: string[] }) {
+  const [revision, setRevision] = useState(0);
+  return (
+    <div>
+      <Overlay name="panel" calls={calls} revision={revision} />
+      <button
+        type="button"
+        data-rerender="true"
+        onClick={() => setRevision((value) => value + 1)}
+      >
+        re-render
+      </button>
+    </div>
+  );
+}
+
+afterEach(() => {
+  document.getElementById('stims-main')?.remove();
+});
+
+describe('useEscapeHandler', () => {
+  test('a re-render does not move the panel above the overlay on top', () => {
+    const calls: string[] = [];
+    // The panel registers first, so it is the one underneath.
+    const rendered = renderWorkspace(<ReRenderingOverlay calls={calls} />);
+    // Then something opens over it. Registered directly, the way the stage
+    // menu's own effect does: stable, and not re-run by the shell's renders.
+    const releaseMenu = registerEscapeHandler(() => calls.push('menu'));
+
+    try {
+      pressEscape();
+      expect(calls).toEqual(['menu']);
+
+      // Re-render the panel with a fresh handler identity, which is what
+      // every frame of audio playback does to the real side panel.
+      rendered.click(rendered.container.querySelector('[data-rerender]'));
+      pressEscape();
+
+      // Still the menu. Re-registering on identity churn made this 'panel@1',
+      // so Escape drifted to closing the panel underneath the open menu.
+      expect(calls).toEqual(['menu', 'menu']);
+    } finally {
+      releaseMenu();
+      rendered.dispose();
+    }
+  });
+
+  test('the latest handler runs even though registration is stable', () => {
+    const calls: string[] = [];
+    function Single({ revision }: { revision: number }) {
+      useEscapeHandler(true, () => calls.push(`only@${revision}`));
+      return null;
+    }
+    function Harness() {
+      const [revision, setRevision] = useState(0);
+      return (
+        <div>
+          <Single revision={revision} />
+          <button
+            type="button"
+            data-rerender="true"
+            onClick={() => setRevision((value) => value + 1)}
+          >
+            re-render
+          </button>
+        </div>
+      );
+    }
+
+    const rendered = renderWorkspace(<Harness />);
+    try {
+      rendered.click(rendered.container.querySelector('[data-rerender]'));
+      pressEscape();
+
+      // Stable registration must not mean a stale closure.
+      expect(calls).toEqual(['only@1']);
+    } finally {
+      rendered.dispose();
+    }
+  });
+
+  test('an inactive overlay claims nothing', () => {
+    const calls: string[] = [];
+    function Inactive() {
+      useEscapeHandler(false, () => calls.push('inactive'));
+      return null;
+    }
+    const rendered = renderWorkspace(<Inactive />);
+    try {
+      pressEscape();
+      expect(calls).toEqual([]);
+    } finally {
+      rendered.dispose();
+    }
+  });
+});
+
+describe('useBottomOverlaySignal', () => {
+  function shell() {
+    let root = document.getElementById('stims-main');
+    if (!root) {
+      root = document.createElement('main');
+      root.id = 'stims-main';
+      document.body.appendChild(root);
+    }
+    return root;
+  }
+
+  function Signal({ active }: { active: boolean }) {
+    useBottomOverlaySignal(active);
+    return null;
+  }
+
+  test('marks the shell while a bottom overlay is open', () => {
+    const root = shell();
+    const rendered = renderWorkspace(<Signal active />);
+    try {
+      expect(root.getAttribute('data-bottom-overlay')).toBe('true');
+    } finally {
+      rendered.dispose();
+    }
+    expect(root.hasAttribute('data-bottom-overlay')).toBe(false);
+  });
+
+  test('two overlapping overlays keep the mark until both close', () => {
+    const root = shell();
+    // The stage menu can be open underneath a help dialog, so the first one to
+    // close must not clear a signal the other still needs.
+    const menu = renderWorkspace(<Signal active />);
+    const dialog = renderWorkspace(<Signal active />);
+    try {
+      expect(root.getAttribute('data-bottom-overlay')).toBe('true');
+      dialog.dispose();
+      expect(root.getAttribute('data-bottom-overlay')).toBe('true');
+    } finally {
+      menu.dispose();
+    }
+    expect(root.hasAttribute('data-bottom-overlay')).toBe(false);
+  });
+});

--- a/tests/unit/escape-stack.test.ts
+++ b/tests/unit/escape-stack.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { registerEscapeHandler } from '../../src/js/core/modal-utils.ts';
+import {
+  escapeIsClaimed,
+  registerEscapeHandler,
+} from '../../src/js/core/modal-utils.ts';
 
 /**
  * Escape must close the overlay in front of the user, and only that one.
@@ -103,6 +106,21 @@ describe('registerEscapeHandler', () => {
     pressEscape(field);
 
     expect(calls).toEqual([]);
+  });
+
+  test('reports whether an overlay has claimed Escape', () => {
+    // The global shortcut handler asks this before acting. It attaches on
+    // document when the shell mounts, before any overlay exists, so it runs
+    // first and cannot be cancelled from here — a user who rebinds Escape to
+    // an action would otherwise fire that action *and* dismiss the overlay.
+    expect(escapeIsClaimed()).toBe(false);
+
+    const calls: string[] = [];
+    const release = register(calls, 'dialog');
+    expect(escapeIsClaimed()).toBe(true);
+
+    release();
+    expect(escapeIsClaimed()).toBe(false);
   });
 
   test('the same handler registered twice unwinds one layer at a time', () => {

--- a/tests/unit/escape-stack.test.ts
+++ b/tests/unit/escape-stack.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerEscapeHandler } from '../../src/js/core/modal-utils.ts';
+
+/**
+ * Escape must close the overlay in front of the user, and only that one.
+ *
+ * Before these handlers were stacked, each overlay listened wherever it liked.
+ * The side panel listened on `document`; the help dialogs used a React
+ * `onKeyDown` on their own backdrop, which React dispatches from the root
+ * container — below `document`, and only for events that start inside that
+ * backdrop. So opening the shortcuts dialog from inside Settings and pressing
+ * Escape closed the sheet underneath and left the dialog open, and a second
+ * press did nothing at all.
+ */
+
+const releases: Array<() => void> = [];
+
+function register(calls: string[], name: string) {
+  const release = registerEscapeHandler(() => calls.push(name));
+  releases.push(release);
+  return release;
+}
+
+/**
+ * A bubbling keydown carrying `key: 'Escape'`. Built from a plain `Event`
+ * with the property defined on it, because happy-dom does not expose
+ * `KeyboardEvent` on the global scope the way a browser does.
+ */
+function pressEscape(target: EventTarget = document) {
+  const event = new Event('keydown', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'key', { value: 'Escape' });
+  target.dispatchEvent(event);
+}
+
+afterEach(() => {
+  while (releases.length > 0) releases.pop()?.();
+  document.body.innerHTML = '';
+});
+
+describe('registerEscapeHandler', () => {
+  test('dispatches to the innermost overlay only', () => {
+    const calls: string[] = [];
+    register(calls, 'sheet');
+    register(calls, 'dialog');
+
+    pressEscape();
+
+    // The defect closed 'sheet' and left 'dialog' open — the wrong one, and
+    // the one the user could not then get out of.
+    expect(calls).toEqual(['dialog']);
+  });
+
+  test('the overlay underneath resumes once the top one closes', () => {
+    const calls: string[] = [];
+    register(calls, 'sheet');
+    const releaseDialog = register(calls, 'dialog');
+
+    releaseDialog();
+    pressEscape();
+
+    expect(calls).toEqual(['sheet']);
+  });
+
+  test('releasing out of order leaves the survivor handling Escape', () => {
+    const calls: string[] = [];
+    const releaseSheet = register(calls, 'sheet');
+    register(calls, 'dialog');
+
+    // The panel underneath can close first; the dialog above it stays open.
+    releaseSheet();
+    pressEscape();
+
+    expect(calls).toEqual(['dialog']);
+  });
+
+  test('with nothing registered the key is left alone', () => {
+    const seen: string[] = [];
+    const onKey = () => seen.push('reached');
+    document.addEventListener('keydown', onKey);
+    try {
+      pressEscape();
+      // Not swallowed: no overlay is open, so Escape stays available to
+      // whatever else listens for it.
+      expect(seen).toEqual(['reached']);
+    } finally {
+      document.removeEventListener('keydown', onKey);
+    }
+  });
+
+  test('a handler stopping propagation first still wins', () => {
+    const calls: string[] = [];
+    register(calls, 'sheet');
+
+    const field = document.createElement('input');
+    document.body.appendChild(field);
+    // This is the Browse search field: Escape clears what you typed and must
+    // not also close the panel around it. It works because the shared
+    // listener is on the bubble phase, so a nearer handler can stop the event.
+    field.addEventListener('keydown', (event) => {
+      if ((event as KeyboardEvent).key === 'Escape') event.stopPropagation();
+    });
+
+    pressEscape(field);
+
+    expect(calls).toEqual([]);
+  });
+
+  test('the same handler registered twice unwinds one layer at a time', () => {
+    const calls: string[] = [];
+    const shared = () => calls.push('shared');
+    const releaseA = registerEscapeHandler(shared);
+    const releaseB = registerEscapeHandler(shared);
+    releases.push(releaseA, releaseB);
+
+    pressEscape();
+    releaseB();
+    pressEscape();
+    releaseA();
+    pressEscape();
+
+    // Two presses land while it is registered, none after both are released.
+    expect(calls).toEqual(['shared', 'shared']);
+  });
+});

--- a/tests/unit/milkdrop-overlay-stacking.test.ts
+++ b/tests/unit/milkdrop-overlay-stacking.test.ts
@@ -62,6 +62,34 @@ describe('shell stacking order', () => {
     expect(z(scale, '--z-sheet-active')).toBeGreaterThan(z(scale, '--z-sheet'));
   });
 
+  test('puts the stage overflow menu above its dock, below any panel', () => {
+    // The menu used to share --z-dock with the bar it opens from, leaving
+    // paint order to the DOM.
+    expect(z(scale, '--z-stage-menu')).toBeGreaterThan(z(scale, '--z-dock'));
+    expect(z(scale, '--z-stage-menu')).toBeGreaterThan(
+      z(scale, '--z-lab-panel'),
+    );
+    expect(z(scale, '--z-modal-backdrop')).toBeGreaterThan(
+      z(scale, '--z-stage-menu'),
+    );
+  });
+
+  test('keeps toasts above every overlay they report on', () => {
+    // Both toast surfaces share --z-toast-floating. The ambient stack used to
+    // sit at --z-toast, below the modal backdrop, so a notice raised while a
+    // panel was open rendered behind it and expired unseen. Being on top is
+    // paired with the dodge rules in app-shell.css, which move a toast to the
+    // top of the screen while a sheet or the stage menu holds the bottom.
+    for (const name of [
+      '--z-dock',
+      '--z-stage-menu',
+      '--z-modal',
+      '--z-shortcut-overlay',
+    ]) {
+      expect(z(scale, '--z-toast-floating')).toBeGreaterThan(z(scale, name));
+    }
+  });
+
   test('reserves the top of the scale for the shortcuts overlay', () => {
     // The shortcuts overlay explains the UI, so nothing in the normal chrome
     // may cover it.


### PR DESCRIPTION
## Summary

An audit of the app's modals, popovers and toasts found three surfaces that needed redesign. The command palette and the shared side-panel chrome were already good and are untouched.

### Escape closed the wrong thing, and stranded a dialog

Escape was handled wherever each overlay felt like handling it. The side panel listened on `document`; the two help dialogs used a React `onKeyDown` on their own backdrop, which React dispatches from the root container, below `document`, and only for events starting inside that backdrop.

Opening Shortcuts from inside Settings and pressing Escape therefore closed the sheet underneath and left the dialog open, with focus still on its Close button. A second press did nothing, because the only thing listening had already gone. The dialog that documents "Esc closes" could not be closed with Esc.

| Shortcuts opened from Settings | Before | After |
| --- | --- | --- |
| One Escape | sheet closes, dialog stuck open | dialog closes, sheet stays |
| Two Escapes | still stuck | sheet closes |

One document listener now dispatches to the innermost registered overlay. It listens on the bubble phase deliberately, so a React handler that stops propagation still wins. That is what lets the Browse search field clear itself without also closing the panel around it, and it is covered by a test.

### Toasts and the menu disagreed about where they belong

The two toast systems disagreed with each other and with themselves. CSS tried to hide toasts whenever a sheet was open. The status toast has an entry animation, and an animation outranks a plain declaration in the cascade, so it faded in over the sheet anyway and landed on the sheet's own header. The ambient stack has no entry animation, so the rule did apply to it, and it sat below the modal backdrop: an audio match found while browsing rendered behind the panel and ran its eight second dismiss timer out unseen.

Hiding was the wrong policy in both directions, because the messages that matter most are raised from inside these panels. Both surfaces now share one layer above every overlay and move clear of whatever holds the bottom of the screen.

| Toast raised while… | Before | After |
| --- | --- | --- |
| A sheet is open | lands on the sheet header | moves to the top, fully visible |
| The stage menu is open | painted over menu items | moves to the top |
| A help dialog is open on a phone | would cover it, incl. its Close button | moves to the top |
| Audio match, panel open | invisible, timer still running | visible above the panel |

The stage overflow menu rendered 835px tall on a 915px screen, still scrolling, so the extra height bought nothing but the impression the app had navigated somewhere. It had no scrim over live visuals, shared `--z-dock` with the bar it opens from, and ignored Tab, which the menu pattern closes on.

| Stage overflow menu | Before | After |
| --- | --- | --- |
| Height on a 915px screen | 91% | 68% |
| Scrim | none | dimmed, on its own layer |
| Layer | tied with the dock | above the dock, below any panel |
| Tab | walked focus under the open menu | closes it |

### The help dialogs had no phone layout

They were the only overlays that stayed centred cards, with 64px of horizontal padding, which at 390px leaves under 300px for a three-column shortcut grid, while the eight panels built on `SidePanel` all present as bottom sheets. They match now. Credits also sized itself in `vh`, the largest viewport on iOS Safari, so with the URL bar showing the card ran past the visible bottom and took its own Close button with it.

Both dialogs also take initial focus on the card rather than the first control inside it, as the side panel already does. Focusing a control scrolled the card to it, so the dialog opened part-way down with its own heading out of view.

Finally, toasts have had a `toast-exit` keyframe and a reduced-motion variant for a long time, both keyed on an attribute nothing ever set. Toasts animated in and then vanished between frames. The attribute is set now.

### Review round (003576a)

Codex raised four P2 findings on the first two commits. All four were real and all four are fixed; the threads carry the detail.

- **Escape ownership depended on render order.** `SidePanel` takes an inline `onClose`, a new function every render, so registering the handler directly pushed the panel back on top of the stack. The provider re-renders every frame while audio plays, so Escape would have drifted to closing the editor underneath an open menu. Every overlay now registers through one hook that reads the handler from a ref and depends only on whether it is active.
- **The global shortcut handler ran first.** It attaches when the shell mounts, so nothing from the stack could cancel it, and a rebound Escape would have fired its action *and* dismissed the overlay. It now asks `escapeIsClaimed()` and stands down, which does not depend on listener order.
- **The toast dodge lost the cascade.** A later live-mode rule with equal specificity reassigned `bottom`, leaving both edges pinned on an auto-height element so the toast stretched down the viewport. The dodge now matches `[data-tone]` and wins on specificity rather than source order.
- **The bottom-sheet dialogs published no dodge signal**, so a toast could cover dialog content. The menu's ad-hoc attribute became a shared, refcounted `data-bottom-overlay` used by the menu and both dialogs.

## Testing

- `bun run check` — **3035 pass, 0 fail**, plus both browser-backed corpus files passing in their own processes.
- Two new suites: `escape-stack` covers ordering, out-of-order unwinding, the bubble-phase contract that protects the search field, and the claimed-ownership query; `escape-handler-hook` covers stable registration and the refcounted bottom-overlay signal.
- Both new suites were confirmed to catch their defects. Reverting the innermost-only guard fails one; reverting the stable registration fails the ordering test. My first attempt at that ordering test passed against the broken code, because both overlays re-registered together, so I rewrote it to reproduce the real asymmetry.
- The existing z-scale test is **extended rather than relaxed**. An earlier version of this change moved `--z-toast` out of sequence and that test caught it; the menu's layer and the toasts-above-everything rule are now part of the contract it enforces.
- Verified in a browser at 412x915: Escape ordering, all three toast dodge cases, the menu's layer, scrim, height, Tab and Escape with focus returning to its button, and both dialogs opening at their heading on phone and desktop. No console or page errors.
- Two regressions were caught by that verification before they reached CI: the palette swallowing Escape while closed, and the live-mode toast stretching.

## Docs touched

- None. Each decision is documented beside the code it governs, including the z-scale comments that explain why toasts sit on top.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (no build/runtime output change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8pDEgkTvpbDDUSwwZ8WYF