### PR TITLE
Remove the three timing flakes from the gate suite

### DIFF
--- a/src/js/frontend/live-modulation.ts
+++ b/src/js/frontend/live-modulation.ts
@@ -154,7 +154,7 @@ function advance(modulator: Modulator, deltaMs: number): number {
   return shapeLfo(shape, phase);
 }
 
-function tick() {
+function tick(frameTimeMs: number) {
   frame = null;
   const active = deps;
   if (!active || modulators.size === 0) {
@@ -162,12 +162,21 @@ function tick() {
     return;
   }
 
-  const now = performance.now();
+  // The frame's own timestamp, not performance.now(): it is the instant the
+  // frame was scheduled for, so the delta carries none of the jitter between
+  // the callback firing and this line running. In a browser both sit on the
+  // same clock, so nothing about the motion changes -- but it also means a
+  // test can drive the loop from a virtual clock instead of sleeping on the
+  // real one and hoping the machine keeps up.
+  const now = Number.isFinite(frameTimeMs) ? frameTimeMs : performance.now();
   // Clamped so a backgrounded tab resuming does not jump every LFO forward by
   // however long it was away.
   const deltaMs = Math.min(100, now - (lastFrameAt ?? now - 16));
   lastFrameAt = now;
-  lastTickAt = now;
+  // Staleness stays on the wall clock. "Stalled" means no frame has arrived in
+  // real time -- the hidden-tab case -- which a frame timestamp cannot report,
+  // because when frames stop it stops being issued too.
+  lastTickAt = performance.now();
 
   const offsets = new Map<string, number>();
   for (const modulator of modulators.values()) {

--- a/tests/corpus/butterchurn-corpus-support.test.ts
+++ b/tests/corpus/butterchurn-corpus-support.test.ts
@@ -27,9 +27,22 @@ function loadButterchurnCorpus() {
 }
 
 describe('butterchurn preset corpus support', () => {
-  // Reading and compiling the full 1,700+ preset corpus takes 6-8s on a warm
-  // laptop, so bun's 5s default made this fail as a matter of course rather
-  // than because anything regressed.
+  /**
+   * Reading and compiling the full 1,700+ preset corpus is pure deterministic
+   * CPU work, so this budget is a hang guard rather than a performance
+   * assertion -- and it has to clear the slowest machine that runs it, not the
+   * fastest.
+   *
+   * Measured 2026-09-10 on an M1 Max: 8.9s run alone, 38.6s inside the
+   * parallel gate, where the previous 30s guard reported "timed out after
+   * 30000ms" and buried whichever count had actually moved. Contention alone
+   * is ~4.4x here, and a 2-core CI runner is slower again before that
+   * multiplier applies, so the budget matches the 90s its sibling
+   * full-corpus compile (milkdrop-loop-visual-sweep) already carries for the
+   * same reason.
+   */
+  const CORPUS_COMPILE_TIMEOUT_MS = 90_000;
+
   test(
     'corpus support statuses match the measured baseline',
     () => {
@@ -117,6 +130,6 @@ describe('butterchurn preset corpus support', () => {
       });
       expect(fullySupported.length).toBe(1578);
     },
-    { timeout: 30000 },
+    { timeout: CORPUS_COMPILE_TIMEOUT_MS },
   );
 });

--- a/tests/unit/live-modulation.test.ts
+++ b/tests/unit/live-modulation.test.ts
@@ -8,7 +8,10 @@ import {
   unbind,
   unbindAll,
 } from '../../src/js/frontend/live-modulation.ts';
-import { installAnimationFrameController } from '../environment/animation-frame.ts';
+import {
+  advanceAnimationFrames,
+  installAnimationFrameController,
+} from '../environment/animation-frame.ts';
 
 function rig(centres: Record<string, number> = {}) {
   const applied: Array<[string, number]> = [];
@@ -23,14 +26,30 @@ function rig(centres: Record<string, number> = {}) {
   return { applied, positions, uninstall: installModulation(deps) };
 }
 
-const settle = (ms = 140) => new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Pump the modulation loop a fixed number of frames.
+ *
+ * This used to sleep 140ms and hope the frame controller's auto-advance timer
+ * got enough turns of the real scheduler to tick more than twice. Under a
+ * loaded machine it sometimes managed one, and "an LFO swings the target
+ * around its centre" failed with `Received: 1` -- a flake about the host, not
+ * the code. Nine frames on the controller's virtual clock covers the same
+ * 144ms of modulation time, deterministically and instantly.
+ */
+const settle = (frames = 9) => {
+  advanceAnimationFrames(frames);
+};
 
 beforeEach(() => {
   // The modulation loop is frame-locked on the shared animation-frame
   // controller. A prior file in the same process can leave that singleton's
   // auto-advance timer in a stale state, starving the loop; a fresh install
   // gives every test its own clean frame queue and rAF globals.
-  installAnimationFrameController();
+  //
+  // autoAdvance is off so frames only happen when `settle` asks for them.
+  // With it on, the loop raced the real scheduler and the timing assertions
+  // below were really assertions about how busy the machine was.
+  installAnimationFrameController({ autoAdvance: false });
 });
 
 afterEach(() => {
@@ -42,7 +61,7 @@ describe('modulation engine', () => {
     const { applied, uninstall } = rig({ warp: 2 });
     bind({ target: 'warp', depth: 1, source: { kind: 'lfo', hz: 8 } });
 
-    await settle();
+    settle();
 
     expect(applied.length).toBeGreaterThan(2);
     const values = applied.map(([, value]) => value);
@@ -59,7 +78,7 @@ describe('modulation engine', () => {
     const { positions, uninstall } = rig({ warp: 2 });
     bind({ target: 'warp', depth: 1, source: { kind: 'lfo', hz: 8 } });
 
-    await settle();
+    settle();
 
     // The centre is the ramp's territory. If modulation fed back into it the
     // resting value would drift away on its own.
@@ -72,10 +91,10 @@ describe('modulation engine', () => {
     const { applied, positions, uninstall } = rig({ warp: 2 });
     bind({ target: 'warp', depth: 0.5, source: { kind: 'lfo', hz: 8 } });
 
-    await settle();
+    settle();
     const before = applied.length;
     positions.set('warp', 10);
-    await settle();
+    settle();
 
     const after = applied.slice(before).map(([, value]) => value);
     expect(after.length).toBeGreaterThan(0);
@@ -98,7 +117,7 @@ describe('modulation engine', () => {
       source: { kind: 'lfo', shape: 'square' },
     });
 
-    await settle();
+    settle();
 
     expect(listModulators()).toHaveLength(2);
     // Two square LFOs at depth 1 reach ±2 together; one alone could not.
@@ -118,7 +137,7 @@ describe('modulation engine', () => {
       source: { kind: 'lfo', hz: 8 },
     });
 
-    await settle();
+    settle();
 
     for (const [, value] of applied) {
       expect(value).toBeGreaterThanOrEqual(0.9);
@@ -131,7 +150,7 @@ describe('modulation engine', () => {
   test('unbinding hands the target back to its centre', async () => {
     const { applied, uninstall } = rig({ warp: 2 });
     bind({ target: 'warp', depth: 1, source: { kind: 'lfo', hz: 8 } });
-    await settle();
+    settle();
 
     const removed = unbind({ target: 'warp' });
 
@@ -148,7 +167,7 @@ describe('modulation engine', () => {
     const { applied, uninstall } = rig({ warp: 2 });
     bind({ target: 'warp', depth: 1, source: { kind: 'audio', band: 'bass' } });
 
-    await settle();
+    settle();
 
     // Silence must read as "no offset", not as an invented value.
     expect(applied.length).toBeGreaterThan(0);
@@ -170,7 +189,7 @@ describe('modulation engine', () => {
     const second = rig({ warp: 2 });
 
     expect(listModulators()).toHaveLength(1);
-    await settle();
+    settle();
     expect(second.applied.length).toBeGreaterThan(0);
 
     second.uninstall();

--- a/tests/unit/vm-golden-traces.test.ts
+++ b/tests/unit/vm-golden-traces.test.ts
@@ -32,26 +32,47 @@ describe('VM golden traces', () => {
     name.endsWith('.json'),
   );
 
+  /**
+   * Replaying a witness is 120 frames of real VM execution, and the gate runs
+   * this file alongside every other suite. On a busy machine a single replay
+   * has been measured at 5.8-7.3s, which silently tripped Bun's 5s default and
+   * reported "timed out after 5000ms" -- a verdict about how loaded the host
+   * was, not about whether the VM still replays bit-for-bit.
+   *
+   * Room rather than fewer frames: a portability guard that only runs on idle
+   * hardware is the failure mode this whole file exists to prevent. Nothing
+   * here loops or waits, so a real hang still fails, just later.
+   */
+  const REPLAY_TIMEOUT_MS = 30_000;
+
   test('witness traces exist', () => {
     expect(traceFiles.length).toBeGreaterThanOrEqual(4);
   });
 
   for (const name of traceFiles) {
-    test(`replays ${name} bit-for-bit`, () => {
-      const trace = JSON.parse(
-        readFileSync(join(tracesDir, name), 'utf8'),
-      ) as TraceFile;
-      const source = loadPresetSource(repoRoot, { presetId: trace.presetId });
-      const replayed = runTrace(source.raw, trace.presetId, traceInputs(trace));
-      const divergence = compareReplay(trace, replayed);
-      expect(
-        divergence === null,
-        divergence
-          ? `diverged at frame ${divergence.frame}:\n${divergence.details.join('\n')}\n` +
-              'If this change is an intended platform-semantics decision, re-record the trace (see file header).'
-          : '',
-      ).toBe(true);
-    });
+    test(
+      `replays ${name} bit-for-bit`,
+      () => {
+        const trace = JSON.parse(
+          readFileSync(join(tracesDir, name), 'utf8'),
+        ) as TraceFile;
+        const source = loadPresetSource(repoRoot, { presetId: trace.presetId });
+        const replayed = runTrace(
+          source.raw,
+          trace.presetId,
+          traceInputs(trace),
+        );
+        const divergence = compareReplay(trace, replayed);
+        expect(
+          divergence === null,
+          divergence
+            ? `diverged at frame ${divergence.frame}:\n${divergence.details.join('\n')}\n` +
+                'If this change is an intended platform-semantics decision, re-record the trace (see file header).'
+            : '',
+        ).toBe(true);
+      },
+      REPLAY_TIMEOUT_MS,
+    );
   }
 
   /**
@@ -120,8 +141,11 @@ describe('VM golden traces', () => {
      * inherent to what these tests check, so they get room instead of being
      * thinned out — a portability guard that only runs on fast hardware is the
      * failure mode this whole describe block exists to prevent.
+     *
+     * Same budget as the plain replays above, from the same constant, so the
+     * two cannot drift apart.
      */
-    const SLOW_REPLAY_TIMEOUT_MS = 30_000;
+    const SLOW_REPLAY_TIMEOUT_MS = REPLAY_TIMEOUT_MS;
 
     const divergedUnder = (patch: (original: typeof originalMath) => void) => {
       try {


### PR DESCRIPTION
## Summary

`bun run check` failed **2 of 2 runs** on a loaded machine. None of the failures were about the code under test — all three were verdicts on how busy the host was. I confirmed that by running the gate suite on **pristine `main`**, where the same tests fail (plus a fourth) without any of this branch's changes.

| Test | Symptom | Cause |
|---|---|---|
| `live-modulation` — LFO swings target | `Received: 1`, expected `> 2` | 140ms wall-clock sleep waiting on a frame loop |
| `vm-golden-traces` — replays *N* bit-for-bit | `timed out after 5000ms` | no explicit timeout; 120 frames of VM work takes 5.8–7.3s under load |
| `butterchurn-corpus-support` | `timed out after 30000ms` | compiles 1,700+ presets; 8.9s alone, 38.6s under load |

## The real fix: live-modulation

Eight tests bound an LFO, slept 140ms of wall clock, and asserted the frame-locked loop had ticked more than twice. Under load it sometimes managed one.

The harness already had a virtual frame clock — `installAnimationFrameController({ autoAdvance: false })` plus `advanceAnimationFrames` — but the engine **couldn't be driven by it**: `tick()` took its delta from `performance.now()` rather than the timestamp `requestAnimationFrame` hands it, so pumping frames synchronously advanced no phase.

`tick()` now uses the frame timestamp. In a browser both sit on the same clock, so nothing about the motion changes — if anything it's steadier, since the delta no longer carries the jitter between the callback firing and the line running.

Staleness deliberately **stays** on `performance.now()`. `stalled` means no frame arrived in *real* time — the hidden-tab case — which a frame timestamp cannot report, because when frames stop being issued it stops advancing too. The health test covering that is unchanged.

The 140ms sleeps become nine virtual frames: the same 144ms of modulation time, deterministic and instant. The file went from ~3.2s of sleeping to under 1s and passes 3 of 3.

## The two timeouts

Both are **hang guards, not performance assertions**, sized to clear the slowest machine rather than the fastest — the convention the other corpus tests in this repo already document.

- **`vm-golden-traces`**: the per-trace `replays <name> bit-for-bit` tests had no explicit timeout and inherited bun's 5s default. The sibling tests *in the same file* already carried a 30s budget for exactly this reason; these were simply missed. Both now read from one shared constant so they can't drift apart.
- **`butterchurn-corpus-support`**: raised 30s → 90s, matching the 90s its sibling full-corpus compile (`milkdrop-loop-visual-sweep`) already carries. Measurements are recorded in the comment, per house style.

Nothing in either loops or waits, so a real hang still fails — just later.

## Scope check

I checked the two other corpus tests carrying a 30s budget rather than assuming they were the same class: `milkdrop-parity` and `milkdrop-projectm-compat` run in **580ms and 748ms** — roughly 40x headroom. Left alone.

I also looked into a `noTemplateCurlyInString` diagnostic in `check-ci-config.test.ts` that appears in full-mode output. It's a **warning**, not an error, and the `${{ matrix.file }}` is intentional GitHub Actions syntax. Not touched.

## Testing

- `bun run check` — **exit 0 on two consecutive runs**, 3058 pass, 0 fail (was 0 for 2 before this branch)
- `tests/unit/live-modulation.test.ts` — 3 of 3 runs green, 9 pass, and ~3x faster
- `tests/unit/vm-golden-traces.test.ts` — 7 pass
- Baseline established on pristine `main` via `bun run test:gate`: same tests fail there without these changes

## Docs touched

None.

## Review risk checklist

- [x] Null/undefined paths reviewed for changed logic — `tick` falls back to `performance.now()` if a host hands it a non-finite timestamp
- [x] Async/lifecycle state transitions reviewed — the frame-timestamp vs wall-clock split is the substance of this change; the stalled/hidden-tab path is explicitly preserved and still covered
- [x] Existing shared helper/module checked before introducing duplicate logic — reuses the existing `advanceAnimationFrames` harness rather than adding a new one
- [x] New visual literals use existing design tokens — n/a
- [x] Behavior change is covered by tests — the nine modulation tests now exercise `tick` through the frame timestamp on every run

## Quality checklist

- [x] `bun run check:quick`
- [x] `bun run check`
- [ ] `bun run build` — n/a, no build output changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
