### PR TITLE
fix(a11y): repair keyboard-only navigation across the shell

### DIFF
--- a/src/css/app-shell.css
+++ b/src/css/app-shell.css
@@ -1499,11 +1499,17 @@ body[data-page="workspace"][data-live="true"] {
     transition: color var(--transition-fast);
   }
 
-  .stims-shell__launch-demo-link:hover:not(:disabled) {
+  .stims-shell__launch-demo-link:hover:not(:disabled):not(
+    [aria-disabled="true"]
+  ) {
     color: var(--stims-ink-strong);
   }
 
-  .stims-shell__launch-demo-link:disabled {
+  /* `aria-disabled` matches too: the busy "Starting…" state keeps the button
+     focusable on purpose (so the press the user just made is still
+     announced), and must still read as unavailable. */
+  .stims-shell__launch-demo-link:disabled,
+  .stims-shell__launch-demo-link[aria-disabled="true"] {
     opacity: 0.55;
     cursor: default;
   }
@@ -1610,12 +1616,13 @@ body[data-page="workspace"][data-live="true"] {
     color: #14100c;
   }
 
-  .stims-shell__launch-cta:hover:not(:disabled) {
+  .stims-shell__launch-cta:hover:not(:disabled):not([aria-disabled="true"]) {
     background: color-mix(in srgb, var(--stims-accent) 88%, #ffffff);
     transform: translateY(-1px);
   }
 
-  .stims-shell__launch-cta:disabled {
+  .stims-shell__launch-cta:disabled,
+  .stims-shell__launch-cta[aria-disabled="true"] {
     opacity: 0.55;
     cursor: default;
   }

--- a/src/js/core/unified-input.ts
+++ b/src/js/core/unified-input.ts
@@ -418,6 +418,22 @@ export function createUnifiedInput({
   if (!target.hasAttribute('tabindex')) {
     target.tabIndex = 0;
   }
+  // This surface is a <canvas> with no text in it, so making it focusable
+  // above without naming it here produced the worst kind of tab stop: a
+  // full-viewport focus ring that announces nothing, on an element a screen
+  // reader cannot describe and a sighted keyboard user cannot tell apart
+  // from a dead end — even though the key layer below is the only way to
+  // steer, zoom and rotate the visuals without a pointer.
+  //
+  // Named here rather than in markup because the canvas belongs to the
+  // renderer, and this is the line that turns it into a stop. A name the
+  // host already chose wins.
+  if (
+    !target.hasAttribute('aria-label') &&
+    !target.hasAttribute('aria-labelledby')
+  ) {
+    target.setAttribute('aria-label', 'Visualizer stage');
+  }
   let bounds = boundsSource.getBoundingClientRect();
 
   const updateBounds = () => {

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -931,6 +931,35 @@ function StimsWorkspaceAppShell() {
         : 'booting';
   }, [liveMode, engine.engineReady]);
 
+  // Going live unmounts the launch page, and with it the button that was
+  // pressed to get here. Whatever is focused inside a removed subtree falls
+  // to `<body>`, which for a keyboard user means their place in the page is
+  // gone: the next Tab starts over at the skip link instead of continuing
+  // into the transport dock, and a screen reader is left on nothing while
+  // the stage it just asked for comes up behind it.
+  //
+  // The stage is the honest landing spot — it is what was just launched, it
+  // carries the stage's accessible name, and it sits immediately before the
+  // dock in DOM order, so one more Tab reaches the controls.
+  const wasLiveRef = useRef(liveMode);
+  useEffect(() => {
+    const wasLive = wasLiveRef.current;
+    wasLiveRef.current = liveMode;
+    if (!liveMode || wasLive) return;
+    // Only rescue focus that was actually orphaned. Someone who has already
+    // tabbed on (or opened a panel from a shortcut while audio started) is
+    // interacting somewhere on purpose, and must not be yanked to the stage.
+    const active = document.activeElement;
+    if (
+      active &&
+      active !== document.body &&
+      active !== document.documentElement
+    ) {
+      return;
+    }
+    ui.stageRef.current?.focus();
+  }, [liveMode, ui.stageRef]);
+
   // A hidden tab gets zero requestAnimationFrame callbacks — the browser
   // stops scheduling them, so nothing in the render path can report the
   // freeze from inside it. Catch the visibility edge here instead and leave

--- a/src/js/frontend/AudioStatusControl.tsx
+++ b/src/js/frontend/AudioStatusControl.tsx
@@ -152,6 +152,16 @@ export function AudioStatusControl({
       setOpen(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
+      // The menu pattern closes on Tab, as the stage overflow menu already
+      // does: Tab means "leave this and carry on through the page". Without
+      // it, Tab walked out of the popover into the transport dock the
+      // popover is sitting on top of, and left the popover open over
+      // whatever the caret had moved to. Focus is left where Tab put it —
+      // pulling it back to the trigger is the one thing Tab did not ask for.
+      if (event.key === 'Tab') {
+        setOpen(false);
+        return;
+      }
       if (event.key !== 'Escape') return;
       event.stopPropagation();
       setOpen(false);

--- a/src/js/frontend/ContextualHelp.tsx
+++ b/src/js/frontend/ContextualHelp.tsx
@@ -31,10 +31,14 @@ type HelpHintDef = {
 const HINTS: HelpHintDef[] = [
   {
     id: 'first-play',
+    // "Move the mouse for controls" was the only route this named, which is
+    // a dead end for anyone driving the page from the keyboard — the one
+    // audience that most needs to be told where the controls are, since the
+    // dock is hidden until something asks for it. Tab reaches the same dock.
     message: () =>
       isMobileDevice()
         ? 'Swipe to change the visuals — double-tap to fill the screen'
-        : 'Press → for a different visual. Move the mouse for controls.',
+        : 'Press → for a different visual. Tab (or move the mouse) for the controls.',
     autoHideMs: 6000,
     anchor: 'stage',
   },
@@ -59,8 +63,10 @@ const HINTS: HelpHintDef[] = [
   },
   {
     id: 'editor-open',
+    // The Esc half is not trivia: Tab indents inside the code, so it is the
+    // one place in the app Tab does not walk you out of, and nothing said so.
     message:
-      'This is the preset’s source code. Edits show up in the visuals live.',
+      'This is the preset’s source code. Edits show up in the visuals live. Tab indents; Esc steps out.',
     autoHideMs: 6000,
     anchor: 'panel',
   },

--- a/src/js/frontend/CreditsDialog.tsx
+++ b/src/js/frontend/CreditsDialog.tsx
@@ -41,17 +41,23 @@ export function CreditsDialog({
     // keydown handler here would be dead code: focus is trapped in the card,
     // so the backdrop never receives one.
     // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard dismiss is Escape, handled above
-    <div
-      className="stims-shell__credits-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-label="About Stims and credits"
-      onClick={onClose}
-    >
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: card is visual-only, backdrop handles dismiss */}
+    // biome-ignore lint/a11y/noStaticElementInteractions: click-to-dismiss scrim; the dialog role belongs on the card it wraps
+    <div className="stims-shell__credits-overlay" onClick={onClose}>
       <div
         ref={creditsRef}
         className="stims-shell__credits-card"
+        // The dialog is the card, not the backdrop around it: the card is
+        // what the focus trap fences, what takes initial focus, and what
+        // `aria-modal` should be scoping.
+        //
+        // With the role on the backdrop and `role="presentation"` here, the
+        // element the trap focused carried a role ARIA ignores on anything
+        // focusable. So the dialog's own name was never announced; a screen
+        // reader fell back to naming the focused element from its contents,
+        // and read the card's entire text as one run-on label.
+        role="dialog"
+        aria-modal="true"
+        aria-label="About Stims and credits"
         // Focusable only as a landing spot for the trap's initial focus, so
         // the sheet opens at its heading rather than scrolled to a control.
         tabIndex={-1}
@@ -64,7 +70,6 @@ export function CreditsDialog({
             e.stopPropagation();
           }
         }}
-        role="presentation"
       >
         <CreditsPanel />
         <button type="button" className="cta-button ghost" onClick={onClose}>

--- a/src/js/frontend/NewHomePage.tsx
+++ b/src/js/frontend/NewHomePage.tsx
@@ -134,6 +134,9 @@ export function NewHomePage() {
   // reads as broken and invites rage-taps; show the in-flight state.
   const [audioStarting, setAudioStarting] = useState(false);
   const startWithFeedback = (source: ResumableAudioSource) => {
+    // The CTAs stay focusable while this runs (see `aria-disabled` below), so
+    // a second Enter can land before the first start resolves.
+    if (audioStarting) return;
     setAudioStarting(true);
     void Promise.resolve(engine.handleAudioStart(source)).finally(() =>
       setAudioStarting(false),
@@ -346,7 +349,16 @@ function Actions({
           {...(resumeHook ? { [resumeHook]: 'true' } : {})}
           type="button"
           className="stims-shell__launch-cta"
-          disabled={!isEngineReady || isStarting}
+          // Disabled only *before* it can be used. Going `disabled` on press
+          // instead — which is what "Starting…" used to do — makes the
+          // browser blur the button the user just activated: focus drops to
+          // `<body>`, the "Starting…"/busy state is never announced because
+          // nothing is focused to announce it, and the next Tab restarts at
+          // the top of the document. `aria-disabled` states the same thing
+          // without taking focus away; `startWithFeedback` ignores the
+          // repeat press that leaves possible.
+          disabled={!isEngineReady}
+          aria-disabled={isStarting || undefined}
           aria-busy={isStarting}
           aria-describedby={!isEngineReady ? engineStatusId : undefined}
           onClick={onResume}
@@ -362,7 +374,16 @@ function Actions({
           data-demo-audio-btn="true"
           type="button"
           className="stims-shell__launch-cta"
-          disabled={!isEngineReady || isStarting}
+          // Disabled only *before* it can be used. Going `disabled` on press
+          // instead — which is what "Starting…" used to do — makes the
+          // browser blur the button the user just activated: focus drops to
+          // `<body>`, the "Starting…"/busy state is never announced because
+          // nothing is focused to announce it, and the next Tab restarts at
+          // the top of the document. `aria-disabled` states the same thing
+          // without taking focus away; `startWithFeedback` ignores the
+          // repeat press that leaves possible.
+          disabled={!isEngineReady}
+          aria-disabled={isStarting || undefined}
           aria-busy={isStarting}
           aria-describedby={!isEngineReady ? engineStatusId : undefined}
           onClick={onPlayDemo}
@@ -393,7 +414,9 @@ function Actions({
           type="button"
           className="stims-shell__launch-demo-link"
           data-demo-audio-btn="true"
-          disabled={!isEngineReady || isStarting}
+          disabled={!isEngineReady}
+          aria-disabled={isStarting || undefined}
+          aria-busy={isStarting}
           onClick={onPlayDemo}
         >
           Try demo audio instead, no permission needed

--- a/src/js/frontend/ShortcutsDialog.tsx
+++ b/src/js/frontend/ShortcutsDialog.tsx
@@ -107,17 +107,23 @@ export function ShortcutsDialog({
     // keydown handler here would be dead code: focus is trapped in the card,
     // so the backdrop never receives one.
     // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard dismiss is Escape, handled above
-    <div
-      className="stims-shell__shortcut-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Shortcuts and gestures"
-      onClick={onClose}
-    >
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: card is visual-only, backdrop handles dismiss */}
+    // biome-ignore lint/a11y/noStaticElementInteractions: click-to-dismiss scrim; the dialog role belongs on the card it wraps
+    <div className="stims-shell__shortcut-overlay" onClick={onClose}>
       <div
         ref={shortcutsRef}
         className="stims-shell__shortcut-card"
+        // The dialog is the card, not the backdrop around it: the card is
+        // what the focus trap fences, what takes initial focus, and what
+        // `aria-modal` should be scoping.
+        //
+        // With the role on the backdrop and `role="presentation"` here, the
+        // element the trap focused carried a role ARIA ignores on anything
+        // focusable. So the dialog's own name was never announced; a screen
+        // reader fell back to naming the focused element from its contents,
+        // and read the card's entire text as one run-on label.
+        role="dialog"
+        aria-modal="true"
+        aria-label="Shortcuts and gestures"
         // Focusable only as a landing spot for the trap's initial focus, so
         // the sheet opens at its heading rather than scrolled to a control.
         tabIndex={-1}
@@ -132,7 +138,6 @@ export function ShortcutsDialog({
             e.stopPropagation();
           }
         }}
-        role="presentation"
       >
         <h2>Shortcuts &amp; gestures</h2>
         {warning ? (

--- a/src/js/frontend/SidePanel.tsx
+++ b/src/js/frontend/SidePanel.tsx
@@ -308,8 +308,38 @@ export function SidePanel({
     if (open) {
       setExiting(false);
       if (onOpen) requestAnimationFrame(onOpen);
+      return;
+    }
+    // `open` has gone false, so the exit is over however it started: our own
+    // timed close landing, or the panel being dismissed from outside (the
+    // route changing, a shortcut toggling the same panel off). Releasing the
+    // latch here is what lets `!open && !exiting` unmount the panel.
+    //
+    // Without it the panel stayed mounted forever after the first dismissal:
+    // an empty `role="dialog" aria-modal="true"` shell holding its Close
+    // button, so Tab walked into a panel that was no longer there, Escape did
+    // nothing (its handler is gated on `open`), and — because `aria-modal`
+    // hides everything outside the dialog — the rest of the app went silent
+    // to a screen reader. Reopening the panel cleared it, which is why
+    // clicking around never surfaced it.
+    setExiting(false);
+    if (closeTimerRef.current) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
     }
   }, [open, onOpen]);
+
+  // A panel unmounted mid-exit (the route changing under it) must not leave
+  // its timer to call `onClose` afterwards.
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   // Registered rather than listening directly, so a dialog opened *over* this
   // panel takes Escape instead of the panel underneath taking it.

--- a/src/js/frontend/StimsStageFrame.tsx
+++ b/src/js/frontend/StimsStageFrame.tsx
@@ -32,11 +32,20 @@ export function StimsStageFrame({
             and the launch page is the one view that was left showing bare
             frame background when attract mode had nothing to show. */}
         {liveMode ? null : <StageSignalField />}
+        {/* A group, not an image. The renderer's canvas lands inside here and
+            is a focus stop in its own right — the stage key layer in
+            core/unified-input.ts is how the visuals are steered, zoomed and
+            rotated without a pointer — and `role="img"` presents its whole
+            subtree as one flat graphic. So that canvas was reachable by Tab
+            while being pruned out of the accessibility tree entirely: a stop
+            a screen reader could land on but never announce. `group` keeps
+            the stage's own name without hiding what is inside it. */}
+        {/* biome-ignore lint/a11y/useSemanticElements: <fieldset> groups form controls; this groups a renderer canvas */}
         <div
           id="stims-visualizer"
           ref={stageRef}
           className="stims-shell__stage-root"
-          role="img"
+          role="group"
           aria-label="Audio-reactive visual output"
           tabIndex={-1}
         />

--- a/src/js/frontend/hooks/use-focus-trap.ts
+++ b/src/js/frontend/hooks/use-focus-trap.ts
@@ -79,10 +79,24 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>({
       if (restoreFocusOnUnmount) {
         const el = previouslyFocusedRef.current;
         previouslyFocusedRef.current = null;
-        if (
-          el?.isConnected &&
-          !document.activeElement?.closest('[role="dialog"]')
-        ) {
+        // Focus goes back to whatever opened this surface — unless it has
+        // already moved into a *different* dialog stacked over this one, in
+        // which case yanking it back would dismiss the user out of the
+        // overlay they are actually looking at.
+        //
+        // Testing for "in any dialog at all" was too broad: a panel that
+        // plays an exit animation deactivates its trap while still mounted
+        // and still holding focus, so its own container matched, the restore
+        // was skipped, and focus was left on a control that vanished a
+        // moment later — dropping the keyboard user back at `<body>` and the
+        // top of the document.
+        const activeDialog =
+          document.activeElement instanceof HTMLElement
+            ? document.activeElement.closest('[role="dialog"]')
+            : null;
+        const focusHeldByAnotherDialog =
+          activeDialog !== null && activeDialog !== container;
+        if (el?.isConnected && !focusHeldByAnotherDialog) {
           restoreFocusIfPresent(el);
         }
       }

--- a/src/js/milkdrop/overlay/editor-panel.ts
+++ b/src/js/milkdrop/overlay/editor-panel.ts
@@ -693,7 +693,15 @@ function createEditorView({
         // field (axe: aria-input-field-name). The dialog title does not
         // carry over — the control needs its own name.
         EditorView.contentAttributes.of({
-          'aria-label': 'MilkDrop preset code',
+          // Tab indents in here (indentWithTabKeybinding, below), so it
+          // cannot also move focus out — this is the one control in the app
+          // Tab will not leave. WCAG 2.1.2 permits that only where the way
+          // out is told to the user, and the way out (Escape, handled on
+          // contentDOM further down) was documented nowhere. The name
+          // carries it, and `aria-keyshortcuts` publishes it as a binding.
+          'aria-label':
+            'MilkDrop preset code. Tab indents; press Escape to leave the editor.',
+          'aria-keyshortcuts': 'Escape',
         }),
         lineNumbers(),
         highlightActiveLine(),

--- a/tests/unit/side-panel-dismissal.test.tsx
+++ b/tests/unit/side-panel-dismissal.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { SidePanel } from '../../src/js/frontend/SidePanel.tsx';
+
+/**
+ * Dismissing a panel has to actually take it out of the document.
+ *
+ * SidePanel plays a 200ms exit animation, so it latches `exiting` and keeps
+ * rendering until the animation is done. The latch was only ever cleared on
+ * the way *in* (`if (open) setExiting(false)`), so once a panel had been
+ * dismissed once, `open` was false and `exiting` was true forever, and the
+ * `!open && !exiting` unmount guard never fired again.
+ *
+ * What was left behind is a `role="dialog" aria-modal="true"` shell holding a
+ * Close button: Tab walked into a panel that was no longer there, Escape did
+ * nothing (its handler is gated on `open`), focus was never handed back to
+ * whatever opened the panel, and `aria-modal` hid the rest of the app from
+ * assistive tech. Reopening the panel cleared the latch, which is why it
+ * survived so much clicking around.
+ */
+
+const EXIT_ANIMATION_MS = 200;
+
+function Harness({ openerLabel }: { openerLabel: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        {openerLabel}
+      </button>
+      <SidePanel
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Browse presets"
+      >
+        <button type="button">inside the panel</button>
+      </SidePanel>
+    </>
+  );
+}
+
+const settle = async (ms: number) => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+};
+
+const pressEscape = () =>
+  act(() => {
+    // happy-dom exposes its constructors on `window`, not on the module's
+    // own global scope the way a browser does.
+    const KeyboardEventCtor = window.KeyboardEvent ?? globalThis.KeyboardEvent;
+    document.dispatchEvent(
+      new KeyboardEventCtor('keydown', { key: 'Escape', bubbles: true }),
+    );
+  });
+
+describe('SidePanel dismissal', () => {
+  let host: HTMLElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    host?.remove();
+    host = null;
+    root = null;
+  });
+
+  const mount = () => {
+    (
+      globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    act(() => {
+      root?.render(<Harness openerLabel="Open browse" />);
+    });
+    return host.querySelector('button') as HTMLButtonElement;
+  };
+
+  const panelInDocument = () =>
+    document.querySelector('[data-shell-dialog="true"]');
+
+  test('a dismissed panel leaves the document instead of latching open', async () => {
+    const opener = mount();
+    act(() => opener.click());
+    expect(panelInDocument()).not.toBeNull();
+
+    await pressEscape();
+    await settle(EXIT_ANIMATION_MS + 80);
+
+    expect(panelInDocument()).toBeNull();
+  });
+
+  test('a panel dismissed once can be reopened and dismissed again', async () => {
+    const opener = mount();
+    for (const round of [1, 2]) {
+      act(() => opener.click());
+      expect(panelInDocument(), `round ${round}: opened`).not.toBeNull();
+      await pressEscape();
+      await settle(EXIT_ANIMATION_MS + 80);
+      expect(panelInDocument(), `round ${round}: dismissed`).toBeNull();
+    }
+  });
+
+  test('dismissal hands focus back to whatever opened the panel', async () => {
+    const opener = mount();
+    opener.focus();
+    act(() => opener.click());
+    // The trap lands on the dialog itself, so focus is inside the panel — the
+    // exact case the restore used to skip, because it treated "focus is in
+    // some dialog" as "another dialog has taken over".
+    expect(document.activeElement).toBe(panelInDocument() as Element);
+
+    await pressEscape();
+    await settle(EXIT_ANIMATION_MS + 80);
+
+    expect(document.activeElement).toBe(opener);
+  });
+
+  test('closing from outside the panel unmounts it without an exit latch', async () => {
+    // The route changing under an open panel (a shortcut toggling the same
+    // panel off, a back navigation) flips `open` straight to false without
+    // ever going through the panel's own timed close.
+    (
+      globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    const renderWith = (open: boolean) =>
+      act(() => {
+        root?.render(
+          <SidePanel open={open} onClose={() => {}} title="Browse presets">
+            <button type="button">inside the panel</button>
+          </SidePanel>,
+        );
+      });
+
+    renderWith(true);
+    expect(panelInDocument()).not.toBeNull();
+
+    renderWith(false);
+    await settle(EXIT_ANIMATION_MS + 80);
+
+    expect(panelInDocument()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

I drove the app end to end with nothing but a keyboard — launch, browse, settings, editor, the overflow menu, the help dialogs — at 1280×800 and 390×780, and fixed what broke along the way.

**A dismissed panel never left the document.** `SidePanel` latches `exiting` for its 200ms exit animation, and only ever cleared the latch on the way *in* (`if (open) setExiting(false)`). So after the first dismissal `open` was false and `exiting` was true forever, and the `!open && !exiting` unmount guard never fired again. What stayed behind was an empty `role="dialog" aria-modal="true"` shell holding its Close button:

- Tab walked into a panel that was no longer there.
- Escape did nothing — its handler is gated on `open`.
- Focus was never handed back to whatever opened the panel.
- `aria-modal` hides everything outside the dialog, so the rest of the app went silent to a screen reader.

Under `prefers-reduced-motion` the exit animation is clamped to 0.01ms, so the shell did not even slide off screen — it sat over half the viewport, empty. Reopening the panel cleared the latch, which is why clicking around never surfaced it.

**Focus was never restored to whatever opened an overlay.** The restore in `useFocusTrap` was skipped whenever focus sat in *any* `[role="dialog"]` — including the closing panel's own container, which is exactly where it sits while the exit animation plays. It now defers only to a *different* dialog stacked over this one.

**Launching the visualizer dropped focus on `<body>`.** Two causes, both fixed. The CTA went `disabled` on press, which makes the browser blur the button the user just activated — so "Starting…" was never announced and the next Tab restarted at the top of the document. The busy state is `aria-disabled` now (with a re-entry guard behind it, and matching CSS). Then the launch page unmounts with nothing to inherit focus, so going live hands focus to the stage — but only when focus was actually orphaned, never stealing it from someone who has already tabbed on.

**The stage canvas was a nameless tab stop inside `role="img"`.** It is a real control — the stage key layer is the only way to steer, zoom and rotate without a pointer — but `role="img"` on its wrapper prunes the whole subtree, so the canvas was reachable by Tab and invisible to a screen reader. The wrapper is a `group` now, and the canvas is named at the line that makes it a focus stop.

**The help dialogs focused a `role="presentation"` card.** ARIA ignores that role on anything focusable, so the dialog's name was never announced — a screen reader fell back to naming the focused element from its contents and read the card's entire text as one run-on label. The dialog role now sits on the card the trap actually fences, and the backdrop is a plain scrim.

**The audio popover ignored Tab**, so Tab walked out into the transport dock behind it and left the menu open on top of wherever the caret landed. It closes on Tab, as the stage overflow menu already did.

**The code editor is the one place Tab cannot leave** — Tab indents there. WCAG 2.1.2 allows that only where the way out is told to the user, and the way out (Escape) was documented nowhere. It is in the field's accessible name and `aria-keyshortcuts` now, and in the editor's opening hint.

The first-play hint said "Move the mouse for controls" — the one route a keyboard user cannot take, and the dock is hidden until something asks for it. It names Tab too.

### Checked and found working (no change needed)

Home/End in the virtualised preset grid looked broken under a 320ms probe — they take ~750ms to settle in a dev build over 2,587 presets, then land correctly. The dock's auto-hide is also fine for keyboard: the Tab that reaches for it wakes it first.

## Testing

- `bun run check` — 3063 pass, 0 fail (324 files)
- `bun run check:quick` — clean
- `bun run test tests/unit/side-panel-dismissal.test.tsx` — 4 new regression tests, all pass. Verified they fail against the old code: reverting the `exiting` latch fix fails "a dismissed panel leaves the document instead of latching open", and reverting the focus-trap guard fails "dismissal hands focus back to whatever opened the panel".
- Keyboard-only browser runs at 1280×800 and 390×780 (Playwright, keystrokes only, no clicks): reach the CTA by Tab → launch → focus held on "Starting…" → focus lands on the stage → open and dismiss browse and settings by shortcut and by Escape → land back on the exact control that opened them, with no dialog left in the document. Canvas reports `aria-label="Visualizer stage"`; the shortcuts dialog now takes focus as `role="dialog"` named "Shortcuts and gestures"; the audio popover reports `aria-expanded="false"` after Tab; the editor's code field reports the Escape route in its name.

## Docs touched

- None. The user-facing guidance that changed is in-app hint copy (`ContextualHelp`), not docs.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic
- [x] Async/lifecycle state transitions reviewed (loading, visibility, audio, teardown)
- [x] Existing shared helper/module checked before introducing duplicate logic
- [x] New visual literals use existing design tokens (or include a new named token)
- [x] Behavior change is covered by tests (or reason provided)

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check` (required for JS/TS changes)
- [ ] `bun run build` (if build/runtime output changed) — no build output change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwjgG36SLnJo8tMxT8ybNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwjgG36SLnJo8tMxT8ybNx)_