### PR TITLE
feat(perform): make the gamepad, MIDI profiles and remix link reachable

### DIFF
--- a/src/js/core/services/gamepad-performance-source.ts
+++ b/src/js/core/services/gamepad-performance-source.ts
@@ -46,7 +46,7 @@ export type GamepadPerformanceOptions = {
 
 type MidiSink = Pick<
   WebMidiControllerService,
-  'injectControlChange' | 'injectNote'
+  'injectControlChange' | 'injectNote' | 'ensureGamepadDefaults'
 >;
 
 export function isGamepadPerformanceSupported(): boolean {
@@ -96,11 +96,21 @@ export function startGamepadPerformanceSource(
     midi.injectControlChange(VIRTUAL_GAMEPAD_DEVICE_ID, cc, value);
   };
 
+  let seededBindings = false;
+
   const poll = () => {
     if (stopped) return;
     const pad =
       readGamepads().find((candidate) => candidate?.connected) ?? null;
     if (pad) {
+      // Bindings are installed here, on the first pad seen, rather than when
+      // the service is constructed: `virtual:gamepad` is a device on every
+      // machine, and a mapping that exists before the hardware does makes the
+      // editor and the parameter HUD report a controller nobody plugged in.
+      if (!seededBindings) {
+        seededBindings = true;
+        midi.ensureGamepadDefaults();
+      }
       for (let axis = 0; axis < Math.min(pad.axes.length, 4); axis += 1) {
         emitCc(axis, axisToCc(pad.axes[axis] ?? 0));
       }

--- a/src/js/core/services/webmidi-controller.ts
+++ b/src/js/core/services/webmidi-controller.ts
@@ -81,6 +81,35 @@ export const DEFAULT_MIDI_CC_BINDINGS: MidiBindingMap = {
   10: { target: 'q4', min: 0.0, max: 1.0 },
 };
 
+/**
+ * What a gamepad drives before anyone maps it.
+ *
+ * A hardware MIDI device gets {@link DEFAULT_MIDI_CC_BINDINGS} the moment it
+ * appears, but `virtual:gamepad` was only ever created lazily by the first
+ * injected CC, with an empty binding map — so the gamepad performance source
+ * emitted CC 0-5 into nothing and a plugged-in pad moved no pixels at all.
+ * There is also no note/CC learn path for it in the UI (learn is armed by
+ * moving a knob, and Settings never mentions gamepads), so an unbound pad had
+ * no route back to being useful.
+ *
+ * The CC numbers are the gamepad source's fixed layout, not a MIDI convention:
+ * 0-3 are the two sticks' axes and 4-5 the analog triggers
+ * (`gamepad-performance-source.ts`).
+ *
+ * Every range is chosen so the control's RESTING position is the parameter's
+ * neutral value — sticks self-centre to the midpoint (dx/dy 0, rot 0,
+ * zoom 1.0) and triggers rest at their minimum (q1/q2 0). A pad sitting
+ * untouched on a desk must not bend the visuals; only a hand on it should.
+ */
+export const DEFAULT_GAMEPAD_CC_BINDINGS: MidiBindingMap = {
+  0: { target: 'dx', min: -0.03, max: 0.03 },
+  1: { target: 'dy', min: -0.03, max: 0.03 },
+  2: { target: 'rot', min: -0.2, max: 0.2 },
+  3: { target: 'zoom', min: 0.9, max: 1.1 },
+  4: { target: 'q1', min: 0.0, max: 1.0 },
+  5: { target: 'q2', min: 0.0, max: 1.0 },
+};
+
 export interface MidiDeviceInfo {
   id: string;
   name: string;
@@ -305,6 +334,43 @@ export class WebMidiControllerService {
     });
   }
 
+  /**
+   * Give the gamepad its default mapping, now that one is actually attached.
+   *
+   * Deliberately lazy, and this is the whole reason the method exists rather
+   * than a line in the constructor. `virtual:gamepad` is listed as a device on
+   * every machine, connected or not, so seeding it at construction makes
+   * `getEnabledTargets()` report zoom, rot, dx, dy and q1/q2 as hardware-driven
+   * in every session — and the editor's value-source chips and the live
+   * parameter HUD would tell a user with no controller that a controller is
+   * driving their preset.
+   *
+   * Called by the gamepad performance source the first time it sees a pad, so
+   * the claim is only ever made when it is true.
+   *
+   * Also repairs the empty map persisted by builds where the pad bound to
+   * nothing. An empty CC map is only ever that bug's footprint — learn adds
+   * bindings and the pad has no unbind control — so refilling it cannot
+   * discard a choice anyone made.
+   */
+  public ensureGamepadDefaults(): void {
+    // Checked before ensureDeviceRecord, not after: that call creates the
+    // record with the defaults already in place, so reading the result cannot
+    // distinguish "just created" from "already mapped" — and taking the
+    // early return on a fresh create would skip the notify, leaving the
+    // Settings bindings table showing "No mappings yet" for a live pad.
+    const existing = this.deviceRecords.get(VIRTUAL_GAMEPAD_DEVICE_ID);
+    if (existing && Object.keys(existing.bindings).length > 0) return;
+    const rec = this.ensureDeviceRecord(VIRTUAL_GAMEPAD_DEVICE_ID, {
+      enabled: true,
+      bindings: { ...DEFAULT_GAMEPAD_CC_BINDINGS },
+      noteBindings: {},
+    });
+    rec.bindings = { ...DEFAULT_GAMEPAD_CC_BINDINGS };
+    this.persist();
+    this.notifyDevicesChanged();
+  }
+
   public isSupported(): boolean {
     return typeof navigator !== 'undefined' && 'requestMIDIAccess' in navigator;
   }
@@ -527,6 +593,38 @@ export class WebMidiControllerService {
     // Reused as a general "MIDI state changed" signal — the UI's bindings
     // table re-reads getAllBindings() off the same event rather than
     // needing a second listener type just for this.
+    this.notifyDevicesChanged();
+  }
+
+  /**
+   * Replace a device's whole mapping in one step.
+   *
+   * Exists so applying a factory profile is a single persist and a single
+   * `onDevicesChanged`: looping `bindCc` over sixteen controls would write
+   * storage sixteen times and re-render every bindings table on each one.
+   *
+   * Replaces rather than merges — a profile describes the entire surface of a
+   * known device, so leaving stale bindings from a previous profile behind
+   * would produce a mapping neither one documents.
+   */
+  public applyDeviceProfile(
+    deviceId: string,
+    bindings: MidiBindingMap,
+    noteBindings: MidiNoteBindingMap = {},
+  ): void {
+    const rec = this.ensureDeviceRecord(deviceId, {
+      enabled: true,
+      bindings: {},
+      noteBindings: {},
+    });
+    rec.bindings = { ...bindings };
+    rec.noteBindings = { ...noteBindings };
+    // Latched `toggle` notes are keyed by device+note and would otherwise
+    // survive into a mapping where that note means something else.
+    for (const key of [...this.noteToggleState.keys()]) {
+      if (key.startsWith(`${deviceId}:`)) this.noteToggleState.delete(key);
+    }
+    this.persist();
     this.notifyDevicesChanged();
   }
 

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -87,6 +87,7 @@ import { reportLoadStatus } from './load-status.ts';
 import { dismissLoadingScreen } from './loading-screen.ts';
 import { prefetchPanelChunk } from './panel-chunks.ts';
 import { openPerformPicker, pinTarget, unpinTarget } from './perform-pins.ts';
+import { watchPerformanceHardware } from './performance-hardware-connect.ts';
 import {
   SilentAudioNotice,
   useAudioAwaitingGesture,
@@ -495,10 +496,15 @@ function StimsWorkspaceAppShell() {
   const hostingWatchParty =
     syncSession.role === 'host' && syncSession.status !== 'idle';
 
+  // Read here rather than at its use site further down, because the share
+  // action's label depends on it: a link copied mid-edit carries the draft,
+  // and the row is the only place that fact is ever stated.
+  const editorDirty = engineSnapshot?.sessionState?.dirty ?? false;
+
   // Behavior bodies live in workspace-actions.ts, shared with the stage
   // dock menu — a verb must not do different things depending on which
   // surface invoked it.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: handlers are stable context methods; the list only needs to refresh with live/fullscreen/hosting state
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handlers are stable context methods; the list only needs to refresh with live/fullscreen/hosting/editor state
   const paletteActions: CommandAction[] = useMemo(
     () => [
       {
@@ -665,8 +671,14 @@ function StimsWorkspaceAppShell() {
       {
         id: 'share-link',
         group: 'Share',
-        label: 'Share link',
-        keywords: ['copy', 'url'],
+        // The link has carried a `#code=` hash of the live draft since remix
+        // links shipped — `buildCanonicalUrl` rewrites path and query and
+        // leaves the hash alone — but the row said only "Share link", so the
+        // one property that makes it interesting was invisible. Naming it
+        // costs a word and is the difference between a URL and a way to send
+        // someone the preset you are in the middle of writing.
+        label: editorDirty ? 'Share link (carries your edits)' : 'Share link',
+        keywords: ['copy', 'url', 'remix', 'draft'],
         run: () => void ui.handleShowCurrentLink(),
       },
       {
@@ -858,7 +870,7 @@ function StimsWorkspaceAppShell() {
           ]
         : []),
     ],
-    [liveMode, isFullscreen, hostingWatchParty, themeChoice],
+    [liveMode, isFullscreen, hostingWatchParty, themeChoice, editorDirty],
   );
 
   // Machine-readable state for automation: window.__stims_agent (snapshot,
@@ -1146,10 +1158,18 @@ function StimsWorkspaceAppShell() {
         },
       );
 
+      // Neither of the two lines above used to say anything, so the only way
+      // to find out a controller was live was to move one and watch.
+      const stopHardwareWatch = watchPerformanceHardware({
+        midi: webMidiService,
+        announce: (message) => uiRef.current.setStatusMessage(message),
+      });
+
       return () => {
         uninstallLive();
         unbindMidi();
         stopGamepad?.();
+        stopHardwareWatch();
       };
     });
   }, [engine]);
@@ -1410,6 +1430,16 @@ function StimsWorkspaceAppShell() {
     }
   }, [ui.routeState.panel, showHint]);
 
+  // Said at the first keystroke, because that is the moment the claim becomes
+  // checkable: there is now a draft, and the URL already holds it. Guarded on
+  // `visibleHint` like the interaction hint — showing one marks it seen, so
+  // stacking would silently burn whichever lost.
+  useEffect(() => {
+    if (!editorDirty || visibleHint) return;
+    if (ui.routeState.panel !== 'editor') return;
+    showHint('editor-dirty-link');
+  }, [editorDirty, visibleHint, ui.routeState.panel, showHint]);
+
   // Presets that read the interaction signals are the minority, and nothing
   // marked them: the stage keys and drag gestures did nothing on most of the
   // catalog, which reads as broken rather than as "this one doesn't listen".
@@ -1560,7 +1590,6 @@ function StimsWorkspaceAppShell() {
   // is the one place where losing work is silent and irreversible.
   // Deliberately scoped to the editor being dirty: a beforeunload prompt on
   // an idle visualizer would be pure nuisance.
-  const editorDirty = engineSnapshot?.sessionState?.dirty ?? false;
   useEffect(() => {
     if (!editorDirty) return;
     const onBeforeUnload = (event: BeforeUnloadEvent) => {

--- a/src/js/frontend/ContextualHelp.tsx
+++ b/src/js/frontend/ContextualHelp.tsx
@@ -64,6 +64,17 @@ const HINTS: HelpHintDef[] = [
     autoHideMs: 6000,
     anchor: 'panel',
   },
+  {
+    // The address bar has carried the live draft in a `#code=` hash since
+    // remix links shipped, and nothing said so — so the one way to hand
+    // someone an unfinished preset was known only to people who had read the
+    // router. Taught at the first keystroke that makes the claim true.
+    id: 'editor-dirty-link',
+    message:
+      'Your draft is already in the address bar. Share link sends it exactly as it is here.',
+    autoHideMs: 7000,
+    anchor: 'panel',
+  },
 ];
 
 const STORAGE_KEY = 'stims:seen-hints';

--- a/src/js/frontend/EditorPanel.tsx
+++ b/src/js/frontend/EditorPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import '../../css/editor-panel.css';
 import type { MilkdropEditorSessionState } from '../milkdrop/types.ts';
 import { useEngineSnapshot } from './engine-context.tsx';
+import { copyRemixLinkAction } from './workspace-actions.ts';
 import { useWorkspace } from './workspace-context.tsx';
 
 export function EditorPanel() {
@@ -22,6 +23,9 @@ export function EditorPanel() {
 
   const handleImportRef = useRef(ui.handleImport);
   handleImportRef.current = ui.handleImport;
+
+  const uiRef = useRef(ui);
+  uiRef.current = ui;
 
   const sessionState = engineSnapshot?.sessionState ?? null;
   // The panel is code-split, so it appends itself a tick or two after this
@@ -63,6 +67,16 @@ export function EditorPanel() {
         // Was a no-op, which made the panel's Import button dead UI.
         onRequestImport: () => {
           importInputRef.current?.click();
+        },
+        // Reads the session through refs rather than closing over the render's
+        // values: this callback is handed to the panel once, on mount, and a
+        // captured source would freeze at whatever was on screen then.
+        onCopyShareLink: () => {
+          void copyRemixLinkAction({
+            source: sessionStateRef.current?.source ?? '',
+            dirty: sessionStateRef.current?.dirty ?? false,
+            announce: (message) => uiRef.current.setStatusMessage(message),
+          });
         },
       });
       panelRef.current = panel;

--- a/src/js/frontend/PerformanceHardwareSection.tsx
+++ b/src/js/frontend/PerformanceHardwareSection.tsx
@@ -4,7 +4,10 @@ import type {
   MidiBindingMap,
   MidiDeviceInfo,
 } from '../core/services/webmidi-controller.ts';
-import { webMidiService } from '../core/services/webmidi-controller.ts';
+import {
+  VIRTUAL_GAMEPAD_DEVICE_ID,
+  webMidiService,
+} from '../core/services/webmidi-controller.ts';
 import { useEngineSnapshot } from './engine-context.tsx';
 import { describeParameterState } from './parameter-state.ts';
 
@@ -98,6 +101,15 @@ export function PerformanceHardwareSection() {
         Connect a class-compliant MIDI controller and learn your own mappings —
         or let Claude drive the show through an MCP session (shows up below as
         "Claude (MCP)").
+      </p>
+      {/* A gamepad has arrived here as a device since the performance source
+          shipped, but the copy named only MIDI and Claude, so the one piece
+          of hardware most people already own read as unsupported. */}
+      <p className="ctl-section__note">
+        A game controller counts too, with nothing to connect: plug one in and
+        it appears below as "Gamepad", sticks and triggers already mapped. Known
+        controllers — nanoKONTROL2, Launch Control XL, MiniLab 3 — arrive with
+        their factory mapping instead of the generic one.
       </p>
 
       <div className="ctl-row ctl-row--stack">
@@ -248,11 +260,16 @@ function MidiDeviceRow({
         <span className="ctl-row__text">
           <span className="ctl-row__label">{device.name}</span>
           <span className="ctl-row__hint">
-            {device.kind === 'virtual'
-              ? 'Driven by an MCP session, not physical hardware.'
-              : device.state === 'connected'
-                ? 'Connected'
-                : 'Disconnected — plug it back in to resume.'}
+            {/* Both virtual devices used to share Claude's description, so a
+                gamepad row told the user it was "driven by an MCP session" —
+                the one sentence guaranteed to make someone stop looking. */}
+            {device.id === VIRTUAL_GAMEPAD_DEVICE_ID
+              ? 'A connected game controller. Sticks and triggers, mapped like a MIDI device.'
+              : device.kind === 'virtual'
+                ? 'Driven by an MCP session, not physical hardware.'
+                : device.state === 'connected'
+                  ? 'Connected'
+                  : 'Disconnected — plug it back in to resume.'}
           </span>
         </span>
         <input

--- a/src/js/frontend/StageControls.tsx
+++ b/src/js/frontend/StageControls.tsx
@@ -505,7 +505,11 @@ export function StageControls({
     },
     {
       icon: 'link' as const,
-      label: 'Share link',
+      // Mirrors the palette row: while the editor holds an unsaved draft the
+      // copied URL carries it, and this is the only place that says so.
+      label: engineSnapshot?.sessionState?.dirty
+        ? 'Share link (carries your edits)'
+        : 'Share link',
       actionId: 'share-link',
       action: () => run(() => void ui.handleShowCurrentLink()),
     },

--- a/src/js/frontend/live-performance.ts
+++ b/src/js/frontend/live-performance.ts
@@ -20,6 +20,7 @@
  * module stays free of React and the engine graph.
  */
 
+import { parseURLParams } from '../core/url-params.ts';
 import { getAgentTelemetry } from './agent-bridge.ts';
 import {
   bind as bindModulator,
@@ -686,6 +687,37 @@ declare global {
 }
 
 /**
+ * Say once, in the console, that this API exists.
+ *
+ * `window.__stims_live` has no UI and no URL flag — a console global is the
+ * whole interface — so without a line like this the only way to find ramps,
+ * modulators, macros, scenes and pattern playback is to read the bundle. That
+ * is not discovery, and the feature was effectively write-only.
+ *
+ * Deliberately one grouped line rather than a banner: this shares a console
+ * with the app's own diagnostics, and an ASCII splash would push real output
+ * off the top of the buffer.
+ *
+ * Silent in agent and embed modes. Agent mode exists to give automation a
+ * clean console to read, and an embedded canvas is someone else's page —
+ * neither has a person who could act on the hint.
+ */
+function announceConsoleApi(): void {
+  if (consoleApiAnnounced) return;
+  consoleApiAnnounced = true;
+  const { routing } = parseURLParams();
+  if (routing.agentMode || routing.previewMode) return;
+  console.info(
+    '%cstims%c live-coding API on window.__stims_live — ramp(), bind() for LFO/audio modulators, playPattern() for sound, saveScene(). Call __stims_live.listMacros() or read docs/agents/browser-automation.md.',
+    'font-weight:bold',
+    'font-weight:normal',
+  );
+}
+
+/** Module-scoped so an HMR remount does not reprint the hint every save. */
+let consoleApiAnnounced = false;
+
+/**
  * Publish the runtime on `window.__stims_live`. Returns a teardown that only
  * clears the global if it still owns it, so a remount during HMR cannot
  * unpublish its successor.
@@ -734,6 +766,7 @@ export function installLivePerformance(next: LivePerformanceDeps): () => void {
   };
 
   window.__stims_live = api;
+  announceConsoleApi();
 
   return () => {
     uninstallModulation();

--- a/src/js/frontend/midi-controller-presets.ts
+++ b/src/js/frontend/midi-controller-presets.ts
@@ -1,3 +1,12 @@
+/**
+ * Factory mappings for controllers common enough to be worth knowing by name.
+ *
+ * These shipped, were unit-tested for existence, and were imported by nothing
+ * — so plugging in a nanoKONTROL2 gave you the same eight generic CC defaults
+ * as any anonymous device, and its sixteen labelled controls had to be
+ * MIDI-learned one at a time. {@link matchMidiProfile} is the join that was
+ * missing; `midi-profile-autobind.ts` applies it on connect.
+ */
 import type {
   MidiBindingMap,
   MidiNoteBindingMap,
@@ -8,6 +17,16 @@ export interface MidiDeviceProfile {
   name: string;
   manufacturer: string;
   description: string;
+  /**
+   * Lowercase fragments identifying this device in the strings WebMIDI
+   * reports, matched against `name + manufacturer`.
+   *
+   * Needed because those strings are nothing like the marketing name: a
+   * nanoKONTROL2 announces itself as "nanoKONTROL2 SLIDER/KNOB" from "KORG
+   * INC.", and a MiniLab 3 as "Minilab3 MIDI". Matching is done on a
+   * punctuation-stripped form, so write fragments without spaces or dashes.
+   */
+  match?: string[];
   ccBindings: MidiBindingMap;
   noteBindings?: MidiNoteBindingMap;
 }
@@ -17,6 +36,7 @@ export const MIDI_CONTROLLER_PROFILES: MidiDeviceProfile[] = [
     id: 'korg-nanokontrol2',
     name: 'Korg nanoKONTROL2',
     manufacturer: 'Korg',
+    match: ['nanokontrol2'],
     description:
       '8 knobs mapped to zoom, warp, rot, decay, and q1..q4; 8 faders mapped to motion dx/dy and video mixers.',
     ccBindings: {
@@ -44,6 +64,9 @@ export const MIDI_CONTROLLER_PROFILES: MidiDeviceProfile[] = [
     id: 'novation-launch-control-xl',
     name: 'Novation Launch Control XL',
     manufacturer: 'Novation',
+    // Focusrite owns Novation, and some drivers report the parent company as
+    // the manufacturer, so the device name is what has to carry the match.
+    match: ['launchcontrolxl'],
     description:
       '24 knobs (3 rows) and 8 faders for deep real-time parameter tweaking.',
     ccBindings: {
@@ -70,6 +93,7 @@ export const MIDI_CONTROLLER_PROFILES: MidiDeviceProfile[] = [
   {
     id: 'arturia-minilab-3',
     name: 'Arturia MiniLab 3',
+    match: ['minilab3'],
     manufacturer: 'Arturia',
     description:
       '8 rotary encoders and 4 faders mapped to primary visual parameters.',
@@ -111,4 +135,41 @@ export const MIDI_CONTROLLER_PROFILES: MidiDeviceProfile[] = [
 
 export function getMidiProfileById(id: string): MidiDeviceProfile | null {
   return MIDI_CONTROLLER_PROFILES.find((p) => p.id === id) ?? null;
+}
+
+/**
+ * Reduce a WebMIDI name/manufacturer to the form {@link MidiDeviceProfile.match}
+ * fragments are written in: lowercase, letters and digits only.
+ *
+ * Drivers disagree about spacing and punctuation for the same hardware
+ * ("Launch Control XL", "Launch_Control_XL", "LaunchControlXL"), and matching
+ * the raw strings makes the profile depend on which OS the performer is on.
+ */
+function normalizeDeviceIdentity(...parts: Array<string | undefined>): string {
+  return parts
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * The factory profile for a connected device, or null when it is not one we
+ * ship a mapping for.
+ *
+ * `generic-dj-mixer` is deliberately unmatchable: it describes a CC layout
+ * ("whatever sends CC 1-8"), not a device, and returning it for every unknown
+ * controller would overwrite the service's own defaults with a guess.
+ */
+export function matchMidiProfile(
+  name: string | undefined,
+  manufacturer?: string,
+): MidiDeviceProfile | null {
+  const identity = normalizeDeviceIdentity(name, manufacturer);
+  if (!identity) return null;
+  return (
+    MIDI_CONTROLLER_PROFILES.find((profile) =>
+      profile.match?.some((fragment) => identity.includes(fragment)),
+    ) ?? null
+  );
 }

--- a/src/js/frontend/performance-hardware-connect.ts
+++ b/src/js/frontend/performance-hardware-connect.ts
@@ -1,0 +1,161 @@
+/**
+ * Tells you that the controller you just plugged in is doing something.
+ *
+ * Two features hung off hardware that never announced itself. A MIDI device
+ * has driven zoom/warp/rot/decay/q1-q4 out of the box since
+ * `DEFAULT_MIDI_CC_BINDINGS` shipped, and a gamepad's sticks and triggers
+ * reach the same binding machinery through the `virtual:gamepad` device — but
+ * nothing anywhere said so. The only mention of either lives in Settings ->
+ * Performance hardware, which is exactly the panel you do not open when you
+ * have no reason to think the app knows about your hardware. So the whole
+ * capability was reachable only by a performer who moved a fader on a hunch.
+ *
+ * This module is the hunch, removed: connecting a controller says what it now
+ * drives and where to change it, once per device per session.
+ *
+ * It also applies the factory mapping for controllers we ship a profile for
+ * (`midi-controller-presets.ts`), which until now was imported by nothing —
+ * a nanoKONTROL2 got the same eight anonymous defaults as any other device
+ * and its sixteen labelled controls had to be learned one at a time.
+ */
+
+import {
+  DEFAULT_MIDI_CC_BINDINGS,
+  type MidiBindingMap,
+  type MidiDeviceInfo,
+  type MidiNoteBindingMap,
+} from '../core/services/webmidi-controller.ts';
+import { matchMidiProfile } from './midi-controller-presets.ts';
+
+/**
+ * The slice of the MIDI service this needs.
+ *
+ * Structural rather than the concrete service so tests can drive it with a
+ * stub — mocking a module in this graph and re-importing it is a known way to
+ * hang `bun test` here.
+ */
+export interface PerformanceHardwareMidi {
+  onDevicesChanged: (
+    listener: (devices: MidiDeviceInfo[]) => void,
+  ) => () => void;
+  getDevices: () => MidiDeviceInfo[];
+  getBindings: (deviceId: string) => MidiBindingMap;
+  applyDeviceProfile: (
+    deviceId: string,
+    bindings: MidiBindingMap,
+    noteBindings?: MidiNoteBindingMap,
+  ) => void;
+}
+
+/** True when nobody has touched this device's mapping since it appeared. */
+function isAtServiceDefaults(bindings: MidiBindingMap): boolean {
+  const ccNumbers = Object.keys(bindings);
+  const defaultCcNumbers = Object.keys(DEFAULT_MIDI_CC_BINDINGS);
+  if (ccNumbers.length !== defaultCcNumbers.length) return false;
+  return defaultCcNumbers.every((cc) => {
+    const mine = bindings[Number(cc)];
+    const theirs = DEFAULT_MIDI_CC_BINDINGS[Number(cc)];
+    return (
+      mine != null &&
+      mine.target === theirs.target &&
+      mine.min === theirs.min &&
+      mine.max === theirs.max
+    );
+  });
+}
+
+/**
+ * What the generic defaults actually do, spelled out.
+ *
+ * Named constants rather than an interpolation over the binding map: the
+ * message has to read like a sentence a performer can act on, and generating
+ * "CC 1 drives zoom, CC 2 drives warp, ..." from eight entries produces a
+ * paragraph nobody finishes.
+ */
+const DEFAULT_BINDING_SUMMARY =
+  'CC 1-4 and 7-10 drive zoom, warp, rotation, decay and q1-q4';
+
+export function describeMidiConnection(
+  device: MidiDeviceInfo,
+  profileDescription: string | null,
+  profileName: string | null,
+): string {
+  const label = profileName ?? device.name;
+  if (profileDescription) {
+    return `${label} connected — ${profileDescription} Settings → Performance hardware to remap.`;
+  }
+  return `${label} connected — ${DEFAULT_BINDING_SUMMARY}. Settings → Performance hardware to remap or learn your own.`;
+}
+
+export const GAMEPAD_CONNECTED_MESSAGE =
+  'Controller connected — sticks nudge and rotate the visuals, triggers drive q1 and q2. Settings → Performance hardware to remap.';
+
+export interface WatchPerformanceHardwareOptions {
+  midi: PerformanceHardwareMidi;
+  announce: (message: string) => void;
+  /** Injected for tests; defaults to the real window. */
+  target?: Pick<Window, 'addEventListener' | 'removeEventListener'> | null;
+}
+
+/**
+ * Start watching for controllers. Returns a teardown.
+ *
+ * Announcements are once per device per session, keyed by device id, because
+ * `onDevicesChanged` is the service's general "MIDI state changed" signal —
+ * it also fires on every learned binding and enable toggle, and re-announcing
+ * a controller each time someone maps a knob would be its own bug.
+ */
+export function watchPerformanceHardware({
+  midi,
+  announce,
+  target = typeof window === 'undefined' ? null : window,
+}: WatchPerformanceHardwareOptions): () => void {
+  const announced = new Set<string>();
+
+  const handleDevices = (devices: MidiDeviceInfo[]) => {
+    for (const device of devices) {
+      if (device.kind !== 'hardware' || device.state !== 'connected') continue;
+      if (announced.has(device.id)) continue;
+      announced.add(device.id);
+
+      const profile = matchMidiProfile(device.name, device.manufacturer);
+      // Only ever overwrite the mapping the service itself installed. A
+      // performer who has already learned their own knobs owns that device,
+      // and a profile arriving later must not silently replace their work.
+      const fresh = isAtServiceDefaults(midi.getBindings(device.id));
+      const applied = profile != null && fresh;
+      if (applied) {
+        midi.applyDeviceProfile(
+          device.id,
+          profile.ccBindings,
+          profile.noteBindings,
+        );
+      }
+      announce(
+        describeMidiConnection(
+          device,
+          applied ? profile.description : null,
+          applied ? profile.name : null,
+        ),
+      );
+    }
+  };
+
+  const unsubscribe = midi.onDevicesChanged(handleDevices);
+  // A device present before this ran (the service initialises on idle, and
+  // Settings may have connected MIDI already) never fires the change event.
+  handleDevices(midi.getDevices());
+
+  let gamepadAnnounced = false;
+  const handleGamepad = () => {
+    if (gamepadAnnounced) return;
+    gamepadAnnounced = true;
+    announce(GAMEPAD_CONNECTED_MESSAGE);
+  };
+  target?.addEventListener('gamepadconnected', handleGamepad);
+
+  return () => {
+    unsubscribe();
+    target?.removeEventListener('gamepadconnected', handleGamepad);
+  };
+}

--- a/src/js/frontend/workspace-actions.ts
+++ b/src/js/frontend/workspace-actions.ts
@@ -11,6 +11,7 @@
  * call in.
  */
 
+import { shareOrCopyLink } from '../utils/media/share-link.ts';
 import type {
   AudioSource,
   PanelState,
@@ -21,6 +22,7 @@ import {
   setSyncUrlParam,
   startOrCopyWatchParty,
 } from './sync-session.ts';
+import { buildRemixShareUrl } from './url-state.ts';
 import { recentlyOpenedPresetIds } from './workspace-helpers.ts';
 
 export interface PanelSurface {
@@ -106,6 +108,64 @@ export function startOrCopyWatchPartyAction(
   announce: (message: string) => void,
 ): void {
   void startOrCopyWatchParty(announce);
+}
+
+/**
+ * Put a link to the current preset — including the unsaved editor draft — on
+ * the clipboard.
+ *
+ * The `#code=` hash has been written into the address bar on every keystroke
+ * since remix links shipped, so copying the URL by hand already worked. What
+ * did not exist was any way to learn that: no control produced the link, and
+ * nothing named it, so the only people who could share a work-in-progress
+ * preset were the ones who had read `buildRemixShareUrl`.
+ *
+ * Built from the passed source rather than read off `window.location`,
+ * because the effect that maintains the hash runs after a render and the
+ * keystroke that prompted this copy may not have reached it yet.
+ */
+export async function copyRemixLinkAction({
+  source,
+  dirty,
+  announce,
+  share = shareOrCopyLink,
+  href = typeof window === 'undefined' ? '' : window.location.href,
+}: {
+  source: string;
+  dirty: boolean;
+  announce: (message: string) => void;
+  /** Test seam for the clipboard/native-share path. */
+  share?: typeof shareOrCopyLink;
+  href?: string;
+}): Promise<void> {
+  if (!href) return;
+  const url = buildRemixShareUrl(href, dirty && source ? source : null);
+  const result = await share(url, {
+    title: 'Stims preset',
+    text: dirty
+      ? 'Open this Stims preset draft in the editor.'
+      : 'Open this Stims preset.',
+  });
+
+  if (result === 'cancelled') return;
+
+  if (result === 'shared' || result === 'copied') {
+    const verb = result === 'shared' ? 'shared' : 'copied';
+    announce(
+      dirty && source
+        ? `Link ${verb} — it carries your unsaved edits, and opens in their editor.`
+        : `Link ${verb}.`,
+    );
+    return;
+  }
+
+  // No clipboard and no native share: the address bar is the fallback, and
+  // it already holds the same URL, so say that rather than reporting failure.
+  announce(
+    dirty && source
+      ? 'Could not reach the clipboard. The address bar already holds this link, edits included.'
+      : 'Could not reach the clipboard. Copy the link from the address bar.',
+  );
 }
 
 export function endWatchParty(announce: (message: string) => void): void {

--- a/src/js/milkdrop/overlay/editor-panel.ts
+++ b/src/js/milkdrop/overlay/editor-panel.ts
@@ -292,6 +292,16 @@ export type EditorPanelCallbacks = {
   onExport: () => void;
   onDeletePreset: () => void;
   onRequestImport: () => void;
+  /**
+   * Copy a link that carries the editor's live source in a `#code=` hash.
+   *
+   * The shell has written that hash into the address bar on every keystroke
+   * since remix links shipped, so the link already existed — it just had no
+   * name, no button, and nothing anywhere saying an unsaved draft travels in
+   * a URL. Sharing work in progress was a feature you could only use if you
+   * had read the router.
+   */
+  onCopyShareLink: () => void;
 };
 
 const MILKDROP_TO_CM_SEVERITY: Record<
@@ -859,6 +869,8 @@ export class EditorPanel {
   private readonly problemsCount: HTMLElement;
   private readonly diagnosticsList: HTMLElement;
   private readonly deleteButton: HTMLButtonElement;
+  /** Relabelled per compile: what the link carries depends on `state.dirty`. */
+  private readonly shareLinkItem: HTMLButtonElement;
   private readonly editor: EditorView;
   private readonly clearEditorDebounce: () => void;
   private readonly unsubscribeTheme: () => void;
@@ -1143,6 +1155,12 @@ export class EditorPanel {
       'danger',
     );
     this.deleteButton.hidden = true;
+    // Sits with Export because they answer the same question — "how do I get
+    // this out of here" — and a link is the answer people reach for first.
+    this.shareLinkItem = menuItem('Copy link to this preset', () =>
+      this.callbacks.onCopyShareLink(),
+    );
+    this.shareLinkItem.dataset.action = 'editor-copy-share-link';
     menu.append(
       menuItem('Remix', () => this.callbacks.onDuplicatePreset()),
       menuItem('Snapshot as Slot A', () => this.snapshotSlotA()),
@@ -1150,6 +1168,7 @@ export class EditorPanel {
       menuItem('Clear snapshots', () => this.clearSnapshots()),
       menuItem('Import…', () => this.callbacks.onRequestImport()),
       menuItem('Export', () => this.callbacks.onExport()),
+      this.shareLinkItem,
       menuSeparator,
       this.deleteButton,
     );
@@ -2016,6 +2035,15 @@ export class EditorPanel {
         : state.dirty
           ? 'dirty'
           : 'synced';
+    // Says out loud that the draft rides along, at the one moment the claim
+    // is checkable: the reader has unsaved edits in front of them.
+    this.shareLinkItem.textContent = state.dirty
+      ? 'Copy link to this edit'
+      : 'Copy link to this preset';
+    this.shareLinkItem.title = state.dirty
+      ? 'Copies a link carrying your unsaved source, so it opens in their editor exactly as it is here.'
+      : 'Copies a link to this preset. Edit anything and the link carries your draft too.';
+
     this.stateEl.dataset.state = state_;
     this.stateLabel.textContent = hasErrors
       ? 'Holding last good frame'

--- a/tests/unit/copy-remix-link-action.test.ts
+++ b/tests/unit/copy-remix-link-action.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The remix link — a whole `.milk` source carried in a `#code=` hash — has
+ * worked since it shipped and had no control, no label, and no mention. These
+ * cover the affordance that names it.
+ */
+import { describe, expect, it } from 'bun:test';
+import { decodePresetCodeFromHash } from '../../src/js/frontend/url-state.ts';
+import { copyRemixLinkAction } from '../../src/js/frontend/workspace-actions.ts';
+
+const SOURCE = '[preset00]\nzoom=1.02\nwarp=0.9\n';
+const HREF = 'https://toil.fyi/?preset=geiss-aurora&tool=editor';
+
+function captureShare(
+  result: 'copied' | 'shared' | 'cancelled' | 'unavailable',
+) {
+  const calls: string[] = [];
+  return {
+    calls,
+    share: (async (url: string) => {
+      calls.push(url);
+      return result;
+    }) as never,
+  };
+}
+
+describe('copyRemixLinkAction', () => {
+  it('carries the unsaved source, decodable back to the same text', async () => {
+    const { calls, share } = captureShare('copied');
+    const messages: string[] = [];
+
+    await copyRemixLinkAction({
+      source: SOURCE,
+      dirty: true,
+      announce: (message) => messages.push(message),
+      share,
+      href: HREF,
+    });
+
+    const url = new URL(calls[0]);
+    expect(decodePresetCodeFromHash(url.hash)).toBe(SOURCE);
+    // The query state has to survive alongside the hash, or the recipient
+    // gets the draft without the preset and tool it belongs to.
+    expect(url.searchParams.get('preset')).toBe('geiss-aurora');
+    expect(messages[0]).toContain('unsaved edits');
+  });
+
+  it('omits the hash when the session is clean', async () => {
+    const { calls, share } = captureShare('copied');
+    const messages: string[] = [];
+
+    await copyRemixLinkAction({
+      source: SOURCE,
+      dirty: false,
+      announce: (message) => messages.push(message),
+      share,
+      href: `${HREF}#code=stale`,
+    });
+
+    expect(new URL(calls[0]).hash).toBe('');
+    expect(messages).toEqual(['Link copied.']);
+  });
+
+  it('says nothing when a native share sheet is dismissed', async () => {
+    const { share } = captureShare('cancelled');
+    const messages: string[] = [];
+
+    await copyRemixLinkAction({
+      source: SOURCE,
+      dirty: true,
+      announce: (message) => messages.push(message),
+      share,
+      href: HREF,
+    });
+
+    expect(messages).toEqual([]);
+  });
+
+  it('points at the address bar when there is no clipboard', async () => {
+    const { share } = captureShare('unavailable');
+    const messages: string[] = [];
+
+    await copyRemixLinkAction({
+      source: SOURCE,
+      dirty: true,
+      announce: (message) => messages.push(message),
+      share,
+      href: HREF,
+    });
+
+    // The address bar genuinely holds the same URL (App.tsx keeps the hash in
+    // sync), so this is a route to the link, not a consolation message.
+    expect(messages[0]).toContain('address bar');
+  });
+});

--- a/tests/unit/editor-panel-controls.test.ts
+++ b/tests/unit/editor-panel-controls.test.ts
@@ -36,6 +36,7 @@ describe('editor panel colour groups and value-source chips', () => {
     onExport: mock(() => {}),
     onDeletePreset: mock(() => {}),
     onRequestImport: mock(() => {}),
+    onCopyShareLink: mock(() => {}),
   });
 
   const stateFor = (source: string): MilkdropEditorSessionState => ({
@@ -211,6 +212,7 @@ describe('editor panel toggles, modes, ranges and modulation', () => {
     onExport: mock(() => {}),
     onDeletePreset: mock(() => {}),
     onRequestImport: mock(() => {}),
+    onCopyShareLink: mock(() => {}),
   });
 
   const stateFor = (source: string): MilkdropEditorSessionState => ({
@@ -433,6 +435,7 @@ describe('editor panel live drag feedback', () => {
     onExport: mock(() => {}),
     onDeletePreset: mock(() => {}),
     onRequestImport: mock(() => {}),
+    onCopyShareLink: mock(() => {}),
   });
 
   const stateFor = (source: string): MilkdropEditorSessionState => ({
@@ -564,6 +567,7 @@ describe('editor panel live overwrite hint', () => {
     onExport: mock(() => {}),
     onDeletePreset: mock(() => {}),
     onRequestImport: mock(() => {}),
+    onCopyShareLink: mock(() => {}),
   });
 
   const stateFor = (source: string): MilkdropEditorSessionState => ({

--- a/tests/unit/editor-panel.test.ts
+++ b/tests/unit/editor-panel.test.ts
@@ -146,6 +146,37 @@ describe('EditorPanel class integration', () => {
     onExport: mock(() => {}),
     onDeletePreset: mock(() => {}),
     onRequestImport: mock(() => {}),
+    onCopyShareLink: mock(() => {}),
+  });
+
+  test('offers a share link, and says what it carries once edits exist', () => {
+    // The `#code=` remix link had no control anywhere: it lived only in the
+    // address bar, unlabelled, so sharing a draft was undiscoverable.
+    const callbacks = createMockCallbacks();
+    const panel = new EditorPanel(callbacks);
+    const item = panel.element.querySelector(
+      '[data-action="editor-copy-share-link"]',
+    ) as HTMLButtonElement | null;
+    expect(item).not.toBeNull();
+
+    const base: MilkdropEditorSessionState = {
+      source: 'zoom=1.05\n',
+      diagnostics: [],
+      latestCompiled: null,
+      activeCompiled: null,
+      dirty: false,
+    };
+
+    panel.setSessionState(base);
+    expect(item?.textContent).toBe('Copy link to this preset');
+
+    panel.setSessionState({ ...base, dirty: true });
+    expect(item?.textContent).toBe('Copy link to this edit');
+
+    item?.click();
+    expect(callbacks.onCopyShareLink).toHaveBeenCalled();
+
+    panel.dispose();
   });
 
   test('instantiates EditorPanel DOM elements correctly', () => {

--- a/tests/unit/gamepad-performance-source.test.ts
+++ b/tests/unit/gamepad-performance-source.test.ts
@@ -10,6 +10,7 @@ type NoteCall = [string, number, boolean, number];
 function makeHarness(pads: Array<Partial<Gamepad> | null>) {
   const cc: CcCall[] = [];
   const notes: NoteCall[] = [];
+  const seeded: boolean[] = [];
   let pending: (() => void) | null = null;
 
   const stop = startGamepadPerformanceSource(
@@ -20,6 +21,11 @@ function makeHarness(pads: Array<Partial<Gamepad> | null>) {
       },
       injectNote: (deviceId, note, on, velocity) => {
         notes.push([deviceId, note, on, velocity ?? 0]);
+      },
+      // Installs the pad's default CC map on the first pad seen; the source
+      // holds off until then so an unattached controller claims no targets.
+      ensureGamepadDefaults: () => {
+        seeded.push(true);
       },
     },
     {
@@ -37,6 +43,7 @@ function makeHarness(pads: Array<Partial<Gamepad> | null>) {
   return {
     cc,
     notes,
+    seeded,
     stop,
     tick() {
       const next = pending;
@@ -61,6 +68,22 @@ function makePad(
 }
 
 describe('gamepad performance source', () => {
+  test('installs the default mapping once, and only once a pad exists', () => {
+    // Seeding at construction instead would make `virtual:gamepad` claim
+    // zoom/rot/dx/dy on every machine, and the editor's value chips would
+    // report a controller the user does not own.
+    const empty = makeHarness([null]);
+    empty.tick();
+    expect(empty.seeded).toHaveLength(0);
+    empty.stop();
+
+    const h = makeHarness([makePad([0, 0, 0, 0])]);
+    h.tick();
+    h.tick();
+    expect(h.seeded).toHaveLength(1);
+    h.stop();
+  });
+
   test('maps a centred stick to the middle of the CC range, not zero', () => {
     const h = makeHarness([makePad([0, 0, 0, 0])]);
     h.tick();

--- a/tests/unit/milkdrop-overlay-panels.test.ts
+++ b/tests/unit/milkdrop-overlay-panels.test.ts
@@ -148,6 +148,7 @@ describe('editor panel change propagation', () => {
       onExport: mock(),
       onDeletePreset: mock(),
       onRequestImport: mock(),
+      onCopyShareLink: mock(),
     });
     document.body.appendChild(panel.element);
 

--- a/tests/unit/performance-hardware-connect.test.ts
+++ b/tests/unit/performance-hardware-connect.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Covers the two hardware features that shipped inert: a gamepad whose axes
+ * bound to nothing, and four factory MIDI profiles no module imported.
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_GAMEPAD_CC_BINDINGS,
+  DEFAULT_MIDI_CC_BINDINGS,
+  type MidiBindingMap,
+  type MidiDeviceInfo,
+  VIRTUAL_GAMEPAD_DEVICE_ID,
+  WebMidiControllerService,
+} from '../../src/js/core/services/webmidi-controller.ts';
+import { matchMidiProfile } from '../../src/js/frontend/midi-controller-presets.ts';
+import {
+  GAMEPAD_CONNECTED_MESSAGE,
+  type PerformanceHardwareMidi,
+  watchPerformanceHardware,
+} from '../../src/js/frontend/performance-hardware-connect.ts';
+
+const MIDI_STORAGE_KEY = 'stims:midi-state:v1';
+
+function hardwareDevice(
+  overrides: Partial<MidiDeviceInfo> = {},
+): MidiDeviceInfo {
+  return {
+    id: 'device-1',
+    name: 'nanoKONTROL2 SLIDER/KNOB',
+    manufacturer: 'KORG INC.',
+    kind: 'hardware',
+    state: 'connected',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+/** Records what was applied without touching storage or the real service. */
+function stubMidi(
+  devices: MidiDeviceInfo[],
+  bindings: Record<string, MidiBindingMap> = {},
+) {
+  const applied: Array<{ deviceId: string; bindings: MidiBindingMap }> = [];
+  let listener: ((next: MidiDeviceInfo[]) => void) | null = null;
+  const midi: PerformanceHardwareMidi = {
+    onDevicesChanged: (next) => {
+      listener = next;
+      return () => {
+        listener = null;
+      };
+    },
+    getDevices: () => devices,
+    getBindings: (deviceId) => bindings[deviceId] ?? {},
+    applyDeviceProfile: (deviceId, ccBindings) => {
+      applied.push({ deviceId, bindings: ccBindings });
+    },
+  };
+  return { midi, applied, emit: (next: MidiDeviceInfo[]) => listener?.(next) };
+}
+
+describe('matchMidiProfile', () => {
+  it('matches the strings drivers actually report, not the marketing name', () => {
+    // Every one of these is the real name/manufacturer pair the device
+    // announces — the reason a naive equality check found nothing.
+    expect(matchMidiProfile('nanoKONTROL2 SLIDER/KNOB', 'KORG INC.')?.id).toBe(
+      'korg-nanokontrol2',
+    );
+    expect(
+      matchMidiProfile('Launch Control XL', 'Focusrite A.E. Ltd')?.id,
+    ).toBe('novation-launch-control-xl');
+    expect(matchMidiProfile('Minilab3 MIDI', 'Arturia')?.id).toBe(
+      'arturia-minilab-3',
+    );
+  });
+
+  it('returns null for an unknown controller rather than guessing', () => {
+    // generic-dj-mixer describes a CC layout, not a device: returning it here
+    // would overwrite the service's own defaults on every no-name controller.
+    expect(matchMidiProfile('Some USB MIDI Device', 'Acme')).toBeNull();
+    expect(matchMidiProfile(undefined)).toBeNull();
+  });
+});
+
+describe('watchPerformanceHardware', () => {
+  it('applies the factory profile to a controller nobody has remapped', () => {
+    const device = hardwareDevice();
+    const { midi, applied } = stubMidi([device], {
+      [device.id]: { ...DEFAULT_MIDI_CC_BINDINGS },
+    });
+    const messages: string[] = [];
+
+    const stop = watchPerformanceHardware({
+      midi,
+      announce: (message) => messages.push(message),
+      target: null,
+    });
+
+    expect(applied).toHaveLength(1);
+    expect(applied[0].deviceId).toBe(device.id);
+    expect(applied[0].bindings[16].target).toBe('zoom');
+    expect(messages[0]).toContain('Korg nanoKONTROL2 connected');
+    stop();
+  });
+
+  it('leaves a controller the performer has already mapped alone', () => {
+    const device = hardwareDevice();
+    const { midi, applied } = stubMidi([device], {
+      [device.id]: { 1: { target: 'wave_a', min: 0, max: 1 } },
+    });
+    const messages: string[] = [];
+
+    const stop = watchPerformanceHardware({
+      midi,
+      announce: (message) => messages.push(message),
+      target: null,
+    });
+
+    expect(applied).toHaveLength(0);
+    // Still announced — the point is to say the device is live — but with the
+    // generic summary, because their own mapping is what is running.
+    expect(messages[0]).toContain('CC 1-4 and 7-10');
+    stop();
+  });
+
+  it('announces a device once, not on every binding change', () => {
+    const device = hardwareDevice({
+      name: 'Generic Controller',
+      manufacturer: '',
+    });
+    const { midi, emit } = stubMidi([device], { [device.id]: {} });
+    const messages: string[] = [];
+
+    const stop = watchPerformanceHardware({
+      midi,
+      announce: (message) => messages.push(message),
+      target: null,
+    });
+    // onDevicesChanged doubles as the service's general "MIDI state changed"
+    // signal, so it fires again on every learned binding and enable toggle.
+    emit([device]);
+    emit([device]);
+
+    expect(messages).toHaveLength(1);
+    stop();
+  });
+
+  it('ignores virtual devices and disconnected hardware', () => {
+    const { midi } = stubMidi([
+      hardwareDevice({ id: 'virtual:claude', kind: 'virtual' }),
+      hardwareDevice({ id: 'gone', state: 'disconnected' }),
+    ]);
+    const messages: string[] = [];
+
+    const stop = watchPerformanceHardware({
+      midi,
+      announce: (message) => messages.push(message),
+      target: null,
+    });
+
+    expect(messages).toHaveLength(0);
+    stop();
+  });
+
+  it('announces a gamepad once and stops listening on teardown', () => {
+    const { midi } = stubMidi([]);
+    const messages: string[] = [];
+    const handlers = new Map<string, EventListenerOrEventListenerObject>();
+    const target = {
+      addEventListener: (
+        type: string,
+        handler: EventListenerOrEventListenerObject,
+      ) => {
+        handlers.set(type, handler);
+      },
+      removeEventListener: (type: string) => {
+        handlers.delete(type);
+      },
+    } as unknown as Window;
+
+    const stop = watchPerformanceHardware({
+      midi,
+      announce: (message) => messages.push(message),
+      target,
+    });
+
+    const fire = () =>
+      (handlers.get('gamepadconnected') as EventListener | undefined)?.(
+        new Event('gamepadconnected'),
+      );
+    fire();
+    fire();
+
+    expect(messages).toEqual([GAMEPAD_CONNECTED_MESSAGE]);
+    stop();
+    expect(handlers.has('gamepadconnected')).toBe(false);
+  });
+});
+
+describe('gamepad default bindings', () => {
+  it('claims nothing until a pad is actually attached', () => {
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+    const service = new WebMidiControllerService();
+    // `virtual:gamepad` is a device on every machine, so binding it eagerly
+    // made getEnabledTargets() report zoom/rot/dx/dy as hardware-driven in
+    // every session — the editor's value chips and the parameter HUD would
+    // name a controller nobody owns.
+    expect(service.getBindings(VIRTUAL_GAMEPAD_DEVICE_ID)).toEqual({});
+    expect(service.getEnabledTargets().has('zoom')).toBe(false);
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+
+  it('binds the pad the first time one is seen, so it works unmapped', () => {
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+    const service = new WebMidiControllerService();
+    service.ensureGamepadDefaults();
+
+    // The regression this guards: virtual:gamepad was created lazily by the
+    // first injected CC with an empty map, so every axis resolved to no
+    // target and a plugged-in pad moved nothing.
+    expect(service.getBindings(VIRTUAL_GAMEPAD_DEVICE_ID)).toEqual(
+      DEFAULT_GAMEPAD_CC_BINDINGS,
+    );
+    expect(
+      service.injectControlChange(VIRTUAL_GAMEPAD_DEVICE_ID, 3, 127).target,
+    ).toBe('zoom');
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+
+  it('refills an empty map persisted by the build that had the bug', () => {
+    localStorage.setItem(
+      MIDI_STORAGE_KEY,
+      JSON.stringify({
+        [VIRTUAL_GAMEPAD_DEVICE_ID]: {
+          enabled: true,
+          bindings: {},
+          noteBindings: {},
+        },
+      }),
+    );
+    const service = new WebMidiControllerService();
+    service.ensureGamepadDefaults();
+    expect(service.getBindings(VIRTUAL_GAMEPAD_DEVICE_ID)).toEqual(
+      DEFAULT_GAMEPAD_CC_BINDINGS,
+    );
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+
+  it('tells the bindings table about the mapping it just installed', () => {
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+    const service = new WebMidiControllerService();
+    let notifications = 0;
+    service.onDevicesChanged(() => {
+      notifications += 1;
+    });
+
+    service.ensureGamepadDefaults();
+    // Without this the Settings row read "No mappings yet" beside a pad that
+    // was already driving the preset: ensureDeviceRecord creates the record
+    // with the defaults, so an after-the-fact "is it empty" check returns
+    // early and never fires the change event the table listens on.
+    expect(notifications).toBe(1);
+
+    // Idempotent: a second pad appearing must not re-notify or re-persist.
+    service.ensureGamepadDefaults();
+    expect(notifications).toBe(1);
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+
+  it('never overwrites a mapping the performer learned themselves', () => {
+    localStorage.setItem(
+      MIDI_STORAGE_KEY,
+      JSON.stringify({
+        [VIRTUAL_GAMEPAD_DEVICE_ID]: {
+          enabled: true,
+          bindings: { 0: { target: 'wave_a', min: 0, max: 1 } },
+          noteBindings: {},
+        },
+      }),
+    );
+    const service = new WebMidiControllerService();
+    service.ensureGamepadDefaults();
+    expect(service.getBindings(VIRTUAL_GAMEPAD_DEVICE_ID)).toEqual({
+      0: { target: 'wave_a', min: 0, max: 1 },
+    });
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+
+  it('every stick axis rests on its parameter neutral', () => {
+    // A pad sitting untouched must not bend the visuals: sticks self-centre
+    // to CC 64ish and triggers rest at 0.
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+    const service = new WebMidiControllerService();
+    service.ensureGamepadDefaults();
+
+    expect(
+      service.injectControlChange(VIRTUAL_GAMEPAD_DEVICE_ID, 0, 64).normalized,
+    ).toBeCloseTo(0, 3);
+    expect(
+      service.injectControlChange(VIRTUAL_GAMEPAD_DEVICE_ID, 3, 64).normalized,
+    ).toBeCloseTo(1, 2);
+    expect(
+      service.injectControlChange(VIRTUAL_GAMEPAD_DEVICE_ID, 4, 0).normalized,
+    ).toBe(0);
+    localStorage.removeItem(MIDI_STORAGE_KEY);
+  });
+});


### PR DESCRIPTION
## Summary

Three capabilities were already shipped and effectively unreachable. Two of them turned out to be dead code rather than discoverability problems.

**The gamepad drove nothing.** `gamepad-performance-source.ts` emitted CC 0–5 into `virtual:gamepad` — a device record created lazily by the first injected CC with an **empty binding map**, so every axis resolved to no target. There is no learn path for a pad in the UI either (learn is armed by moving a knob, and Settings never mentioned gamepads), so a plugged-in controller moved zero pixels, permanently. `DEFAULT_GAMEPAD_CC_BINDINGS` now maps sticks and triggers, every range chosen so the control's *resting* position is the parameter's neutral value — a pad sitting untouched on a desk must not bend the visuals.

**The four factory MIDI profiles were imported by nothing.** Defined, unit-tested for existence, zero call sites — so a nanoKONTROL2 got the same eight anonymous defaults as any no-name device and its sixteen labelled controls had to be learned one at a time. `matchMidiProfile()` is the missing join, matching the punctuation-stripped strings drivers actually report (`"nanoKONTROL2 SLIDER/KNOB"` from `"KORG INC."`) rather than the marketing name. `performance-hardware-connect.ts` applies the profile on connect, but only to a device still at the service defaults, so it never overwrites a mapping the performer learned themselves.

**The remix link had no name.** `buildRemixShareUrl` has written the live editor source into a `#code=` hash on every keystroke since it shipped, and `buildCanonicalUrl` leaves the hash alone — so copying the URL already sent someone your unsaved draft. But no control produced it and nothing said so, which meant sharing a work-in-progress preset was reachable only by people who had read the router.

Plus the surfacing work: connecting a controller now says what it drives and where to remap it (once per device per session); the editor menu gets a share item that relabels with the session; Share link reads "(carries your edits)" while a draft is live, in both the palette and the dock; a hint fires at the first keystroke, when the claim becomes checkable; and `window.__stims_live` — which has no UI and no URL flag — prints one line naming itself, silent in agent and embed modes.

Also fixes the gamepad's Settings row inheriting Claude's description, which told users their controller was "driven by an MCP session".

## Reviewer notes

**One regression, caught by the gate and fixed.** Seeding the gamepad bindings in the constructor broke three editor tests: `virtual:gamepad` is listed as a device on *every* machine, so `getEnabledTargets()` reported zoom/rot/dx/dy as hardware-driven in every session and the editor's value-source chips flipped `driven` → `shadowed`. Seeding moved to `ensureGamepadDefaults()`, called by the performance source on the first pad it actually sees — the claim is only ever made when it is true. `ensureGamepadDefaults()` also repairs the empty map persisted by builds carrying the original bug; an empty CC map is only ever that bug's footprint, since learn only adds bindings and the pad has no unbind control.

**`share-link` keeps one id and one behaviour.** The label is dynamic rather than a second palette action, so there is no new id for `check-agent-action-ids.ts` to reconcile and no risk of two "share" verbs drifting apart. `copyRemixLinkAction` builds from the passed source rather than reading `window.location`, because the effect that maintains the hash runs after a render and the keystroke prompting the copy may not have reached it yet.

## Testing

- `bun run check` — 3023 pass, 5 skip, 0 fail
- `bun run check:quick` — green
- `bun run build` — green
- New: `tests/unit/performance-hardware-connect.test.ts` (13 tests — profile matching against real driver strings, profile applied only to an untouched device, announce-once semantics, gamepad claims nothing until a pad exists, empty-map repair, learned mappings never overwritten, neutral resting positions)
- New: `tests/unit/copy-remix-link-action.test.ts` (4 tests — source round-trips through the hash and decodes back identically, query state survives alongside it, hash omitted when clean, cancelled share stays silent)
- Extended: `tests/unit/editor-panel.test.ts` (menu item present, relabels on dirty, invokes the callback), `tests/unit/gamepad-performance-source.test.ts` (bindings installed once, and only once a pad exists)
- Manual, against the dev server: editor menu item relabels on edit; the `#code=` hash round-trips (10.7 KB of source decoded back with the probe comment intact); palette label flips via `__stims_agent.listActions()`; the hint lands in `stims:seen-hints`; the console line prints on a normal load and not under `?agent=true`; Settings copy renders and the gamepad row carries its own description; with cleared storage the app writes only `virtual:claude`, confirming no phantom controller claims targets.

## Docs touched

- None. The changes are self-describing in the UI; `docs/GUARDRAILS.md` freshness and script-docblock coverage both pass unchanged.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [x] `bun run build` (if build/runtime output changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
