### PR TITLE
feat(audio-match): profile a listening window instead of one frame

### DIFF
--- a/src/js/core/services/audio-matcher.ts
+++ b/src/js/core/services/audio-matcher.ts
@@ -10,7 +10,30 @@ export interface AudioProfile {
   trebleEnergy: number;
   beatIntensity: number;
   rms: number;
-  centroid: number;
+  /**
+   * Present only on windowed profiles: the loudest instant in the analysed
+   * span. The ratio against `rms` is the music's crest factor — how much
+   * dynamic headroom it keeps, which is what separates a compressed wall of
+   * sound from a punchy, transient-driven one at equal loudness.
+   */
+  peakRms?: number;
+  /** Present only on windowed profiles: detected bass onsets per second. */
+  onsetRate?: number;
+}
+
+/**
+ * One reading of the live audio signal, sampled on the engine's frame cadence.
+ * A window of these — a couple of seconds, not one frame — is what a piece of
+ * music actually sounds like; any single frame is a coin flip between a kick
+ * drum and the silence between kicks.
+ */
+export interface AudioWindowSample {
+  rms: number;
+  bass: number;
+  mid: number;
+  treble: number;
+  /** Timestamp in ms (performance.now()-scale), used for onset pacing. */
+  t: number;
 }
 
 export function buildAudioProfile(snapshot: {
@@ -27,7 +50,6 @@ export function buildAudioProfile(snapshot: {
       trebleEnergy: treble,
       beatIntensity: energy > 0.04 ? 1 : 0,
       rms: energy,
-      centroid: 500 + energy * 2000,
     };
   }
 
@@ -37,20 +59,91 @@ export function buildAudioProfile(snapshot: {
     trebleEnergy: energy * 0.1,
     beatIntensity: energy > 0.04 ? 1 : 0,
     rms: energy,
-    centroid: 500 + energy * 2000,
+  };
+}
+
+/** Below this window mean the signal is silence, not quiet music. */
+const WINDOW_SILENCE_RMS = 0.005;
+
+/** Absolute bass floor for onset detection, keeping noise from counting. */
+const ONSET_FLOOR = 0.08;
+
+/** Fewer samples than this cannot characterise a window. */
+const MIN_WINDOW_SAMPLES = 4;
+
+/**
+ * Profiles a span of audio rather than one frame of it, so the description
+ * tracks the piece — its balance, dynamics, and beat — instead of whichever
+ * transient happened to be playing when someone clicked.
+ *
+ * Returns null for a silent window: callers keep their own "nothing is
+ * playing" handling rather than searching against a fabrication.
+ */
+export function buildWindowAudioProfile(
+  samples: AudioWindowSample[],
+): AudioProfile | null {
+  if (samples.length < MIN_WINDOW_SAMPLES) return null;
+
+  let sumRms = 0;
+  let peakRms = 0;
+  let sumBass = 0;
+  let sumMid = 0;
+  let sumTreble = 0;
+  for (const sample of samples) {
+    sumRms += sample.rms;
+    if (sample.rms > peakRms) peakRms = sample.rms;
+    sumBass += sample.bass;
+    sumMid += sample.mid;
+    sumTreble += sample.treble;
+  }
+  const n = samples.length;
+  const rms = sumRms / n;
+  if (rms < WINDOW_SILENCE_RMS) return null;
+
+  // Onsets: bass local peaks that stand clear of the window's own bass
+  // average. The relative threshold adapts to the mix; the absolute floor
+  // keeps a hissing hi-hat track from registering as bass pulses.
+  const bassMean = sumBass / n;
+  const bassThreshold = Math.max(ONSET_FLOOR, bassMean * 1.3);
+  let onsets = 0;
+  for (let i = 1; i < n - 1; i += 1) {
+    const level = samples[i]!.bass;
+    if (
+      level >= bassThreshold &&
+      level > samples[i - 1]!.bass &&
+      level >= samples[i + 1]!.bass
+    ) {
+      onsets += 1;
+    }
+  }
+
+  const spanMs = samples[n - 1]!.t - samples[0]!.t;
+  const seconds = Math.max(0.25, spanMs / 1000);
+
+  return {
+    bassEnergy: sumBass / n,
+    midEnergy: sumMid / n,
+    trebleEnergy: sumTreble / n,
+    // A steady groove at 120bpm lands near 2 onsets/s; intensity saturates
+    // there rather than at the old binary loudness flag.
+    beatIntensity: Math.min(1, onsets / seconds / 2.5),
+    rms,
+    peakRms,
+    onsetRate: onsets / seconds,
   };
 }
 
 /**
  * Turns a profile into query text in the same vocabulary the catalog is
- * described with (see describeFrame in visual-embedding.ts).
+ * described with (see describeFrameParts in visual-embedding.ts) — palette,
+ * edges, motion, and nothing else, so the two sides of the index can match.
  *
  * This used to read `rms` and ignore the other five fields, which left the
- * whole feature with five possible queries — two tracks at equal loudness got
- * byte-identical results regardless of what they actually sounded like.
- * Spectral balance now picks the palette and edge language, and loudness
- * picks the motion language, so the query varies with the music rather than
- * just its volume.
+ * whole feature with five possible queries. Spectral balance picks the
+ * palette and edge language, and on a windowed profile the edge language is
+ * earned by measured transients and dynamics rather than by raw loudness, so
+ * a smooth ambient track and a punchy one no longer describe themselves
+ * identically.
  */
 export function describeAudioProfile(profile: AudioProfile): string {
   const { rms, bassEnergy, midEnergy, trebleEnergy, beatIntensity } = profile;
@@ -80,13 +173,26 @@ export function describeAudioProfile(profile: AudioProfile): string {
         ? `${hue}-dominant palette`
         : `vibrant ${hue}-centered palette`;
 
-  // Treble and transients are where visual busyness comes from.
-  const edges =
-    trebleShare > 0.35 || beatIntensity > 0
-      ? trebleShare > 0.5
+  // Busyness comes from treble content and from transients. A single frame
+  // cannot see transients, so without window stats loudness stands in (the
+  // binary beat flag); with them, measured onsets and crest decide.
+  let edges: string;
+  if (profile.onsetRate !== undefined && profile.peakRms !== undefined) {
+    const crest = profile.peakRms / Math.max(rms, 0.0001);
+    edges =
+      trebleShare > 0.5 || profile.onsetRate > 3
         ? 'dense edges'
-        : 'moderate edges'
-      : 'smooth gradients';
+        : trebleShare > 0.35 || profile.onsetRate > 1 || crest > 2.5
+          ? 'moderate edges'
+          : 'smooth gradients';
+  } else {
+    edges =
+      trebleShare > 0.35 || beatIntensity > 0
+        ? trebleShare > 0.5
+          ? 'dense edges'
+          : 'moderate edges'
+        : 'smooth gradients';
+  }
 
   const motion =
     rms < 0.02
@@ -101,6 +207,7 @@ export function describeAudioProfile(profile: AudioProfile): string {
 export async function searchByAudioProfile(
   profile: AudioProfile,
   signal?: AbortSignal,
+  topK?: number,
 ): Promise<Array<{ presetId: string; score: number }>> {
   const endpoint = resolveOptionalApiUrl('/api/visual-search');
   if (!endpoint) return [];
@@ -108,6 +215,9 @@ export async function searchByAudioProfile(
   const request: VisualSearchRequest = {
     description: describeAudioProfile(profile),
   };
+  if (topK !== undefined) {
+    request.topK = topK;
+  }
   const res = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/js/frontend/App.tsx
+++ b/src/js/frontend/App.tsx
@@ -72,6 +72,7 @@ import { CreditsDialog } from './CreditsDialog.tsx';
 import type { CommandAction } from './command-palette-registry.ts';
 import { StimsErrorBoundary } from './ErrorBoundary.tsx';
 import {
+  getAudioBands,
   getAudioEnergy,
   subscribeAudioEnergy,
 } from './engine-audio-energy-store.ts';
@@ -1589,7 +1590,14 @@ function StimsWorkspaceAppShell() {
     const tryMatch = () => {
       if (controller.signal.aborted) return;
       const audioEnergy = engineSnapshotRef.current?.audioEnergy;
-      const profile = buildAudioProfile({ audioEnergy });
+      // Real bands, not the fabricated 0.6/0.3/0.1 split of a lone scalar:
+      // the store carries the engine's per-frame balance, and without it a
+      // bassy track and a bright one at equal loudness matched identically.
+      const bands = getAudioBands();
+      const profile = buildAudioProfile({
+        audioEnergy,
+        fftBands: [bands.bass, bands.mid, bands.treble],
+      });
       if (profile.rms < QUIET_AUDIO_RMS_THRESHOLD) {
         if (attempts < AUDIO_MATCH_RETRY_SCHEDULE_MS.length) {
           retryTimer = window.setTimeout(

--- a/src/js/frontend/PresetFinderPanel.tsx
+++ b/src/js/frontend/PresetFinderPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  buildAudioProfile,
+  type AudioWindowSample,
+  buildWindowAudioProfile,
   searchByAudioProfile,
 } from '../core/services/audio-matcher.ts';
 import { searchByFrame } from '../core/services/visual-embedding.ts';
@@ -43,6 +44,48 @@ export type FinderMode = 'sound' | 'look';
 const MIN_SCORE = 0.62;
 
 const FINDER_MODE_STORAGE_KEY = 'stims:finder-mode';
+
+/**
+ * How long the sound search listens before describing what it heard.
+ *
+ * One frame is a coin flip between a kick drum and the gap after it, so the
+ * old single-snapshot profile described whichever transient was playing at
+ * the moment of the click. A couple of seconds sees the piece's actual
+ * balance, dynamics and beat — long enough to span several beats, short
+ * enough that the wait still reads as "analysing" rather than hanging.
+ */
+const AUDIO_WINDOW_MS = 2500;
+
+/** Ask deep enough that the score floor still leaves useful rows. */
+const AUDIO_RESULT_DEPTH = 12;
+
+/**
+ * Samples the live audio store for a fixed span. The store notifies per
+ * engine frame during playback, so subscribing collects at frame cadence;
+ * the leading push guarantees at least one sample even if playback stops
+ * mid-window.
+ */
+function collectAudioSamples(durationMs: number): Promise<AudioWindowSample[]> {
+  return new Promise((resolve) => {
+    const samples: AudioWindowSample[] = [];
+    const push = () => {
+      const { bass, mid, treble } = getAudioBands();
+      samples.push({
+        rms: getAudioEnergy(),
+        bass,
+        mid,
+        treble,
+        t: performance.now(),
+      });
+    };
+    push();
+    const unsubscribe = subscribeAudioEnergy(push);
+    window.setTimeout(() => {
+      unsubscribe();
+      resolve(samples);
+    }, durationMs);
+  });
+}
 
 function readStoredFinderMode(): FinderMode | null {
   try {
@@ -121,22 +164,24 @@ export function PresetFinderPanel({
     setLoading(true);
     setResults(null);
     setError(null);
+    const runMode = mode;
     try {
       // Both services return the same {presetId, score} ranking, so the only
       // real difference between the two modes is what gets embedded.
       let matches: Array<{ presetId: string; score: number }>;
       if (mode === 'sound') {
-        // Real bands, not the fabricated 0.6/0.3/0.1 split of a single scalar
-        // that buildAudioProfile falls back to, so the query reflects how the
-        // music is voiced and not only how loud it is.
-        // No slice: the endpoint already returns topK=5.
-        const bands = getAudioBands();
-        matches = await searchByAudioProfile(
-          buildAudioProfile({
-            audioEnergy: getAudioEnergy(),
-            fftBands: [bands.bass, bands.mid, bands.treble],
-          }),
-        );
+        // Listen for a span, then profile the window: the mean balance says
+        // how the music is voiced, measured onsets and crest say how it
+        // moves, and no single transient can define the whole query.
+        const samples = await collectAudioSamples(AUDIO_WINDOW_MS);
+        if (runMode !== modeRef.current) return;
+        const profile = buildWindowAudioProfile(samples);
+        // Silence mid-window: nothing to profile, so an empty list is the
+        // honest answer (the unavailable hint takes over when it applies).
+        matches = profile
+          ? await searchByAudioProfile(profile, undefined, AUDIO_RESULT_DEPTH)
+          : [];
+        if (runMode !== modeRef.current) return;
       } else {
         const canvas = ui.stageRef.current?.querySelector(
           'canvas',
@@ -165,6 +210,11 @@ export function PresetFinderPanel({
       setLoading(false);
     }
   }, [catalogEntryById, mode, ui]);
+
+  // Latest mode, readable inside the async search: a window takes seconds to
+  // collect, and results for a tab the user already left must not land.
+  const modeRef = useRef<FinderMode>(mode);
+  modeRef.current = mode;
 
   // Each mode runs itself once when it becomes visible, matching what the two
   // separate panels did on mount. Keyed by mode so switching tabs searches

--- a/tests/unit/optional-api.test.ts
+++ b/tests/unit/optional-api.test.ts
@@ -15,7 +15,6 @@ describe('optional API endpoint resolution', () => {
         trebleEnergy: 0.05,
         beatIntensity: 1,
         rms: 0.08,
-        centroid: 1200,
       });
 
       expect(results).toEqual([]);

--- a/tests/unit/preset-visual-description.test.ts
+++ b/tests/unit/preset-visual-description.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  type AudioWindowSample,
   buildAudioProfile,
+  buildWindowAudioProfile,
   describeAudioProfile,
 } from '../../src/js/core/services/audio-matcher.ts';
 import {
@@ -225,6 +227,148 @@ describe('audio band plumbing', () => {
     expect(bassy).not.toBe(bright);
     expect(bassy).toContain('red');
     expect(bright).toContain('cyan');
+  });
+});
+
+describe('buildWindowAudioProfile', () => {
+  const FRAME_MS = 16;
+
+  /** A uniform window of `frames` frames, all carrying the same voice. */
+  function windowOf(
+    frames: number,
+    voice: { rms: number; bass: number; mid: number; treble: number },
+    overrides: Record<number, Partial<AudioWindowSample>> = {},
+  ): AudioWindowSample[] {
+    const samples: AudioWindowSample[] = [];
+    for (let i = 0; i < frames; i += 1) {
+      samples.push({
+        rms: voice.rms,
+        bass: voice.bass,
+        mid: voice.mid,
+        treble: voice.treble,
+        t: i * FRAME_MS,
+        ...overrides[i],
+      });
+    }
+    return samples;
+  }
+
+  it('rejects a silent or too-short window instead of fabricating a profile', () => {
+    expect(
+      buildWindowAudioProfile(
+        windowOf(150, { rms: 0.001, bass: 0, mid: 0, treble: 0 }),
+      ),
+    ).toBeNull();
+    expect(
+      buildWindowAudioProfile(
+        windowOf(3, { rms: 0.1, bass: 0.2, mid: 0.3, treble: 0.1 }),
+      ),
+    ).toBeNull();
+  });
+
+  it('does not let one transient define the whole query', () => {
+    // The regression: the old single-frame profile read whichever instant it
+    // sampled, so one kick-drum spike turned a calm track into a busy,
+    // high-motion query.
+    const calm = windowOf(150, {
+      rms: 0.04,
+      bass: 0.2,
+      mid: 0.3,
+      treble: 0.1,
+    });
+    const spiky = [...calm];
+    spiky[75] = {
+      rms: 0.3,
+      bass: 1.4,
+      mid: 0.3,
+      treble: 0.1,
+      t: 75 * FRAME_MS,
+    };
+
+    const windowed = describeAudioProfile(buildWindowAudioProfile(spiky)!);
+    const snapshot = describeAudioProfile(
+      buildAudioProfile({ audioEnergy: 0.3, fftBands: [1.4, 0.3, 0.1] }),
+    );
+    expect(windowed).not.toBe(snapshot);
+    expect(windowed).not.toContain('dense edges');
+    expect(windowed).not.toContain('high motion');
+  });
+
+  it('hears the difference between a steady pad and a pulsed bassline', () => {
+    // Equal loudness, equal spectral balance — only the beat differs, which
+    // is invisible to any single-frame profile.
+    const pad = buildWindowAudioProfile(
+      windowOf(150, { rms: 0.06, bass: 0.2, mid: 0.3, treble: 0.1 }),
+    )!;
+    const pulses = windowOf(150, {
+      rms: 0.06,
+      bass: 0.15,
+      mid: 0.3,
+      treble: 0.1,
+    });
+    for (let i = 6; i < 150; i += 12) {
+      pulses[i] = {
+        rms: 0.06,
+        bass: 0.55,
+        mid: 0.3,
+        treble: 0.1,
+        t: i * FRAME_MS,
+      };
+    }
+    const pulsed = buildWindowAudioProfile(pulses)!;
+
+    expect(pad.onsetRate).toBe(0);
+    expect(pulsed.onsetRate!).toBeGreaterThan(0);
+    expect(describeAudioProfile(pad)).toContain('smooth gradients');
+    expect(describeAudioProfile(pulsed)).not.toBe(describeAudioProfile(pad));
+  });
+
+  it('keeps the hue convention for windowed profiles', () => {
+    const bassy = describeAudioProfile(
+      buildWindowAudioProfile(
+        windowOf(150, { rms: 0.1, bass: 0.9, mid: 0.05, treble: 0.05 }),
+      )!,
+    );
+    const bright = describeAudioProfile(
+      buildWindowAudioProfile(
+        windowOf(150, { rms: 0.1, bass: 0.05, mid: 0.05, treble: 0.9 }),
+      )!,
+    );
+    expect(bassy).toContain('red');
+    expect(bright).toContain('cyan');
+  });
+
+  it('stays inside the catalog vocabulary for every window it profiles', () => {
+    // Both sides of the index speak `dominant {palette}, {edges}, {motion}`;
+    // the audio query is only comparable while it borrows the same words.
+    const palettes =
+      /^(monochrome \w+|\w+-dominant palette|vibrant \w+-centered palette)$/;
+    const edges = /^(smooth gradients|moderate edges|dense edges)$/;
+    const motion = /^(static|subtle motion|moderate motion|high motion)$/;
+
+    for (const rms of [0.01, 0.04, 0.1, 0.3]) {
+      for (const bands of [
+        [0.9, 0.05, 0.05],
+        [0.2, 0.5, 0.3],
+        [0.05, 0.05, 0.9],
+      ]) {
+        const text = describeAudioProfile(
+          buildWindowAudioProfile(
+            windowOf(150, {
+              rms,
+              bass: bands[0]!,
+              mid: bands[1]!,
+              treble: bands[2]!,
+            }),
+          )!,
+        );
+        const parts = text.match(/^dominant (.*), (.*), (.*)$/);
+        expect(parts).not.toBeNull();
+        expect(palettes.test(parts![1]!)).toBe(true);
+        expect(edges.test(parts![2]!)).toBe(true);
+        expect(motion.test(parts?.[3] ?? '')).toBe(true);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The audio match feature described a single frame of audio, so its query reflected whichever transient happened to be playing when you clicked — a kick-drum spike turned a calm track into a "vibrant palette, dense edges, high motion" search. Beat intensity was a raw loudness threshold (`energy > 0.04 ? 1 : 0`), the toast suggestion ignored real FFT bands entirely (fabricated 0.6/0.3/0.1 split), and a dead `centroid` field was pure fiction.

- `buildWindowAudioProfile()` in `audio-matcher.ts` profiles a ~2.5s span: mean spectral balance, crest factor (peak/mean dynamics), and real onset detection (bass local peaks above an adaptive threshold) with an onsets-per-second rate. Returns null for silence so callers keep their own quiet handling.
- `describeAudioProfile` earns its edge/motion words from measured transients and dynamics on windowed profiles; single-frame callers keep the old behavior. Queries stay locked to the catalog's `dominant {palette}, {edges}, {motion}` vocabulary so both sides of the embedding index remain comparable.
- The finder panel listens for 2.5s before searching ("Analysing audio…" is now honest), requests 12 results instead of the endpoint default of 5 so the 0.62 score floor keeps useful rows, and drops stale results if you switch tabs mid-window.
- The audio-match toast now reads the engine's real per-frame band balance from the store.

## Tests run

- `bun run test tests/unit/preset-visual-description.test.ts tests/unit/optional-api.test.ts` — 26 pass, including new coverage: transient resilience (one spike cannot define the query), steady-pad vs pulsed-bass discrimination at equal loudness, silence → null, and a vocabulary-alignment sweep across the window space
- `bun run check` — full gate (Biome + typecheck + fast sharded suite), exit 0